### PR TITLE
fix(codegen): infer SymbolNode as symbol in ivar init type, not string

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -4373,7 +4373,7 @@ class Compiler
       return "string"
     end
     if t == "SymbolNode"
-      return "string"
+      return "symbol"
     end
     if t == "TrueNode"
       return "bool"

--- a/test/symbol_ivar_reassign.rb
+++ b/test/symbol_ivar_reassign.rb
@@ -1,0 +1,25 @@
+# Reassigning an instance variable to a different symbol used to demote
+# its type to `poly` because `infer_ivar_init_type` reported `:foo` as
+# `string` while `infer_type` reported it as `symbol`. The mismatch
+# tripped `update_ivar_type`'s "old != new_type" branch, widening the
+# field to `sp_RbVal`. Subsequent assignments emitted `self->s = SPS_bar`
+# (sp_sym = mrb_int) into an `sp_RbVal` slot — a C type error.
+
+class C
+  def initialize
+    @s = :foo
+  end
+
+  def reset
+    @s = :bar
+  end
+
+  def show
+    @s
+  end
+end
+
+c = C.new
+puts c.show
+c.reset
+puts c.show


### PR DESCRIPTION
Reassigning an instance variable to a different symbol literal silently demotes it to `poly` and breaks compilation.

## Reproducer

```ruby
class C
  def initialize; @s = :foo; end
  def reset;      @s = :bar; end
  def show;       @s; end
end

c = C.new
puts c.show
c.reset
puts c.show
```

## Expected

```
foo
bar
```

## Actual

```
/tmp/_t.c:8:17: error: incompatible types when assigning to type ‘sp_RbVal’ from type ‘long int’
    8 | #define SPS_foo ((sp_sym)0)
      |                 ^
/tmp/_t.c:30:16: note: in expansion of macro ‘SPS_foo’
   30 |       self->s = SPS_foo;
      |                 ^~~~~~~
```

## Analysis and fix

`infer_ivar_init_type` returns `string` for `SymbolNode` while the general `infer_type` returns `symbol`. `scan_ivars` adds `@s` with type `string` from the first assignment; later, `scan_writer_calls` re-asks via `infer_type` and sees `symbol`, which doesn't match, so `update_ivar_type`'s catch-all branch widens the field to `poly`. The struct field becomes `sp_RbVal`, but the first assignment had already been compiled as `self->s = SPS_foo` (an `sp_sym`, i.e. `mrb_int`), and gcc rejects that.

Make `infer_ivar_init_type` return `symbol` for `SymbolNode` so both inference paths agree.

Adds `test/symbol_ivar_reassign.rb`.