### PR TITLE
build: install lib/*.rb stdlib stubs alongside binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,12 +192,7 @@ install: all
 	install -m 644 spinel_codegen.rb $(SPNLDIR)/
 	install -m 644 lib/libspinel_rt.a $(SPNLDIR)/lib/
 	install -m 644 lib/sp_runtime.h   $(SPNLDIR)/lib/
-	install -m 644 lib/erb.rb         $(SPNLDIR)/lib/
-	install -m 644 lib/forwardable.rb $(SPNLDIR)/lib/
-	install -m 644 lib/optparse.rb    $(SPNLDIR)/lib/
-	install -m 644 lib/set.rb         $(SPNLDIR)/lib/
-	install -m 644 lib/stringio.rb    $(SPNLDIR)/lib/
-	install -m 644 lib/strscan.rb     $(SPNLDIR)/lib/
+	install -m 644 lib/*.rb           $(SPNLDIR)/lib/
 	install -d $(PREFIX)/bin
 	ln -sf $(SPNLDIR)/spinel $(PREFIX)/bin/spinel
 

--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,12 @@ install: all
 	install -m 644 spinel_codegen.rb $(SPNLDIR)/
 	install -m 644 lib/libspinel_rt.a $(SPNLDIR)/lib/
 	install -m 644 lib/sp_runtime.h   $(SPNLDIR)/lib/
+	install -m 644 lib/erb.rb         $(SPNLDIR)/lib/
+	install -m 644 lib/forwardable.rb $(SPNLDIR)/lib/
+	install -m 644 lib/optparse.rb    $(SPNLDIR)/lib/
+	install -m 644 lib/set.rb         $(SPNLDIR)/lib/
+	install -m 644 lib/stringio.rb    $(SPNLDIR)/lib/
+	install -m 644 lib/strscan.rb     $(SPNLDIR)/lib/
 	install -d $(PREFIX)/bin
 	ln -sf $(SPNLDIR)/spinel $(PREFIX)/bin/spinel
 


### PR DESCRIPTION
## 概要
`make install`  で `lib/*.rb` が対象から抜けていたことにより、`require` で lib 参照がコンパイルエラーになる不具合がありました。

## 再現手順
```bash
make install

cat > uses_set.rb <<'Ruby'
require "set"
s = Set.new([1, 2, 3])
puts "ok"
Ruby

spinel ./uses_set.rb
error: use of undeclared identifier 'sp_Set'; ...
```

## 変更内容
make install で`lib/*.rb` が `$(SPNLDIR)/lib/` へコピーされるように修正