### PR TITLE
fix(codegen): infer StringIO ivar type correctly

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -4118,6 +4118,9 @@ class Compiler
             if rname == "Hash"
               return "str_int_hash"
             end
+            if rname == "StringIO"
+              return "stringio"
+            end
             return "obj_" + rname
           end
         end

--- a/test/bm_stringio.rb
+++ b/test/bm_stringio.rb
@@ -69,3 +69,16 @@ s10 = StringIO.new
 s10.flush
 puts s10.sync
 puts s10.isatty
+
+# StringIO stored in an instance variable
+class StringIOHolder
+  def initialize
+    @io = StringIO.new("abc")
+  end
+
+  def value
+    @io.string
+  end
+end
+
+puts StringIOHolder.new.value


### PR DESCRIPTION
* Fixes codegen type inference for `StringIO` values stored in instance variables
* Adds regression test covering `StringIO` values stored in instance variable accessed via `@io.string`

#### Compilation error from red/green test case:
```ruby
class StringIOHolder
  def initialize
    @io = StringIO.new("abc")
  end

  def value
    @io.string
  end
end

puts StringIOHolder.new.value
```

```text
/tmp/spinel_out.XXXXXX.c:19:12: error: assigning to 'sp_RbVal' from incompatible type 'sp_StringIO *'
   19 |   self->io = sp_StringIO_new_s((&("\xff" "abc")[1]));
      |            ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/spinel_out.XXXXXX.c:25:12: error: assigning to 'sp_RbVal' from incompatible type 'sp_StringIO *'
   25 |   self->io = sp_StringIO_new_s((&("\xff" "abc")[1]));
      |            ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/spinel_out.XXXXXX.c:34:12: error: incompatible pointer to integer conversion returning 'const char *' from a function with result type 'mrb_int' (aka 'long long') [-Wint-conversion]
   34 |     return _t1;
      |            ^~~
3 errors generated.
spinel: C compilation failed
 ```