### PR TITLE
fix(codegen): support nested ConstantPath constant reads

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -1070,8 +1070,11 @@ class Compiler
     end
     if t == "ConstantPathNode"
       if @nd_receiver[nid] >= 0
-        rname = @nd_name[@nd_receiver[nid]]
+        rname = const_ref_flat_name(@nd_receiver[nid])
         nname = @nd_name[nid]
+        if rname == ""
+          return "int"
+        end
         cpname = rname + "_" + nname
         ci = find_const_idx(cpname)
         if ci >= 0
@@ -3465,6 +3468,24 @@ class Compiler
     collect_class_with_prefix(nid, "")
   end
 
+  def collect_scoped_constant(scope_name, nid)
+    cname = scope_name + "_" + @nd_name[nid]
+    expr_id = @nd_expression[nid]
+    ct = "int"
+    if expr_id >= 0
+      ct = infer_type(expr_id)
+    end
+    ci = find_const_idx(cname)
+    if ci >= 0
+      @const_types[ci] = ct
+      @const_expr_ids[ci] = expr_id
+      return
+    end
+    @const_names.push(cname)
+    @const_types.push(ct)
+    @const_expr_ids.push(expr_id)
+  end
+
   def collect_class_with_prefix(nid, module_prefix)
     ci = @cls_names.length
     cname = ""
@@ -3519,6 +3540,9 @@ class Compiler
       body_stmts.each { |sid|
         if @nd_type[sid] == "DefNode"
           collect_class_method(ci, sid)
+        end
+        if @nd_type[sid] == "ConstantWriteNode"
+          collect_scoped_constant(cname, sid)
         end
         if @nd_type[sid] == "CallNode"
           cn = @nd_name[sid]
@@ -3665,6 +3689,9 @@ class Compiler
     body_stmts.each { |sid|
       if @nd_type[sid] == "DefNode"
         collect_class_method(ci, sid)
+      end
+      if @nd_type[sid] == "ConstantWriteNode"
+        collect_scoped_constant(cname, sid)
       end
       if @nd_type[sid] == "CallNode"
         cn = @nd_name[sid]
@@ -11402,8 +11429,11 @@ class Compiler
     end
     if t == "ConstantPathNode"
       if @nd_receiver[nid] >= 0
-        rname = @nd_name[@nd_receiver[nid]]
+        rname = const_ref_flat_name(@nd_receiver[nid])
         nname = @nd_name[nid]
+        if rname == ""
+          return @nd_name[nid]
+        end
         cpname = rname + "_" + nname
         ci = find_const_idx(cpname)
         if ci >= 0

--- a/test/bm_constant_path_nested_read.rb
+++ b/test/bm_constant_path_nested_read.rb
@@ -1,0 +1,16 @@
+# Test nested ConstantPath reads (A::B::C, M::C::X).
+
+module A
+  module B
+    C = 7
+  end
+end
+
+module M
+  class C
+    X = 11
+  end
+end
+
+puts A::B::C
+puts M::C::X


### PR DESCRIPTION
## Summary

This PR fixes nested `ConstantPath` constant reads such as `A::B::C` and `M::C::X`.

## Changes

- Use flattened constant-path names when resolving `ConstantPathNode` reads in both type inference and expression codegen.
- Add class-scoped constant collection so constants defined inside class bodies (e.g. `class M::C; X = ...; end`) are registered and resolvable.

## Tests

Added:

- `test/bm_constant_path_nested_read.rb`

Covers:

- `A::B::C`
- `M::C::X`

## Validation

- `make bootstrap` passes
- `make test` passes (`103 pass, 0 fail, 0 error`)

## Follow-up (separate PR)

Out of scope for this PR:

- lexical-vs-root constant lookup behavior (`M::A::B` vs `::M::A::B`)
- unifying constant collection behavior across top-level/module/class paths (including duplicate/update semantics)
- Refactor duplicated class-body member collection loops in `collect_class_with_prefix` (existing class reopen path vs new class path) into a shared helper for maintainability.