### PR TITLE
Fix use-after-free of transient strings during mid-expression GC

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -67,7 +67,7 @@ static char *sp_str_alloc(size_t len) {
   sp_str_heap = h;
   sp_gc_bytes += total;
   char *body = (char *)(h + 1);
-  body[0] = (char)0xfe;
+  body[0] = (char)0xfc; /* young: survive one sweep */
   body[1 + len] = 0;
   return body + 1;
 }


### PR DESCRIPTION
# Fix use-after-free of transient strings during mid-expression GC

## Summary

`make bench` failed on macOS with `FAIL: io_wordcount` (54/55). Root cause is a
use-after-free of heap strings that are C-stack temporaries when a GC cycle
fires inside the same expression that produced them. Platform-latent — Linux
glibc happens to leave the freed bytes intact long enough that the bug is
invisible there.

One-byte fix to `sp_str_alloc`: newly allocated strings start "young" (header
byte `0xfc`) and survive exactly one sweep before becoming eligible for
collection.

## Symptom

`benchmark/io_wordcount.rb` produced corrupted word-frequency counts on macOS:

```
ruby:                         spinel:
the: 625                      the: 625
quick: 625                    quick: 624   ← low
brown: 625                    brown: 621   ← low
fox: 625                      fox: 623     ← low
jumps: 625                    jumps: 625
over: 625                     over: 625
lazy: 625                     lazy: 624    ← low
dog: 625                      dog: 624     ← low
done                          Bog: 1       ← garbage key
                              }\x04\x01: 1 ← garbage key
                              done
```

Low counts plus stray garbage keys is the fingerprint of a dangling hash
string-key pointer: the hash slot survives but the bytes it points to have
been freed and overwritten. Subsequent `has_key?` misses a previously-inserted
entry and inserts a fresh one; the old slot still exists, now spelling
whatever reused its memory.

## Root cause

Codegen emits this for `line.strip.split(" ")`:

```c
lv_parts = sp_str_split(sp_str_strip(lv_line), " ");
```

And the runtime functions are:

```c
static const char *sp_str_strip(const char *s) {
  …
  char *r = sp_str_alloc_raw(l + 1);   // S1: new GC string, header 0xfe
  memcpy(r, s, l);
  return r;                            // S1 is a C-stack temp, not in sp_gc_roots
}

static sp_StrArray *sp_str_split(const char *s, const char *sep) {
  sp_StrArray *a = sp_StrArray_new();  // ← sp_gc_alloc may trigger sp_gc_collect
  …                                    // ← then uses `s`
}
```

And `sp_gc_alloc` (`lib/sp_runtime.h:128`) checks the threshold and collects
**synchronously** before returning. `sp_gc_collect` calls `sp_gc_mark_all`
(which walks `sp_gc_roots[]` only — the C stack is never scanned) then
`sp_str_sweep`, which frees any string whose header byte is not `0xfc`.

Sequence that bites:

1. `sp_str_strip` allocates `S1`, header = `0xfe`. `S1` is a C argument, not
   rooted.
2. `sp_str_split` enters, calls `sp_StrArray_new` → `sp_gc_alloc` → threshold
   crossed → `sp_gc_collect` → `sp_str_sweep` sees `S1` at `0xfe`, frees it.
3. `sp_str_split` returns to its body and reads `*s` — freed memory.

## Why Linux hides it

glibc's `malloc` typically delays reuse and does not scribble freed chunks, so
`S1`'s bytes still spell the original word when `sp_str_split` reads them.
Apple's `malloc` reuses and scribbles small allocations aggressively, so on
macOS the read after free almost always hits overwritten bytes. The bug is
real on both platforms; Linux is just masking it.

## Fix

`lib/sp_runtime.h:70`:

```diff
-  body[0] = (char)0xfe;
+  body[0] = (char)0xfc; /* young: survive one sweep */
```

The existing mark/sweep protocol already distinguishes `0xfc` (marked this
cycle) from `0xfe` (old & unmarked). By initializing new strings at `0xfc`:

- The sweep immediately following allocation demotes `0xfc` → `0xfe` and
  keeps the string — this is the one-cycle grace window that protects C-stack
  temporaries.
- Next cycle, if no root-reachable container has marked the string back to
  `0xfc`, it is collected normally. No permanent leak.

Bounded memory overhead: one GC cycle of extra liveness for genuinely dead
strings. No performance cost on the hot path.

## Alternatives considered

| Option | Rejected because |
|---|---|
| Raise GC threshold very high | Silences the canary; bug re-surfaces on any long-running string-heavy program. |
| Emit `SP_GC_ROOT` for every intermediate in codegen | Invasive; every runtime primitive would need to be audited for which args it consumes before its first internal allocation. |
| Conservative C stack scan | Portable conservative scan adds significant complexity and changes collector semantics. |
| **Young-gen grace byte (this PR)** | Minimal, localized, correct-by-construction for the observed pattern. |

## Test plan

- [x] `make bench` — before: 54 pass / 1 fail (`io_wordcount`). After: **55 pass / 0 fail**.
- [x] `make test` — **74 pass / 0 fail / 0 error**.
- [x] Direct diff of `ruby io_wordcount.rb` vs compiled binary — identical output.
- [ ] Confirm `make bench` + `make test` still green on Linux.
