### PR TITLE
fix(codegen): typed-array dispatch holes in push/<</reverse!/sort!

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -208,6 +208,9 @@ static inline mrb_int sp_FloatArray_length(sp_FloatArray*a){return a->len;}
 static inline mrb_bool sp_FloatArray_empty(sp_FloatArray*a){return a->len==0;}
 static inline mrb_float sp_FloatArray_get(sp_FloatArray*a,mrb_int i){if(i<0)i+=a->len;return a->data[i];}
 static inline void sp_FloatArray_set(sp_FloatArray*a,mrb_int i,mrb_float v){if(i<0)i+=a->len;while(i>=a->cap){a->cap=a->cap*2+1;a->data=(mrb_float*)realloc(a->data,sizeof(mrb_float)*a->cap);}while(i>=a->len){a->data[a->len]=0.0;a->len++;}a->data[i]=v;}
+static void sp_FloatArray_reverse_bang(sp_FloatArray*a){for(mrb_int i=0,j=a->len-1;i<j;i++,j--){mrb_float t=a->data[i];a->data[i]=a->data[j];a->data[j]=t;}}
+static int _sp_float_cmp(const void*a,const void*b){mrb_float va=*(const mrb_float*)a,vb=*(const mrb_float*)b;return(va>vb)-(va<vb);}
+static void sp_FloatArray_sort_bang(sp_FloatArray*a){qsort(a->data,a->len,sizeof(mrb_float),_sp_float_cmp);}
 
 /* ---- PtrArray: array of void* pointers ---- */
 typedef struct{void**data;mrb_int len;mrb_int cap;void(*scan_elem)(void*);}sp_PtrArray;
@@ -220,6 +223,7 @@ static inline void*sp_PtrArray_get(sp_PtrArray*a,mrb_int i){if(i<0)i+=a->len;ret
 static inline void sp_PtrArray_set(sp_PtrArray*a,mrb_int i,void*v){if(i<0)i+=a->len;a->data[i]=v;}
 static inline mrb_int sp_PtrArray_length(sp_PtrArray*a){return a->len;}
 static inline mrb_bool sp_PtrArray_empty(sp_PtrArray*a){return a->len==0;}
+static void sp_PtrArray_reverse_bang(sp_PtrArray*a){for(mrb_int i=0,j=a->len-1;i<j;i++,j--){void*t=a->data[i];a->data[i]=a->data[j];a->data[j]=t;}}
 
 typedef struct{const char**data;mrb_int len;mrb_int cap;}sp_StrArray;
 static void sp_StrArray_fin(void*p){sp_StrArray*a=(sp_StrArray*)p;sp_gc_hdr*h=(sp_gc_hdr*)((char*)a-sizeof(sp_gc_hdr));sp_gc_bytes-=sizeof(const char*)*a->cap;h->size-=sizeof(const char*)*a->cap;free(a->data);}
@@ -232,6 +236,9 @@ static inline mrb_int sp_StrArray_length(sp_StrArray*a){return a->len;}
 static inline mrb_bool sp_StrArray_empty(sp_StrArray*a){return a->len==0;}
 static inline const char*sp_StrArray_get(sp_StrArray*a,mrb_int i){if(i<0)i+=a->len;return a->data[i];}
 static inline void sp_StrArray_set(sp_StrArray*a,mrb_int i,const char*v){if(i<0)i+=a->len;while(i>=a->len)sp_StrArray_push(a,"");a->data[i]=v;}
+static void sp_StrArray_reverse_bang(sp_StrArray*a){for(mrb_int i=0,j=a->len-1;i<j;i++,j--){const char*t=a->data[i];a->data[i]=a->data[j];a->data[j]=t;}}
+static int _sp_str_cmp(const void*a,const void*b){return strcmp(*(const char*const*)a,*(const char*const*)b);}
+static void sp_StrArray_sort_bang(sp_StrArray*a){qsort(a->data,a->len,sizeof(const char*),_sp_str_cmp);}
 static const char*sp_StrArray_join(sp_StrArray*a,const char*sep){size_t sl=strlen(sep),cap=256;char*buf=(char*)malloc(cap);size_t len=0;for(mrb_int i=0;i<a->len;i++){if(i>0){if(len+sl>=cap){cap*=2;buf=(char*)realloc(buf,cap);}memcpy(buf+len,sep,sl);len+=sl;}size_t el=strlen(a->data[i]);if(len+el>=cap){cap=(len+el)*2+1;buf=(char*)realloc(buf,cap);}memcpy(buf+len,a->data[i],el);len+=el;}buf[len]=0;char*r=sp_str_alloc(len);memcpy(r,buf,len);free(buf);return r;}
 static mrb_bool sp_StrArray_include(sp_StrArray*a,const char*v){for(mrb_int i=0;i<a->len;i++)if(strcmp(a->data[i],v)==0)return TRUE;return FALSE;}
 static mrb_int sp_StrArray_index(sp_StrArray*a,const char*v){for(mrb_int i=0;i<a->len;i++)if(strcmp(a->data[i],v)==0)return i;return -1;}

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -17505,9 +17505,23 @@ class Compiler
     if mname == "<<"
       if recv >= 0
         rt = infer_type(recv)
-        if rt == "int_array"
+        if rt == "int_array" || rt == "sym_array"
           rc = compile_expr_gc_rooted(recv)
-          emit("  sp_IntArray_push(" + rc + ", " + compile_arg0(nid) + ");")
+          av = compile_arg0(nid)
+          a0id = -1
+          args_id2 = @nd_arguments[nid]
+          if args_id2 >= 0
+            aargs2 = get_args(args_id2)
+            if aargs2.length > 0
+              a0id = aargs2[0]
+            end
+          end
+          if a0id >= 0
+            if infer_type(a0id) == "lambda"
+              av = "(mrb_int)" + av
+            end
+          end
+          emit("  sp_IntArray_push(" + rc + ", " + av + ");")
           return 1
         end
         if rt == "str_array"
@@ -17659,8 +17673,8 @@ class Compiler
     if mname == "push"
       if recv >= 0
         rt = infer_type(recv)
-        rc = compile_expr_gc_rooted(recv)
-        if rt == "int_array"
+        if rt == "int_array" || rt == "sym_array"
+          rc = compile_expr_gc_rooted(recv)
           av = compile_arg0(nid)
           # If pushing a lambda value, cast to mrb_int
           a0id = -1
@@ -17680,7 +17694,18 @@ class Compiler
           return 1
         end
         if rt == "str_array"
+          rc = compile_expr_gc_rooted(recv)
           emit("  sp_StrArray_push(" + rc + ", " + compile_arg0(nid) + ");")
+          return 1
+        end
+        if rt == "float_array"
+          rc = compile_expr_gc_rooted(recv)
+          emit("  sp_FloatArray_push(" + rc + ", " + compile_arg0(nid) + ");")
+          return 1
+        end
+        if is_ptr_array_type(rt) == 1
+          rc = compile_expr_gc_rooted(recv)
+          emit("  sp_PtrArray_push(" + rc + ", " + compile_arg0(nid) + ");")
           return 1
         end
       end
@@ -17690,9 +17715,22 @@ class Compiler
     if mname == "reverse!"
       if recv >= 0
         rt = infer_type(recv)
-        rc = compile_expr_gc_rooted(recv)
-        if rt == "int_array"
-          emit("  sp_IntArray_reverse_bang(" + rc + ");")
+        rev_pfx = ""
+        if rt == "int_array" || rt == "sym_array"
+          rev_pfx = "IntArray"
+        end
+        if rt == "str_array"
+          rev_pfx = "StrArray"
+        end
+        if rt == "float_array"
+          rev_pfx = "FloatArray"
+        end
+        if is_ptr_array_type(rt) == 1
+          rev_pfx = "PtrArray"
+        end
+        if rev_pfx != ""
+          rc = compile_expr_gc_rooted(recv)
+          emit("  sp_" + rev_pfx + "_reverse_bang(" + rc + ");")
           return 1
         end
       end
@@ -17700,13 +17738,25 @@ class Compiler
     if mname == "sort!"
       if recv >= 0
         rt = infer_type(recv)
-        rc = compile_expr_gc_rooted(recv)
+        if rt == "int_array"
+          rc = compile_expr_gc_rooted(recv)
+          emit("  sp_IntArray_sort_bang(" + rc + ");")
+          return 1
+        end
         if rt == "sym_array"
+          # sym sort compares by symbol name, not numeric ID
+          rc = compile_expr_gc_rooted(recv)
           emit("  sp_sym_array_sort(" + rc + ");")
           return 1
         end
-        if rt == "int_array"
-          emit("  sp_IntArray_sort_bang(" + rc + ");")
+        if rt == "str_array"
+          rc = compile_expr_gc_rooted(recv)
+          emit("  sp_StrArray_sort_bang(" + rc + ");")
+          return 1
+        end
+        if rt == "float_array"
+          rc = compile_expr_gc_rooted(recv)
+          emit("  sp_FloatArray_sort_bang(" + rc + ");")
           return 1
         end
       end

--- a/test/bm_array_push.rb
+++ b/test/bm_array_push.rb
@@ -1,0 +1,54 @@
+# Array#push across typed-array variants.
+# Previously push only dispatched for IntArray and StrArray; FloatArray
+# and SymArray (and PtrArray) silently fell through to a no-op expression.
+
+ints = [1, 2, 3]
+ints.push(4)
+ints.push(5)
+puts ints.length          # 5
+puts ints[3]              # 4
+puts ints[4]              # 5
+
+# Float values use non-integer fractional parts so Spinel's float-puts
+# (which strips a trailing ".0") matches CRuby's output.
+floats = [1.5, 2.5]
+floats.push(3.5)
+floats.push(4.25)
+puts floats.length        # 4
+puts floats[2]            # 3.5
+puts floats[3]            # 4.25
+
+strs = ["a", "b"]
+strs.push("c")
+strs.push("d")
+puts strs.length          # 4
+puts strs[2]              # c
+puts strs[3]              # d
+
+syms = [:x, :y]
+syms.push(:z)
+puts syms.length          # 3
+puts syms[2]              # z
+
+# << on every typed-array variant. Previously << did not dispatch
+# for sym_array, so `syms << :z` silently fell through.
+ints2 = [10]
+ints2 << 20
+ints2 << 30
+puts ints2.length         # 3
+puts ints2[2]             # 30
+
+floats2 = [1.5]
+floats2 << 2.5
+puts floats2.length       # 2
+puts floats2[1]           # 2.5
+
+strs2 = ["x"]
+strs2 << "y"
+puts strs2.length         # 2
+puts strs2[1]             # y
+
+syms2 = [:p]
+syms2 << :q
+puts syms2.length         # 2
+puts syms2[1]             # q

--- a/test/bm_array_reverse_bang.rb
+++ b/test/bm_array_reverse_bang.rb
@@ -1,0 +1,32 @@
+# Array#reverse! across typed-array variants.
+# Previously only IntArray dispatched; SymArray, StrArray, FloatArray
+# silently fell through.
+
+ints = [1, 2, 3, 4, 5]
+ints.reverse!
+ints.each { |i| puts i }   # 5 4 3 2 1
+
+floats = [1.5, 2.5, 3.5, 4.25]
+floats.reverse!
+floats.each { |f| puts f }  # 4.25 3.5 2.5 1.5
+
+strs = ["alpha", "beta", "gamma"]
+strs.reverse!
+strs.each { |s| puts s }    # gamma beta alpha
+
+syms = [:a, :b, :c, :d]
+syms.reverse!
+syms.each { |y| puts y }    # d c b a
+
+# Even-length and single-element edge cases
+even = [10, 20]
+even.reverse!
+even.each { |i| puts i }   # 20 10
+
+one = [42]
+one.reverse!
+one.each { |i| puts i }    # 42
+
+empty = []
+empty.reverse!
+puts empty.length          # 0

--- a/test/bm_array_sort_bang.rb
+++ b/test/bm_array_sort_bang.rb
@@ -1,0 +1,28 @@
+# Array#sort! across typed-array variants.
+# Previously only IntArray and SymArray dispatched; StrArray and
+# FloatArray silently fell through.
+
+ints = [3, 1, 4, 1, 5, 9, 2, 6]
+ints.sort!
+ints.each { |i| puts i }   # 1 1 2 3 4 5 6 9
+
+floats = [3.5, 1.25, 4.75, 1.5, 0.25]
+floats.sort!
+floats.each { |f| puts f }  # 0.25 1.25 1.5 3.5 4.75
+
+strs = ["banana", "apple", "cherry", "date"]
+strs.sort!
+strs.each { |s| puts s }    # apple banana cherry date
+
+syms = [:c, :a, :d, :b]
+syms.sort!
+syms.each { |y| puts y }    # a b c d
+
+# Single-element and empty edge cases
+one = [99]
+one.sort!
+one.each { |i| puts i }     # 99
+
+empty = []
+empty.sort!
+puts empty.length           # 0


### PR DESCRIPTION
## Summary

- `push`, `<<`, `reverse!`, and `sort!` silently fell through for non-IntArray typed-array variants — `floats.reverse!`, `strs.sort!`, `syms << x` and friends were no-ops.
- Extends each handler to dispatch for IntArray/SymArray/StrArray/FloatArray (plus PtrArray for `push`/`<<`), and adds the missing runtime helpers (`sp_FloatArray_reverse_bang`, `sp_StrArray_sort_bang`, etc.).
- Three regression tests under `test/`; two of them fail on `master` without this fix.

## What was tried and skipped

A dispatcher that uses `array_c_prefix` to fold the per-type branches into a single helper call was attempted, but broke bootstrap — an unrelated compound boolean expression at `compile_call_expr:14750` came out as malformed C in the gen2 output. Reverted.

A template-driven version of the runtime helpers was also considered. The per-type variation (IntArray's deque-style `start` offset, StrArray's GC scan callback, divergent `min`/`max`-on-empty behavior) is larger than it looks at first glance, and given the dispatcher attempt's regression, didn't want to push the self-host fragility further. Both are reasonable follow-ups in a separate PR.

## Note on `_sp_float_cmp` and NaN

`(va > vb) - (va < vb)` returns 0 for any NaN-involved comparison, so `qsort` ordering of arrays containing NaN is unspecified. This matches the existing `_sp_int_cmp` precedent (no NaN edge case) and CRuby's `Array#sort` doesn't guarantee anything sane with NaN either.

## Test plan

- [x] `make bootstrap` converges (gen2.c == gen3.c)
- [x] `make test`: 88 pass, 2 pre-existing fail (`bm_constant_path_builtin_new`, `bm_fiber`), 1 pre-existing error (`bm_sym_case`) — same as `master` plus 3 new passing tests
- [x] `bm_array_reverse_bang` and `bm_array_sort_bang` confirmed to fail on `master` without the fix
- [x] `bm_array_push` covers `push` + `<<` for all four typed-array variants