### PR TITLE
Support class collection inside modules and ConstantPath.new (A::B.new)

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -1454,13 +1454,12 @@ class Compiler
     end
     if mname == "new"
       if recv >= 0
-        if @nd_type[recv] == "ConstantReadNode"
-          if @nd_name[recv] == "Proc"
-            return "proc"
-          end
-          if @nd_name[recv] == "Fiber"
-            return "fiber"
-          end
+        rcname = constructor_class_name(recv)
+        if rcname == "Proc"
+          return "proc"
+        end
+        if rcname == "Fiber"
+          return "fiber"
         end
       end
     end
@@ -1476,10 +1475,9 @@ class Compiler
     # Fiber.yield returns poly
     if mname == "yield"
       if recv >= 0
-        if @nd_type[recv] == "ConstantReadNode"
-          if @nd_name[recv] == "Fiber"
-            return "poly"
-          end
+        rcname = constructor_class_name(recv)
+        if rcname == "Fiber"
+          return "poly"
         end
       end
     end
@@ -1504,10 +1502,9 @@ class Compiler
     # Fiber.current returns fiber
     if mname == "current"
       if recv >= 0
-        if @nd_type[recv] == "ConstantReadNode"
-          if @nd_name[recv] == "Fiber"
-            return "fiber"
-          end
+        rcname = constructor_class_name(recv)
+        if rcname == "Fiber"
+          return "fiber"
         end
       end
     end
@@ -2444,7 +2441,7 @@ class Compiler
       if recv >= 0
         rn = constructor_class_name(recv)
         if rn != ""
-          if @nd_type[recv] == "ConstantReadNode" && rn == "Array"
+          if rn == "Array"
             # Check fill value type
             args_id = @nd_arguments[nid]
             if args_id >= 0
@@ -2461,16 +2458,16 @@ class Compiler
             end
             return "int_array"
           end
-          if @nd_type[recv] == "ConstantReadNode" && rn == "Hash"
+          if rn == "Hash"
             return "str_int_hash"
           end
-          if @nd_type[recv] == "ConstantReadNode" && rn == "Proc"
+          if rn == "Proc"
             return "proc"
           end
-          if @nd_type[recv] == "ConstantReadNode" && rn == "StringIO"
+          if rn == "StringIO"
             return "stringio"
           end
-          if @nd_type[recv] == "ConstantReadNode" && rn == "Fiber"
+          if rn == "Fiber"
             return "fiber"
           end
           return "obj_" + rn
@@ -2515,7 +2512,7 @@ class Compiler
     if recv >= 0
       rcname = constructor_class_name(recv)
       if rcname != ""
-        if @nd_type[recv] == "ConstantReadNode" && rcname == "Fiber"
+        if rcname == "Fiber"
           if mname == "new"
             return "fiber"
           end
@@ -4160,10 +4157,10 @@ class Compiler
         if r >= 0
           rname = constructor_class_name(r)
           if rname != ""
-            if @nd_type[r] == "ConstantReadNode" && rname == "Array"
+            if rname == "Array"
               return "int_array"
             end
-            if @nd_type[r] == "ConstantReadNode" && rname == "Hash"
+            if rname == "Hash"
               return "str_int_hash"
             end
             return "obj_" + rname
@@ -11911,7 +11908,7 @@ class Compiler
       mn = @nd_name[nid]
       if mn == "new"
         rv = @nd_receiver[nid]
-        if rv >= 0 && @nd_type[rv] == "ConstantReadNode" && @nd_name[rv] == "Fiber"
+        if rv >= 0 && constructor_class_name(rv) == "Fiber"
           return
         end
       end
@@ -12204,10 +12201,8 @@ class Compiler
 
     # Fiber.new { block }
     if mname == "new" && recv >= 0
-      if @nd_type[recv] == "ConstantReadNode"
-        if @nd_name[recv] == "Fiber"
-          return compile_fiber_new(nid)
-        end
+      if constructor_class_name(recv) == "Fiber"
+        return compile_fiber_new(nid)
       end
     end
     # fiber.resume(val)
@@ -12227,17 +12222,16 @@ class Compiler
     end
     # Fiber.yield(val)
     if mname == "yield" && recv >= 0
-      if @nd_type[recv] == "ConstantReadNode"
-        if @nd_name[recv] == "Fiber"
-          args_id = @nd_arguments[nid]
-          if args_id >= 0
-            arg_ids = get_args(args_id)
-            if arg_ids.length > 0
-              return "sp_Fiber_yield(" + box_expr_to_poly(arg_ids[0]) + ")"
-            end
+      if constructor_class_name(recv) == "Fiber"
+        @needs_fiber = 1
+        args_id = @nd_arguments[nid]
+        if args_id >= 0
+          arg_ids = get_args(args_id)
+          if arg_ids.length > 0
+            return "sp_Fiber_yield(" + box_expr_to_poly(arg_ids[0]) + ")"
           end
-          return "sp_Fiber_yield(sp_box_nil())"
         end
+        return "sp_Fiber_yield(sp_box_nil())"
       end
     end
     # fiber.alive?
@@ -12265,10 +12259,9 @@ class Compiler
     end
     # Fiber.current
     if mname == "current" && recv >= 0
-      if @nd_type[recv] == "ConstantReadNode"
-        if @nd_name[recv] == "Fiber"
-          return "sp_fiber_current"
-        end
+      if constructor_class_name(recv) == "Fiber"
+        @needs_fiber = 1
+        return "sp_fiber_current"
       end
     end
 
@@ -13238,13 +13231,13 @@ class Compiler
   def compile_constructor_expr(nid, recv)
     cname = constructor_class_name(recv)
     if cname != ""
-      if @nd_type[recv] == "ConstantReadNode" && cname == "Proc"
+      if cname == "Proc"
         if @nd_block[nid] >= 0
           @needs_proc = 1
           return compile_proc_literal(nid)
         end
       end
-      if @nd_type[recv] == "ConstantReadNode" && cname == "Array"
+      if cname == "Array"
         @needs_gc = 1
         args_id = @nd_arguments[nid]
         if args_id >= 0
@@ -13276,7 +13269,7 @@ class Compiler
         @needs_int_array = 1
         return "sp_IntArray_new()"
       end
-      if @nd_type[recv] == "ConstantReadNode" && cname == "Hash"
+      if cname == "Hash"
         @needs_str_int_hash = 1
         @needs_gc = 1
         args_id = @nd_arguments[nid]
@@ -13296,7 +13289,7 @@ class Compiler
         end
         return "sp_StrIntHash_new()"
       end
-      if @nd_type[recv] == "ConstantReadNode" && cname == "StringIO"
+      if cname == "StringIO"
         @needs_stringio = 1
         args_id = @nd_arguments[nid]
         if args_id >= 0
@@ -14264,13 +14257,7 @@ class Compiler
     end
     # Array methods
     if recv_type == "int_array" || recv_type == "sym_array"
-      if mname == "length"
-        if @hoisted_strlen_var != "" && @hoisted_strlen_recv == rc
-          return @hoisted_strlen_var
-        end
-        return "sp_IntArray_length(" + rc + ")"
-      end
-      if mname == "size"
+      if mname == "length" || mname == "size"
         if @hoisted_strlen_var != "" && @hoisted_strlen_recv == rc
           return @hoisted_strlen_var
         end

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -704,11 +704,36 @@ class Compiler
       end
       base = const_ref_flat_name(parent)
       if base == ""
-        return leaf
+        return ""
       end
       return base + "_" + leaf
     end
     ""
+  end
+
+  def const_ref_is_relative(nid)
+    if nid < 0
+      return 0
+    end
+    t = @nd_type[nid]
+    if t == "ConstantReadNode"
+      return 1
+    end
+    if t == "ConstantPathNode"
+      parent = @nd_receiver[nid]
+      if parent < 0
+        return 0
+      end
+      pt = @nd_type[parent]
+      if pt == "ConstantReadNode"
+        return 1
+      end
+      if pt == "ConstantPathNode"
+        return const_ref_is_relative(parent)
+      end
+      return 0
+    end
+    0
   end
 
   def constructor_class_name(recv_nid)
@@ -3379,7 +3404,7 @@ class Compiler
       cname = const_ref_flat_name(cp)
       # For `module M; class C; ... end; end`, Prism gives class name as
       # ConstantReadNode("C"), so attach lexical module prefix.
-      if module_prefix != "" && @nd_type[cp] == "ConstantReadNode"
+      if module_prefix != "" && const_ref_is_relative(cp) == 1
         cname = module_prefix + "_" + cname
       end
     end
@@ -4313,7 +4338,7 @@ class Compiler
     cp = @nd_constant_path[nid]
     if cp >= 0
       mname = const_ref_flat_name(cp)
-      if module_prefix != "" && @nd_type[cp] == "ConstantReadNode"
+      if module_prefix != "" && const_ref_is_relative(cp) == 1
         mname = module_prefix + "_" + mname
       end
     end

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -683,6 +683,45 @@ class Compiler
     result
   end
 
+  # Flatten a constant reference into an internal name.
+  #   C       -> C
+  #   ::C     -> C
+  #   M::C    -> M_C
+  #   A::B::C -> A_B_C
+  def const_ref_flat_name(nid)
+    if nid < 0
+      return ""
+    end
+    t = @nd_type[nid]
+    if t == "ConstantReadNode"
+      return @nd_name[nid]
+    end
+    if t == "ConstantPathNode"
+      leaf = @nd_name[nid]
+      parent = @nd_receiver[nid]
+      if parent < 0
+        return leaf
+      end
+      base = const_ref_flat_name(parent)
+      if base == ""
+        return leaf
+      end
+      return base + "_" + leaf
+    end
+    ""
+  end
+
+  def constructor_class_name(recv_nid)
+    if recv_nid < 0
+      return ""
+    end
+    rt = @nd_type[recv_nid]
+    if rt == "ConstantReadNode" || rt == "ConstantPathNode"
+      return const_ref_flat_name(recv_nid)
+    end
+    ""
+  end
+
   # ---- Scope management ----
   def push_scope
     @scope_names.push("---")
@@ -2403,9 +2442,9 @@ class Compiler
   def infer_constructor_type(nid, mname, recv)
     if mname == "new"
       if recv >= 0
-        if @nd_type[recv] == "ConstantReadNode"
-          rn = @nd_name[recv]
-          if rn == "Array"
+        rn = constructor_class_name(recv)
+        if rn != ""
+          if @nd_type[recv] == "ConstantReadNode" && rn == "Array"
             # Check fill value type
             args_id = @nd_arguments[nid]
             if args_id >= 0
@@ -2422,16 +2461,16 @@ class Compiler
             end
             return "int_array"
           end
-          if rn == "Hash"
+          if @nd_type[recv] == "ConstantReadNode" && rn == "Hash"
             return "str_int_hash"
           end
-          if rn == "Proc"
+          if @nd_type[recv] == "ConstantReadNode" && rn == "Proc"
             return "proc"
           end
-          if rn == "StringIO"
+          if @nd_type[recv] == "ConstantReadNode" && rn == "StringIO"
             return "stringio"
           end
-          if rn == "Fiber"
+          if @nd_type[recv] == "ConstantReadNode" && rn == "Fiber"
             return "fiber"
           end
           return "obj_" + rn
@@ -2474,9 +2513,9 @@ class Compiler
     end
     # User-defined class methods
     if recv >= 0
-      if @nd_type[recv] == "ConstantReadNode"
-        rcname = @nd_name[recv]
-        if rcname == "Fiber"
+      rcname = constructor_class_name(recv)
+      if rcname != ""
+        if @nd_type[recv] == "ConstantReadNode" && rcname == "Fiber"
           if mname == "new"
             return "fiber"
           end
@@ -3332,11 +3371,20 @@ class Compiler
   end
 
   def collect_class(nid)
+    collect_class_with_prefix(nid, "")
+  end
+
+  def collect_class_with_prefix(nid, module_prefix)
     ci = @cls_names.length
     cname = ""
     cp = @nd_constant_path[nid]
     if cp >= 0
-      cname = @nd_name[cp]
+      cname = const_ref_flat_name(cp)
+      # For `module M; class C; ... end; end`, Prism gives class name as
+      # ConstantReadNode("C"), so attach lexical module prefix.
+      if module_prefix != "" && @nd_type[cp] == "ConstantReadNode"
+        cname = module_prefix + "_" + cname
+      end
     end
 
     # Check for open class on built-in type
@@ -4110,12 +4158,12 @@ class Compiler
       if mname == "new"
         r = @nd_receiver[nid]
         if r >= 0
-          if @nd_type[r] == "ConstantReadNode"
-            rname = @nd_name[r]
-            if rname == "Array"
+          rname = constructor_class_name(r)
+          if rname != ""
+            if @nd_type[r] == "ConstantReadNode" && rname == "Array"
               return "int_array"
             end
-            if rname == "Hash"
+            if @nd_type[r] == "ConstantReadNode" && rname == "Hash"
               return "str_int_hash"
             end
             return "obj_" + rname
@@ -4260,10 +4308,17 @@ class Compiler
   end
 
   def collect_module(nid)
+    collect_module_with_prefix(nid, "")
+  end
+
+  def collect_module_with_prefix(nid, module_prefix)
     mname = ""
     cp = @nd_constant_path[nid]
     if cp >= 0
-      mname = @nd_name[cp]
+      mname = const_ref_flat_name(cp)
+      if module_prefix != "" && @nd_type[cp] == "ConstantReadNode"
+        mname = module_prefix + "_" + mname
+      end
     end
     body = @nd_body[nid]
     # Store module info for include
@@ -4273,6 +4328,19 @@ class Compiler
       return
     end
     body_stmts = get_stmts(body)
+
+    # Match top-level collection order: modules first, then classes.
+    body_stmts.each { |sid|
+      if @nd_type[sid] == "ModuleNode"
+        collect_module_with_prefix(sid, mname)
+      end
+    }
+    body_stmts.each { |sid|
+      if @nd_type[sid] == "ClassNode"
+        collect_class_with_prefix(sid, mname)
+      end
+    }
+
     body_stmts.each { |sid|
       if @nd_type[sid] == "ConstantWriteNode"
         cname = mname + "_" + @nd_name[sid]
@@ -4664,8 +4732,8 @@ class Compiler
       if @nd_name[nid] == "new"
         recv = @nd_receiver[nid]
         if recv >= 0
-          if @nd_type[recv] == "ConstantReadNode"
-            cname = @nd_name[recv]
+          cname = constructor_class_name(recv)
+          if cname != ""
             ci = find_class_idx(cname)
             if ci >= 0
               init_ci = find_init_class(ci)
@@ -13168,15 +13236,15 @@ class Compiler
   end
 
   def compile_constructor_expr(nid, recv)
-    if @nd_type[recv] == "ConstantReadNode"
-      cname = @nd_name[recv]
-      if cname == "Proc"
+    cname = constructor_class_name(recv)
+    if cname != ""
+      if @nd_type[recv] == "ConstantReadNode" && cname == "Proc"
         if @nd_block[nid] >= 0
           @needs_proc = 1
           return compile_proc_literal(nid)
         end
       end
-      if cname == "Array"
+      if @nd_type[recv] == "ConstantReadNode" && cname == "Array"
         @needs_gc = 1
         args_id = @nd_arguments[nid]
         if args_id >= 0
@@ -13208,7 +13276,7 @@ class Compiler
         @needs_int_array = 1
         return "sp_IntArray_new()"
       end
-      if cname == "Hash"
+      if @nd_type[recv] == "ConstantReadNode" && cname == "Hash"
         @needs_str_int_hash = 1
         @needs_gc = 1
         args_id = @nd_arguments[nid]
@@ -13228,7 +13296,7 @@ class Compiler
         end
         return "sp_StrIntHash_new()"
       end
-      if cname == "StringIO"
+      if @nd_type[recv] == "ConstantReadNode" && cname == "StringIO"
         @needs_stringio = 1
         args_id = @nd_arguments[nid]
         if args_id >= 0

--- a/test/bm_constant_path_builtin_new.rb
+++ b/test/bm_constant_path_builtin_new.rb
@@ -1,0 +1,26 @@
+# Test: built-in constructors via absolute ConstantPath (::X.new)
+
+require "stringio"
+
+a = ::Array.new(3, 2)
+puts a[0] + a[2]
+
+h = ::Hash.new
+h["k"] = a[1]
+puts h["k"]
+
+p = ::Proc.new { |x| x + 1 }
+puts p.call(5)
+
+s = ::StringIO.new("ab")
+puts s.getc
+
+f = ::Fiber.new { |x|
+  ::Fiber.yield(x + 1)
+  x + 2
+}
+puts f.resume(4)
+puts f.resume(4)
+
+cur = ::Fiber.current
+puts cur.alive?

--- a/test/bm_constant_path_new.rb
+++ b/test/bm_constant_path_new.rb
@@ -1,0 +1,10 @@
+# Test: constructor call via ConstantPathNode (::C.new)
+
+class C
+  def initialize
+    puts "init"
+  end
+end
+
+puts "start"
+::C.new

--- a/test/bm_module_class_new.rb
+++ b/test/bm_module_class_new.rb
@@ -1,0 +1,17 @@
+# Test: class defined inside module and instantiated through M::C.new
+
+module M
+  class C
+    def initialize
+      puts "init"
+    end
+
+    def step
+      puts "step"
+    end
+  end
+end
+
+puts "start"
+obj = M::C.new
+obj.step

--- a/test/bm_module_relative_constant_path.rb
+++ b/test/bm_module_relative_constant_path.rb
@@ -1,0 +1,26 @@
+# Test: relative ConstantPath class/module definitions inside a module.
+
+module M
+  class A
+  end
+
+  class A::B
+    def value
+      10
+    end
+  end
+
+  module N
+  end
+
+  module N::P
+    class C
+      def value
+        30
+      end
+    end
+  end
+end
+
+puts M::A::B.new.value
+puts M::N::P::C.new.value


### PR DESCRIPTION
## Summary

This PR fixes two related issues in class/constructor resolution:

- Classes defined inside `module` were not collected correctly.
- `.new` handling assumed a `ConstantReadNode` receiver and did not support `ConstantPathNode` receivers such as `A::B.new`.

## Changes

- Updated class/module collection so classes under module namespaces are collected.
- Extended constructor resolution for `.new` to handle constant paths (`ConstantPathNode`) in addition to simple constants.
- Updated related constructor/type inference paths to use the same constant-path aware resolution.

## Tests

Added:

- `test/bm_module_class_new.rb`
- `test/bm_constant_path_new.rb`
- `test/bm_module_relative_constant_path.rb`
- `test/bm_constant_path_builtin_new.rb`

These cover:

- class definitions under modules
- constructor calls via constant paths (`A::B.new`)
- relative constant-path class/module definitions inside modules (`class A::B`, `module N::P`)
- built-in constructors via absolute constant paths (`::Array.new`, `::Hash.new`, etc.)

## Out of Scope

The following are intentionally not addressed in this PR:

- namespaced superclass resolution (e.g. `class D < M::C`)
- namespaced include targets (e.g. `include M::Mixin`)