### PR TITLE
Fix uninitialized C_TMP variable in EXIT trap

### DIFF
--- a/spinel
+++ b/spinel
@@ -38,6 +38,7 @@ STDOUT_MODE=0
 OPT_LEVEL="2"
 CC_CMD="cc"
 EXTRA_FLAGS=""
+C_TMP=""
 
 while [ $# -gt 0 ]; do
   case "$1" in


### PR DESCRIPTION
## Summary
- The EXIT trap references `$C_TMP` but the variable is only assigned later in the script (line 108) when not in `-S` or `-c` mode.
- If the script exits early (parse failure, `-S` mode, `-c` mode), `$C_TMP` is unset. Initialize it to `""` before the trap to prevent issues under `set -u` or strict shells.

## How to reproduce
```bash
# Before fix: under set -u, this would error
bash -u spinel nonexistent.rb
```

## Test plan
- [x] Verified the fix is a minimal one-line change
- [ ] Existing test suite should pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)