### PR TITLE
Fix use-after-free in long string concatenations

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -6374,6 +6374,11 @@ class Compiler
           rt = infer_type(@nd_receiver[nid])
           if rt == "string"
             @needs_string_helpers = 1
+            # Long string concat chains emit SP_GC_ROOT temps, so the
+            # enclosing function needs SP_GC_SAVE() in its header.
+            if mname == "+"
+              @needs_gc = 1
+            end
           end
         end
       end
@@ -12849,18 +12854,33 @@ class Compiler
           return "sp_str_concat4(" + parts[0] + ", " + parts[1] + ", " + parts[2] + ", " + parts[3] + ")"
         end
         if parts.length >= 5
-          # Variable-length: single malloc for N parts via sp_str_concat_arr
-          arr = "(const char *const[]){"
+          # Variable-length: single malloc for N parts via sp_str_concat_arr.
+          # Hoist each part into a rooted temp first — the compound-literal
+          # initializer order is unspecified, and any part that is a fresh
+          # GC string would otherwise sit unrooted on the C stack while
+          # later parts evaluate (and may trigger sp_gc_collect).
+          # @needs_gc is set in scan_features for any string `+`, ensuring
+          # SP_GC_SAVE() is in the function header before we emit roots here.
+          tnames = "".split(",")
           k = 0
           while k < parts.length
+            t = new_temp
+            emit("  const char * " + t + " = " + parts[k] + ";")
+            emit("  SP_GC_ROOT(" + t + ");")
+            tnames.push(t)
+            k = k + 1
+          end
+          arr = "(const char *const[]){"
+          k = 0
+          while k < tnames.length
             if k > 0
               arr = arr + ", "
             end
-            arr = arr + parts[k]
+            arr = arr + tnames[k]
             k = k + 1
           end
           arr = arr + "}"
-          return "sp_str_concat_arr(" + arr + ", " + parts.length.to_s + ")"
+          return "sp_str_concat_arr(" + arr + ", " + tnames.length.to_s + ")"
         end
         return "sp_str_concat(" + compile_expr(recv) + ", " + compile_arg0(nid) + ")"
       end


### PR DESCRIPTION
# Fix use-after-free in long string concatenations

## Root cause

When 5+ string parts are concatenated with `+`, codegen emits a single
`sp_str_concat_arr` call whose argument is a C99 compound literal:

```c
sp_str_concat_arr((const char *const[]){a, b, c, d, e, f}, 6);
```

C99 leaves the evaluation order of compound-literal initializers
unspecified. If any element is a freshly allocated GC string and a later
element triggers `sp_gc_collect` (e.g. via another `sp_str_concat`), the
earlier element sits on the C stack unrooted and can be freed before the
array is consumed.

This surfaced in the self-hosting compiler: `emit_forward_decls` builds a
13-part name string, and the resulting bin1 occasionally produced a
corrupted function name (`sp_Compiler_(sp_Compiler ...)`), breaking the
gen2 == gen3 fixed-point.

## Fix

Two changes in `spinel_codegen.rb`:

1. **Chain emitter** (`compile_operator_expr`, the `parts.length >= 5`
   branch): hoist each part into a `const char *` C local and call
   `SP_GC_ROOT` on it before assembling the compound-literal array. The
   roots keep every part alive across initializer evaluation regardless
   of order.

2. **`scan_features`**: any `+` CallNode with a string-typed receiver now
   sets `@needs_gc = 1` alongside `@needs_string_helpers = 1`. This is the
   pre-compile pass that decides whether to emit `SP_GC_SAVE()` in the
   function header — it has to run before the chain emitter runs, so the
   header is correct by the time `SP_GC_ROOT` calls land in the body.

## Verification

- `make bootstrap` — gen2.c == gen3.c
- `make test` — 77/77 pass
- `make bench` — 55/55 pass
