### PR TITLE
feat(codegen): add Math.tan, atan, asin, acos, log10, hypot

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2500,13 +2500,28 @@ class Compiler
     if mname == "sin"
       return "float"
     end
+    if mname == "tan"
+      return "float"
+    end
+    if mname == "acos" || mname == "asin" || mname == "atan"
+      return "float"
+    end
     if mname == "log"
+      return "float"
+    end
+    if mname == "log2"
+      return "float"
+    end
+    if mname == "log10"
       return "float"
     end
     if mname == "exp"
       return "float"
     end
     if mname == "atan2"
+      return "float"
+    end
+    if mname == "hypot"
       return "float"
     end
     if mname == "freeze"
@@ -14688,11 +14703,26 @@ class Compiler
         if mname == "sin"
           return "sin(" + compile_arg0(nid) + ")"
         end
+        if mname == "tan"
+          return "tan(" + compile_arg0(nid) + ")"
+        end
+        if mname == "acos"
+          return "acos(" + compile_arg0(nid) + ")"
+        end
+        if mname == "asin"
+          return "asin(" + compile_arg0(nid) + ")"
+        end
+        if mname == "atan"
+          return "atan(" + compile_arg0(nid) + ")"
+        end
         if mname == "log"
           return "log(" + compile_arg0(nid) + ")"
         end
         if mname == "log2"
           return "log2(" + compile_arg0(nid) + ")"
+        end
+        if mname == "log10"
+          return "log10(" + compile_arg0(nid) + ")"
         end
         if mname == "exp"
           return "exp(" + compile_arg0(nid) + ")"
@@ -14703,6 +14733,15 @@ class Compiler
             arg_ids = get_args(args_id)
             if arg_ids.length >= 2
               return "atan2(" + compile_expr(arg_ids[0]) + ", " + compile_expr(arg_ids[1]) + ")"
+            end
+          end
+        end
+        if mname == "hypot"
+          args_id = @nd_arguments[nid]
+          if args_id >= 0
+            arg_ids = get_args(args_id)
+            if arg_ids.length >= 2
+              return "hypot(" + compile_expr(arg_ids[0]) + ", " + compile_expr(arg_ids[1]) + ")"
             end
           end
         end

--- a/test/bm_math.rb
+++ b/test/bm_math.rb
@@ -1,0 +1,34 @@
+# Math module methods. All should return Float.
+
+# Trig (in radians)
+puts (Math.sin(0.0) * 1000).to_i        # 0
+puts (Math.cos(0.0) * 1000).to_i        # 1000
+puts (Math.tan(0.0) * 1000).to_i        # 0
+puts (Math.sin(0.5) * 1000).to_i        # 479
+puts (Math.cos(0.5) * 1000).to_i        # 877
+puts (Math.tan(0.5) * 1000).to_i        # 546
+
+# Inverse trig
+puts (Math.atan(1.0) * 1000).to_i       # 785
+puts (Math.atan2(1.0, 1.0) * 1000).to_i # 785
+puts (Math.asin(1.0) * 1000).to_i       # 1570
+puts (Math.acos(0.0) * 1000).to_i       # 1570
+
+# Powers / logs
+puts (Math.sqrt(2.0) * 1000).to_i       # 1414
+puts (Math.log(1.0) * 1000).to_i        # 0
+puts (Math.log2(8.0) * 1000).to_i       # 3000
+puts (Math.log10(100.0) * 1000).to_i    # 2000
+puts (Math.exp(0.0) * 1000).to_i        # 1000
+
+# Float-typed result (would print "1" / "0" if inferred as int).
+# Use the *1000+to_i idiom to dodge precision-formatting differences
+# between Spinel's float-puts and CRuby's.
+puts (Math.log2(3.0) * 1000).to_i       # 1584
+puts (Math.log10(3.0) * 1000).to_i      # 477
+
+# Hypot
+puts (Math.hypot(3.0, 4.0) * 1000).to_i # 5000
+
+# PI
+puts (Math::PI * 1000).to_i             # 3141


### PR DESCRIPTION
## Summary

\`Math.sin\`, \`Math.cos\`, \`Math.sqrt\`, \`Math.log\`, \`Math.log2\`, \`Math.exp\`,
and \`Math.atan2\` are dispatched, but their close relatives are not.
Calls to the missing methods returned \`0\`:

\`\`\`ruby
Math.sin(0.5)    # 0.479  (works)
Math.cos(0.5)    # 0.878  (works)
Math.tan(0.5)    # was: 0       now: 0.546
Math.atan(1.0)   # was: 0       now: 0.785
Math.asin(1.0)   # was: 0       now: 1.5708
Math.acos(0.0)   # was: 0       now: 1.5708
Math.log10(100)  # was: 0       now: 2.0
Math.hypot(3, 4) # was: 0       now: 5.0
\`\`\`

Each method had no entry in \`infer_method_name_type\` (so \`Math.tan(x)\`
was inferred as \`int\` instead of \`float\`) and no dispatch in the \`Math\`
constant handler in \`compile_call_expr\`. Both gaps fixed; the dispatch
forwards directly to libm (\`tan\`, \`atan\`, \`asin\`, \`acos\`, \`log10\`, \`hypot\`).

## Test plan

- [x] \`make test\` passes (74 -> 75 with the new \`bm_math.rb\`; pre-existing
  \`gvar\` error unaffected).
- [x] New \`test/bm_math.rb\` exercises every Math method this PR touches
  (and the existing ones), with multiple inputs (0.0, 0.5, 1.0). All
  results compared against CRuby via the standard \`make test\` harness.