### PR TITLE
fix(codegen): emit side effects for void last stmt in Fiber body

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -12294,13 +12294,17 @@ class Compiler
         last = stmts.last
         # Compile last as statement for side effects, then capture value
         last_type = infer_type(last)
-        if @nd_type[last] == "LocalVariableWriteNode" || @nd_type[last] == "LocalVariableOperatorWriteNode"
+        if last_type == "void"
+          # Side-effect-only stmt (puts, print, etc.) — compile_expr would drop the call
           compile_stmt(last)
-          last_val = compile_expr(last)
+          emit("  _fb->yielded_value = sp_box_nil();")
         else
+          if @nd_type[last] == "LocalVariableWriteNode" || @nd_type[last] == "LocalVariableOperatorWriteNode"
+            compile_stmt(last)
+          end
           last_val = compile_expr(last)
+          emit("  _fb->yielded_value = " + box_val_to_poly(last_val, last_type) + ";")
         end
-        emit("  _fb->yielded_value = " + box_val_to_poly(last_val, last_type) + ";")
       end
     end
     pop_scope
@@ -17068,6 +17072,18 @@ class Compiler
       while k < stmts.length
         compile_stmt(stmts[k])
         k = k + 1
+      end
+      return
+    end
+    if t == "ParenthesesNode"
+      body = @nd_body[nid]
+      if body >= 0
+        pstmts = get_stmts(body)
+        pk = 0
+        while pk < pstmts.length
+          compile_stmt(pstmts[pk])
+          pk = pk + 1
+        end
       end
       return
     end


### PR DESCRIPTION
A `puts`/`print` as the last statement of a `Fiber.new` block was dropped from the generated C, so the call's side effect never ran. For example:

```ruby
fiber = Fiber.new do
  puts 'Hello'
  Fiber.yield
  puts 'Hello2'
end
fiber.resume
fiber.resume
```

Before: only `Hello` was printed. After: both `Hello` and `Hello2`.

The fiber-body codegen used `compile_expr` for the last stmt, but top-level `puts`/`print` only emit via `compile_call_stmt`. Added a `void` branch that calls `compile_stmt` and sets `yielded_value` to `sp_box_nil()`. Value-returning stmts (`Fiber.yield`, arithmetic, etc.) keep the existing `compile_expr` path.

Also fixed a related general issue noted in review: `compile_stmt` had no `ParenthesesNode` handler, so `(puts "hi")` in statement position would fall through to `compile_expr` and lose its side effect. Added a recursive case that compiles each inner stmt with `compile_stmt`. This makes the fiber fix work uniformly for parenthesized last stmts too, and fixes the same bug anywhere else parenthesized statements appear.

make test: 120 pass / 0 fail.