### PR TITLE
fix(codegen): skip Array method dispatch on non-array receivers

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -14907,8 +14907,15 @@ class Compiler
   end
 
   def compile_array_method_expr(nid, mname, rc, recv_type)
-    # Skip non-array types
-    if recv_type == "str_int_hash" || recv_type == "str_str_hash"
+    # Skip non-array types. Without this guard a user class with a
+    # method whose name happens to overlap an Array method (e.g.
+    # `def sample`, `def first`) would be dispatched as that Array
+    # method, with `array_c_prefix` falling back to `IntArray` and
+    # the receiver pointer used as if it were an `sp_IntArray *`.
+    # `is_array_type` deliberately omits *_ptr_array (see its
+    # docstring), so include it explicitly here — Array#length, #[],
+    # #each, … all work on a ptr_array via `sp_PtrArray_*`.
+    if is_array_type(recv_type) == 0 && is_ptr_array_type(recv_type) == 0
       return ""
     end
     # Array#inspect and Array#to_s (CRuby aliases them for arrays, so

--- a/test/array_method_name_clash.rb
+++ b/test/array_method_name_clash.rb
@@ -1,0 +1,15 @@
+# A user class with a method whose name overlaps an Array method (e.g.
+# `def sample`, `def first`) used to compile to the Array dispatch even
+# when the receiver wasn't an array. `array_c_prefix` falls back to
+# `IntArray`, so e.g. `m.sample` on `sp_Mixer *` emitted
+# `sp_IntArray_get(m, rand() % sp_IntArray_length(m))` and gcc rejected
+# the pointer-type mismatch.
+
+class Mixer
+  def sample
+    42
+  end
+end
+
+m = Mixer.new
+puts m.sample


### PR DESCRIPTION
A user class with a method whose name happens to overlap an Array method (e.g. `def sample`, `def first`) was dispatched as the Array variant, with `array_c_prefix` falling back to `IntArray`, so the receiver pointer was used as if it were an `sp_IntArray *`.

## Reproducer

```ruby
class Mixer
  def sample
    42
  end
end

puts Mixer.new.sample
```

## Expected

```
42
```

## Actual

```
/tmp/_arr.c: In function ‘main’:
/tmp/_arr.c:39:83: error: passing argument 1 of ‘sp_IntArray_length’ from incompatible pointer type [-Wincompatible-pointer-types]
   39 |     printf("%lld\n", (long long)sp_IntArray_get(lv_m, rand() % sp_IntArray_length(lv_m)));
      |                                                                                   ^~~~
      |                                                                                   sp_Mixer * {aka struct sp_Mixer_s *}
note: expected ‘sp_IntArray *’ but argument is of type ‘sp_Mixer *’ {aka ‘struct sp_Mixer_s *’}
```

## Analysis and fix

`compile_array_method_expr` only skipped two specific hash types (`str_int_hash`, `str_str_hash`) and otherwise ran the Array path for any receiver. For a user-class receiver, the dispatcher matched `sample` against Array#sample, picked `array_c_prefix(recv_type)` which falls back to `"IntArray"`, and emitted `sp_IntArray_get(m, rand() % sp_IntArray_length(m))` against the `sp_Mixer *` value.

Replace the narrow hash-only skip with a positive `is_array_type` check (introduced in #82). On anything else the dispatcher returns `""` and the call falls through to the user-class lookup, which finds `Mixer#sample` and emits `sp_Mixer_sample(m)` as expected.

Adds `test/array_method_name_clash.rb`.