### PR TITLE
Fix infinite recursion on circular require_relative

### DIFF
--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -762,8 +762,17 @@ static char *read_file(const char *path) {
 }
 
 /* Simple require_relative resolver: replace lines matching
-   require_relative "path" with the file content */
-static char *resolve_requires(const char *source, const char *source_path) {
+   require_relative "path" with the file content.
+   visited/visited_count track absolute paths already resolved to prevent
+   infinite recursion on circular require_relative chains. */
+static int resolve_visited_contains(char **visited, int count, const char *path) {
+  for (int i = 0; i < count; i++)
+    if (strcmp(visited[i], path) == 0) return 1;
+  return 0;
+}
+
+static char *resolve_requires_impl(const char *source, const char *source_path,
+                                    char **visited, int visited_count) {
   /* Get base directory */
   char *path_copy = strdup(source_path);
   char *dir = strdup(path_copy);
@@ -772,6 +781,13 @@ static char *resolve_requires(const char *source, const char *source_path) {
   if (slash) *slash = '\0';
   else { free(dir); dir = strdup("."); }
   free(path_copy);
+
+  /* Record this file as visited */
+  {
+    char abs[1024];
+    if (realpath(source_path, abs))
+      visited[visited_count++] = strdup(abs);
+  }
 
   char *result = strdup(source);
   char *pos;
@@ -800,10 +816,10 @@ static char *resolve_requires(const char *source, const char *source_path) {
     } else if (q2 && q2 < line_end) {
       quote_char = '\'';
       start = q2 + 1;
-    } else break;
+    } else { scan_from = pos + 1; continue; }
 
     char *end = strchr(start, quote_char);
-    if (!end || end > line_end) break;
+    if (!end || end > line_end) { scan_from = pos + 1; continue; }
 
     size_t path_len = end - start;
     char rel_path[512];
@@ -815,12 +831,21 @@ static char *resolve_requires(const char *source, const char *source_path) {
     if (!strstr(full_path, ".rb"))
       strcat(full_path, ".rb");
 
+    /* Check for circular require */
+    {
+      char abs[1024];
+      if (realpath(full_path, abs) && resolve_visited_contains(visited, visited_count, abs)) {
+        scan_from = pos + 1;
+        continue;
+      }
+    }
+
     char *content = read_file(full_path);
     if (!content) {
       content = strdup("# require_relative not found");
     } else {
       /* Recursively resolve */
-      char *resolved = resolve_requires(content, full_path);
+      char *resolved = resolve_requires_impl(content, full_path, visited, visited_count);
       free(content);
       content = resolved;
     }
@@ -845,6 +870,14 @@ static char *resolve_requires(const char *source, const char *source_path) {
     free(content);
   }
   free(dir);
+  return result;
+}
+
+static char *resolve_requires(const char *source, const char *source_path) {
+  char *visited[256];
+  int visited_count = 0;
+  char *result = resolve_requires_impl(source, source_path, visited, 0);
+  for (int i = 0; i < visited_count; i++) free(visited[i]);
   return result;
 }
 

--- a/spinel_parse.rb
+++ b/spinel_parse.rb
@@ -16,10 +16,11 @@
 #   A <id> <field> <id1,id2,...> - array of node refs (empty = no ids)
 
 require "prism"
+require "set"
 
 # Recursively resolve require_relative and inline file contents,
 # exactly matching the original spinel.rb behavior.
-def resolve_requires(source, source_path)
+def resolve_requires(source, source_path, visited = Set.new)
   base_dir = File.dirname(File.expand_path(source_path))
   resolved = source.dup
   # require_relative
@@ -27,9 +28,12 @@ def resolve_requires(source, source_path)
     rel_path = $1
     req_file = File.join(base_dir, rel_path)
     req_file += ".rb" unless req_file.end_with?(".rb")
-    if File.exist?(req_file)
+    abs_path = File.expand_path(req_file)
+    if visited.include?(abs_path)
+      "# require_relative skipped (circular): #{rel_path}"
+    elsif File.exist?(req_file)
       content = File.read(req_file)
-      resolve_requires(content, req_file)
+      resolve_requires(content, req_file, visited + [abs_path])
     else
       "# require_relative not found: #{rel_path}"
     end
@@ -40,9 +44,12 @@ def resolve_requires(source, source_path)
     lib_name = $1
     lib_file = File.join(lib_dir, lib_name)
     lib_file += ".rb" unless lib_file.end_with?(".rb")
-    if File.exist?(lib_file)
+    abs_path = File.expand_path(lib_file)
+    if visited.include?(abs_path)
+      "# require skipped (circular): #{lib_name}"
+    elsif File.exist?(lib_file)
       content = File.read(lib_file)
-      resolve_requires(content, lib_file)
+      resolve_requires(content, lib_file, visited + [abs_path])
     else
       "# require not resolved: #{lib_name}"
     end


### PR DESCRIPTION
## Summary
- Both `spinel_parse.rb` and `spinel_parse.c` would infinite-loop (crashing with a stack overflow) when processing files with circular `require_relative` chains (e.g., file A requires B, B requires A).
- Adds a visited-files set that tracks which files have already been resolved in the current recursion chain, skipping any re-encounter.

## How to reproduce
Create two files:
```ruby
# a.rb
require_relative "b"
puts "a"
```
```ruby
# b.rb
require_relative "a"
puts "b"
```
Then run `spinel a.rb` — it crashes with `SystemStackError` (Ruby parser) or a segfault (C parser).

## Test plan
- [x] Verified the fix compiles and runs
- [ ] Existing test suite should still pass (`make test`)
- [ ] Manually test with circular require files

🤖 Generated with [Claude Code](https://claude.com/claude-code)