### PR TITLE
Fix boxed object class id storage

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -527,13 +527,13 @@ typedef uint64_t sp_RbValue;
 #define SP_TAG_NIL  4
 #define SP_TAG_OBJ  5
 #define SP_TAG_SYM  6
-typedef struct { int tag; union { mrb_int i; const char *s; mrb_float f; mrb_bool b; void *p; int cls_id; } v; } sp_RbVal;
+typedef struct { int tag; int cls_id; union { mrb_int i; const char *s; mrb_float f; mrb_bool b; void *p; } v; } sp_RbVal;
 static sp_RbVal sp_box_int(mrb_int v) { sp_RbVal r; r.tag = SP_TAG_INT; r.v.i = v; return r; }
 static sp_RbVal sp_box_str(const char *v) { sp_RbVal r; r.tag = SP_TAG_STR; r.v.s = v; return r; }
 static sp_RbVal sp_box_float(mrb_float v) { sp_RbVal r; r.tag = SP_TAG_FLT; r.v.f = v; return r; }
 static sp_RbVal sp_box_bool(mrb_bool v) { sp_RbVal r; r.tag = SP_TAG_BOOL; r.v.b = v; return r; }
 static sp_RbVal sp_box_nil(void) { sp_RbVal r; r.tag = SP_TAG_NIL; r.v.i = 0; return r; }
-static sp_RbVal sp_box_obj(void *p, int cls_id) { sp_RbVal r; r.tag = SP_TAG_OBJ; r.v.p = p; r.v.cls_id = cls_id; return r; }
+static sp_RbVal sp_box_obj(void *p, int cls_id) { sp_RbVal r; r.tag = SP_TAG_OBJ; r.cls_id = cls_id; r.v.p = p; return r; }
 static sp_RbVal sp_box_sym(sp_sym v) { sp_RbVal r; r.tag = SP_TAG_SYM; r.v.i = (mrb_int)v; return r; }
 static void sp_poly_puts(sp_RbVal v) {
   switch (v.tag) {

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -8441,13 +8441,13 @@ class Compiler
     emit_raw("#define SP_TAG_BOOL 3")
     emit_raw("#define SP_TAG_NIL  4")
     emit_raw("#define SP_TAG_OBJ  5")
-    emit_raw("typedef struct { int tag; union { mrb_int i; const char *s; mrb_float f; mrb_bool b; void *p; int cls_id; } v; } sp_RbVal;")
+    emit_raw("typedef struct { int tag; int cls_id; union { mrb_int i; const char *s; mrb_float f; mrb_bool b; void *p; } v; } sp_RbVal;")
     emit_raw("static sp_RbVal sp_box_int(mrb_int v) { sp_RbVal r; r.tag = SP_TAG_INT; r.v.i = v; return r; }")
     emit_raw("static sp_RbVal sp_box_str(const char *v) { sp_RbVal r; r.tag = SP_TAG_STR; r.v.s = v; return r; }")
     emit_raw("static sp_RbVal sp_box_float(mrb_float v) { sp_RbVal r; r.tag = SP_TAG_FLT; r.v.f = v; return r; }")
     emit_raw("static sp_RbVal sp_box_bool(mrb_bool v) { sp_RbVal r; r.tag = SP_TAG_BOOL; r.v.b = v; return r; }")
     emit_raw("static sp_RbVal sp_box_nil(void) { sp_RbVal r; r.tag = SP_TAG_NIL; r.v.i = 0; return r; }")
-    emit_raw("static sp_RbVal sp_box_obj(void *p, int cls_id) { sp_RbVal r; r.tag = SP_TAG_OBJ; r.v.p = p; r.v.cls_id = cls_id; return r; }")
+    emit_raw("static sp_RbVal sp_box_obj(void *p, int cls_id) { sp_RbVal r; r.tag = SP_TAG_OBJ; r.cls_id = cls_id; r.v.p = p; return r; }")
     emit_raw("static void sp_poly_puts(sp_RbVal v) {")
     emit_raw("  switch (v.tag) {")
     emit_raw("    case SP_TAG_INT: printf(\"%lld" + bsl_n + "\", (long long)v.v.i); break;")
@@ -15749,7 +15749,7 @@ class Compiler
       # Check if this class has the method
       midx = cls_find_method_direct(i, mname)
       if midx >= 0
-        emit("    if (" + rc + ".v.cls_id == " + i.to_s + ") " + tmp + " = sp_" + cname + "_" + sanitize_name(mname) + "((sp_" + cname + " *)" + rc + ".v.p);")
+        emit("    if (" + rc + ".cls_id == " + i.to_s + ") " + tmp + " = sp_" + cname + "_" + sanitize_name(mname) + "((sp_" + cname + " *)" + rc + ".v.p);")
       end
       i = i + 1
     end


### PR DESCRIPTION
Fixes #59.

`sp_box_obj` stored the object pointer and class id in the same union slot, so writing `cls_id` overwrote `v.p`. This moves `cls_id` next to the tag and updates generated poly dispatch to read it from the separate field.

Checked for contribution docs/templates before filing; Spinel has no top-level contribution guide or PR template.

Verification:
- compiled and ran a direct `sp_box_obj` runtime repro; it now exits 0
- compiled and ran `test/bm_poly2.rb` through `spinel_parse` + `ruby spinel_codegen.rb` + `cc`
