### PR TITLE
feat(codegen): support Array#* (repeat) for typed arrays

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -1726,6 +1726,10 @@ class Compiler
         if lt == "poly"
           return "poly"
         end
+        if is_array_type(lt) == 1
+          # Array#* (repeat) yields another array of the same element type.
+          return lt
+        end
         # Check RHS for float promotion
         args_id = @nd_arguments[nid]
         if args_id >= 0
@@ -3551,6 +3555,19 @@ class Compiler
       return 1
     end
     0
+  end
+
+  # Set the right @needs_<runtime> flag for the given array type.
+  def mark_array_runtime_needs(t)
+    if t == "float_array"
+      @needs_float_array = 1
+    elsif t == "str_array"
+      @needs_str_array = 1
+    elsif t == "poly_array"
+      @needs_rb_value = 1
+    else
+      @needs_int_array = 1
+    end
   end
 
   # ---- Collection pass ----
@@ -13862,6 +13879,22 @@ class Compiler
       if lt == "poly"
         @needs_rb_value = 1
         return "sp_poly_mul(" + compile_expr(recv) + ", " + box_expr_to_poly(get_args(@nd_arguments[nid])[0]) + ")"
+      end
+      if is_array_type(lt) == 1
+        # All array kinds expose `_new` / `_length` / `_get` / `_push` with
+        # the same shape, so the repeat loop is a single template
+        # parameterized by the C prefix.
+        mark_array_runtime_needs(lt)
+        @needs_gc = 1
+        pfx = array_c_prefix(lt)
+        tmp = new_temp
+        src = new_temp
+        cnt = new_temp
+        emit("  sp_" + pfx + " *" + src + " = " + compile_expr(recv) + ";")
+        emit("  mrb_int " + cnt + " = " + compile_arg0(nid) + ";")
+        emit("  sp_" + pfx + " *" + tmp + " = sp_" + pfx + "_new();")
+        emit("  { mrb_int _mi; mrb_int _sl = sp_" + pfx + "_length(" + src + "); for (_mi = 0; _mi < " + cnt + "; _mi++) { mrb_int _mj; for (_mj = 0; _mj < _sl; _mj++) sp_" + pfx + "_push(" + tmp + ", sp_" + pfx + "_get(" + src + ", _mj)); } }")
+        return tmp
       end
       return "(" + compile_expr(recv) + " * " + compile_arg0(nid) + ")"
     end

--- a/test/array_mul.rb
+++ b/test/array_mul.rb
@@ -1,0 +1,49 @@
+# Array#* (repeat). Works uniformly across every typed array kind
+# is_array_type() recognises (int / float / str / sym / poly).
+
+# IntArray
+ints = [1, 2, 3] * 3
+puts ints.length      # 9
+puts ints[0]          # 1
+puts ints[3]          # 1
+puts ints[8]          # 3
+
+# IntArray * 0 → empty
+empty = [1, 2, 3] * 0
+puts empty.length     # 0
+
+# IntArray * 1 → copy (independent of source)
+arr = [1, 2]
+copy = arr * 1
+arr.push(99)
+puts copy.length      # 2
+
+# FloatArray
+floats = [1.5, 2.5] * 2
+puts floats.length    # 4
+puts floats[0]        # 1.5
+puts floats[3]        # 2.5
+
+# StrArray
+strs = ["a", "b"] * 3
+puts strs.length      # 6
+puts strs[0]          # a
+puts strs[5]          # b
+
+# SymArray
+syms = [:x, :y] * 2
+puts syms.length      # 4
+puts syms[0]          # x
+puts syms[3]          # y
+
+# PolyArray (mixed types)
+mixed = [1, "two", 3.0] * 2
+puts mixed.length     # 6
+
+# Pre-fill an array
+zeros = [0] * 5
+puts zeros.length     # 5
+puts zeros[0]         # 0
+puts zeros[4]         # 0
+
+puts "done"


### PR DESCRIPTION
## Summary

`arr * n` was unhandled — it fell through to the default `*` operator and
emitted `(ptr * int)` in C, a type error that prevented patterns like
`@prg_ref = [nil] * 0x10000` from compiling at all.

Add codegen and type inference for the repeat form across every typed
array kind `is_array_type` recognises (int / float / str / sym / poly).
All five share the same `_new` / `_length` / `_get` / `_push` runtime
shape, so the emitted loop is a single template parameterized by
`array_c_prefix(lt)` — no per-type duplication.

`*_ptr_array` inherits its existing exclusion from `is_array_type`
(sp_PtrArray lacks `_dup`/`_shuffle` and friends), so it is not in
scope here.

## Notes

- Adds a small `mark_array_runtime_needs(t)` helper that picks the right
  `@needs_<runtime>` flag for an array type. The same 4-way switch was
  already open-coded in zip / `+` / concat / etc.; this PR introduces
  the helper and uses it at the new site, leaving the existing
  duplications alone for a later sweep.
- Type inference (the `infer_operator_type` `*` branch) returns the
  receiver's array type, matching how Ruby's `Array#*` works.

## Test plan

- [x] `test/array_mul.rb` covers int / float / str / sym / poly arrays,
      `n = 0`, `n = 1` (independence from source after later mutation),
      and the `[0] * 5` preallocation idiom
- [x] `make bootstrap` (gen2 == gen3 fixpoint holds)
- [x] `make test` — 137/137 pass on linux