### PR TITLE
Respect return value of `Kernel#system`

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -1437,6 +1437,9 @@ class Compiler
     if mname == "print"
       return "void"
     end
+    if mname == "system"
+      return "bool"
+    end
 
     # Constructor .new
     r = infer_constructor_type(nid, mname, recv)
@@ -12617,6 +12620,11 @@ class Compiler
         return "(_block != NULL)"
       end
       return "0"
+    end
+    if mname == "system"
+      @needs_file_io = 1
+      @needs_system = 1
+      return "({ fflush(stdout); sp_last_status = system(" + compile_arg0(nid) + "); sp_last_status == 0; })"
     end
     if mname == "__method__"
       return "\"" + @current_method_name + "\""

--- a/test/bm_system_expr.rb
+++ b/test/bm_system_expr.rb
@@ -1,0 +1,6 @@
+ok = system("echo hello_from_expr")
+puts ok
+puts($? == 0)
+ok = system("false")
+puts ok
+puts($? == 0)


### PR DESCRIPTION
`Kernel#system` did not return a value like CRuby's `Kernel#system` in expression context.  Fix this by implementing `Kernel#system` for expression context.
