### PR TITLE
fix(runtime): move cls_id out of sp_RbVal union to avoid pointer corruption

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -527,14 +527,14 @@ typedef uint64_t sp_RbValue;
 #define SP_TAG_NIL  4
 #define SP_TAG_OBJ  5
 #define SP_TAG_SYM  6
-typedef struct { int tag; union { mrb_int i; const char *s; mrb_float f; mrb_bool b; void *p; int cls_id; } v; } sp_RbVal;
-static sp_RbVal sp_box_int(mrb_int v) { sp_RbVal r; r.tag = SP_TAG_INT; r.v.i = v; return r; }
-static sp_RbVal sp_box_str(const char *v) { sp_RbVal r; r.tag = SP_TAG_STR; r.v.s = v; return r; }
-static sp_RbVal sp_box_float(mrb_float v) { sp_RbVal r; r.tag = SP_TAG_FLT; r.v.f = v; return r; }
-static sp_RbVal sp_box_bool(mrb_bool v) { sp_RbVal r; r.tag = SP_TAG_BOOL; r.v.b = v; return r; }
-static sp_RbVal sp_box_nil(void) { sp_RbVal r; r.tag = SP_TAG_NIL; r.v.i = 0; return r; }
-static sp_RbVal sp_box_obj(void *p, int cls_id) { sp_RbVal r; r.tag = SP_TAG_OBJ; r.v.p = p; r.v.cls_id = cls_id; return r; }
-static sp_RbVal sp_box_sym(sp_sym v) { sp_RbVal r; r.tag = SP_TAG_SYM; r.v.i = (mrb_int)v; return r; }
+typedef struct { int tag; int cls_id; union { mrb_int i; const char *s; mrb_float f; mrb_bool b; void *p; } v; } sp_RbVal;
+static sp_RbVal sp_box_int(mrb_int v) { sp_RbVal r; r.tag = SP_TAG_INT; r.cls_id = 0; r.v.i = v; return r; }
+static sp_RbVal sp_box_str(const char *v) { sp_RbVal r; r.tag = SP_TAG_STR; r.cls_id = 0; r.v.s = v; return r; }
+static sp_RbVal sp_box_float(mrb_float v) { sp_RbVal r; r.tag = SP_TAG_FLT; r.cls_id = 0; r.v.f = v; return r; }
+static sp_RbVal sp_box_bool(mrb_bool v) { sp_RbVal r; r.tag = SP_TAG_BOOL; r.cls_id = 0; r.v.b = v; return r; }
+static sp_RbVal sp_box_nil(void) { sp_RbVal r; r.tag = SP_TAG_NIL; r.cls_id = 0; r.v.i = 0; return r; }
+static sp_RbVal sp_box_obj(void *p, int cls_id) { sp_RbVal r; r.tag = SP_TAG_OBJ; r.cls_id = cls_id; r.v.p = p; return r; }
+static sp_RbVal sp_box_sym(sp_sym v) { sp_RbVal r; r.tag = SP_TAG_SYM; r.cls_id = 0; r.v.i = (mrb_int)v; return r; }
 static void sp_poly_puts(sp_RbVal v) {
   switch (v.tag) {
     case SP_TAG_INT: printf("%lld\n", (long long)v.v.i); break;

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -8411,13 +8411,13 @@ class Compiler
     emit_raw("#define SP_TAG_BOOL 3")
     emit_raw("#define SP_TAG_NIL  4")
     emit_raw("#define SP_TAG_OBJ  5")
-    emit_raw("typedef struct { int tag; union { mrb_int i; const char *s; mrb_float f; mrb_bool b; void *p; int cls_id; } v; } sp_RbVal;")
-    emit_raw("static sp_RbVal sp_box_int(mrb_int v) { sp_RbVal r; r.tag = SP_TAG_INT; r.v.i = v; return r; }")
-    emit_raw("static sp_RbVal sp_box_str(const char *v) { sp_RbVal r; r.tag = SP_TAG_STR; r.v.s = v; return r; }")
-    emit_raw("static sp_RbVal sp_box_float(mrb_float v) { sp_RbVal r; r.tag = SP_TAG_FLT; r.v.f = v; return r; }")
-    emit_raw("static sp_RbVal sp_box_bool(mrb_bool v) { sp_RbVal r; r.tag = SP_TAG_BOOL; r.v.b = v; return r; }")
-    emit_raw("static sp_RbVal sp_box_nil(void) { sp_RbVal r; r.tag = SP_TAG_NIL; r.v.i = 0; return r; }")
-    emit_raw("static sp_RbVal sp_box_obj(void *p, int cls_id) { sp_RbVal r; r.tag = SP_TAG_OBJ; r.v.p = p; r.v.cls_id = cls_id; return r; }")
+    emit_raw("typedef struct { int tag; int cls_id; union { mrb_int i; const char *s; mrb_float f; mrb_bool b; void *p; } v; } sp_RbVal;")
+    emit_raw("static sp_RbVal sp_box_int(mrb_int v) { sp_RbVal r; r.tag = SP_TAG_INT; r.cls_id = 0; r.v.i = v; return r; }")
+    emit_raw("static sp_RbVal sp_box_str(const char *v) { sp_RbVal r; r.tag = SP_TAG_STR; r.cls_id = 0; r.v.s = v; return r; }")
+    emit_raw("static sp_RbVal sp_box_float(mrb_float v) { sp_RbVal r; r.tag = SP_TAG_FLT; r.cls_id = 0; r.v.f = v; return r; }")
+    emit_raw("static sp_RbVal sp_box_bool(mrb_bool v) { sp_RbVal r; r.tag = SP_TAG_BOOL; r.cls_id = 0; r.v.b = v; return r; }")
+    emit_raw("static sp_RbVal sp_box_nil(void) { sp_RbVal r; r.tag = SP_TAG_NIL; r.cls_id = 0; r.v.i = 0; return r; }")
+    emit_raw("static sp_RbVal sp_box_obj(void *p, int cls_id) { sp_RbVal r; r.tag = SP_TAG_OBJ; r.cls_id = cls_id; r.v.p = p; return r; }")
     emit_raw("static void sp_poly_puts(sp_RbVal v) {")
     emit_raw("  switch (v.tag) {")
     emit_raw("    case SP_TAG_INT: printf(\"%lld" + bsl_n + "\", (long long)v.v.i); break;")
@@ -15711,7 +15711,7 @@ class Compiler
       # Check if this class has the method
       midx = cls_find_method_direct(i, mname)
       if midx >= 0
-        emit("    if (" + rc + ".v.cls_id == " + i.to_s + ") " + tmp + " = sp_" + cname + "_" + sanitize_name(mname) + "((sp_" + cname + " *)" + rc + ".v.p);")
+        emit("    if (" + rc + ".cls_id == " + i.to_s + ") " + tmp + " = sp_" + cname + "_" + sanitize_name(mname) + "((sp_" + cname + " *)" + rc + ".v.p);")
       end
       i = i + 1
     end

--- a/test/bm_poly_self_deref.rb
+++ b/test/bm_poly_self_deref.rb
@@ -1,0 +1,28 @@
+# Polymorphic dispatch where the called method dereferences `self`.
+# `cls_id` used to share memory with `v.p` inside the sp_RbVal union,
+# so writing cls_id after v.p clobbered the low 32 bits of the pointer.
+# Methods that touch instance fields then crashed (SIGSEGV).
+# Methods that did not touch self happened to work, masking the bug.
+
+class C
+  attr_accessor :n
+  def initialize(n)
+    @n = n
+  end
+  def name
+    @n.to_s
+  end
+end
+
+class D
+  def name
+    "other"
+  end
+end
+
+def show(o)
+  o.name
+end
+
+puts show(C.new(42))
+puts show(D.new)


### PR DESCRIPTION
### Reproducer

```ruby
class C
  attr_accessor :n
  def initialize(n); @n = n; end
  def name; @n.to_s; end
end
class D
  def name; "other"; end
end
def show(o); o.name; end
puts show(C.new(42))
puts show(D.new)
```

### Expected

```
42
other
```

### Actual (master)

```
$ ./r3_bin
Segmentation fault (core dumped)
$ echo $?
139
```

### Why it crashes — `sp_RbVal` layout (before)

```c
typedef struct {
  int tag;
  union {
    mrb_int i;
    const char *s;
    mrb_float f;
    mrb_bool b;
    void *p;     // 8 bytes
    int cls_id;  // 4 bytes  ← shares storage with v.p
  } v;
} sp_RbVal;

static sp_RbVal sp_box_obj(void *p, int cls_id) {
  sp_RbVal r;
  r.tag = SP_TAG_OBJ;
  r.v.p = p;             // writes 8 bytes
  r.v.cls_id = cls_id;   // overwrites the first 4 of those 8 bytes
  return r;
}
```

The second store clobbers the **low 32 bits** of the pointer. Reading `cls_id` itself returns the correct value (so the dispatcher picks the right branch), but the moment the dispatched method dereferences `(sp_C *)recv.v.p`, the program SIGSEGV's. Existing tests masked this because every poly-dispatched method ignored its receiver.

### `sp_RbVal` layout (after)

```c
typedef struct {
  int tag;
  int cls_id;                                  // separate field — no longer shares
  union { ...; void *p; } v;
} sp_RbVal;

static sp_RbVal sp_box_obj(void *p, int cls_id) {
  sp_RbVal r;
  r.tag = SP_TAG_OBJ;
  r.cls_id = cls_id;
  r.v.p = p;             // independent storage, doesn't overlap
  return r;
}
```

The struct stays 16 bytes (the 4-byte slot was previously padding after `tag`). Each `sp_box_*` helper writes `r.cls_id = 0` (or the actual value), and the dispatch path reads `recv.cls_id` instead of `recv.v.cls_id`.

Adds `test/bm_poly_self_deref.rb` as a small reproducer.