### PR TITLE
perf: hoist infer_type(recv) once at top of infer_operator_type

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -1457,9 +1457,11 @@ class Compiler
   end
 
   def infer_operator_type(nid, mname, recv)
-    # Bigint operators return bigint
+    # Receiver type is consulted by nearly every branch below; compute once.
+    lt = ""
     if recv >= 0
       lt = infer_type(recv)
+      # Bigint operators return bigint
       if lt == "bigint"
         if mname == "+" || mname == "-" || mname == "*" || mname == "/" || mname == "%"
           return "bigint"
@@ -1477,7 +1479,6 @@ class Compiler
     end
     if mname == "+"
       if recv >= 0
-        lt = infer_type(recv)
         if lt == "string"
           return "string"
         end
@@ -1509,7 +1510,6 @@ class Compiler
     end
     if mname == "-"
       if recv >= 0
-        lt = infer_type(recv)
         if lt == "float"
           return "float"
         end
@@ -1529,7 +1529,6 @@ class Compiler
     end
     if mname == "*"
       if recv >= 0
-        lt = infer_type(recv)
         if lt == "float"
           return "float"
         end
@@ -1555,7 +1554,6 @@ class Compiler
     end
     if mname == "/"
       if recv >= 0
-        lt = infer_type(recv)
         if lt == "float"
           return "float"
         end
@@ -1578,7 +1576,6 @@ class Compiler
     end
     if mname == "<<"
       if recv >= 0
-        lt = infer_type(recv)
         if lt == "mutable_str"
           return "mutable_str"
         end
@@ -1590,7 +1587,7 @@ class Compiler
     end
     if mname == "-@"
       if recv >= 0
-        return infer_type(recv)
+        return lt
       end
       return "int"
     end


### PR DESCRIPTION
`infer_operator_type` の各演算子分岐 (`+`, `-`, `*`, `/`, `<<`, `-@`) で `lt = infer_type(recv)` を再計算しており、関数冒頭の bigint チェック呼び出しと合わせて同じ `recv` について複数回 `infer_type` が走っていました。`infer_type` は `infer_call_type` → `infer_operator_type` と再帰するため、二重呼びが各階層で重なり、深い呼び出し連鎖で指数的にコストが膨らんでいました。

`recv >= 0` のときに `lt` を一度だけ計算し、各分岐ではそれを再利用するように変更。`build/codegen.ast` に対する出力は byte-identical (MD5 一致)。

`ruby spinel_codegen.rb build/codegen.ast build/gen1.c`:

| | real | user | sys |
|---|---|---|---|
| before | 2m15.297s | 2m15.258s | 0m1.241s |
| after  | 0m17.634s | 0m15.828s | 0m0.467s |

約 7.7 倍速 (135s → 18s, -86.9%)。