### PR TITLE
fix(codegen): support block form of Array.new(N) { |i| ... }

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -13201,11 +13201,15 @@ class Compiler
             arrnew_iv = new_temp
             @needs_int_array = 1
             emit("  sp_IntArray *" + arrnew_tmp + " = sp_IntArray_new();")
+            # Root the new array before running the block body — pushing
+            # poly/string values inside the loop can trigger a GC cycle
+            # that would otherwise sweep the local pointer.
+            emit("  SP_GC_ROOT(" + arrnew_tmp + ");")
             emit("  for (mrb_int " + arrnew_iv + " = 0; " + arrnew_iv + " < " + arrnew_count + "; " + arrnew_iv + "++) {")
-            if arrnew_bp != ""
-              emit("    lv_" + arrnew_bp + " = " + arrnew_iv + ";")
-            end
             @indent = @indent + 1
+            if arrnew_bp != ""
+              emit("  lv_" + arrnew_bp + " = " + arrnew_iv + ";")
+            end
             if arrnew_body >= 0
               arrnew_stmts2 = get_stmts(arrnew_body)
               if arrnew_stmts2.length > 0

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -13185,6 +13185,44 @@ class Compiler
       if cname == "Array"
         @needs_gc = 1
         args_id = @nd_arguments[nid]
+        # Array.new(n) { |i| ... } -- IntArray-only fast path. We don't
+        # try to introspect the block body to pick a typed container
+        # (calling infer_type from this dispatch perturbs the bootstrap;
+        # see bug-11 commit). Float/String collectors must be built via
+        # explicit `[]` + `N.times { ... << }` instead.
+        if args_id >= 0 && @nd_block[nid] >= 0
+          arrnew_aargs = get_args(args_id)
+          if arrnew_aargs.length >= 1
+            arrnew_blk = @nd_block[nid]
+            arrnew_body = @nd_body[arrnew_blk]
+            arrnew_count = compile_expr(arrnew_aargs.first)
+            arrnew_bp = get_block_param(nid, 0)
+            arrnew_tmp = new_temp
+            arrnew_iv = new_temp
+            @needs_int_array = 1
+            emit("  sp_IntArray *" + arrnew_tmp + " = sp_IntArray_new();")
+            emit("  for (mrb_int " + arrnew_iv + " = 0; " + arrnew_iv + " < " + arrnew_count + "; " + arrnew_iv + "++) {")
+            if arrnew_bp != ""
+              emit("    lv_" + arrnew_bp + " = " + arrnew_iv + ";")
+            end
+            @indent = @indent + 1
+            if arrnew_body >= 0
+              arrnew_stmts2 = get_stmts(arrnew_body)
+              if arrnew_stmts2.length > 0
+                arrnew_k = 0
+                while arrnew_k < arrnew_stmts2.length - 1
+                  compile_stmt(arrnew_stmts2[arrnew_k])
+                  arrnew_k = arrnew_k + 1
+                end
+                arrnew_lastv = compile_expr(arrnew_stmts2.last)
+                emit("  sp_IntArray_push(" + arrnew_tmp + ", " + arrnew_lastv + ");")
+              end
+            end
+            @indent = @indent - 1
+            emit("  }")
+            return arrnew_tmp
+          end
+        end
         if args_id >= 0
           aargs = get_args(args_id)
           if aargs.length >= 2

--- a/test/bm_array_new_block.rb
+++ b/test/bm_array_new_block.rb
@@ -1,0 +1,20 @@
+# Array.new(N) { |i| ... }: block form with index parameter.
+# Previously returned an empty IntArray (the block was ignored).
+
+# Block uses index
+a = Array.new(5) { |i| i * 2 }
+puts a.length      # 5
+puts a[0]          # 0
+puts a[2]          # 4
+puts a[4]          # 8
+puts a.sum         # 20
+
+# Block returns constant
+b = Array.new(3) { 42 }
+puts b.length      # 3
+puts b[0]          # 42
+puts b[2]          # 42
+
+# Zero-length
+c = Array.new(0) { 99 }
+puts c.length      # 0


### PR DESCRIPTION
## Summary

`Array.new(5) { |i| i * 2 }` returned an empty array because the
`Array.new` dispatch handled only no-args, 1-arg (`n`), and 2-arg
(`n, val`) forms. The block form fell through to the no-args path
that emitted `sp_IntArray_new()` with no loop:

```ruby
arr = Array.new(5) { |i| i * 2 }
puts arr.length    # was: 0    now: 5
puts arr.sum       # was: 0    now: 20
```

## Implementation

Adds an IntArray block path to the `cname == \"Array\"` handler
in `compile_call_expr`: allocates an IntArray, loops `count` times
binding the block param to the index, pushes the block's last
expression each iteration. Mirrors the existing `N.times.map`
codegen.

## Scope: IntArray only

This PR limits the block path to IntArray. Introspecting the block
body via `infer_type` to pick a typed container (StrArray /
FloatArray) destabilises the bootstrap (calling `infer_type` from
this dispatch site causes bin1 to mis-compile unrelated comparisons
elsewhere — same issue I worked around in \#21 for `Array#size`).

For now, Float/String collectors must be built manually with
`[]` + `N.times { ... << }`. Expanding to other typed arrays is a
clean follow-up once the underlying inference fragility is sorted.

## Test plan

- [x] `make test` passes (one new `test/bm_array_new_block.rb`
      covering block-with-index, block-with-constant, and zero-length).
