### PR TITLE
Fix buffer overflow and incorrect .rb extension check

### DIFF
--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -812,8 +812,11 @@ static char *resolve_requires(const char *source, const char *source_path) {
     /* Build full path */
     char full_path[1024];
     snprintf(full_path, sizeof(full_path), "%s/%s", dir, rel_path);
-    if (!strstr(full_path, ".rb"))
-      strcat(full_path, ".rb");
+    {
+      size_t fl = strlen(full_path);
+      if (fl < sizeof(full_path) - 4 && (fl < 3 || strcmp(full_path + fl - 3, ".rb") != 0))
+        strcat(full_path, ".rb");
+    }
 
     char *content = read_file(full_path);
     if (!content) {
@@ -881,7 +884,11 @@ static char *resolve_plain_requires(char *source, const char *exe_path) {
     snprintf(lib_name, sizeof(lib_name), "%.*s", (int)(end - start), start);
     char lib_path[1024];
     snprintf(lib_path, sizeof(lib_path), "%s/%s", lib_dir, lib_name);
-    if (!strstr(lib_path, ".rb")) strcat(lib_path, ".rb");
+    {
+      size_t fl = strlen(lib_path);
+      if (fl < sizeof(lib_path) - 4 && (fl < 3 || strcmp(lib_path + fl - 3, ".rb") != 0))
+        strcat(lib_path, ".rb");
+    }
 
     char *content = read_file(lib_path);
     if (!content) {


### PR DESCRIPTION
## Summary
Two issues in the C parser's require resolution logic (`spinel_parse.c`):

1. **Buffer overflow**: `strcat(full_path, ".rb")` and `strcat(lib_path, ".rb")` could overflow their 1024-byte stack buffers when the path was close to the limit. Added a length check (`strlen < sizeof(buf) - 4`) before appending.

2. **Incorrect extension check**: `strstr(path, ".rb")` matches ".rb" anywhere in the path — e.g., `"lib/rb_helper/file"` would incorrectly match, skipping the extension. Changed to `strcmp(path + len - 3, ".rb")` to check only the suffix.

## How to reproduce
```bash
# Create a file in a deeply nested directory with a long path (>1020 chars)
mkdir -p /tmp/very_long_directory_name_that_is_repeated_over_and_over_...
echo 'puts 1' > /tmp/.../test.rb
spinel /tmp/.../test.rb
# Before fix: stack buffer overflow in resolve_requires
```

## Test plan
- [x] Verified the fix compiles
- [ ] Existing test suite should pass (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)