### PR TITLE
fix(codegen): infer poly method return type as common-or-poly, not first match

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -15731,21 +15731,36 @@ class Compiler
     end
     ret_ct = c_type(ret_type)
     ret_def = c_default_val(ret_type)
+    # Stash the receiver in a temp so we don't re-evaluate the
+    # expression for every if-branch below.
+    recv_tmp = new_temp
+    emit("  sp_RbVal " + recv_tmp + " = " + rc + ";")
+    # Compile the call's argument list once.
+    arg_strs = ""
+    args_id = @nd_arguments[nid]
+    if args_id >= 0
+      aargs = get_args(args_id)
+      k = 0
+      while k < aargs.length
+        arg_strs = arg_strs + ", " + compile_expr(aargs[k])
+        k = k + 1
+      end
+    end
     tmp = new_temp
     emit("  " + ret_ct + " " + tmp + " = " + ret_def + ";")
-    emit("  if (" + rc + ".tag == SP_TAG_OBJ) {")
+    emit("  if (" + recv_tmp + ".tag == SP_TAG_OBJ) {")
     i = 0
     while i < @cls_names.length
       cname = @cls_names[i]
       midx = cls_find_method_direct(i, mname)
       if midx >= 0
-        call_expr = "sp_" + cname + "_" + sanitize_name(mname) + "((sp_" + cname + " *)" + rc + ".v.p)"
+        call_expr = "sp_" + cname + "_" + sanitize_name(mname) + "((sp_" + cname + " *)" + recv_tmp + ".v.p" + arg_strs + ")"
         rhs = call_expr
         if is_poly_ret == 1
           this_rt = cls_method_return(i, mname)
           rhs = box_val_to_poly(call_expr, this_rt)
         end
-        emit("    if (" + rc + ".v.cls_id == " + i.to_s + ") " + tmp + " = " + rhs + ";")
+        emit("    if (" + recv_tmp + ".v.cls_id == " + i.to_s + ") " + tmp + " = " + rhs + ";")
       end
       i = i + 1
     end

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2711,16 +2711,10 @@ class Compiler
         if mname == "nil?"
           return "bool"
         end
-        # Check all classes for this method and return the first matching return type
-        ci = 0
-        while ci < @cls_names.length
-          midx = cls_find_method_direct(ci, mname)
-          if midx >= 0
-            return cls_method_return(ci, mname)
-          end
-          ci = ci + 1
-        end
-        return "int"
+        # Scan every user class that defines this method. If they all
+        # agree on the return type, the call has that concrete type.
+        # If they disagree, the call is genuinely polymorphic.
+        return poly_dispatch_return_type(mname)
       end
       # Method call on int (possible IntArray element storing object pointers)
       if rt == "int"
@@ -15691,6 +15685,33 @@ class Compiler
   end
 
 
+  # Inferred return type for `recv.mname(...)` when `recv` is poly.
+  # If every user class that defines mname agrees on the return type,
+  # that concrete type is used. If any two disagree, the call is
+  # genuinely polymorphic and the caller must treat the result as
+  # an sp_RbVal.
+  def poly_dispatch_return_type(mname)
+    common = ""
+    ci = 0
+    while ci < @cls_names.length
+      if cls_find_method_direct(ci, mname) >= 0
+        rt = cls_method_return(ci, mname)
+        if common == ""
+          common = rt
+        else
+          if common != rt
+            return "poly"
+          end
+        end
+      end
+      ci = ci + 1
+    end
+    if common == ""
+      return "int"
+    end
+    common
+  end
+
   def compile_poly_method_call(nid, rc, mname)
     @needs_rb_value = 1
     if mname == "nil?"
@@ -15699,19 +15720,32 @@ class Compiler
     if mname == "to_s"
       return "sp_poly_to_s(" + rc + ")"
     end
-    # For object method calls, dispatch based on cls_id
-    # Generate: switch on v.tag and cls_id
+    # For object method calls, dispatch based on cls_id. The result
+    # temp is typed by the method's return type. If user classes
+    # disagree on that type, the result is sp_RbVal and each branch
+    # boxes its concrete return value.
+    ret_type = poly_dispatch_return_type(mname)
+    is_poly_ret = 0
+    if ret_type == "poly"
+      is_poly_ret = 1
+    end
+    ret_ct = c_type(ret_type)
+    ret_def = c_default_val(ret_type)
     tmp = new_temp
-    emit("  const char *" + tmp + " = \"\";")
+    emit("  " + ret_ct + " " + tmp + " = " + ret_def + ";")
     emit("  if (" + rc + ".tag == SP_TAG_OBJ) {")
-    # Dispatch to each possible class
     i = 0
     while i < @cls_names.length
       cname = @cls_names[i]
-      # Check if this class has the method
       midx = cls_find_method_direct(i, mname)
       if midx >= 0
-        emit("    if (" + rc + ".v.cls_id == " + i.to_s + ") " + tmp + " = sp_" + cname + "_" + sanitize_name(mname) + "((sp_" + cname + " *)" + rc + ".v.p);")
+        call_expr = "sp_" + cname + "_" + sanitize_name(mname) + "((sp_" + cname + " *)" + rc + ".v.p)"
+        rhs = call_expr
+        if is_poly_ret == 1
+          this_rt = cls_method_return(i, mname)
+          rhs = box_val_to_poly(call_expr, this_rt)
+        end
+        emit("    if (" + rc + ".v.cls_id == " + i.to_s + ") " + tmp + " = " + rhs + ";")
       end
       i = i + 1
     end

--- a/test/bm_poly_method_args.rb
+++ b/test/bm_poly_method_args.rb
@@ -1,0 +1,23 @@
+# Polymorphic method dispatch must pass arguments through to the
+# selected class's method. Before this fix, `compile_poly_method_call`
+# emitted `sp_<Class>_<method>((sp_<Class> *)recv.v.p)` with no
+# argument list — the call-site arguments were dropped on the floor.
+
+class Doubler
+  def call(x)
+    x * 2
+  end
+end
+
+class Tripler
+  def call(x)
+    x * 3
+  end
+end
+
+def apply(a, x)
+  a.call(x)
+end
+
+puts apply(Doubler.new, 5)
+puts apply(Tripler.new, 5)

--- a/test/bm_poly_method_mixed_return.rb
+++ b/test/bm_poly_method_mixed_return.rb
@@ -1,0 +1,23 @@
+# Poly dispatch where user classes disagree on the method's return
+# type. `Foo#name` returns int, `Bar#name` returns string. The result
+# of `a.name` is genuinely polymorphic — the dispatcher must use
+# sp_RbVal as the result type and box each branch's return value.
+
+class Foo
+  def name
+    42
+  end
+end
+
+class Bar
+  def name
+    "bar"
+  end
+end
+
+def show(a)
+  a.name
+end
+
+puts show(Foo.new)
+puts show(Bar.new)


### PR DESCRIPTION
### Reproducer

```ruby
class Foo
  def name; 42; end       # mrb_int
end
class Bar
  def name; "bar"; end    # const char *
end
def show(a); a.name; end
puts show(Foo.new)
puts show(Bar.new)
```

### Expected

```
42
bar
```

### Actual (master)

```
/tmp/r.c: In function ‘sp_show’:
/tmp/r.c:54:35: error: assignment to ‘const char *’ from ‘mrb_int’ ...
   54 |       if (lv_a.v.cls_id == 0) _t1 = sp_Foo_name((sp_Foo *)lv_a.v.p);
      |                                   ^
/tmp/r.c:57:12: error: returning ‘const char *’ from a function with return type ‘mrb_int’ ...
   57 |     return _t1;
      |            ^~~
```

### What the codegen / inference were doing (before)

`infer_recv_method_type` (line 2706+) and `compile_poly_method_call` both decided the return type of `recv.mname(...)` (when `recv` is poly) by **picking the first user class that defines the method**:

```ruby
ci = 0
while ci < @cls_names.length
  midx = cls_find_method_direct(ci, mname)
  if midx >= 0
    return cls_method_return(ci, mname)   # first match wins
  end
  ci = ci + 1
end
```

So `a.name` was inferred as `Foo`'s `mrb_int`, `sp_show` was declared `static mrb_int sp_show(...)`, and the C compiler then refused the `const char *` flowing out of `sp_Bar_name`. The bug was masked for the homogeneous case (all classes returning the same type), which is why existing tests passed.

### What the codegen emits after

If every user class that defines `mname` agrees on the return type, the call keeps that concrete C type (homogeneous case — emitted C unchanged from before). If any two disagree, the call is genuinely polymorphic and the result temp is `sp_RbVal`, with each dispatch branch boxing its concrete return value:

```c
sp_RbVal _t1 = sp_box_nil();
if (lv_a.tag == SP_TAG_OBJ) {
  if (lv_a.v.cls_id == 0) _t1 = sp_box_int(sp_Foo_name((sp_Foo *)lv_a.v.p));
  if (lv_a.v.cls_id == 1) _t1 = sp_box_str(sp_Bar_name((sp_Bar *)lv_a.v.p));
}
return _t1;          // sp_show now returns sp_RbVal, picked up by puts via sp_poly_puts
```

### Fix

Both call sites now route through one helper:

```ruby
def poly_dispatch_return_type(mname)
  common = ""
  ci = 0
  while ci < @cls_names.length
    if cls_find_method_direct(ci, mname) >= 0
      rt = cls_method_return(ci, mname)
      if common == ""
        common = rt
      else
        if common != rt
          return "poly"          # disagree → genuine sp_RbVal
        end
      end
    end
    ci = ci + 1
  end
  if common == ""
    return "int"
  end
  common
end
```

`compile_poly_method_call` boxes per branch via `box_val_to_poly` when the return is `"poly"`.

Adds `test/bm_poly_method_mixed_return.rb` as a small reproducer.

---

### Drive-by: also forward arguments through the dispatcher

While in `compile_poly_method_call`, `sp_<Class>_<method>(recv)` was being emitted with no argument list — the call-site arguments were dropped on the floor:

```ruby
class Doubler; def call(x); x * 2; end; end
class Tripler; def call(x); x * 3; end; end
def apply(a, x); a.call(x); end
apply(Doubler.new, 5)   # error: too few arguments to function 'sp_Doubler_call'
```

Stash the receiver in `recv_tmp` (so it isn't re-evaluated for every cls_id branch), compile the argument list once into `arg_strs`, and forward it verbatim into every `sp_<Class>_<method>(self, args...)` call.

Reproducer added as `test/bm_poly_method_args.rb`.