### PR TITLE
fix(codegen): promote local sym_array type after empty-then-push (#85)

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -11069,6 +11069,19 @@ class Compiler
                   end
                   ki = ki + 1
                 end
+              elsif arg_type == "symbol"
+                # sym_array uses sp_IntArray storage, so int_array
+                # helpers stay required even after promotion.
+                @needs_int_array = 1
+                ki = 0
+                while ki < names.length
+                  if names[ki] == arr_name
+                    if types[ki] == "int_array"
+                      types[ki] = "sym_array"
+                    end
+                  end
+                  ki = ki + 1
+                end
               end
             end
           end
@@ -17443,8 +17456,11 @@ class Compiler
       end
       vref = fiber_var_ref(lname)
       vt = find_var_type(lname)
-      # Empty array literal: create the correct array type
-      if vt == "str_array" || vt == "float_array" || is_ptr_array_type(vt) == 1
+      # Empty array literal: create the correct array type. Returning
+      # early here also preserves the scope's already-promoted type
+      # (issue #58, #85) — the fall-through path below would clobber
+      # vt with infer_type([])'s "int_array" via set_var_type.
+      if vt == "str_array" || vt == "float_array" || vt == "sym_array" || is_ptr_array_type(vt) == 1
         expr_id = @nd_expression[nid]
         if expr_id >= 0 && @nd_type[expr_id] == "ArrayNode"
           elems = parse_id_list(@nd_elements[expr_id])
@@ -17457,6 +17473,11 @@ class Compiler
               @needs_float_array = 1
               @needs_gc = 1
               emit("  " + vref + " = sp_FloatArray_new();")
+            elsif vt == "sym_array"
+              # sym_array shares sp_IntArray storage.
+              @needs_int_array = 1
+              @needs_gc = 1
+              emit("  " + vref + " = sp_IntArray_new();")
             else
               @needs_ptr_array = 1
               @needs_gc = 1


### PR DESCRIPTION
  Fixes #85.

  ## Summary

  `puts syms[i]` on a `sym_array` printed the symbol id instead of the
  name when `syms` was built up via `[]` + `push(:sym)` rather than a
  non-empty array literal:

  ```ruby
  syms = []
  syms.push(:tag)
  syms.push(:more)
  puts syms[0]   # printed: 0   (expected: tag)
  ```
  Root cause

  The issue body suspected a missing case in compile_puts's CallNode["[]"] branch, but infer_method_name_type already returns "symbol" for sym_array[i] and compile_puts already has the at == "symbol" branch. The bug was upstream: the variable's tracked Ruby type never reached sym_array, so infer_type(syms[0]) returned "int" and element access fell through to the printf-int path.

  Two paths needed the missing case:

  1. scan_locals push-promotion pass. Already promoted
  2. scan_locals push-promotion pass. Already promoted int_array → str_array / float_array / *_ptr_array based on the type of the pushed element; missed symbol → sym_array.
  3. compile_stmt LocalVariableWriteNode empty-array early-return. Special-cased str_array / float_array / *_ptr_array to avoid the fall-through set_var_type(lname, infer_type([])) stomping the scope's already-promoted type back to int_array. Missed sym_array.

  Adding sym_array to both sites mirrors the existing str_array and float_array handling. sym_array shares sp_IntArray storage, so the empty-literal case emits sp_IntArray_new() and sets @needs_int_array = 1.

  Test plan

  - Original issue reproducer (syms = [:tag, :more]; puts syms[0]) — was already passing, still passes
  - Empty-then-push reproducer — was failing, now passes (.push and <<)
  - make bootstrap — gen2.c == gen3.c (byte-identical self-host)