### PR TITLE
fix(codegen): prefix ivar fields with iv_ to avoid C identifier collisions

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -3314,12 +3314,11 @@ class Compiler
   end
 
   def sanitize_ivar(name)
-    if name.length > 0
-      if name[0] == "@"
-        return name[1, name.length - 1]
-      end
+    # @x → iv_x, x → iv_x
+    if name.length > 0 && name[0] == "@"
+      return "iv_" + name[1, name.length - 1]
     end
-    name
+    "iv_" + name
   end
 
   def sanitize_gvar(name)
@@ -9849,7 +9848,7 @@ class Compiler
           if @cls_is_value_type[ci] == 1
             sa = "."
           end
-          emit_raw("  self" + sa + pnames2[sk] + " = lv_" + pnames2[sk] + ";")
+          emit_raw("  self" + sa + sanitize_ivar(pnames2[sk]) + " = lv_" + pnames2[sk] + ";")
           sk = sk + 1
         end
       end
@@ -15354,7 +15353,7 @@ class Compiler
         j = 0
         while j < readers.length
           if readers[j] == mname
-            return rc + arrow + mname
+            return rc + arrow + sanitize_ivar(mname)
           end
           j = j + 1
         end
@@ -15366,7 +15365,7 @@ class Compiler
             j = 0
             while j < writers.length
               if writers[j] == bname
-                return "(" + rc + arrow + bname + " = " + compile_arg0(nid) + ", 0)"
+                return "(" + rc + arrow + sanitize_ivar(bname) + " = " + compile_arg0(nid) + ", 0)"
               end
               j = j + 1
             end
@@ -15422,7 +15421,7 @@ class Compiler
           j2 = j2 + 1
         end
         if found_reader == 1
-          return "((sp_" + cname2 + " *)" + rc + ")->" + mname
+          return "((sp_" + cname2 + " *)" + rc + ")->" + sanitize_ivar(mname)
         end
         # Check writers
         if mname.length > 1
@@ -15432,7 +15431,7 @@ class Compiler
             j2 = 0
             while j2 < writers2.length
               if writers2[j2] == bname2
-                return "(((sp_" + cname2 + " *)" + rc + ")->" + bname2 + " = " + compile_arg0(nid) + ")"
+                return "(((sp_" + cname2 + " *)" + rc + ")->" + sanitize_ivar(bname2) + " = " + compile_arg0(nid) + ")"
               end
               j2 = j2 + 1
             end
@@ -18148,7 +18147,7 @@ class Compiler
             if is_value_type_obj(rt) == 1
               arrow2 = "."
             end
-            emit("  " + rc + arrow2 + bname + " = " + compile_arg0(nid) + ";")
+            emit("  " + rc + arrow2 + sanitize_ivar(bname) + " = " + compile_arg0(nid) + ";")
             return 1
           end
         end
@@ -21566,7 +21565,17 @@ class Compiler
     @in_loop = 1
     # N.times.map { |i| ... } -> build int_array with block body; param = index
     recv = @nd_receiver[nid]
-    if recv >= 0 && @nd_type[recv] == "CallNode" && @nd_name[recv] == "times" && @nd_block[recv] < 0
+    times_recv = 0
+    if recv >= 0
+      if @nd_type[recv] == "CallNode"
+        if @nd_name[recv] == "times"
+          if @nd_block[recv] < 0
+            times_recv = 1
+          end
+        end
+      end
+    end
+    if times_recv == 1
       ncount = compile_expr(@nd_receiver[recv])
       bpn = get_block_param(nid, 0)
       tmp_arrn = new_temp

--- a/test/bm_attr.rb
+++ b/test/bm_attr.rb
@@ -57,3 +57,21 @@ puts sum          # 15
 
 # String#to_s on object
 puts p1.to_s      # (10, 4)
+
+# attr_accessor path should keep ivar/local namespaces distinct.
+class IvarCollision
+  attr_accessor :x, :iv_x
+
+  def initialize
+    @x = 1
+    @iv_x = 2
+  end
+
+  def sum
+    x = 10
+    iv_x = 20
+    @x + @iv_x + self.x + self.iv_x + x + iv_x
+  end
+end
+
+puts IvarCollision.new.sum   # 36

--- a/test/bm_ivar_c_keyword.rb
+++ b/test/bm_ivar_c_keyword.rb
@@ -1,0 +1,14 @@
+# Test: ivar naming remains safe for C keywords and iv_ prefix collisions.
+
+class KeywordIvar
+  def initialize
+    @if = 40
+    @iv_if = 1
+  end
+
+  def value
+    @if + @iv_if + 1
+  end
+end
+
+puts KeywordIvar.new.value

--- a/test/bm_struct.rb
+++ b/test/bm_struct.rb
@@ -16,3 +16,10 @@ c = Color.new(255, 128, 0)
 puts c.r        # 255
 puts c.g        # 128
 puts c.b        # 0
+
+# Struct synthetic constructor path should also handle iv_ prefixed names.
+Pair = Struct.new(:x, :iv_x)
+p2 = Pair.new(3, 4)
+puts p2.x + p2.iv_x   # 7
+p2.iv_x = 6
+puts p2.x + p2.iv_x   # 9


### PR DESCRIPTION
## Summary

This PR normalizes ivar-backed C field names to always use the `iv_` prefix.

## Changes

- Changed ivar name sanitization to map both `@x` and ivar-context `x` to `iv_x`.
- Updated attr_reader/attr_writer and struct-synthetic constructor code paths to use the same ivar sanitization.
- Kept naming consistent with existing `gv_` handling for globals.

## Tests

- Updated `test/bm_ivar_c_keyword.rb` to cover keyword-style and `iv_`-prefixed ivar coexistence.
- Added ivar/local + `attr_accessor` coexistence coverage in `test/bm_attr.rb`.
- Added struct synthetic constructor coverage for `:x` and `:iv_x` in `test/bm_struct.rb`.

## Validation

- `make bootstrap` passes.
- `make test` passes except known `bm_sym_case` error.

## Note

One condition in `compile_map_block` was intentionally expanded from a chained `&&` form into step-by-step checks.
This is a bootstrap-stability workaround: with the original chained condition, self-hosted bootstrap sometimes emitted malformed C in `build/gen2.c` (`if (( && ...))`) and failed to compile.
The logic is unchanged; only the form was adjusted to avoid that miscompile.