### PR TITLE
fix(codegen): root each string-concat part before chaining

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -13048,27 +13048,38 @@ class Compiler
       end
       if lt == "string"
         @needs_string_helpers = 1
-        # Flatten chained string concat: a + b + c → sp_str_concat3(a,b,c)
+        # Flatten chained string concat: a + b + c → sp_str_concat3(a,b,c).
+        # Materialize each part into a rooted temp first so a later part's
+        # GC trigger can't sweep an earlier part's unrooted heap string.
         parts = collect_concat_chain(nid)
-        if parts.length == 3
-          return "sp_str_concat3(" + parts[0] + ", " + parts[1] + ", " + parts[2] + ")"
-        end
-        if parts.length == 4
-          return "sp_str_concat4(" + parts[0] + ", " + parts[1] + ", " + parts[2] + ", " + parts[3] + ")"
-        end
-        if parts.length >= 5
-          # Variable-length: single malloc for N parts via sp_str_concat_arr
-          arr = "(const char *const[]){"
+        if parts.length >= 3
+          @needs_gc = 1
+          tmps = "".split(",")
           k = 0
           while k < parts.length
+            tmp = new_temp
+            emit("  const char *" + tmp + " = " + parts[k] + ";")
+            emit("  SP_GC_ROOT(" + tmp + ");")
+            tmps.push(tmp)
+            k = k + 1
+          end
+          if tmps.length == 3
+            return "sp_str_concat3(" + tmps[0] + ", " + tmps[1] + ", " + tmps[2] + ")"
+          end
+          if tmps.length == 4
+            return "sp_str_concat4(" + tmps[0] + ", " + tmps[1] + ", " + tmps[2] + ", " + tmps[3] + ")"
+          end
+          arr = "(const char *const[]){"
+          k = 0
+          while k < tmps.length
             if k > 0
               arr = arr + ", "
             end
-            arr = arr + parts[k]
+            arr = arr + tmps[k]
             k = k + 1
           end
           arr = arr + "}"
-          return "sp_str_concat_arr(" + arr + ", " + parts.length.to_s + ")"
+          return "sp_str_concat_arr(" + arr + ", " + tmps.length.to_s + ")"
         end
         return "sp_str_concat(" + compile_expr(recv) + ", " + compile_arg0(nid) + ")"
       end


### PR DESCRIPTION
The macOS arm64 + clang -O3 -flto job has been failing the bootstrap with a malformed-C error in `build/gen2.c`:

    build/gen2.c:22102:16: error: expected identifier
     22102 |       if (( && (sp_IntArray_get(self->nd_block, lv_nid) >= 0))) {

(see https://github.com/matz/spinel/actions/runs/24975334238/job/73126091506).

The empty left operand of `&&` comes out of `compile_expr` for `AndNode`, which is currently emitted as a single `sp_str_concat_arr` call whose array initializer evaluates each part inline:

    sp_str_concat_arr((const char *const[]){
      "(", compile_expr(left), " && ", compile_expr(right), ")"
    }, 5)

The heap string returned by `compile_expr(left)` is not rooted while `compile_expr(right)` runs. If the right-hand recursion crosses the GC threshold, `sp_str_sweep` reaps the left result and the array element is left dangling; `sp_str_concat_arr` then `strlen`/`memcpy`s freed memory and the join comes back missing the left operand. Linux x86_64 happens to keep the freed slab around long enough that the bootstrap survives; macOS arm64 + clang -O3 -flto sweeps before the join and the build deterministically dies.

ASAN on Linux x86_64 reports it as `heap-use-after-free` with the same call chain (`sp_str_concat_arr` -> sweep triggered from a sibling `sp_str_split` recursion).

The fix is to materialize each part of a 3+ part chain into a `const char *` local rooted via `SP_GC_ROOT` before assembling the call, so that no part can be swept while a later part is being computed. Bootstrap (4 stages, idempotent) and the test suite pass; the gen2.c output also matches between gcc -O3 -flto and clang -O3 -flto on Linux.

The 2-part `sp_str_concat(recv, arg)` fallback has the same theoretical issue but does not trigger the CI failure; left as a follow-up. PR #34's manual `&&` un-chaining in `compile_map_block` becomes unnecessary after this and can be reverted separately.