### PR TITLE
Untrack local Claude config files

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(gem list:*)",
-      "Bash(gem env:*)",
-      "Bash(find:*)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@
 lib/libspinel_rt.a
 lib/libspbi.a
 HANDOFF.md
+
+# Local Claude config
+.claude/settings.local.json
+CLAUDE.local.md


### PR DESCRIPTION
Claude files with `.local` in their name are not meant to be
checked into git (local-only overrides). `settings.local.json` slipped
in.

It should be renamed to `settings.json` or removed instead.
I think removing here make sense. 

- Untrack `.claude/settings.local.json`
- Add `.claude/settings.local.json` and `CLAUDE.local.md` to `.gitignore`