### PR TITLE
fix(codegen): exclude classes stored in ptr_array from value-type optimization

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -9359,6 +9359,30 @@ class Compiler
     ""
   end
 
+  def detect_ptr_array_stored_types
+    # Find object types `obj_<C>` that appear as the element type of an
+    # array literal. Such an array becomes a `sp_PtrArray *` whose
+    # `_push` takes `void *`; if `<C>` were optimized into a value type
+    # then `sp_<C>_new(...)` would return the struct by value and the
+    # generated push call would be a C type error.
+    @ptr_array_stored_types = "".split(",")
+    nid = 0
+    while nid < @nd_type.length
+      if @nd_type[nid] == "ArrayNode"
+        at = infer_array_elem_type(nid)
+        if is_ptr_array_type(at) == 1
+          obj_t = ptr_array_elem_type(at)
+          if is_obj_type(obj_t) == 1
+            if not_in(obj_t, @ptr_array_stored_types) == 1
+              @ptr_array_stored_types.push(obj_t)
+            end
+          end
+        end
+      end
+      nid = nid + 1
+    end
+  end
+
   def detect_param_mutated_types
     # Find classes whose instances are mutated when passed as method parameters
     @param_mutated_types = "".split(",")
@@ -9491,6 +9515,7 @@ class Compiler
     auto_register_attr_readers
     auto_register_attr_writers
     detect_param_mutated_types
+    detect_ptr_array_stored_types
     # Multiple passes: value type detection depends on other classes
     2.times do
       i = 0
@@ -9542,6 +9567,20 @@ class Compiler
                 all_val = 0
               end
               pmi = pmi + 1
+            end
+          end
+          # Exclude classes whose instances are pushed into a ptr_array
+          # (array literal of `obj_<C>` becomes a `sp_PtrArray *` whose
+          # `_push` takes `void *`; a value-type return from `Foo.new`
+          # is a struct by value and can't be passed through `void *`).
+          if all_val == 1
+            type_str = "obj_" + @cls_names[i]
+            psi = 0
+            while psi < @ptr_array_stored_types.length
+              if @ptr_array_stored_types[psi] == type_str
+                all_val = 0
+              end
+              psi = psi + 1
             end
           end
           if all_val == 1

--- a/test/ptr_array_of_value_class.rb
+++ b/test/ptr_array_of_value_class.rb
@@ -1,0 +1,15 @@
+# A class with no attr_writers / no mutating methods is normally
+# compiled as a value type — `sp_Foo_new(x)` returns the struct by
+# value. But when its instances are stored in an array literal, the
+# inferred container is `obj_Foo_ptr_array` (`sp_PtrArray *`), whose
+# `_push` takes `void *`. The push call ended up emitting
+# `sp_PtrArray_push(arr, sp_Foo_new(1))`, which doesn't compile.
+
+class Foo
+  def initialize(x); @x = x; end
+  attr_reader :x
+end
+
+arr = [Foo.new(1), Foo.new(2), Foo.new(3)]
+puts arr.length
+arr.each {|f| puts f.x }


### PR DESCRIPTION
A class without attr_writers / mutating methods is normally optimized into a value type (`sp_Foo_new(x)` returns the struct by value, locals hold the struct directly). When such a class is also stored in an array literal, the inferred container is `obj_<C>_ptr_array` (`sp_PtrArray *`), whose `_push` takes `void *` — a struct by value can't fit.

## Reproducer

```ruby
class Foo
  def initialize(x); @x = x; end
  attr_reader :x
end

arr = [Foo.new(1), Foo.new(2), Foo.new(3)]
puts arr.length
arr.each {|f| puts f.x }
```

## Expected

```
3
1
2
3
```

## Actual

```
/tmp/_t.c:43:27: error: incompatible type for argument 2 of ‘sp_PtrArray_push’
   43 |     sp_PtrArray_push(_t1, sp_Foo_new(1));
      |                           ^~~~~~~~~~~~~
      |                           sp_Foo {aka struct sp_Foo_s}
note: expected ‘void *’ but argument is of type ‘sp_Foo’
```

The bug fires whenever a value-type-eligible class is referenced from a literal `[Foo.new(...)]` anywhere in the program.

## Analysis and fix

`sp_PtrArray` stores elements as `void *`, so anything pushed into it needs heap-pointer identity. A value-type Foo by definition lives unboxed (stack, struct field, …) and can't satisfy that. The two ways to fix it are:

1. Heap-allocate at push time, returning a `sp_Foo *` for the array slot. That makes `arr[i].x` need to become `arr[i]->x`, cascading through every accessor codegen.
2. Don't optimize Foo as a value type if it ever lands in a ptr_array. Foo stays heap-allocated as `sp_Foo *`; Spinel's existing non-value-type code path handles everything as-is.

This PR takes (2). Add `detect_ptr_array_stored_types`: scan the AST for `ArrayNode`s whose inferred type is an `obj_<C>_ptr_array`, and exclude `<C>` from the value-type pass — parallel to the existing `detect_param_mutated_types` exclusion.

The trade-off is that any program containing even an unused `[Foo.new(...)]` literal loses the value-type optimization for Foo. In exchange the construction actually compiles, and existing accessors don't move.

Adds `test/ptr_array_of_value_class.rb`.