### PR TITLE
fix: green up test suite on master

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -100,7 +100,9 @@ static char *sp_str_alloc(size_t len) {
   sp_str_heap = h;
   sp_gc_bytes += total;
   char *body = (char *)(h + 1);
-  body[0] = (char)0xfe;
+  /* Mark live so results of nested calls in stack-temp array literals
+     survive a sweep triggered by a later sibling arg's evaluation. */
+  body[0] = (char)0xfc;
   body[1 + len] = 0;
   return body + 1;
 }

--- a/test/bm_constant_path_builtin_new.rb
+++ b/test/bm_constant_path_builtin_new.rb
@@ -1,6 +1,7 @@
 # Test: built-in constructors via absolute ConstantPath (::X.new)
 
 require "stringio"
+require "fiber"
 
 a = ::Array.new(3, 2)
 puts a[0] + a[2]

--- a/test/bm_fiber.rb
+++ b/test/bm_fiber.rb
@@ -1,4 +1,5 @@
 # Test Fiber (cooperative concurrency)
+require "fiber"
 
 # Basic yield/resume
 f = Fiber.new {


### PR DESCRIPTION
## Summary

Three failures on master, fixed independently.

**bm_fiber and bm_constant_path_builtin_new**: both call `Fiber.current` / `Fiber#alive?`, which on Ruby 3.0+ require `require \"fiber\"`. Spinel produced the right output; MRI raised `NoMethodError`, so the expected-vs-actual comparison failed. Added the require.

**bm_sym_case** hit a real GC bug. Long string concat chains (5+ parts) compile to `sp_str_concat_arr` with a stack-temp array literal, e.g. `(const char *const[]){\"sp_\", sanitize_name(...), \"(\", args(...), ...}`. The intermediate strings returned by earlier args live only in the array-literal slot, which isn't a GC root; if a later sibling arg's evaluation triggers a sweep, those earlier strings get freed mid-construction. The visible symptom was `sp_classify(...)` becoming `sp_(...)` in generated C — `sanitize_name`'s result was swept while `compile_call_args_with_defaults` ran.

Fix in `sp_str_alloc`: mark fresh strings live (`0xfc`) instead of unmarked (`0xfe`) so they survive one sweep. Rooted strings still behave correctly across multiple cycles.

## Test plan

- [x] \`make test\` — 88 pass, 0 fail, 0 error (was 85 / 2 / 1 on master)
- [x] \`make bench\` — 55 pass, 0 fail, 0 skip
- [x] \`make all\` clean rebuild bootstraps successfully (gen2.c == gen3.c)