### PR TITLE
feat(codegen): add Array#shuffle and String#% with str_array

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -210,6 +210,8 @@ static inline mrb_int sp_FloatArray_length(sp_FloatArray*a){return a->len;}
 static inline mrb_bool sp_FloatArray_empty(sp_FloatArray*a){return a->len==0;}
 static inline mrb_float sp_FloatArray_get(sp_FloatArray*a,mrb_int i){if(i<0)i+=a->len;return a->data[i];}
 static inline void sp_FloatArray_set(sp_FloatArray*a,mrb_int i,mrb_float v){if(i<0)i+=a->len;while(i>=a->cap){a->cap=a->cap*2+1;a->data=(mrb_float*)realloc(a->data,sizeof(mrb_float)*a->cap);}while(i>=a->len){a->data[a->len]=0.0;a->len++;}a->data[i]=v;}
+static void sp_FloatArray_shuffle_bang(sp_FloatArray*a){for(mrb_int i=a->len-1;i>0;i--){mrb_int j=(mrb_int)(rand()%(i+1));mrb_float t=a->data[i];a->data[i]=a->data[j];a->data[j]=t;}}
+static sp_FloatArray*sp_FloatArray_shuffle(sp_FloatArray*a){sp_FloatArray*r=sp_FloatArray_new();sp_FloatArray_replace(r,a);sp_FloatArray_shuffle_bang(r);return r;}
 
 /* ---- PtrArray: array of void* pointers ---- */
 typedef struct{void**data;mrb_int len;mrb_int cap;void(*scan_elem)(void*);}sp_PtrArray;
@@ -248,7 +250,7 @@ static const char*sp_StrArray_delete_at(sp_StrArray*a,mrb_int i){if(i<0)i+=a->le
 static const char*sp_StrArray_delete(sp_StrArray*a,const char*v){mrb_int w=0;const char*found=NULL;for(mrb_int i=0;i<a->len;i++){if(strcmp(a->data[i],v)!=0){a->data[w]=a->data[i];w++;}else{found=a->data[i];}}a->len=w;return found;}
 static void sp_StrArray_insert(sp_StrArray*a,mrb_int i,const char*v){if(i<0)i+=a->len+1;sp_StrArray_push(a,"");for(mrb_int j=a->len-1;j>i;j--)a->data[j]=a->data[j-1];a->data[i]=v;}
 static void sp_StrArray_shuffle_bang(sp_StrArray*a){for(mrb_int i=a->len-1;i>0;i--){mrb_int j=(mrb_int)(rand()%(i+1));const char*t=a->data[i];a->data[i]=a->data[j];a->data[j]=t;}}
-static sp_StrArray*sp_StrArray_shuffle(sp_StrArray*a){sp_StrArray*r=sp_StrArray_new();for(mrb_int i=0;i<a->len;i++)sp_StrArray_push(r,a->data[i]);sp_StrArray_shuffle_bang(r);return r;}
+static sp_StrArray*sp_StrArray_shuffle(sp_StrArray*a){sp_StrArray*r=sp_StrArray_new();sp_StrArray_replace(r,a);sp_StrArray_shuffle_bang(r);return r;}
 
 static inline uint64_t sp_str_hash(const char*s){uint64_t h=14695981039346656037ULL;while(*s){h^=(unsigned char)*s++;h*=1099511628211ULL;}return h;}
 typedef struct{const char**keys;mrb_int*vals;const char**order;mrb_int len;mrb_int cap;mrb_int mask;}sp_StrIntHash;
@@ -347,7 +349,10 @@ static const char*sp_str_sub_range(const char*s,mrb_int start,mrb_int len){mrb_i
    (useful when strlen has been hoisted out of a loop). */
 static const char*sp_str_sub_range_len(const char*s,mrb_int sl,mrb_int start,mrb_int len){if(start<0)start+=sl;if(start<0)start=0;if(start>=sl)return &("\xff" "")[1];if(len<0)len=0;if(start+len>sl)len=sl-start;if(len==1){unsigned char c=(unsigned char)s[start];if(!sp_char_cache_init){for(int i=0;i<256;i++){sp_char_cache[i][0]=(char)0xff;sp_char_cache[i][1]=(char)i;sp_char_cache[i][2]=0;}sp_char_cache_init=1;}return &sp_char_cache[c][1];}char*r=sp_str_alloc_raw(len+1);memcpy(r,s+start,len);r[len]=0;return r;}
 static const char*sp_sprintf(const char*fmt,...){char*b=sp_str_alloc_raw(4096);va_list ap;va_start(ap,fmt);vsnprintf(b,4096,fmt,ap);va_end(ap);return b;}
-static const char*sp_str_format_strarr(const char*fmt,sp_StrArray*a){size_t cap=strlen(fmt)+64;char*buf=(char*)malloc(cap);size_t out=0;mrb_int idx=0;const char*p=fmt;while(*p){if(*p=='%'){if(p[1]=='s'){const char*s=(idx<a->len)?a->data[idx]:"";size_t sl=strlen(s);if(out+sl>=cap){cap=(out+sl)*2+1;buf=(char*)realloc(buf,cap);}memcpy(buf+out,s,sl);out+=sl;idx++;p+=2;}else if(p[1]=='%'){if(out+1>=cap){cap*=2;buf=(char*)realloc(buf,cap);}buf[out++]='%';p+=2;}else{if(out+1>=cap){cap*=2;buf=(char*)realloc(buf,cap);}buf[out++]=*p++;}}else{if(out+1>=cap){cap*=2;buf=(char*)realloc(buf,cap);}buf[out++]=*p++;}}buf[out]=0;char*r=sp_str_alloc(out);memcpy(r,buf,out);free(buf);return r;}
+/* Use a temp pointer for realloc so the original buffer is not leaked
+   on allocation failure. Match the perror+exit pattern used elsewhere
+   (see sp_IntArray_replace) instead of returning a partial result. */
+static const char*sp_str_format_strarr(const char*fmt,sp_StrArray*a){size_t cap=strlen(fmt)+64;char*buf=(char*)malloc(cap);if(!buf){perror("malloc");exit(1);}size_t out=0;mrb_int idx=0;const char*p=fmt;while(*p){if(*p=='%'){if(p[1]=='s'){const char*s=(idx<a->len)?a->data[idx]:"";size_t sl=strlen(s);if(out+sl>=cap){size_t nc=(out+sl)*2+1;char*nb=(char*)realloc(buf,nc);if(!nb){free(buf);perror("realloc");exit(1);}buf=nb;cap=nc;}memcpy(buf+out,s,sl);out+=sl;idx++;p+=2;}else if(p[1]=='%'){if(out+1>=cap){size_t nc=cap*2;char*nb=(char*)realloc(buf,nc);if(!nb){free(buf);perror("realloc");exit(1);}buf=nb;cap=nc;}buf[out++]='%';p+=2;}else{if(out+1>=cap){size_t nc=cap*2;char*nb=(char*)realloc(buf,nc);if(!nb){free(buf);perror("realloc");exit(1);}buf=nb;cap=nc;}buf[out++]=*p++;}}else{if(out+1>=cap){size_t nc=cap*2;char*nb=(char*)realloc(buf,nc);if(!nb){free(buf);perror("realloc");exit(1);}buf=nb;cap=nc;}buf[out++]=*p++;}}buf[out]=0;char*r=sp_str_alloc(out);memcpy(r,buf,out);free(buf);return r;}
 static const char*sp_str_reverse(const char*s){size_t l=strlen(s);char*r=sp_str_alloc_raw(l+1);for(size_t i=0;i<l;i++)r[i]=s[l-1-i];r[l]=0;return r;}
 static const char*sp_str_sub(const char*s,const char*pat,const char*rep){const char*f=strstr(s,pat);if(!f)return s;size_t pl=strlen(pat),rl=strlen(rep),sl=strlen(s);char*r=sp_str_alloc_raw(sl-pl+rl+1);size_t n=f-s;memcpy(r,s,n);memcpy(r+n,rep,rl);memcpy(r+n+rl,f+pl,sl-n-pl+1);return r;}
 static const char*sp_str_capitalize(const char*s){size_t l=strlen(s);char*r=sp_str_alloc_raw(l+1);for(size_t i=0;i<=l;i++)r[i]=tolower((unsigned char)s[i]);if(l>0)r[0]=toupper((unsigned char)r[0]);return r;}

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -180,6 +180,8 @@ static void sp_IntArray_reverse_bang(sp_IntArray*a){for(mrb_int i=0,j=a->len-1;i
 static int _sp_int_cmp(const void*a,const void*b){mrb_int va=*(const mrb_int*)a,vb=*(const mrb_int*)b;return(va>vb)-(va<vb);}
 static sp_IntArray*sp_IntArray_sort(sp_IntArray*a){sp_IntArray*b=sp_IntArray_dup(a);qsort(b->data+b->start,b->len,sizeof(mrb_int),_sp_int_cmp);return b;}
 static void sp_IntArray_sort_bang(sp_IntArray*a){qsort(a->data+a->start,a->len,sizeof(mrb_int),_sp_int_cmp);}
+static void sp_IntArray_shuffle_bang(sp_IntArray*a){for(mrb_int i=a->len-1;i>0;i--){mrb_int j=(mrb_int)(rand()%(i+1));mrb_int t=a->data[a->start+i];a->data[a->start+i]=a->data[a->start+j];a->data[a->start+j]=t;}}
+static sp_IntArray*sp_IntArray_shuffle(sp_IntArray*a){sp_IntArray*b=sp_IntArray_dup(a);sp_IntArray_shuffle_bang(b);return b;}
 static mrb_int sp_IntArray_min(sp_IntArray*a){mrb_int m=a->data[a->start];for(mrb_int i=1;i<a->len;i++)if(a->data[a->start+i]<m)m=a->data[a->start+i];return m;}
 static mrb_int sp_IntArray_max(sp_IntArray*a){mrb_int m=a->data[a->start];for(mrb_int i=1;i<a->len;i++)if(a->data[a->start+i]>m)m=a->data[a->start+i];return m;}
 static mrb_int sp_IntArray_sum(sp_IntArray*a){mrb_int s=0;for(mrb_int i=0;i<a->len;i++)s+=a->data[a->start+i];return s;}
@@ -245,6 +247,8 @@ static sp_StrArray*sp_StrArray_compact(sp_StrArray*a){sp_StrArray*r=sp_StrArray_
 static const char*sp_StrArray_delete_at(sp_StrArray*a,mrb_int i){if(i<0)i+=a->len;if(i<0||i>=a->len)return NULL;const char*v=a->data[i];for(mrb_int j=i;j<a->len-1;j++)a->data[j]=a->data[j+1];a->len--;return v;}
 static const char*sp_StrArray_delete(sp_StrArray*a,const char*v){mrb_int w=0;const char*found=NULL;for(mrb_int i=0;i<a->len;i++){if(strcmp(a->data[i],v)!=0){a->data[w]=a->data[i];w++;}else{found=a->data[i];}}a->len=w;return found;}
 static void sp_StrArray_insert(sp_StrArray*a,mrb_int i,const char*v){if(i<0)i+=a->len+1;sp_StrArray_push(a,"");for(mrb_int j=a->len-1;j>i;j--)a->data[j]=a->data[j-1];a->data[i]=v;}
+static void sp_StrArray_shuffle_bang(sp_StrArray*a){for(mrb_int i=a->len-1;i>0;i--){mrb_int j=(mrb_int)(rand()%(i+1));const char*t=a->data[i];a->data[i]=a->data[j];a->data[j]=t;}}
+static sp_StrArray*sp_StrArray_shuffle(sp_StrArray*a){sp_StrArray*r=sp_StrArray_new();for(mrb_int i=0;i<a->len;i++)sp_StrArray_push(r,a->data[i]);sp_StrArray_shuffle_bang(r);return r;}
 
 static inline uint64_t sp_str_hash(const char*s){uint64_t h=14695981039346656037ULL;while(*s){h^=(unsigned char)*s++;h*=1099511628211ULL;}return h;}
 typedef struct{const char**keys;mrb_int*vals;const char**order;mrb_int len;mrb_int cap;mrb_int mask;}sp_StrIntHash;
@@ -343,6 +347,7 @@ static const char*sp_str_sub_range(const char*s,mrb_int start,mrb_int len){mrb_i
    (useful when strlen has been hoisted out of a loop). */
 static const char*sp_str_sub_range_len(const char*s,mrb_int sl,mrb_int start,mrb_int len){if(start<0)start+=sl;if(start<0)start=0;if(start>=sl)return &("\xff" "")[1];if(len<0)len=0;if(start+len>sl)len=sl-start;if(len==1){unsigned char c=(unsigned char)s[start];if(!sp_char_cache_init){for(int i=0;i<256;i++){sp_char_cache[i][0]=(char)0xff;sp_char_cache[i][1]=(char)i;sp_char_cache[i][2]=0;}sp_char_cache_init=1;}return &sp_char_cache[c][1];}char*r=sp_str_alloc_raw(len+1);memcpy(r,s+start,len);r[len]=0;return r;}
 static const char*sp_sprintf(const char*fmt,...){char*b=sp_str_alloc_raw(4096);va_list ap;va_start(ap,fmt);vsnprintf(b,4096,fmt,ap);va_end(ap);return b;}
+static const char*sp_str_format_strarr(const char*fmt,sp_StrArray*a){size_t cap=strlen(fmt)+64;char*buf=(char*)malloc(cap);size_t out=0;mrb_int idx=0;const char*p=fmt;while(*p){if(*p=='%'){if(p[1]=='s'){const char*s=(idx<a->len)?a->data[idx]:"";size_t sl=strlen(s);if(out+sl>=cap){cap=(out+sl)*2+1;buf=(char*)realloc(buf,cap);}memcpy(buf+out,s,sl);out+=sl;idx++;p+=2;}else if(p[1]=='%'){if(out+1>=cap){cap*=2;buf=(char*)realloc(buf,cap);}buf[out++]='%';p+=2;}else{if(out+1>=cap){cap*=2;buf=(char*)realloc(buf,cap);}buf[out++]=*p++;}}else{if(out+1>=cap){cap*=2;buf=(char*)realloc(buf,cap);}buf[out++]=*p++;}}buf[out]=0;char*r=sp_str_alloc(out);memcpy(r,buf,out);free(buf);return r;}
 static const char*sp_str_reverse(const char*s){size_t l=strlen(s);char*r=sp_str_alloc_raw(l+1);for(size_t i=0;i<l;i++)r[i]=s[l-1-i];r[l]=0;return r;}
 static const char*sp_str_sub(const char*s,const char*pat,const char*rep){const char*f=strstr(s,pat);if(!f)return s;size_t pl=strlen(pat),rl=strlen(rep),sl=strlen(s);char*r=sp_str_alloc_raw(sl-pl+rl+1);size_t n=f-s;memcpy(r,s,n);memcpy(r+n,rep,rl);memcpy(r+n+rl,f+pl,sl-n-pl+1);return r;}
 static const char*sp_str_capitalize(const char*s){size_t l=strlen(s);char*r=sp_str_alloc_raw(l+1);for(size_t i=0;i<=l;i++)r[i]=tolower((unsigned char)s[i]);if(l>0)r[0]=toupper((unsigned char)r[0]);return r;}

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -174,6 +174,7 @@ class Compiler
     @needs_mutable_str = 0
     @needs_rb_value = 0
     @needs_regexp = 0
+    @needs_rand = 0
     @regexp_patterns = "".split(",")
     @regexp_flags = "".split(",")
 
@@ -1670,6 +1671,12 @@ class Compiler
       return "int"
     end
     if mname == "%"
+      if recv >= 0
+        rt = infer_type(recv)
+        if rt == "string" || rt == "mutable_str"
+          return "string"
+        end
+      end
       return "int"
     end
     if mname == "-@"
@@ -2227,6 +2234,12 @@ class Compiler
       return "int"
     end
     if mname == "reverse"
+      if recv >= 0
+        return infer_type(recv)
+      end
+      return "int_array"
+    end
+    if mname == "shuffle" || mname == "shuffle!"
       if recv >= 0
         return infer_type(recv)
       end
@@ -6501,6 +6514,10 @@ class Compiler
          mname == "ljust" || mname == "rjust" || mname == "capitalize" ||
          mname == "count" || mname == "<<"
         @needs_string_helpers = 1
+      end
+      if mname == "rand" || mname == "srand" || mname == "sample" ||
+         mname == "shuffle" || mname == "shuffle!"
+        @needs_rand = 1
       end
       if mname == "split"
         @needs_string_helpers = 1
@@ -10997,6 +11014,9 @@ class Compiler
     emit_raw("")
     emit_raw("int main(int argc,char**argv){")
     emit_raw("  sp_argv.len=argc-1;sp_argv.data=(const char**)malloc(sizeof(const char*)*(argc>1?argc-1:1));{int _i;for(_i=0;_i<sp_argv.len;_i++)sp_argv.data[_i]=sp_str_dup_external(argv[_i+1]);}")
+    if @needs_rand == 1
+      emit_raw("  srand((unsigned)time(NULL));")
+    end
     if @needs_regexp == 1
       emit_raw("  sp_re_init();")
     end
@@ -12644,6 +12664,7 @@ class Compiler
       return "0"
     end
     if mname == "srand"
+      @needs_rand = 1
       emit("  srand((unsigned)" + compile_arg0(nid) + ");")
       return "0"
     end
@@ -12663,6 +12684,7 @@ class Compiler
       return "sp_readlines()"
     end
     if mname == "rand"
+      @needs_rand = 1
       args_id = @nd_arguments[nid]
       if args_id >= 0
         return "((mrb_int)(rand() % (int)" + compile_arg0(nid) + "))"
@@ -13152,6 +13174,23 @@ class Compiler
       return "sp_idiv(" + compile_expr(recv) + ", " + compile_arg0(nid) + ")"
     end
     if mname == "%"
+      lt = infer_type(recv)
+      if lt == "string" || lt == "mutable_str"
+        args_id = @nd_arguments[nid]
+        if args_id >= 0
+          aargs = get_args(args_id)
+          if aargs.length > 0
+            rt = infer_type(aargs[0])
+            if rt == "str_array"
+              recv_c = compile_expr(recv)
+              if lt == "mutable_str"
+                recv_c = recv_c + "->data"
+              end
+              return "sp_str_format_strarr(" + recv_c + ", " + compile_expr(aargs[0]) + ")"
+            end
+          end
+        end
+      end
       return "sp_imod(" + compile_expr(recv) + ", " + compile_arg0(nid) + ")"
     end
     if mname == "<"
@@ -14276,8 +14315,20 @@ class Compiler
       return tmp
     end
     if mname == "sample"
+      @needs_rand = 1
       pfx = array_c_prefix(recv_type)
       return "sp_" + pfx + "_get(" + rc + ", rand() % sp_" + pfx + "_length(" + rc + "))"
+    end
+    if mname == "shuffle"
+      @needs_rand = 1
+      pfx = array_c_prefix(recv_type)
+      return "sp_" + pfx + "_shuffle(" + rc + ")"
+    end
+    if mname == "shuffle!"
+      @needs_rand = 1
+      pfx = array_c_prefix(recv_type)
+      emit("  sp_" + pfx + "_shuffle_bang(" + rc + ");")
+      return rc
     end
     if mname == "any?" && @nd_block[nid] < 0
       pfx = array_c_prefix(recv_type)

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -1671,10 +1671,19 @@ class Compiler
       return "int"
     end
     if mname == "%"
+      # String#% returns "string" only when the RHS is a str_array
+      # (sprintf-style format). Other RHS types fall through to sp_imod
+      # in compile_operator_expr, which yields int.
       if recv >= 0
         rt = infer_type(recv)
         if rt == "string" || rt == "mutable_str"
-          return "string"
+          args_id = @nd_arguments[nid]
+          if args_id >= 0
+            aargs = get_args(args_id)
+            if aargs.length > 0 && infer_type(aargs[0]) == "str_array"
+              return "string"
+            end
+          end
         end
       end
       return "int"
@@ -14319,12 +14328,14 @@ class Compiler
       pfx = array_c_prefix(recv_type)
       return "sp_" + pfx + "_get(" + rc + ", rand() % sp_" + pfx + "_length(" + rc + "))"
     end
-    if mname == "shuffle"
+    if mname == "shuffle" &&
+       (recv_type == "int_array" || recv_type == "str_array" || recv_type == "float_array")
       @needs_rand = 1
       pfx = array_c_prefix(recv_type)
       return "sp_" + pfx + "_shuffle(" + rc + ")"
     end
-    if mname == "shuffle!"
+    if mname == "shuffle!" &&
+       (recv_type == "int_array" || recv_type == "str_array" || recv_type == "float_array")
       @needs_rand = 1
       pfx = array_c_prefix(recv_type)
       emit("  sp_" + pfx + "_shuffle_bang(" + rc + ");")

--- a/test/bm_shuffle.rb
+++ b/test/bm_shuffle.rb
@@ -1,0 +1,19 @@
+arr = [1, 2, 3, 4, 5]
+s = arr.shuffle
+puts s.length
+puts s.sort.join(",")
+puts arr.join(",")
+
+words = ["foo", "bar", "baz", "qux"]
+s2 = words.shuffle
+puts s2.length
+puts s2.include?("foo")
+puts s2.include?("bar")
+puts s2.include?("baz")
+puts s2.include?("qux")
+puts words.join(",")
+
+nums = [10, 20, 30]
+nums.shuffle!
+puts nums.length
+puts nums.sort.join(",")


### PR DESCRIPTION
Adds Fisher-Yates `shuffle` / `shuffle!` for `IntArray` and `StrArray` in `sp_runtime.h` and routes `Array#shuffle` / `shuffle!` through them, inferring the result type from the receiver. Also routes `String#%` with a `str_array` RHS to a new `sp_str_format_strarr` helper so `"%s and %s" % ["a", "b"]` works; the integer `%` path is unchanged for non-string receivers.

Whenever `rand`, `srand`, `sample`, `shuffle`, or `shuffle!` is referenced, the generated `main` now seeds with `srand((unsigned)time(NULL))` so calls do not start from a fixed sequence.

Note: index selection uses `rand() % (i+1)`, which carries the usual modulo bias. This matches how `sample` already picks an index in this codebase, so no regression there. A separate change can switch both call sites to an unbiased helper if desired.

`test/bm_shuffle.rb` exercises the new paths but only validates length/membership/sort, not that the result is actually permuted; manual runs confirm distinct orderings across invocations.