### PR TITLE
fix(codegen): respect start/length in Array#fill(val, start, len)

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -14041,9 +14041,43 @@ class Compiler
     end
     if mname == "fill"
       pfx = array_c_prefix(recv_type)
+      args_id_fill = @nd_arguments[nid]
       val = compile_arg0(nid)
+      start_expr = "0"
+      # Default end: current array length (matches CRuby's no-args
+      # form which fills the entire existing array).
+      end_expr = "sp_" + pfx + "_length(" + rc + ")"
+      if args_id_fill >= 0
+        aargs_fill = get_args(args_id_fill)
+        if aargs_fill.length >= 3
+          # arr.fill(value, start, length): negative start counts from
+          # the end; if still negative after that, clamp to 0
+          # (matches CRuby: `[1,2,3].fill(9, -5, 2) #=> [9, 9, 3]`).
+          # end_expr = start + length lets the array grow past its
+          # current length when start+length > length; sp_*_set
+          # auto-grows and zero-fills gaps (matches CRuby:
+          # `[1,2,3].fill(9, 5, 2) #=> [1, 2, 3, 0, 0, 9, 9]`).
+          start_tmp = new_temp
+          len_tmp = new_temp
+          emit("  mrb_int " + start_tmp + " = " + compile_expr(aargs_fill[1]) + ";")
+          emit("  mrb_int " + len_tmp + " = " + compile_expr(aargs_fill[2]) + ";")
+          emit("  if (" + start_tmp + " < 0) " + start_tmp + " += sp_" + pfx + "_length(" + rc + ");")
+          emit("  if (" + start_tmp + " < 0) " + start_tmp + " = 0;")
+          start_expr = start_tmp
+          end_expr = "(" + start_tmp + " + " + len_tmp + ")"
+        elsif aargs_fill.length == 2
+          # arr.fill(value, start): fills from start to end of EXISTING
+          # array. If start >= length, fills nothing (does NOT grow,
+          # matching CRuby: `[1,2,3].fill(9, 5) #=> [1, 2, 3]`).
+          start_tmp = new_temp
+          emit("  mrb_int " + start_tmp + " = " + compile_expr(aargs_fill[1]) + ";")
+          emit("  if (" + start_tmp + " < 0) " + start_tmp + " += sp_" + pfx + "_length(" + rc + ");")
+          emit("  if (" + start_tmp + " < 0) " + start_tmp + " = 0;")
+          start_expr = start_tmp
+        end
+      end
       itmp = new_temp
-      emit("  for (mrb_int " + itmp + " = 0; " + itmp + " < sp_" + pfx + "_length(" + rc + "); " + itmp + "++)")
+      emit("  for (mrb_int " + itmp + " = " + start_expr + "; " + itmp + " < " + end_expr + "; " + itmp + "++)")
       emit("    sp_" + pfx + "_set(" + rc + ", " + itmp + ", " + val + ");")
       return rc
     end

--- a/test/bm_array_fill.rb
+++ b/test/bm_array_fill.rb
@@ -1,0 +1,58 @@
+# Array#fill: 1-arg, 2-arg, 3-arg forms.
+# Previously the 2-/3-arg forms silently ignored start/length and
+# filled the entire array.
+
+# 1-arg: fill all
+a = [1, 2, 3, 4, 5]
+a.fill(9)
+puts a[0]    # 9
+puts a[4]    # 9
+
+# 2-arg: fill from start to end
+b = [1, 2, 3, 4, 5]
+b.fill(9, 2)
+puts b[0]    # 1
+puts b[1]    # 2
+puts b[2]    # 9
+puts b[4]    # 9
+
+# 3-arg: fill from start, length elements
+c = [1, 2, 3, 4, 5]
+c.fill(0, 1, 3)
+puts c[0]    # 1
+puts c[1]    # 0
+puts c[3]    # 0
+puts c[4]    # 5
+
+# Negative start
+d = [1, 2, 3, 4, 5]
+d.fill(7, -2)
+puts d[0]    # 1
+puts d[2]    # 3
+puts d[3]    # 7
+puts d[4]    # 7
+
+# 3-arg with start beyond length: array grows.
+# CRuby fills the gap with nil; Spinel's IntArray can't hold nil so it
+# uses 0. The grown length and the explicit fill values are the same;
+# we only assert on those (skip e[3]/e[4] which differ in formatting).
+e = [1, 2, 3]
+e.fill(9, 5, 2)
+puts e.length   # 7
+puts e[2]       # 3
+puts e[5]       # 9
+puts e[6]       # 9
+
+# 2-arg with start beyond length: no-op, array unchanged.
+f = [1, 2, 3]
+f.fill(9, 5)
+puts f.length   # 3
+puts f[2]       # 3
+
+# Very-negative start: clamped to 0 after wrap (start + len < 0).
+# CRuby: [1,2,3].fill(9, -5, 2) #=> [9, 9, 3]
+g = [1, 2, 3]
+g.fill(9, -5, 2)
+puts g[0]       # 9
+puts g[1]       # 9
+puts g[2]       # 3


### PR DESCRIPTION
## Summary

The 2-arg and 3-arg forms of `Array#fill` silently filled the whole
array. The dispatch only used `compile_arg0` for the value and ignored
the remaining args:

```ruby
arr = [1, 2, 3, 4, 5]
arr.fill(0, 1, 3)
# was: [0, 0, 0, 0, 0]
# now: [1, 0, 0, 0, 5]   (matches CRuby)
```

Adds proper 2-arg (`val, start`) and 3-arg (`val, start, length`)
handling. Negative start indexes from the end, matching CRuby.

## Note on a related issue

`arr = []; arr.fill(0, 0, 3) rescue puts \"x\"` still fails to compile
in Spinel (`incompatible pointer to integer conversion assigning to
mrb_int from sp_IntArray*`). That's a separate inference bug where
empty `[]` infers as IntArray and `rescue` tries to unify the
expression's type. Out of scope here; this PR only fixes the dispatch
correctness for the 2/3-arg forms.

## Test plan

- [x] `make test` passes (new `bm_array_fill.rb` covering 1-, 2-,
      and 3-arg forms plus negative-start).
