### PR TITLE
Use -flto=auto for bootstrap LTO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ CFLAGS   = -O2 -Wno-all
 # Override with LTO=0 on toolchains without LTO support.
 LTO     ?= 1
 ifeq ($(LTO),1)
-  BOOTSTRAP_CFLAGS = -O3 -flto -Wno-all
+  BOOTSTRAP_CFLAGS = -O3 -flto=auto -Wno-all
 else
   BOOTSTRAP_CFLAGS = $(CFLAGS)
 endif


### PR DESCRIPTION
## Summary

Use `-flto=auto` for the bootstrap compiler build when LTO is enabled.

## Why

The bootstrap build currently passes plain `-flto`, which can make GCC run LTO LTRANS jobs serially and emit this warning:

```text
lto-wrapper: warning: using serial compilation of 28 LTRANS jobs
lto-wrapper: note: see the ‘-flto’ option documentation for more information
```

Using `-flto=auto` lets GCC use GNU make's jobserver when available, or otherwise auto-detect the number of CPU threads. Current Clang also accepts `-flto=auto`, treating it as full LTO, and the CI matrix only uses the default clang from `ubuntu-latest` and `macos-latest`.

`LTO=0` remains available for toolchains without LTO support.

## Validation

- `make -B`
- Confirmed bootstrap succeeds with `gen2.c == gen3.c`
- Confirmed the GCC LTO serial LTRANS warning no longer appears
