### PR TITLE
Resolve class constants in instance methods

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -1045,6 +1045,13 @@ class Compiler
       if @nd_name[nid] == "ARGV"
         return "argv"
       end
+      if @current_class_idx >= 0
+        cpname = @cls_names[@current_class_idx] + "_" + @nd_name[nid]
+        ci2 = find_const_idx(cpname)
+        if ci2 >= 0
+          return @const_types[ci2]
+        end
+      end
       ci = find_const_idx(@nd_name[nid])
       if ci >= 0
         return @const_types[ci]
@@ -11397,6 +11404,17 @@ class Compiler
     if t == "ConstantReadNode"
       if @nd_name[nid] == "ARGV"
         return "sp_argv"
+      end
+      if @current_class_idx >= 0
+        cpname_cls = @cls_names[@current_class_idx] + "_" + @nd_name[nid]
+        ci_cls = find_const_idx(cpname_cls)
+        if ci_cls >= 0
+          lv_cls = const_literal_c_value(ci_cls)
+          if lv_cls != ""
+            return lv_cls
+          end
+          return "cst_" + cpname_cls
+        end
       end
       ci = find_const_idx(@nd_name[nid])
       if ci >= 0

--- a/test/bm_class_constant_sym_array.rb
+++ b/test/bm_class_constant_sym_array.rb
@@ -1,0 +1,19 @@
+class Parser
+  SOFT_IDENTIFIER_KEYWORDS = %i[with]
+  SHADOWED = %i[class]
+
+  def soft?(value)
+    SOFT_IDENTIFIER_KEYWORDS.include?(value)
+  end
+
+  def shadowed?(value)
+    SHADOWED.include?(value)
+  end
+end
+
+SHADOWED = %i[top]
+
+puts Parser.new.soft?(:with)        # true
+puts Parser.new.soft?(:without)     # false
+puts Parser.new.shadowed?(:class)   # true
+puts Parser.new.shadowed?(:top)     # false


### PR DESCRIPTION
Fixes #68.

Unqualified constants inside instance methods were only resolved as top-level or module constants. Class-scoped constants are collected under their class-qualified name, so a method like `Parser#soft?` saw `SOFT_IDENTIFIER_KEYWORDS` as an unresolved/int receiver and compiled `include?` to `false`.

This checks the current class scope during both type inference and expression compilation, then adds a regression for a symbol-array class constant used with `include?`.

Checked for contribution docs/templates before filing; Spinel has no top-level contribution guide or PR template.

Verification:
- compiled and ran `test/bm_class_constant_sym_array.rb` through `spinel_parse` + `ruby spinel_codegen.rb` + `cc`; output is `true` then `false`
- compiled and ran `test/bm_constants.rb` through the same path
