### PR TITLE
fix(codegen): emit GC scan function for tuples holding GC pointers

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -3083,6 +3083,34 @@ class Compiler
     "sp_Tuple_" + tuple_elem_types_str(t).split(",").join("_")
   end
 
+  # Whether a tuple element type must be traced by the GC scan function.
+  # Scalars (int/float/bool/symbol) are pure values; pointer-to-GC-object
+  # element types must be marked, otherwise the GC frees the inner object
+  # while the tuple keeps a dangling pointer.
+  def tuple_field_needs_mark(et)
+    if et == "poly"
+      return 1
+    end
+    if et == "int" || et == "float" || et == "bool" || et == "symbol" || et == "void" || et == "nil"
+      return 0
+    end
+    type_is_pointer(et)
+  end
+
+  # Returns the scan function name for the tuple, or "NULL" if no field
+  # requires marking.
+  def tuple_scan_name(t)
+    parts = tuple_elem_types_str(t).split(",")
+    fi = 0
+    while fi < parts.length
+      if tuple_field_needs_mark(parts[fi]) == 1
+        return tuple_c_name(t) + "_scan"
+      end
+      fi = fi + 1
+    end
+    "NULL"
+  end
+
   def register_tuple_type(t)
     if is_tuple_type(t) == 1
       k = 0
@@ -8076,6 +8104,33 @@ class Compiler
         @deferred_tuple << " } "
         @deferred_tuple << name
         @deferred_tuple << ";\n"
+        # GC scan function — only emit when at least one field is a GC ref.
+        # Without this the tuple's children are collected while the tuple
+        # itself is still alive, leaving dangling pointers in the fields.
+        needs_scan = 0
+        fi = 0
+        while fi < parts.length
+          if tuple_field_needs_mark(parts[fi]) == 1
+            needs_scan = 1
+          end
+          fi = fi + 1
+        end
+        if needs_scan == 1
+          body = ""
+          fi = 0
+          while fi < parts.length
+            if tuple_field_needs_mark(parts[fi]) == 1
+              field = "_t->_" + fi.to_s
+              if parts[fi] == "poly"
+                body = body + " sp_mark_rbval(" + field + ");"
+              else
+                body = body + " sp_gc_mark((void *)" + field + ");"
+              end
+            end
+            fi = fi + 1
+          end
+          @deferred_tuple << "static void " + name + "_scan(void *_p) { " + name + " *_t = (" + name + " *)_p;" + body + " }\n"
+        end
         k = k + 1
       end
     end
@@ -14302,7 +14357,7 @@ class Compiler
       tname = tuple_c_name(tt)
       sep = compile_arg0(nid)
       tmp = new_temp
-      emit("  " + tname + " *" + tmp + " = (" + tname + " *)sp_gc_alloc(sizeof(" + tname + "), NULL, NULL);")
+      emit("  " + tname + " *" + tmp + " = (" + tname + " *)sp_gc_alloc(sizeof(" + tname + "), NULL, " + tuple_scan_name(tt) + ");")
       emit("  { const char *_p = strstr(" + rc + ", " + sep + ");")
       emit("    if (_p) { " + tmp + "->_0 = sp_str_substr(" + rc + ", 0, _p - " + rc + "); " + tmp + "->_1 = " + sep + "; " + tmp + "->_2 = sp_str_substr(" + rc + ", _p - " + rc + " + strlen(" + sep + "), strlen(_p) - strlen(" + sep + ")); }")
       emit("    else { " + tmp + "->_0 = " + rc + "; " + tmp + "->_1 = \"\"; " + tmp + "->_2 = \"\"; } }")
@@ -14315,7 +14370,7 @@ class Compiler
       tname = tuple_c_name(tt)
       sep = compile_arg0(nid)
       tmp = new_temp
-      emit("  " + tname + " *" + tmp + " = (" + tname + " *)sp_gc_alloc(sizeof(" + tname + "), NULL, NULL);")
+      emit("  " + tname + " *" + tmp + " = (" + tname + " *)sp_gc_alloc(sizeof(" + tname + "), NULL, " + tuple_scan_name(tt) + ");")
       emit("  { size_t _sl = strlen(" + rc + "), _pl = strlen(" + sep + "); const char *_last = NULL;")
       emit("    for (const char *_p = " + rc + "; (_p = strstr(_p, " + sep + ")); _p += _pl) _last = _p;")
       emit("    if (_last) { " + tmp + "->_0 = sp_str_substr(" + rc + ", 0, _last - " + rc + "); " + tmp + "->_1 = " + sep + "; " + tmp + "->_2 = sp_str_substr(" + rc + ", _last - " + rc + " + _pl, _sl - (_last - " + rc + ") - _pl); }")
@@ -14798,7 +14853,7 @@ class Compiler
       name = tuple_c_name(tt)
       arg = compile_arg0(nid)
       tmp = new_temp
-      emit("  " + name + " *" + tmp + " = (" + name + " *)sp_gc_alloc(sizeof(" + name + "), NULL, NULL);")
+      emit("  " + name + " *" + tmp + " = (" + name + " *)sp_gc_alloc(sizeof(" + name + "), NULL, " + tuple_scan_name(tt) + ");")
       emit("  " + tmp + "->_0 = " + rc + " / " + arg + ";")
       emit("  " + tmp + "->_1 = sp_imod(" + rc + ", " + arg + ");")
       return tmp
@@ -14898,7 +14953,7 @@ class Compiler
       tname = tuple_c_name(tt)
       arg = compile_arg0(nid)
       tmp = new_temp
-      emit("  " + tname + " *" + tmp + " = (" + tname + " *)sp_gc_alloc(sizeof(" + tname + "), NULL, NULL);")
+      emit("  " + tname + " *" + tmp + " = (" + tname + " *)sp_gc_alloc(sizeof(" + tname + "), NULL, " + tuple_scan_name(tt) + ");")
       emit("  " + tmp + "->_0 = (mrb_int)floor(" + rc + " / " + arg + ");")
       emit("  " + tmp + "->_1 = " + rc + " - " + tmp + "->_0 * " + arg + ";")
       return tmp
@@ -14970,7 +15025,7 @@ class Compiler
         tt = "tuple:" + parts.join(",")
         register_tuple_type(tt)
         tname = tuple_c_name(tt)
-        emit("    " + tname + " *" + pair_tmp + " = (" + tname + " *)sp_gc_alloc(sizeof(" + tname + "), NULL, NULL);")
+        emit("    " + tname + " *" + pair_tmp + " = (" + tname + " *)sp_gc_alloc(sizeof(" + tname + "), NULL, " + tuple_scan_name(tt) + ");")
         emit("    " + pair_tmp + "->_0 = sp_" + pfx_recv + "_get(" + rc + ", " + itmp + ");")
         k = 0
         while k < arg_rcs.length
@@ -15189,7 +15244,7 @@ class Compiler
       end
       emit("    if (" + bexpr + ") sp_" + pfx + "_push(" + tmp_t + ", lv_" + bp1 + "); else sp_" + pfx + "_push(" + tmp_f + ", lv_" + bp1 + ");")
       emit("  }")
-      emit("  " + name + " *" + tmp_res + " = (" + name + " *)sp_gc_alloc(sizeof(" + name + "), NULL, NULL);")
+      emit("  " + name + " *" + tmp_res + " = (" + name + " *)sp_gc_alloc(sizeof(" + name + "), NULL, " + tuple_scan_name(tt) + ");")
       emit("  " + tmp_res + "->_0 = " + tmp_t + ";")
       emit("  " + tmp_res + "->_1 = " + tmp_f + ";")
       return tmp_res
@@ -15217,7 +15272,7 @@ class Compiler
         emit("    if (_v > " + tmp_max + ") " + tmp_max + " = _v;")
       end
       emit("  }")
-      emit("  " + name + " *" + tmp + " = (" + name + " *)sp_gc_alloc(sizeof(" + name + "), NULL, NULL);")
+      emit("  " + name + " *" + tmp + " = (" + name + " *)sp_gc_alloc(sizeof(" + name + "), NULL, " + tuple_scan_name(tt) + ");")
       emit("  " + tmp + "->_0 = " + tmp_min + ";")
       emit("  " + tmp + "->_1 = " + tmp_max + ";")
       return tmp
@@ -15784,7 +15839,7 @@ class Compiler
         itmp = new_temp
         emit("  sp_PtrArray *" + tmp + " = sp_PtrArray_new();")
         emit("  for (mrb_int " + itmp + " = 0; " + itmp + " < " + rc + "->len; " + itmp + "++) {")
-        emit("    " + tname + " *_tp = (" + tname + " *)sp_gc_alloc(sizeof(" + tname + "), NULL, NULL);")
+        emit("    " + tname + " *_tp = (" + tname + " *)sp_gc_alloc(sizeof(" + tname + "), NULL, " + tuple_scan_name(tt) + ");")
         emit("    _tp->_0 = " + rc + "->order[" + itmp + "];")
         emit("    _tp->_1 = sp_StrIntHash_get(" + rc + ", " + rc + "->order[" + itmp + "]);")
         emit("    sp_PtrArray_push(" + tmp + ", _tp);")
@@ -15890,7 +15945,7 @@ class Compiler
         itmp = new_temp
         emit("  sp_PtrArray *" + tmp + " = sp_PtrArray_new();")
         emit("  for (mrb_int " + itmp + " = 0; " + itmp + " < " + rc + "->len; " + itmp + "++) {")
-        emit("    " + tname + " *_tp = (" + tname + " *)sp_gc_alloc(sizeof(" + tname + "), NULL, NULL);")
+        emit("    " + tname + " *_tp = (" + tname + " *)sp_gc_alloc(sizeof(" + tname + "), NULL, " + tuple_scan_name(tt) + ");")
         emit("    _tp->_0 = " + rc + "->order[" + itmp + "];")
         emit("    _tp->_1 = sp_StrStrHash_get(" + rc + ", " + rc + "->order[" + itmp + "]);")
         emit("    sp_PtrArray_push(" + tmp + ", _tp);")
@@ -17207,20 +17262,8 @@ class Compiler
     if is_tuple_type(arr_type) == 1
       name = tuple_c_name(arr_type)
       tmp = new_temp
-      has_ptr = 0
       parts = tuple_elem_types_str(arr_type).split(",")
-      fi = 0
-      while fi < parts.length
-        if type_is_pointer(parts[fi]) == 1
-          has_ptr = 1
-        end
-        fi = fi + 1
-      end
-      scan_fn = "NULL"
-      if has_ptr == 1
-        scan_fn = name + "_gc_scan"
-      end
-      emit("  " + name + " *" + tmp + " = (" + name + " *)sp_gc_alloc(sizeof(" + name + "), NULL, " + scan_fn + ");")
+      emit("  " + name + " *" + tmp + " = (" + name + " *)sp_gc_alloc(sizeof(" + name + "), NULL, " + tuple_scan_name(arr_type) + ");")
       k = 0
       while k < elems.length && k < parts.length
         emit("  " + tmp + "->_" + k.to_s + " = " + compile_expr(elems[k]) + ";")

--- a/test/array_partition_gc.rb
+++ b/test/array_partition_gc.rb
@@ -1,0 +1,20 @@
+# Regression: Array#partition (block form) returns a tuple holding two
+# inner arrays. The tuple's sp_gc_alloc was emitted with scan=NULL, so
+# the inner arrays were swept while the tuple was still alive, and a
+# subsequent allocation reused the freed memory — `parts[0].length`
+# came back as the length of whatever object now sat there.
+
+arr = [1, 2, 3, 4, 5, 6]
+parts = arr.partition { |x| x.odd? }
+
+# Force many GCs by allocating lots of GC-managed objects.
+i = 0
+while i < 200000
+  tmp = [1, 2, 3]
+  tmp.push(i)
+  i += 1
+end
+
+puts parts[0].length   # 3
+puts parts[1].length   # 3
+puts "done"


### PR DESCRIPTION
## Summary

Tuples (`sp_Tuple_*`) were allocated with `sp_gc_alloc(..., NULL, NULL)`, so the GC kept the tuple itself alive but never traced its fields. When a tuple's only reference to an inner GC object (sp_IntArray, const char * string, sp_String, ...) was the field itself, the next collection swept the inner object and a later allocation could reuse that memory — leaving a dangling pointer in the tuple.

## Reproduction

```ruby
arr = [1, 2, 3, 4, 5, 6]
parts = arr.partition { |x| x.odd? }   # tuple:int_array,int_array

i = 0
while i < 200000                        # force many GCs
  tmp = [1, 2, 3]
  tmp.push(i)
  i += 1
end

puts parts[0].length   # expected 3, got 4
puts parts[1].length   # expected 3, got 4
```

The inner `sp_IntArray`s were freed mid-program; later `[1, 2, 3] + push` allocations landed at the same address, so `parts[0]` ended up reading the length of an unrelated 4-element array.

## Fix

For each registered tuple type with at least one pointer field, emit a static `<TupleName>_scan(void *)` that calls `sp_gc_mark` on each pointer field (and `sp_mark_rbval` on `poly` fields). Wire every tuple `sp_gc_alloc` site to pass the per-type scan via a new `tuple_scan_name` helper:

- `String#partition` / `rpartition` → `tuple:string,string,string`
- `Integer#divmod` / `Float#divmod` → scalar-only, scan stays `NULL`
- `Array#zip` (heterogeneous) → `tuple:elem1,elem2,...`
- `Array#partition` (block form) → `tuple:T_arr,T_arr`
- `Array#minmax` → `tuple:elem,elem`
- `Hash#to_a` (StrIntHash, StrStrHash) → `tuple:string,int` / `tuple:string,string`
- Tuple literals (the previously-dead `_gc_scan` codepath is now consolidated through the same helper)

Tuples whose fields are all scalars (int/float/bool/symbol) continue to emit `scan=NULL` — nothing to trace.

## Test plan

- [x] `make` — bootstrap loop closes (gen2.c == gen3.c)
- [x] `make test` — 137 pass (added `test/array_partition_gc.rb` as a regression test that constructs the partition tuple and forces ~200k array allocations before reading the inner lengths)
- [x] `make bench` — 56 pass, no regressions