### PR TITLE
fix(codegen): poly_array follow-ups — shuffle, +, concat, each_with_object, flat_map

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -594,6 +594,9 @@ static sp_PolyArray *sp_PolyArray_new(void) { sp_PolyArray *a = (sp_PolyArray *)
 static void sp_PolyArray_push(sp_PolyArray *a, sp_RbVal v) { if (a->len >= a->cap) { a->cap = a->cap * 2 + 1; a->data = (sp_RbVal *)realloc(a->data, sizeof(sp_RbVal) * a->cap); } a->data[a->len++] = v; }
 static mrb_int sp_PolyArray_length(sp_PolyArray *a) { return a->len; }
 static sp_RbVal sp_PolyArray_get(sp_PolyArray *a, mrb_int i) { if (i < 0) i += a->len; return a->data[i]; }
+static sp_PolyArray *sp_PolyArray_dup(sp_PolyArray *a) { sp_PolyArray *b = sp_PolyArray_new(); for (mrb_int i = 0; i < a->len; i++) sp_PolyArray_push(b, a->data[i]); return b; }
+static void sp_PolyArray_shuffle_bang(sp_PolyArray *a) { for (mrb_int i = a->len - 1; i > 0; i--) { mrb_int j = (mrb_int)(rand() % (i + 1)); sp_RbVal t = a->data[i]; a->data[i] = a->data[j]; a->data[j] = t; } }
+static sp_PolyArray *sp_PolyArray_shuffle(sp_PolyArray *a) { sp_PolyArray *b = sp_PolyArray_dup(a); sp_PolyArray_shuffle_bang(b); return b; }
 
 /* Object#inspect for a tagged sp_RbVal. Dispatches on the runtime tag;
    each branch reuses the matching primitive inspect helper. Falls back

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -3022,6 +3022,9 @@ class Compiler
     if t == "sym_array"
       return "symbol"
     end
+    if t == "poly_array"
+      return "poly"
+    end
     if is_ptr_array_type(t) == 1
       return ptr_array_elem_type(t)
     end
@@ -20398,7 +20401,7 @@ class Compiler
     result = new_temp
     emit("  " + obj_ct + " " + result + " = " + obj_arg + ";")
     tmp_i = new_temp
-    if rt == "int_array" || rt == "str_array" || rt == "float_array" || rt == "sym_array"
+    if rt == "int_array" || rt == "str_array" || rt == "float_array" || rt == "sym_array" || rt == "poly_array"
       pfx = array_c_prefix(rt)
       emit("  {")
       @indent = @indent + 1

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -18103,7 +18103,7 @@ class Compiler
     if mname == "concat"
       if recv >= 0
         rt = infer_type(recv)
-        if rt == "int_array" || rt == "str_array" || rt == "float_array" || rt == "sym_array"
+        if rt == "int_array" || rt == "str_array" || rt == "float_array" || rt == "sym_array" || rt == "poly_array"
           rc = compile_expr_gc_rooted(recv)
           arg = compile_arg0(nid)
           pfx = array_c_prefix(rt)

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -3503,6 +3503,9 @@ class Compiler
     if t == "float_array"
       return "FloatArray"
     end
+    if t == "poly_array"
+      return "PolyArray"
+    end
     "IntArray"
   end
 

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -8558,6 +8558,9 @@ class Compiler
     emit_raw("static void sp_PolyArray_push(sp_PolyArray *a, sp_RbVal v) { if (a->len >= a->cap) { a->cap = a->cap * 2 + 1; a->data = (sp_RbVal *)realloc(a->data, sizeof(sp_RbVal) * a->cap); } a->data[a->len++] = v; }")
     emit_raw("static mrb_int sp_PolyArray_length(sp_PolyArray *a) { return a->len; }")
     emit_raw("static sp_RbVal sp_PolyArray_get(sp_PolyArray *a, mrb_int i) { if (i < 0) i += a->len; return a->data[i]; }")
+    emit_raw("static sp_PolyArray *sp_PolyArray_dup(sp_PolyArray *a) { sp_PolyArray *b = sp_PolyArray_new(); for (mrb_int i = 0; i < a->len; i++) sp_PolyArray_push(b, a->data[i]); return b; }")
+    emit_raw("static void sp_PolyArray_shuffle_bang(sp_PolyArray *a) { for (mrb_int i = a->len - 1; i > 0; i--) { mrb_int j = (mrb_int)(rand() % (i + 1)); sp_RbVal t = a->data[i]; a->data[i] = a->data[j]; a->data[j] = t; } }")
+    emit_raw("static sp_PolyArray *sp_PolyArray_shuffle(sp_PolyArray *a) { sp_PolyArray *b = sp_PolyArray_dup(a); sp_PolyArray_shuffle_bang(b); return b; }")
     emit_raw("")
   end
 
@@ -14560,13 +14563,13 @@ class Compiler
       return "sp_" + pfx + "_get(" + rc + ", rand() % sp_" + pfx + "_length(" + rc + "))"
     end
     if mname == "shuffle" &&
-       (recv_type == "int_array" || recv_type == "str_array" || recv_type == "float_array")
+       (recv_type == "int_array" || recv_type == "str_array" || recv_type == "float_array" || recv_type == "sym_array" || recv_type == "poly_array")
       @needs_rand = 1
       pfx = array_c_prefix(recv_type)
       return "sp_" + pfx + "_shuffle(" + rc + ")"
     end
     if mname == "shuffle!" &&
-       (recv_type == "int_array" || recv_type == "str_array" || recv_type == "float_array")
+       (recv_type == "int_array" || recv_type == "str_array" || recv_type == "float_array" || recv_type == "sym_array" || recv_type == "poly_array")
       @needs_rand = 1
       pfx = array_c_prefix(recv_type)
       emit("  sp_" + pfx + "_shuffle_bang(" + rc + ");")

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -1667,7 +1667,7 @@ class Compiler
         if lt == "poly"
           return "poly"
         end
-        if lt == "int_array" || lt == "str_array" || lt == "float_array" || lt == "sym_array" || lt == "poly_array"
+        if is_array_type(lt) == 1
           return lt
         end
         if lt == "float"
@@ -2371,7 +2371,7 @@ class Compiler
             if bbs.length > 0
               bret = infer_type(bbs.last)
               # If block returns an array type, use it as result type
-              if bret == "int_array" || bret == "str_array" || bret == "float_array" || bret == "sym_array" || bret == "poly_array"
+              if is_array_type(bret) == 1
                 return bret
               end
             end
@@ -3510,6 +3510,20 @@ class Compiler
       return "PolyArray"
     end
     "IntArray"
+  end
+
+  # The canonical "is this an array type?" check. Use this when you need
+  # to dispatch a method that's defined for every typed array — `+`,
+  # `concat`, `shuffle`, `each_with_object`, `flat_map`, etc. Covers the
+  # 5 typed arrays (int/str/float/sym/poly). *_ptr_array is intentionally
+  # excluded for now: sp_PtrArray lacks `_dup`/`_shuffle` and several
+  # other helpers, and the existing dispatchers don't route ptr_array
+  # through this path correctly even on master.
+  def is_array_type(t)
+    if t == "int_array" || t == "str_array" || t == "float_array" || t == "sym_array" || t == "poly_array"
+      return 1
+    end
+    0
   end
 
   # ---- Collection pass ----
@@ -13290,7 +13304,7 @@ class Compiler
         @needs_string_helpers = 1
         return "sp_poly_add(" + compile_expr(recv) + ", " + box_expr_to_poly(@nd_arguments[nid] >= 0 ? get_args(@nd_arguments[nid])[0] : -1) + ")"
       end
-      if lt == "int_array" || lt == "str_array" || lt == "float_array" || lt == "sym_array" || lt == "poly_array"
+      if is_array_type(lt) == 1
         rc = compile_expr_gc_rooted(recv)
         arg = compile_arg0(nid)
         pfx = array_c_prefix(lt)
@@ -14379,7 +14393,7 @@ class Compiler
     # the same method name (e.g. (poly).to_s, (int).to_s) fall through
     # to their own scalar dispatchers.
     if mname == "inspect" || mname == "to_s"
-      if recv_type == "int_array" || recv_type == "float_array" || recv_type == "str_array" || recv_type == "sym_array" || recv_type == "poly_array"
+      if is_array_type(recv_type) == 1
         r = compile_inspect_for(recv_type, rc)
         if r != ""
           return r
@@ -14565,14 +14579,12 @@ class Compiler
       pfx = array_c_prefix(recv_type)
       return "sp_" + pfx + "_get(" + rc + ", rand() % sp_" + pfx + "_length(" + rc + "))"
     end
-    if mname == "shuffle" &&
-       (recv_type == "int_array" || recv_type == "str_array" || recv_type == "float_array" || recv_type == "sym_array" || recv_type == "poly_array")
+    if mname == "shuffle" && is_array_type(recv_type) == 1
       @needs_rand = 1
       pfx = array_c_prefix(recv_type)
       return "sp_" + pfx + "_shuffle(" + rc + ")"
     end
-    if mname == "shuffle!" &&
-       (recv_type == "int_array" || recv_type == "str_array" || recv_type == "float_array" || recv_type == "sym_array" || recv_type == "poly_array")
+    if mname == "shuffle!" && is_array_type(recv_type) == 1
       @needs_rand = 1
       pfx = array_c_prefix(recv_type)
       emit("  sp_" + pfx + "_shuffle_bang(" + rc + ");")
@@ -18106,7 +18118,7 @@ class Compiler
     if mname == "concat"
       if recv >= 0
         rt = infer_type(recv)
-        if rt == "int_array" || rt == "str_array" || rt == "float_array" || rt == "sym_array" || rt == "poly_array"
+        if is_array_type(rt) == 1
           rc = compile_expr_gc_rooted(recv)
           arg = compile_arg0(nid)
           pfx = array_c_prefix(rt)
@@ -20401,7 +20413,7 @@ class Compiler
     result = new_temp
     emit("  " + obj_ct + " " + result + " = " + obj_arg + ";")
     tmp_i = new_temp
-    if rt == "int_array" || rt == "str_array" || rt == "float_array" || rt == "sym_array" || rt == "poly_array"
+    if is_array_type(rt) == 1
       pfx = array_c_prefix(rt)
       emit("  {")
       @indent = @indent + 1
@@ -21162,7 +21174,7 @@ class Compiler
       end
     end
     # Fall back to receiver type if block doesn't return an array
-    if block_ret != "int_array" && block_ret != "str_array" && block_ret != "float_array" && block_ret != "sym_array" && block_ret != "poly_array"
+    if is_array_type(block_ret) == 0
       block_ret = rt
     end
     @needs_gc = 1

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -1667,7 +1667,7 @@ class Compiler
         if lt == "poly"
           return "poly"
         end
-        if lt == "int_array" || lt == "str_array" || lt == "float_array" || lt == "sym_array"
+        if lt == "int_array" || lt == "str_array" || lt == "float_array" || lt == "sym_array" || lt == "poly_array"
           return lt
         end
         if lt == "float"
@@ -13287,7 +13287,7 @@ class Compiler
         @needs_string_helpers = 1
         return "sp_poly_add(" + compile_expr(recv) + ", " + box_expr_to_poly(@nd_arguments[nid] >= 0 ? get_args(@nd_arguments[nid])[0] : -1) + ")"
       end
-      if lt == "int_array" || lt == "str_array" || lt == "float_array" || lt == "sym_array"
+      if lt == "int_array" || lt == "str_array" || lt == "float_array" || lt == "sym_array" || lt == "poly_array"
         rc = compile_expr_gc_rooted(recv)
         arg = compile_arg0(nid)
         pfx = array_c_prefix(lt)

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2371,7 +2371,7 @@ class Compiler
             if bbs.length > 0
               bret = infer_type(bbs.last)
               # If block returns an array type, use it as result type
-              if bret == "int_array" || bret == "str_array" || bret == "float_array" || bret == "sym_array"
+              if bret == "int_array" || bret == "str_array" || bret == "float_array" || bret == "sym_array" || bret == "poly_array"
                 return bret
               end
             end
@@ -21162,7 +21162,7 @@ class Compiler
       end
     end
     # Fall back to receiver type if block doesn't return an array
-    if block_ret != "int_array" && block_ret != "str_array" && block_ret != "float_array" && block_ret != "sym_array"
+    if block_ret != "int_array" && block_ret != "str_array" && block_ret != "float_array" && block_ret != "sym_array" && block_ret != "poly_array"
       block_ret = rt
     end
     @needs_gc = 1
@@ -21179,6 +21179,8 @@ class Compiler
       elem_type = "string"
     elsif rt == "float_array"
       elem_type = "float"
+    elsif rt == "poly_array"
+      elem_type = "poly"
     end
     declare_var(bp1, elem_type)
     emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_" + pfx_src + "_length(" + rc + "); " + tmp_i + "++) {")

--- a/test/array_concat_poly.rb
+++ b/test/array_concat_poly.rb
@@ -1,0 +1,6 @@
+# Array#concat on a poly_array used to silently miss the type-check and
+# the loop never ran, so the receiver kept its original length.
+
+a = [1, "x"]
+a.concat([2, "y"])
+puts a.length

--- a/test/array_each_with_object_poly.rb
+++ b/test/array_each_with_object_poly.rb
@@ -1,0 +1,6 @@
+# Array#each_with_object on a poly_array used to silently miss the
+# type-check; the loop body never ran.
+
+n = 0
+[1, "a", :sym].each_with_object("") {|_elem, _acc| n += 1 }
+puts n

--- a/test/array_flat_map_poly.rb
+++ b/test/array_flat_map_poly.rb
@@ -1,0 +1,6 @@
+# Array#flat_map where the block returns a poly_array failed to type
+# the result; the inferred receiver-array type clashed with the
+# generated sp_PolyArray * inner accumulator.
+
+a = [1, 2].flat_map { |x| [x, x.to_s] }
+puts a.length

--- a/test/array_plus_poly.rb
+++ b/test/array_plus_poly.rb
@@ -1,0 +1,7 @@
+# Array#+ on a poly_array used to fall through to the C `+` operator
+# applied to two `sp_PolyArray *` pointers — a compile error.
+
+a = [1, "x"]
+b = [2, "y"]
+c = a + b
+puts c.length

--- a/test/array_shuffle_sym_poly.rb
+++ b/test/array_shuffle_sym_poly.rb
@@ -1,0 +1,11 @@
+# Array#shuffle / Array#shuffle! used to skip sym_array and poly_array.
+# For sym_array the dispatcher silently fell through (bin output empty);
+# for poly_array the runtime had no shuffle helper at all.
+
+# sym_array
+sa = [:a, :b, :c, :d].shuffle
+puts sa.length
+
+# poly_array
+pa = [1, "a", :s, 2.0].shuffle
+puts pa.length


### PR DESCRIPTION
Several Array methods didn't pick up `poly_array` (heterogeneous arrays) when that type was introduced. The dispatch sites kept their original `int_array | str_array | float_array | sym_array` lists and either fell through silently or compiled to the wrong runtime call.

## Reproducers

```ruby
# 1. shuffle (sym_array also affected; bin output is empty on master)
puts [1, "a", :s, 2.0].shuffle.length

# 2. +
a = [1, "x"]; b = [2, "y"]
puts (a + b).length

# 3. concat
a = [1, "x"]; a.concat([2, "y"])
puts a.length

# 4. each_with_object
n = 0
[1, "a", :sym].each_with_object("") {|_e, _a| n += 1 }
puts n

# 5. flat_map (block returns a heterogeneous array)
puts [1, 2].flat_map { |x| [x, x.to_s] }.length
```

## Expected

```
4
4
4
3
4
```

## Actual

```
# 1. shuffle
(empty — ran but produced no output; lv_arr ended up `0` because the
dispatch fell through and the result temp was never assigned)

# 2. +
/tmp/_t.c:24:18: error: invalid operands to binary +
(have 'sp_PolyArray *' and 'sp_PolyArray *')

# 3. concat
2     # the loop was never emitted; receiver kept its original length

# 4. each_with_object
0     # body never ran

# 5. flat_map
/tmp/_t.c:28:26: error: initialization of 'sp_IntArray *' from
incompatible pointer type 'sp_PolyArray *'
```

## Analysis and fix

Each of these sites checked the receiver (or block return) type against an explicit list. The list pre-dated the poly_array type, so the new type just wasn't in it — the check returned false, and the dispatcher either fell through or used the IntArray fallback in `array_c_prefix`. They're all the same kind of miss; commits split per method:

1. `array_c_prefix`: map `poly_array → "PolyArray"` so callers don't need a per-call ternary.
2. `Array#shuffle / shuffle!`: extend the type list to include `sym_array` (uses the IntArray runtime internally) and `poly_array` (new `sp_PolyArray_dup` / `_shuffle{_bang}` runtime helpers).
3. `Array#+`: extend both `infer_call_type` (so the result type is poly_array) and `compile_operator_call_expr`.
4. `Array#concat`: extend the receiver-type check.
5. `Array#each_with_object`: extend the receiver-type check; let `elem_type_of_array` map poly_array → "poly" so the block param is typed `sp_RbVal`.
6. `Array#flat_map`: extend the block-return recognition (in `infer_call_type`) and the accumulator typing (in `compile_flat_map_expr`).
7. After the above, eight sites independently spelled out the same `int_array | str_array | float_array | sym_array | poly_array` predicate. Factor it into `is_array_type` and use it at those sites. *_ptr_array stays out of the helper — `sp_PtrArray` lacks several helpers (`_dup`, `_shuffle`, …) and the dispatchers don't route ptr_array correctly even on master, so that's a separate concern.

Each fix has its own reproducer test in `test/`.