### PR TITLE
fix(codegen): don't bypass user-defined 'def x=` writers

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -3257,6 +3257,30 @@ class Compiler
     0
   end
 
+  # True when class `ci` (or any of its parents) has registered `bname` as
+  # an attr_writer / attr_accessor or a struct field — i.e. `obj.bname = v`
+  # may safely become a direct field write.
+  def cls_has_attr_writer(ci, bname)
+    if ci < 0
+      return 0
+    end
+    writers = @cls_attr_writers[ci].split(";")
+    wi = 0
+    while wi < writers.length
+      if writers[wi] == bname
+        return 1
+      end
+      wi = wi + 1
+    end
+    if @cls_parents[ci] != ""
+      pi = find_class_idx(@cls_parents[ci])
+      if pi >= 0
+        return cls_has_attr_writer(pi, bname)
+      end
+    end
+    0
+  end
+
   def is_value_type_obj(t)
     if is_obj_type(t) == 1
       cname = t[4, t.length - 4]
@@ -19392,20 +19416,31 @@ class Compiler
   end
 
   def compile_writer_and_block_call_stmt(nid, mname, recv)
-    # attr_writer: obj.x = val
+    # attr_writer: obj.x = val — only short-circuit to a direct field
+    # write when `x=` is actually a registered attr_writer on the class
+    # (or transitive parent). Otherwise fall through to method-call
+    # dispatch so a real `def x=(v)` method gets called.
     if recv >= 0
       if mname.length > 1
         if mname[mname.length - 1] == "="
           bname = mname[0, mname.length - 1]
           rt = infer_type(recv)
           if is_obj_type(rt) == 1
-            rc = compile_expr_gc_rooted(recv)
-            arrow2 = "->"
-            if is_value_type_obj(rt) == 1
-              arrow2 = "."
+            r_cname = rt[4, rt.length - 4]
+            r_ci = find_class_idx(r_cname)
+            is_writer = 0
+            if r_ci >= 0
+              is_writer = cls_has_attr_writer(r_ci, bname)
             end
-            emit("  " + rc + arrow2 + sanitize_ivar(bname) + " = " + compile_arg0(nid) + ";")
-            return 1
+            if is_writer == 1
+              rc = compile_expr_gc_rooted(recv)
+              arrow2 = "->"
+              if is_value_type_obj(rt) == 1
+                arrow2 = "."
+              end
+              emit("  " + rc + arrow2 + sanitize_ivar(bname) + " = " + compile_arg0(nid) + ";")
+              return 1
+            end
           end
         end
       end

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -9116,33 +9116,41 @@ class Compiler
 
   def is_simple_writer_method(mn, bid)
     # Check if method is a simple attr_writer pattern: def x=(v); @x = v; end
+    # The RHS must be a bare reference to the parameter — `@x = v * 2`
+    # is NOT a simple writer and must not bypass dispatch.
     if mn.length <= 1 || mn[mn.length - 1] != "="
       return 0
     end
     if bid < 0 || bid >= @nd_count
       return 0
     end
-    # Body should be a StatementsNode with a single InstanceVariableWriteNode
+    # Find the single InstanceVariableWriteNode body (directly or wrapped
+    # in a StatementsNode of length 1).
     t = @nd_type[bid]
-    if t == "StatementsNode"
+    iv_id = -1
+    if t == "InstanceVariableWriteNode"
+      iv_id = bid
+    elsif t == "StatementsNode"
       stmts = @nd_stmts[bid]
       if stmts != ""
         parts = stmts.split(",")
         if parts.length == 1
           sid = parts[0].to_i
-          if sid >= 0 && sid < @nd_count
-            if @nd_type[sid] == "InstanceVariableWriteNode"
-              return 1
-            end
+          if sid >= 0 && sid < @nd_count && @nd_type[sid] == "InstanceVariableWriteNode"
+            iv_id = sid
           end
         end
       end
     end
-    # Body might be a single InstanceVariableWriteNode directly
-    if t == "InstanceVariableWriteNode"
-      return 1
+    if iv_id < 0
+      return 0
     end
-    0
+    # RHS must be a bare LocalVariableReadNode for the writer's single param.
+    rhs = @nd_value[iv_id]
+    if rhs < 0 || @nd_type[rhs] != "LocalVariableReadNode"
+      return 0
+    end
+    1
   end
 
   def cls_has_self_mutating_methods(ci)

--- a/test/no_attr_write_shortcut_complex.rb
+++ b/test/no_attr_write_shortcut_complex.rb
@@ -1,0 +1,33 @@
+# `def x=(v); @x = v * 2; end` looks like an attr_writer at first glance
+# (single InstanceVariableWriteNode body) but the assignment value is a
+# computation, not a bare param reference — `is_simple_writer_method`
+# must not classify it as auto-attr_writer.
+#
+# Without that fix, the method gets auto-registered in @cls_attr_writers,
+# `cls_has_attr_writer(C, "doubled")` returns true, and the call site
+# short-circuits `c.doubled = 5` to `c->iv_doubled = 5` — bypassing the
+# `* 2` entirely. Ruby would print 10; pre-fix Spinel printed 5.
+
+class C
+  def initialize
+    @doubled = 0
+  end
+
+  def doubled=(v)
+    @doubled = v * 2
+  end
+
+  def get_doubled
+    @doubled
+  end
+end
+
+c = C.new
+
+c.doubled = 5
+puts c.get_doubled    # 10  (5 * 2)
+
+c.doubled = -7
+puts c.get_doubled    # -14
+
+puts "done"

--- a/test/no_attr_write_shortcut_multi.rb
+++ b/test/no_attr_write_shortcut_multi.rb
@@ -1,0 +1,38 @@
+# `obj.x = v` must dispatch to `def x=(v)` when x= is not a registered
+# attr_writer. A multi-statement body never matched the auto-attr_writer
+# pattern (which requires a single `InstanceVariableWriteNode` body), so
+# the fix at the call site is sufficient on its own to make this case
+# work — no auto-classification change required.
+
+class C
+  attr_accessor :real
+
+  def initialize
+    @real = 0
+    @logged = ""
+  end
+
+  # Multi-statement writer. Side-effects on a *different* ivar so we can
+  # tell whether the def actually ran.
+  def logged=(v)
+    @logged = "set:" + v
+    @real = v.length
+  end
+
+  def get_logged
+    @logged
+  end
+end
+
+c = C.new
+
+# attr_accessor path: still short-circuits to field write.
+c.real = 7
+puts c.real           # 7
+
+# Multi-statement def x=: must dispatch (not bypass).
+c.logged = "hello"
+puts c.get_logged     # set:hello
+puts c.real           # 5  (overwritten by the side effect)
+
+puts "done"


### PR DESCRIPTION
## Summary

`obj.x = v` was unconditionally lowered to `obj->iv_x = v` (a direct
struct field write) regardless of whether `x=` was declared as an
attr_writer. A user-written `def x=(v); …; end` whose body did real
work was silently bypassed — only the field assignment ran.

Reproducer:

````ruby
class C
  def initialize; @doubled = 0; end
  def doubled=(v); @doubled = v * 2; end
  def get; @doubled; end
end

c = C.new
c.doubled = 5
puts c.get   # Ruby: 10  /  pre-fix Spinel: 5
````

There are two interlocking bugs; this PR fixes them in two
independently-testable commits.

## Commits

**1. don't short-circuit unless the writer is registered**

`compile_writer_and_block_call_stmt` now consults a new
`cls_has_attr_writer(ci, bname)` helper (transitive through
`@cls_parents`) and only takes the field-write shortcut when the
class actually registered the writer. Otherwise it falls through to
method-call dispatch.

This commit alone fixes the multi-statement case, e.g.

````ruby
def logged=(v)
  @logged = "set:" + v
  @real = v.length
end
````

— `is_simple_writer_method` already rejected multi-statement bodies,
so they were never auto-registered; the bug was purely at the call
site.

**2. tighten `is_simple_writer_method` to require a bare param RHS**

Single-statement `def x=(v); @x = v * 2; end` looked like a simple
attr_writer at first glance (single `InstanceVariableWriteNode` body)
and got auto-registered in `@cls_attr_writers`. After commit 1, the
call site would still find that registration and short-circuit.

Tighten the classification so the assignment's RHS must be a bare
`LocalVariableReadNode` for the writer's parameter. Computations,
literals, method calls — none qualify. Existing canonical
`def x=(v); @x = v; end` writers are unaffected.

## Test plan

- [x] `test/no_attr_write_shortcut_multi.rb` covers the
      multi-statement case (passes after commit 1)
- [x] `test/no_attr_write_shortcut_complex.rb` covers the
      single-stmt-complex case `@doubled = v * 2` (passes after
      commit 2)
- [x] both tests verify the `attr_accessor` short-circuit still
      fires (regression check that we don't *over*-disable it)
- [x] `make bootstrap` (gen2 == gen3 fixpoint holds)
- [x] `make test` — 140/140 pass on linux