### PR TITLE
fix(codegen): ptr_array follow-ups — shuffle, +, concat, each_with_object, flat_map

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -251,6 +251,9 @@ static inline void sp_PtrArray_set(sp_PtrArray*a,mrb_int i,void*v){if(i<0)i+=a->
 static inline mrb_int sp_PtrArray_length(sp_PtrArray*a){return a->len;}
 static inline mrb_bool sp_PtrArray_empty(sp_PtrArray*a){return a->len==0;}
 static void sp_PtrArray_reverse_bang(sp_PtrArray*a){for(mrb_int i=0,j=a->len-1;i<j;i++,j--){void*t=a->data[i];a->data[i]=a->data[j];a->data[j]=t;}}
+static sp_PtrArray*sp_PtrArray_dup(sp_PtrArray*a){sp_PtrArray*b=sp_PtrArray_new_scan(a->scan_elem);for(mrb_int i=0;i<a->len;i++)sp_PtrArray_push(b,a->data[i]);return b;}
+static void sp_PtrArray_shuffle_bang(sp_PtrArray*a){for(mrb_int i=a->len-1;i>0;i--){mrb_int j=(mrb_int)(rand()%(i+1));void*t=a->data[i];a->data[i]=a->data[j];a->data[j]=t;}}
+static sp_PtrArray*sp_PtrArray_shuffle(sp_PtrArray*a){sp_PtrArray*b=sp_PtrArray_dup(a);sp_PtrArray_shuffle_bang(b);return b;}
 
 /* Small-array optimization: keep the first SP_STRARR_INLINE elements
  * inside the struct so empty/short StrArrays skip the data malloc.

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -1676,7 +1676,7 @@ class Compiler
         if lt == "poly"
           return "poly"
         end
-        if is_array_type(lt) == 1
+        if is_array_type(lt) == 1 || is_ptr_array_type(lt) == 1
           return lt
         end
         if lt == "float"
@@ -13873,7 +13873,7 @@ class Compiler
         @needs_string_helpers = 1
         return "sp_poly_add(" + compile_expr(recv) + ", " + box_expr_to_poly(@nd_arguments[nid] >= 0 ? get_args(@nd_arguments[nid])[0] : -1) + ")"
       end
-      if is_array_type(lt) == 1
+      if is_array_type(lt) == 1 || is_ptr_array_type(lt) == 1
         rc = compile_expr_gc_rooted(recv)
         arg = compile_arg0(nid)
         pfx = array_c_prefix(lt)

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -21029,7 +21029,7 @@ class Compiler
     result = new_temp
     emit("  " + obj_ct + " " + result + " = " + obj_arg + ";")
     tmp_i = new_temp
-    if is_array_type(rt) == 1
+    if is_array_type(rt) == 1 || is_ptr_array_type(rt) == 1
       pfx = array_c_prefix(rt)
       emit("  {")
       @indent = @indent + 1

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2380,7 +2380,7 @@ class Compiler
             if bbs.length > 0
               bret = infer_type(bbs.last)
               # If block returns an array type, use it as result type
-              if is_array_type(bret) == 1
+              if is_array_type(bret) == 1 || is_ptr_array_type(bret) == 1
                 return bret
               end
             end
@@ -21790,7 +21790,7 @@ class Compiler
       end
     end
     # Fall back to receiver type if block doesn't return an array
-    if is_array_type(block_ret) == 0
+    if is_array_type(block_ret) == 0 && is_ptr_array_type(block_ret) == 0
       block_ret = rt
     end
     @needs_gc = 1
@@ -21809,6 +21809,8 @@ class Compiler
       elem_type = "float"
     elsif rt == "poly_array"
       elem_type = "poly"
+    elsif is_ptr_array_type(rt) == 1
+      elem_type = ptr_array_elem_type(rt)
     end
     declare_var(bp1, elem_type)
     emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_" + pfx_src + "_length(" + rc + "); " + tmp_i + "++) {")

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -3536,6 +3536,9 @@ class Compiler
     if t == "poly_array"
       return "PolyArray"
     end
+    if is_ptr_array_type(t) == 1
+      return "PtrArray"
+    end
     "IntArray"
   end
 

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -8523,6 +8523,9 @@ class Compiler
     emit_raw("static inline void sp_PtrArray_set(sp_PtrArray*a,mrb_int i,void*v){if(i<0)i+=a->len;a->data[i]=v;}")
     emit_raw("static inline mrb_int sp_PtrArray_length(sp_PtrArray*a){return a->len;}")
     emit_raw("static inline mrb_bool sp_PtrArray_empty(sp_PtrArray*a){return a->len==0;}")
+    emit_raw("static sp_PtrArray*sp_PtrArray_dup(sp_PtrArray*a){sp_PtrArray*b=sp_PtrArray_new_scan(a->scan_elem);for(mrb_int i=0;i<a->len;i++)sp_PtrArray_push(b,a->data[i]);return b;}")
+    emit_raw("static void sp_PtrArray_shuffle_bang(sp_PtrArray*a){for(mrb_int i=a->len-1;i>0;i--){mrb_int j=(mrb_int)(rand()%(i+1));void*t=a->data[i];a->data[i]=a->data[j];a->data[j]=t;}}")
+    emit_raw("static sp_PtrArray*sp_PtrArray_shuffle(sp_PtrArray*a){sp_PtrArray*b=sp_PtrArray_dup(a);sp_PtrArray_shuffle_bang(b);return b;}")
     emit_raw("")
   end
 
@@ -15152,12 +15155,12 @@ class Compiler
       pfx = array_c_prefix(recv_type)
       return "sp_" + pfx + "_get(" + rc + ", rand() % sp_" + pfx + "_length(" + rc + "))"
     end
-    if mname == "shuffle" && is_array_type(recv_type) == 1
+    if mname == "shuffle" && (is_array_type(recv_type) == 1 || is_ptr_array_type(recv_type) == 1)
       @needs_rand = 1
       pfx = array_c_prefix(recv_type)
       return "sp_" + pfx + "_shuffle(" + rc + ")"
     end
-    if mname == "shuffle!" && is_array_type(recv_type) == 1
+    if mname == "shuffle!" && (is_array_type(recv_type) == 1 || is_ptr_array_type(recv_type) == 1)
       @needs_rand = 1
       pfx = array_c_prefix(recv_type)
       emit("  sp_" + pfx + "_shuffle_bang(" + rc + ");")

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -1676,7 +1676,7 @@ class Compiler
         if lt == "poly"
           return "poly"
         end
-        if is_array_type(lt) == 1 || is_ptr_array_type(lt) == 1
+        if is_array_type(lt) == 1
           return lt
         end
         if lt == "float"
@@ -2380,7 +2380,7 @@ class Compiler
             if bbs.length > 0
               bret = infer_type(bbs.last)
               # If block returns an array type, use it as result type
-              if is_array_type(bret) == 1 || is_ptr_array_type(bret) == 1
+              if is_array_type(bret) == 1
                 return bret
               end
             end
@@ -3545,12 +3545,12 @@ class Compiler
   # The canonical "is this an array type?" check. Use this when you need
   # to dispatch a method that's defined for every typed array — `+`,
   # `concat`, `shuffle`, `each_with_object`, `flat_map`, etc. Covers the
-  # 5 typed arrays (int/str/float/sym/poly). *_ptr_array is intentionally
-  # excluded for now: sp_PtrArray lacks `_dup`/`_shuffle` and several
-  # other helpers, and the existing dispatchers don't route ptr_array
-  # through this path correctly even on master.
+  # 5 typed arrays (int/str/float/sym/poly) and any *_ptr_array.
   def is_array_type(t)
     if t == "int_array" || t == "str_array" || t == "float_array" || t == "sym_array" || t == "poly_array"
+      return 1
+    end
+    if is_ptr_array_type(t) == 1
       return 1
     end
     0
@@ -13873,7 +13873,7 @@ class Compiler
         @needs_string_helpers = 1
         return "sp_poly_add(" + compile_expr(recv) + ", " + box_expr_to_poly(@nd_arguments[nid] >= 0 ? get_args(@nd_arguments[nid])[0] : -1) + ")"
       end
-      if is_array_type(lt) == 1 || is_ptr_array_type(lt) == 1
+      if is_array_type(lt) == 1
         rc = compile_expr_gc_rooted(recv)
         arg = compile_arg0(nid)
         pfx = array_c_prefix(lt)
@@ -15155,12 +15155,12 @@ class Compiler
       pfx = array_c_prefix(recv_type)
       return "sp_" + pfx + "_get(" + rc + ", rand() % sp_" + pfx + "_length(" + rc + "))"
     end
-    if mname == "shuffle" && (is_array_type(recv_type) == 1 || is_ptr_array_type(recv_type) == 1)
+    if mname == "shuffle" && is_array_type(recv_type) == 1
       @needs_rand = 1
       pfx = array_c_prefix(recv_type)
       return "sp_" + pfx + "_shuffle(" + rc + ")"
     end
-    if mname == "shuffle!" && (is_array_type(recv_type) == 1 || is_ptr_array_type(recv_type) == 1)
+    if mname == "shuffle!" && is_array_type(recv_type) == 1
       @needs_rand = 1
       pfx = array_c_prefix(recv_type)
       emit("  sp_" + pfx + "_shuffle_bang(" + rc + ");")
@@ -18734,7 +18734,7 @@ class Compiler
     if mname == "concat"
       if recv >= 0
         rt = infer_type(recv)
-        if is_array_type(rt) == 1 || is_ptr_array_type(rt) == 1
+        if is_array_type(rt) == 1
           rc = compile_expr_gc_rooted(recv)
           arg = compile_arg0(nid)
           pfx = array_c_prefix(rt)
@@ -21029,7 +21029,7 @@ class Compiler
     result = new_temp
     emit("  " + obj_ct + " " + result + " = " + obj_arg + ";")
     tmp_i = new_temp
-    if is_array_type(rt) == 1 || is_ptr_array_type(rt) == 1
+    if is_array_type(rt) == 1
       pfx = array_c_prefix(rt)
       emit("  {")
       @indent = @indent + 1
@@ -21790,7 +21790,7 @@ class Compiler
       end
     end
     # Fall back to receiver type if block doesn't return an array
-    if is_array_type(block_ret) == 0 && is_ptr_array_type(block_ret) == 0
+    if is_array_type(block_ret) == 0
       block_ret = rt
     end
     @needs_gc = 1

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -18734,7 +18734,7 @@ class Compiler
     if mname == "concat"
       if recv >= 0
         rt = infer_type(recv)
-        if is_array_type(rt) == 1
+        if is_array_type(rt) == 1 || is_ptr_array_type(rt) == 1
           rc = compile_expr_gc_rooted(recv)
           arg = compile_arg0(nid)
           pfx = array_c_prefix(rt)

--- a/test/array_concat_ptr.rb
+++ b/test/array_concat_ptr.rb
@@ -1,0 +1,11 @@
+# Array#concat on a ptr_array used to silently miss the type-check; the
+# loop never ran, so the receiver kept its original length.
+
+class Bar
+  def initialize(x); @x = x; end
+  attr_accessor :x
+end
+
+a = [Bar.new(1)]
+a.concat([Bar.new(2), Bar.new(3)])
+puts a.length

--- a/test/array_each_with_object_ptr.rb
+++ b/test/array_each_with_object_ptr.rb
@@ -1,0 +1,11 @@
+# Array#each_with_object on a ptr_array used to silently miss the
+# type-check; the loop body never ran.
+
+class Bar
+  def initialize(x); @x = x; end
+  attr_accessor :x
+end
+
+n = 0
+[Bar.new(1), Bar.new(2)].each_with_object("") {|_e, _a| n += 1 }
+puts n

--- a/test/array_flat_map_ptr.rb
+++ b/test/array_flat_map_ptr.rb
@@ -1,0 +1,11 @@
+# Array#flat_map where the block returns a ptr_array failed to type
+# the result; the inferred receiver-array type clashed with the
+# generated sp_PtrArray * inner accumulator.
+
+class Bar
+  def initialize(x); @x = x; end
+  attr_accessor :x
+end
+
+a = [Bar.new(1), Bar.new(2)].flat_map { |b| [b, b] }
+puts a.length

--- a/test/array_plus_ptr.rb
+++ b/test/array_plus_ptr.rb
@@ -1,0 +1,11 @@
+# Array#+ on a ptr_array used to fall through; the result temp held its
+# default 0 because the dispatcher's type-list omitted ptr_array.
+
+class Bar
+  def initialize(x); @x = x; end
+  attr_accessor :x
+end
+
+a = [Bar.new(1)]
+b = [Bar.new(2)]
+puts (a + b).length

--- a/test/array_shuffle_ptr.rb
+++ b/test/array_shuffle_ptr.rb
@@ -1,0 +1,11 @@
+# Array#shuffle / Array#shuffle! used to skip ptr_array. The
+# dispatcher silently fell through, the result temp ended up `0`,
+# and the runtime had no PtrArray shuffle helper to call anyway.
+
+class Bar
+  def initialize(x); @x = x; end
+  attr_accessor :x
+end
+
+arr = [Bar.new(1), Bar.new(2), Bar.new(3)]
+puts arr.shuffle.length


### PR DESCRIPTION
Several Array methods don't pick up `*_ptr_array` (Spinel's array of obj-pointers) and either fall through silently or compile to the wrong runtime call. Same shape as the poly_array follow-ups in #82, applied here to ptr_array. After all the per-method fixes land, `is_array_type` (introduced in #82) can finally absorb ptr_array — its docstring explicitly excluded ptr_array because of the very gaps this PR closes ("`sp_PtrArray` lacks `_dup`/`_shuffle` and the existing dispatchers don't route ptr_array correctly even on master").

## Reproducers

```ruby
class Bar
  def initialize(x); @x = x; end
  attr_accessor :x
end

# 1. shuffle
puts [Bar.new(1), Bar.new(2), Bar.new(3)].shuffle.length

# 2. +
a = [Bar.new(1)]; b = [Bar.new(2)]
puts (a + b).length

# 3. concat
a = [Bar.new(1)]; a.concat([Bar.new(2), Bar.new(3)])
puts a.length

# 4. each_with_object
n = 0
[Bar.new(1), Bar.new(2)].each_with_object("") {|_e, _a| n += 1 }
puts n

# 5. flat_map (block returns a ptr_array)
puts [Bar.new(1), Bar.new(2)].flat_map {|b| [b, b] }.length
```

## Expected

```
3
2
3
2
4
```

## Actual on master

```
# 1. shuffle
(empty — dispatch fell through; the result temp ended up `0` and the
runtime didn't even have an sp_PtrArray_shuffle helper)

# 2. +
0     # lv_arr stayed `0`; ptr_array wasn't in the type list

# 3. concat
1     # the loop was never emitted; receiver kept its original length

# 4. each_with_object
0     # body never ran

# 5. flat_map
/tmp/_t.c:53:24: error: initialization of 'sp_PtrArray *' from
incompatible pointer type 'sp_IntArray *'
```

## Analysis and fix

Each site checked the receiver (or block return) type against an explicit list. The list pre-dated the ptr_array type, so the new type just wasn't in it — the check returned false, and the dispatcher either fell through or used the IntArray fallback in `array_c_prefix`. Same pattern as #82, commits split per method:

1. `array_c_prefix`: map `*_ptr_array → "PtrArray"` so callers that already check for an array receiver via the type list can use array_c_prefix directly.
2. `Array#shuffle / shuffle!`: extend the type list and add `sp_PtrArray_dup` / `sp_PtrArray_shuffle{_bang}` to the runtime. `_dup` preserves the source's `scan_elem` callback so GC tracking stays correct.
3. `Array#+`: extend `infer_call_type` (so the result type is the ptr_array) and `compile_operator_call_expr`.
4. `Array#concat`: extend the receiver-type check.
5. `Array#each_with_object`: extend the receiver-type check; `elem_type_of_array` already maps `*_ptr_array` to its obj element type via `ptr_array_elem_type`, so the block param is typed correctly.
6. `Array#flat_map`: extend the block-return recognition, the accumulator typing, and the block-param type case (`ptr_array_elem_type(rt)`).
7. `is_array_type` (introduced in #82) now absorbs ptr_array; collapse the per-site `is_array_type(t) || is_ptr_array_type(t)` disjunctions back to a single helper call.

Each fix has its own reproducer test in `test/array_*_ptr.rb`.