### PR TITLE
fix(codegen): make array iterator block params truly block-local

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -15222,12 +15222,7 @@ class Compiler
     # each_with_object as expression: run the loop as side effect, return obj
     if mname == "each_with_object"
       if @nd_block[nid] >= 0
-        compile_each_with_object_block(nid)
-        bp2 = get_block_param(nid, 1)
-        if bp2 == ""
-          bp2 = "_obj"
-        end
-        return "lv_" + bp2
+        return compile_each_with_object_block(nid)
       end
     end
 
@@ -18158,10 +18153,11 @@ class Compiler
           bp2 = "_b"
         end
         pfx = array_c_prefix(rt)
+        et = c_type(elem_type_of_array(rt))
         tmp_i = new_temp
         emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_" + pfx + "_length(" + rc + "); " + tmp_i + "++) {")
-        emit("    lv_" + bp1 + " = sp_" + pfx + "_get(" + rc + ", " + tmp_i + ");")
-        emit("    lv_" + bp2 + " = sp_" + pfx + "_get(" + arg + ", " + tmp_i + ");")
+        emit("    " + et + " lv_" + bp1 + " = sp_" + pfx + "_get(" + rc + ", " + tmp_i + ");")
+        emit("    " + et + " lv_" + bp2 + " = sp_" + pfx + "_get(" + arg + ", " + tmp_i + ");")
         @indent = @indent + 1
         compile_stmts_body(@nd_body[@nd_block[nid]])
         @indent = @indent - 1
@@ -19984,6 +19980,14 @@ class Compiler
     @in_loop = 1
     rt = infer_type(@nd_receiver[nid])
     rc = compile_expr_gc_rooted(@nd_receiver[nid])
+    obj_ct = "mrb_int"
+    args_id = @nd_arguments[nid]
+    if args_id >= 0
+      aargs = get_args(args_id)
+      if aargs.length > 0
+        obj_ct = c_type(infer_type(aargs[0]))
+      end
+    end
     obj_arg = compile_arg0(nid)
     bp1 = get_block_param(nid, 0)
     bp2 = get_block_param(nid, 1)
@@ -19993,18 +19997,28 @@ class Compiler
     if bp2 == ""
       bp2 = "_obj"
     end
+    # Outer-scope slot survives the inner `{}` so the expression form
+    # of each_with_object can still observe the final accumulator.
+    result = new_temp
+    emit("  " + obj_ct + " " + result + " = " + obj_arg + ";")
     tmp_i = new_temp
     if rt == "int_array" || rt == "str_array" || rt == "float_array" || rt == "sym_array"
       pfx = array_c_prefix(rt)
-      emit("  lv_" + bp2 + " = " + obj_arg + ";")
+      emit("  {")
+      @indent = @indent + 1
+      emit("  " + obj_ct + " lv_" + bp2 + " = " + result + ";")
       emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_" + pfx + "_length(" + rc + "); " + tmp_i + "++) {")
-      emit("    lv_" + bp1 + " = sp_" + pfx + "_get(" + rc + ", " + tmp_i + ");")
+      emit("    " + c_type(elem_type_of_array(rt)) + " lv_" + bp1 + " = sp_" + pfx + "_get(" + rc + ", " + tmp_i + ");")
       @indent = @indent + 1
       compile_stmts_body(@nd_body[@nd_block[nid]])
       @indent = @indent - 1
       emit("  }")
+      emit("  " + result + " = lv_" + bp2 + ";")
+      @indent = @indent - 1
+      emit("  }")
     end
     @in_loop = old
+    result
   end
 
   def compile_each_with_index_block(nid)
@@ -20023,8 +20037,8 @@ class Compiler
     tmp = new_temp
     pfx = array_c_prefix(rt)
     emit("  for (mrb_int " + tmp + " = 0; " + tmp + " < sp_" + pfx + "_length(" + rc + "); " + tmp + "++) {")
-    emit("    lv_" + bp1 + " = sp_" + pfx + "_get(" + rc + ", " + tmp + ");")
-    emit("    lv_" + bp2 + " = " + tmp + ";")
+    emit("    " + c_type(elem_type_of_array(rt)) + " lv_" + bp1 + " = sp_" + pfx + "_get(" + rc + ", " + tmp + ");")
+    emit("    mrb_int lv_" + bp2 + " = " + tmp + ";")
     @indent = @indent + 1
     compile_stmts_body(@nd_body[@nd_block[nid]])
     @indent = @indent - 1
@@ -20050,7 +20064,7 @@ class Compiler
       pfx = array_c_prefix(rt)
       emit("  for (mrb_int " + tmp + " = 0; " + tmp + " < sp_" + pfx + "_length(" + rc + "); " + tmp + "++) {")
       if has_bp == 1
-        emit("    lv_" + bp1 + " = sp_" + pfx + "_get(" + rc + ", " + tmp + ");")
+        emit("    " + c_type(elem_type_of_array(rt)) + " lv_" + bp1 + " = sp_" + pfx + "_get(" + rc + ", " + tmp + ");")
       end
       @indent = @indent + 1
       compile_stmts_body(@nd_body[@nd_block[nid]])
@@ -21048,7 +21062,7 @@ class Compiler
       @needs_gc = 1
       emit("  sp_IntArray *" + tmp_arr + " = sp_IntArray_new();")
       emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_IntArray_length(" + rc + "); " + tmp_i + "++) {")
-      emit("    lv_" + bp1 + " = sp_IntArray_get(" + rc + ", " + tmp_i + ");")
+      emit("    mrb_int lv_" + bp1 + " = sp_IntArray_get(" + rc + ", " + tmp_i + ");")
       @indent = @indent + 1
       blk = @nd_block[nid]
       if blk >= 0
@@ -21095,7 +21109,7 @@ class Compiler
     pfx = array_c_prefix(rt)
     tmp = new_temp
     emit("  for (mrb_int " + tmp + " = 0; " + tmp + " < sp_" + pfx + "_length(" + rc + "); " + tmp + "++) {")
-    emit("    lv_" + bp2 + " = sp_" + pfx + "_get(" + rc + ", " + tmp + ");")
+    emit("    " + c_type(elem_type_of_array(rt)) + " lv_" + bp2 + " = sp_" + pfx + "_get(" + rc + ", " + tmp + ");")
     @indent = @indent + 1
     blk = @nd_block[nid]
     if blk >= 0
@@ -21126,7 +21140,7 @@ class Compiler
       emit("  sp_IntArray *" + tmp_arr + " = sp_IntArray_new();")
       tmp_i = new_temp
       emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_IntArray_length(" + rc + "); " + tmp_i + "++) {")
-      emit("    lv_" + bp1 + " = sp_IntArray_get(" + rc + ", " + tmp_i + ");")
+      emit("    mrb_int lv_" + bp1 + " = sp_IntArray_get(" + rc + ", " + tmp_i + ");")
       @indent = @indent + 1
       blk = @nd_block[nid]
       if blk >= 0
@@ -21160,7 +21174,7 @@ class Compiler
       emit("  sp_IntArray *" + tmp_arr + " = sp_IntArray_new();")
       tmp_i = new_temp
       emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_IntArray_length(" + rc + "); " + tmp_i + "++) {")
-      emit("    lv_" + bp1 + " = sp_IntArray_get(" + rc + ", " + tmp_i + ");")
+      emit("    mrb_int lv_" + bp1 + " = sp_IntArray_get(" + rc + ", " + tmp_i + ");")
       @indent = @indent + 1
       blk = @nd_block[nid]
       if blk >= 0
@@ -22028,7 +22042,7 @@ class Compiler
     if rt == "int_array"
       emit("  sp_IntArray *" + tmp_arr + " = sp_IntArray_new();")
       emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_IntArray_length(" + rc + "); " + tmp_i + "++) {")
-      emit("    lv_" + bp1 + " = sp_IntArray_get(" + rc + ", " + tmp_i + ");")
+      emit("    mrb_int lv_" + bp1 + " = sp_IntArray_get(" + rc + ", " + tmp_i + ");")
       @indent = @indent + 1
       blk = @nd_block[nid]
       if blk >= 0
@@ -22049,7 +22063,7 @@ class Compiler
       @needs_str_array = 1
       emit("  sp_StrArray *" + tmp_arr + " = sp_StrArray_new();")
       emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_StrArray_length(" + rc + "); " + tmp_i + "++) {")
-      emit("    lv_" + bp1 + " = sp_StrArray_get(" + rc + ", " + tmp_i + ");")
+      emit("    const char *lv_" + bp1 + " = sp_StrArray_get(" + rc + ", " + tmp_i + ");")
       @indent = @indent + 1
       blk = @nd_block[nid]
       if blk >= 0
@@ -22085,7 +22099,7 @@ class Compiler
     if rt == "int_array" || rt == "sym_array"
       emit("  sp_IntArray *" + tmp_arr + " = sp_IntArray_new();")
       emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_IntArray_length(" + rc + "); " + tmp_i + "++) {")
-      emit("    lv_" + bp1 + " = sp_IntArray_get(" + rc + ", " + tmp_i + ");")
+      emit("    mrb_int lv_" + bp1 + " = sp_IntArray_get(" + rc + ", " + tmp_i + ");")
       @indent = @indent + 1
       blk = @nd_block[nid]
       if blk >= 0

--- a/test/bm_int_array_each_with_index.rb
+++ b/test/bm_int_array_each_with_index.rb
@@ -1,0 +1,14 @@
+# Array#each_with_index on an int_array. The element block param must
+# shadow an outer same-named local of a different C type, and the
+# index block param must be block-local mrb_int (not leak the outer
+# `j`). Body skips reading the params to keep this scope-shadow case
+# separate from the format-specifier path.
+
+i = "hi"
+j = "ho"
+puts i
+puts j
+foo = [10, 20, 30]
+n = 0
+foo.each_with_index { |i, j| n = n + 1 }
+puts n   # 3

--- a/test/bm_int_array_each_with_object.rb
+++ b/test/bm_int_array_each_with_object.rb
@@ -1,0 +1,16 @@
+# Array#each_with_object on an int_array. The element block param
+# must shadow an outer same-named local of a different C type, and
+# the accumulator block param must take the C type of the seed
+# (here mrb_int) — not leak the outer `acc` (string). Body avoids
+# reading the params to keep this scope-shadow case separate from
+# the separate type-inferer behavior when reading the param inside
+# the block.
+
+i = "hi"
+acc = "ho"
+puts i
+puts acc
+foo = [10, 20, 30]
+n = 0
+foo.each_with_object(0) { |i, acc| n = n + 1 }
+puts n   # 3

--- a/test/bm_int_array_inject.rb
+++ b/test/bm_int_array_inject.rb
@@ -1,0 +1,10 @@
+# Array#inject on an int_array. inject and reduce share
+# compile_reduce_block, but inject has its own dispatch entry,
+# so cover it independently in case the entry points diverge.
+# Block param must shadow the outer same-named local.
+
+i = "hi"
+puts i
+foo = [1, 2, 3, 4, 5]
+sum = foo.inject(0) { |acc, i| acc + i }
+puts sum   # 15

--- a/test/bm_int_array_reduce.rb
+++ b/test/bm_int_array_reduce.rb
@@ -1,0 +1,8 @@
+# Array#reduce on an int_array. The element block param must shadow
+# an outer same-named local of a different C type.
+
+i = "hi"
+puts i
+foo = [1, 2, 3, 4, 5]
+sum = foo.reduce(0) { |acc, i| acc + i }
+puts sum   # 15

--- a/test/bm_int_array_reject.rb
+++ b/test/bm_int_array_reject.rb
@@ -1,0 +1,15 @@
+# Array#reject on an int_array. The block param must shadow an outer
+# same-named local of a different C type. Body uses a constant
+# predicate so this isolates the shadow case from the separate
+# type-inferer behavior when reading the param inside the block.
+
+i = "hi"
+puts i
+foo = [10, 20, 30]
+none = foo.reject { |i| true }
+puts none.length  # 0
+all = foo.reject { |i| false }
+puts all.length   # 3
+puts all[0]       # 10
+puts all[1]       # 20
+puts all[2]       # 30

--- a/test/bm_int_array_select.rb
+++ b/test/bm_int_array_select.rb
@@ -1,0 +1,15 @@
+# Array#select on an int_array. The block param must shadow an outer
+# same-named local of a different C type. Body uses a constant
+# predicate so this isolates the shadow case from the separate
+# type-inferer behavior when reading the param inside the block.
+
+i = "hi"
+puts i
+foo = [10, 20, 30]
+all = foo.select { |i| true }
+puts all.length   # 3
+puts all[0]       # 10
+puts all[1]       # 20
+puts all[2]       # 30
+none = foo.select { |i| false }
+puts none.length  # 0

--- a/test/bm_int_array_zip.rb
+++ b/test/bm_int_array_zip.rb
@@ -1,0 +1,13 @@
+# Array#zip with a block on int_arrays. Both block params must shadow
+# outer same-named locals of a different C type. Body uses a counter
+# so this isolates the scope-shadow case from any param-read path.
+
+a = "ha"
+b = "hb"
+puts a
+puts b
+foo = [1, 2, 3]
+bar = [10, 20, 30]
+n = 0
+foo.zip(bar) { |a, b| n = n + 1 }
+puts n   # 3

--- a/test/bm_str_array_each.rb
+++ b/test/bm_str_array_each.rb
@@ -1,0 +1,11 @@
+# Array#each on a str_array. The block param must shadow an outer
+# same-named mrb_int local. Body skips `puts i` to keep this scope-
+# shadow case separate from the format-specifier path.
+
+3.times do |i|
+  puts i
+end
+foo = ["a", "b", "c"]
+n = 0
+foo.each { |i| n = n + 1 }
+puts n   # 3


### PR DESCRIPTION
## Summary
Follow up: https://github.com/matz/spinel/issues/43#issuecomment-4326817577

- Emit block params for array iterators (each_with_index, each_with_object, zip, select, reject, inject, reduce, etc.) as freshly-declared block-local variables with the correct element C type, so they shadow outer same-named locals of a different type instead of leaking the outer type.
  - I modified only the methods I wanted to use.
- Rework each_with_object so the inner `{}` block scope still lets the expression form observe the final accumulator, by threading it through an outer-scope slot.
- Add benchmark/regression tests covering the scope-shadow case for each affected iterator on int_array (and each on str_array).

## Test plan
- [ ] Run the new test/bm_int_array_*.rb and test/bm_str_array_each.rb cases and confirm expected output.
- [ ] Run the existing codegen test suite to confirm no regression.