### PR TITLE
Infer typed array from Array.new(n, fill) in instance-variable init

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2529,7 +2529,9 @@ class Compiler
         rn = constructor_class_name(recv)
         if rn != ""
           if rn == "Array"
-            # Check fill value type
+            # Check fill value type. Pointer-type fills must produce a typed
+            # PtrArray; falling through to int_array would leave the
+            # elements unscanned by GC.
             args_id = @nd_arguments[nid]
             if args_id >= 0
               aargs = get_args(args_id)
@@ -2540,6 +2542,18 @@ class Compiler
                 end
                 if vt == "string"
                   return "str_array"
+                end
+                if vt == "symbol"
+                  return "sym_array"
+                end
+                if vt == "poly"
+                  @needs_rb_value = 1
+                  return "poly_array"
+                end
+                if type_is_pointer(vt) == 1
+                  @needs_ptr_array = 1
+                  @needs_gc = 1
+                  return vt + "_ptr_array"
                 end
               end
             end
@@ -4252,7 +4266,9 @@ class Compiler
           rname = constructor_class_name(r)
           if rname != ""
             if rname == "Array"
-              # Check fill value type for Array.new(n, val) -- match infer_constructor_type
+              # Check fill value type for Array.new(n, val).
+              # Pointer-type fills must produce a typed PtrArray; falling
+              # through to int_array would leave the elements unscanned by GC.
               args_id = @nd_arguments[nid]
               if args_id >= 0
                 aargs = get_args(args_id)
@@ -4263,6 +4279,18 @@ class Compiler
                   end
                   if vt == "string"
                     return "str_array"
+                  end
+                  if vt == "symbol"
+                    return "sym_array"
+                  end
+                  if vt == "poly"
+                    @needs_rb_value = 1
+                    return "poly_array"
+                  end
+                  if type_is_pointer(vt) == 1
+                    @needs_ptr_array = 1
+                    @needs_gc = 1
+                    return vt + "_ptr_array"
                   end
                 end
               end
@@ -13431,6 +13459,17 @@ class Compiler
               tmp = new_temp
               emit("  sp_StrArray *" + tmp + " = sp_StrArray_new();")
               emit("  { mrb_int _n = " + compile_expr(aargs.first) + "; const char *_v = " + compile_expr(aargs[1]) + "; for (mrb_int _i = 0; _i < _n; _i++) sp_StrArray_push(" + tmp + ", _v); }")
+              return tmp
+            end
+            # Pointer-type fills (objects, other arrays) need a typed PtrArray
+            # so the GC scans the elements. Without this they'd be pushed
+            # into an int_array and silently swept.
+            if type_is_pointer(vt) == 1
+              @needs_ptr_array = 1
+              @needs_gc = 1
+              tmp = new_temp
+              emit("  sp_PtrArray *" + tmp + " = sp_PtrArray_new();")
+              emit("  { mrb_int _n = " + compile_expr(aargs.first) + "; void *_v = (void *)(" + compile_expr(aargs[1]) + "); for (mrb_int _i = 0; _i < _n; _i++) sp_PtrArray_push(" + tmp + ", _v); }")
               return tmp
             end
             @needs_int_array = 1

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -4252,6 +4252,20 @@ class Compiler
           rname = constructor_class_name(r)
           if rname != ""
             if rname == "Array"
+              # Check fill value type for Array.new(n, val) -- match infer_constructor_type
+              args_id = @nd_arguments[nid]
+              if args_id >= 0
+                aargs = get_args(args_id)
+                if aargs.length >= 2
+                  vt = infer_type(aargs[1])
+                  if vt == "float"
+                    return "float_array"
+                  end
+                  if vt == "string"
+                    return "str_array"
+                  end
+                end
+              end
               return "int_array"
             end
             if rname == "Hash"

--- a/test/bm_ivar_float_array.rb
+++ b/test/bm_ivar_float_array.rb
@@ -1,33 +1,43 @@
-# Regression: instance variables initialized via Array.new(n, FLOAT)
-# must be typed as sp_FloatArray *, not the containing class's pointer.
+# Regression: instance variables initialized via Array.new(n, FILL) must be
+# typed by inspecting the fill argument, not always returned as "int_array".
 #
-# infer_ivar_init_type's CallNode/"new" branch used to unconditionally
-# return "int_array" for Array.new(...) regardless of fill type. The
-# resulting struct field was then typed as the class itself; assigning
-# the FloatArray* into the field worked with a warning, but reads
-# went through the wrong type and silently returned zero.
+# infer_ivar_init_type's CallNode/"new" branch used to unconditionally return
+# "int_array" for Array.new(...). That mistyped class fields as the
+# containing class's pointer; pointer-type fills additionally lost their GC
+# scan function, which would let live elements be swept.
 #
-# (Use float values whose fractional part is non-zero so that
-# Spinel's float-puts and CRuby's match -- "0.5" not "0.0".)
+# We now check the fill type and use the appropriate typed array container
+# (FloatArray for float fills, StrArray for string, sym_array (IntArray
+# internally) for symbol, PtrArray for object/pointer fills).
+#
+# Use float values whose fractional part is non-zero so Spinel's float-puts
+# matches CRuby's.
 
 class Box
   attr_accessor :nums
-
   def initialize
     @nums = Array.new(3, 0.5)
   end
 end
 
-class Holder
-  attr_accessor :weights
+class SymHolder
+  attr_accessor :tags
+  def initialize
+    @tags = Array.new(2, :alpha)
+  end
+end
 
-  def initialize(n)
-    @weights = Array.new(n, 0.25)
-    i = 0
-    while i < n
-      @weights[i] = i * 0.5 + 0.25
-      i += 1
-    end
+class Marker
+  attr_accessor :id
+  def initialize(id)
+    @id = id
+  end
+end
+
+class ObjHolder
+  attr_accessor :marks
+  def initialize
+    @marks = Array.new(3, Marker.new(42))
   end
 end
 
@@ -37,8 +47,13 @@ puts b.nums[1]      # 0.5
 puts b.nums[2]      # 0.5
 puts b.nums.length  # 3
 
-h = Holder.new(4)
-puts h.weights[0]   # 0.25
-puts h.weights[1]   # 0.75
-puts h.weights[2]   # 1.25
-puts h.weights[3]   # 1.75
+s = SymHolder.new
+puts s.tags[0]      # alpha
+puts s.tags[1]      # alpha
+puts s.tags.length  # 2
+
+m = ObjHolder.new
+puts m.marks[0].id  # 42
+puts m.marks[1].id  # 42  (Array.new(n, obj) shares the same obj)
+puts m.marks[2].id  # 42
+puts m.marks.length # 3

--- a/test/bm_ivar_float_array.rb
+++ b/test/bm_ivar_float_array.rb
@@ -1,0 +1,44 @@
+# Regression: instance variables initialized via Array.new(n, FLOAT)
+# must be typed as sp_FloatArray *, not the containing class's pointer.
+#
+# infer_ivar_init_type's CallNode/"new" branch used to unconditionally
+# return "int_array" for Array.new(...) regardless of fill type. The
+# resulting struct field was then typed as the class itself; assigning
+# the FloatArray* into the field worked with a warning, but reads
+# went through the wrong type and silently returned zero.
+#
+# (Use float values whose fractional part is non-zero so that
+# Spinel's float-puts and CRuby's match -- "0.5" not "0.0".)
+
+class Box
+  attr_accessor :nums
+
+  def initialize
+    @nums = Array.new(3, 0.5)
+  end
+end
+
+class Holder
+  attr_accessor :weights
+
+  def initialize(n)
+    @weights = Array.new(n, 0.25)
+    i = 0
+    while i < n
+      @weights[i] = i * 0.5 + 0.25
+      i += 1
+    end
+  end
+end
+
+b = Box.new
+puts b.nums[0]      # 0.5
+puts b.nums[1]      # 0.5
+puts b.nums[2]      # 0.5
+puts b.nums.length  # 3
+
+h = Holder.new(4)
+puts h.weights[0]   # 0.25
+puts h.weights[1]   # 0.75
+puts h.weights[2]   # 1.25
+puts h.weights[3]   # 1.75


### PR DESCRIPTION
## Summary

  `infer_ivar_init_type` unconditionally returned `"int_array"` for any
  `Array.new(...)` expression in an instance-variable initializer,
  regardless of the fill argument's type. This caused a class field
  initialized to `Array.new(n, 0.5)` (or any non-int fill) to be typed
  as the **containing class's pointer type** in the generated struct,
  which compiled with warnings and read back zeros.

  The same logic is already correct in `infer_constructor_type` (used
  for local variables), so this PR ports the fill-type check over.

  ## Reproducer

  ```ruby
  class Box
    attr_accessor :nums
    def initialize
      @nums = Array.new(3, 0.5)
    end
  end

  b = Box.new
  puts b.nums[0]   # ruby: 0.5    spinel before fix: 0
```
  Before:
```
  struct sp_Box_s {
    sp_Box * iv_nums;             // wrong type
  };
  // warning: incompatible pointer types assigning to 'sp_Box *' from 'sp_FloatArray *'
```
  After:
```
  struct sp_Box_s {
    sp_FloatArray * iv_nums;      // correct
  };
```
  Changes

  - spinel_codegen.rb: in infer_ivar_init_type, when the call is
  Array.new(n, val), inspect the second argument's type and return
  "float_array" / "str_array" / "int_array" accordingly. Logic
  mirrors the existing infer_constructor_type branch.
  - test/bm_ivar_float_array.rb: regression test exercising the path.

  Validation

  - All 103 tests pass (make test).
  - Bootstrap loop closes (gen2.c == gen3.c).
  - Reproducer above now prints 0.5.

  Notes

  This was hit while trying to compile a small from-scratch transformer
  LM (Mat class with @flat = Array.new(rows*cols, 0.0)). After this
  patch the model state builds correctly under Spinel.

  **Spinel commit message** (for use on your branch before PR):
  Infer typed array from Array.new(n, fill) in instance-variable init

  infer_ivar_init_type returned "int_array" for any Array.new(...)
  expression, regardless of the fill argument type. Class fields
  initialized to Array.new(n, 0.5) ended up typed as the containing
  class's pointer (sp_Foo *) in the generated struct.

  Mirror the fill-type check from infer_constructor_type so a Float
  fill yields "float_array" and a String fill yields "str_array".

  test/bm_ivar_float_array.rb covers the regression. All 103 tests
  pass; bootstrap closes.