### PR TITLE
fix(codegen): declare synthesized index for paramless Integer#step blocks

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -18390,14 +18390,27 @@ class Compiler
           end
         end
         bp1 = get_block_param(nid, 0)
+        synth = 0
         if bp1 == ""
           bp1 = "_i"
+          synth = 1
+        end
+        # When the block omits its parameter, the synthesized `_i` isn't
+        # declared anywhere — wrap the loop in a block scope and declare
+        # it locally. This also avoids redefinition errors when multiple
+        # paramless `step` blocks appear in the same function.
+        if synth == 1
+          emit("  {")
+          emit("  mrb_int lv_" + bp1 + " = 0;")
         end
         emit("  for (lv_" + bp1 + " = " + rc + "; lv_" + bp1 + " <= " + limit_val + "; lv_" + bp1 + " += " + step_val + ") {")
         @indent = @indent + 1
         compile_stmts_body(@nd_body[@nd_block[nid]])
         @indent = @indent - 1
         emit("  }")
+        if synth == 1
+          emit("  }")
+        end
         @in_loop = old
         return 1
       end

--- a/test/range_step_no_block_param.rb
+++ b/test/range_step_no_block_param.rb
@@ -1,0 +1,22 @@
+# When `Integer#step` is called with a do-block that omits its
+# parameter, the generated C used a synthesized `_i` index without
+# declaring it. Two paramless `step` blocks in the same function also
+# caused a redefinition error. Wrap each in a scoped block and declare
+# the synthesized variable locally.
+
+sum = 0
+
+# Single paramless step — `_i` was undeclared.
+1.step(10, 1) do
+  sum += 1
+end
+
+# Two paramless steps in the same scope — `_i` was redefined.
+1.step(5, 1) do
+  sum += 10
+end
+1.step(5, 1) do
+  sum += 100
+end
+
+puts sum


### PR DESCRIPTION
`Integer#step` with a do-block that omits its parameter referenced an undeclared `_i` index.

## Reproducer

```ruby
sum = 0
1.step(10, 1) do
  sum += 1
end
puts sum
```

## Expected

```
10
```

## Actual

```
/tmp/_step.c: In function ‘main’:
/tmp/_step.c:14:10: error: ‘lv__i’ undeclared (first use in this function)
   14 |     for (lv__i = 1; lv__i <= 10; lv__i += 1) {
      |          ^~~~~
```

## Analysis and fix

`compile_block_iteration_stmt` synthesizes `_i` as the index name when the block omits its parameter, but never declares it. Two paramless `step` blocks in the same function would hit `redefinition of 'lv__i'` for the same reason if the declaration *were* added without a scope.

Wrap the loop in a `{ ... }` block and emit `mrb_int lv__i = 0;` inside it when the block param is synthesized — the block scope makes the declaration local and side-steps the redefinition case at the same time.

Adds `test/range_step_no_block_param.rb`.