### PR TITLE
fix(codegen): route Array#size to length for IntArray/SymArray/StrArray

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -14008,6 +14008,12 @@ class Compiler
         end
         return "sp_IntArray_length(" + rc + ")"
       end
+      if mname == "size"
+        if @hoisted_strlen_var != "" && @hoisted_strlen_recv == rc
+          return @hoisted_strlen_var
+        end
+        return "sp_IntArray_length(" + rc + ")"
+      end
       if mname == "[]"
         return "sp_IntArray_get(" + rc + ", " + compile_arg0(nid) + ")"
       end
@@ -14225,6 +14231,12 @@ class Compiler
     end
     if recv_type == "str_array"
       if mname == "length"
+        if @hoisted_strlen_var != "" && @hoisted_strlen_recv == rc
+          return @hoisted_strlen_var
+        end
+        return "sp_StrArray_length(" + rc + ")"
+      end
+      if mname == "size"
         if @hoisted_strlen_var != "" && @hoisted_strlen_recv == rc
           return @hoisted_strlen_var
         end

--- a/test/bm_array_lit.rb
+++ b/test/bm_array_lit.rb
@@ -3,15 +3,28 @@
 # Integer array literal
 arr = [5, 3, 8, 1, 4]
 puts arr.length    # 5
+puts arr.size      # 5  (alias for length)
 puts arr[0]        # 5
 puts arr.sort[0]   # 1
 puts arr.sum       # 21
 puts arr.min       # 1
 puts arr.max       # 8
 
+# IntArray.size after mutation
+arr.push(99)
+puts arr.size      # 6  (length+1 after push)
+arr.pop
+puts arr.size      # 5  (length-1 after pop)
+
+# Symbol array literal -- size shares the same dispatch as IntArray
+syms = [:foo, :bar, :baz]
+puts syms.length   # 3
+puts syms.size     # 3
+
 # String array literal
 words = ["hello", "world", "foo"]
 puts words.length  # 3
+puts words.size    # 3
 puts words[0]      # hello
 puts words.join(", ") # hello, world, foo
 
@@ -19,6 +32,34 @@ puts words.join(", ") # hello, world, foo
 empty = []
 empty.push(42)
 puts empty.length  # 1
+puts empty.size    # 1
 puts empty[0]      # 42
+
+# Hoisted-length optimisation: .size should behave the same as
+# .length when used as a loop bound. Both compile to a single
+# read of the array's len field, hoisted out of the loop body.
+sum = 0
+i = 0
+while i < arr.size
+  sum += arr[i]
+  i += 1
+end
+puts sum           # 21
+
+ssum = 0
+si = 0
+while si < syms.size
+  ssum += 1
+  si += 1
+end
+puts ssum          # 3
+
+wlen = 0
+wi = 0
+while wi < words.size
+  wlen += words[wi].length
+  wi += 1
+end
+puts wlen          # 13
 
 puts "done"


### PR DESCRIPTION
## Summary

`[1, 2, 3].size` returned `0` even though `[1, 2, 3].length` returned `3`.
The IntArray/SymArray and StrArray dispatch in `compile_array_method_expr`
matched only `mname == "length"`, so `"size"` fell through to a default
that returned `0`. FloatArray and PtrArray already accept both names; this
brings the remaining three array types in line.

\`\`\`ruby
b = [1, 2, 3, 4, 5]
puts b.size            # was: 0    now: 5
puts [:a, :b].size     # was: 0    now: 2
puts [\"x\", \"y\"].size   # was: 0    now: 2
\`\`\`

## Implementation note

In the \`str_array\` branch, \`\"size\"\` is added as its own \`if\` arm rather
than \`if mname == \"length\" || mname == \"size\"\`. The compound form
destabilises the self-build: gen1 emits valid C, but bin1 then
mis-compiles unrelated \`==\` comparisons in \`spinel_codegen\` itself,
producing fragments like \`if (( && ...))\`. The duplicate-arm form
sidesteps it. Worth chasing the underlying inference quirk separately;
I hit the same pattern in two other unrelated fixes.

## Test plan

- [x] \`make test\` passes (74 pass; the one pre-existing \`gvar\` error is
  unaffected).
- [x] \`test/bm_array_lit.rb\` extended with \`.size\` on IntArray, SymArray,
  StrArray, and on an array post \`push\`/\`pop\`. CRuby and Spinel outputs
  match.