### PR TITLE
fix(codegen): merge initialize param types from call sites and body

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -6378,7 +6378,32 @@ class Compiler
         if mnames[j] == "initialize"
           k = 0
           while k < pnames.length
-            pt = infer_init_param_type(i, pnames[k])
+            # Two sources of param types feed this slot:
+            #   existing_pt: from infer_constructor_types scanning Foo.new(...)
+            #     call sites (already widened to "poly" via unify_call_types
+            #     when call sites disagree).
+            #   body_pt: from scanning the initialize body for `@x = param`
+            #     ivar writes; "int" means "no info" (the fallback).
+            # Body inference must not silently clobber call-site evidence.
+            existing_pt = "int"
+            if k < ptypes.length
+              existing_pt = ptypes[k]
+            end
+            body_pt = infer_init_param_type(i, pnames[k])
+            pt = body_pt
+            if existing_pt != "int" && existing_pt != "nil"
+              if body_pt == "int" || body_pt == "nil"
+                # Body has no info; keep call-site type.
+                pt = existing_pt
+              elsif existing_pt == "poly"
+                # Call sites already widened to poly; do not narrow.
+                pt = "poly"
+              elsif body_pt != existing_pt && body_pt != "poly"
+                # Two concrete types disagree; demote to poly.
+                @needs_rb_value = 1
+                pt = "poly"
+              end
+            end
             if k < ptypes.length
               ptypes[k] = pt
             end

--- a/test/initialize_param_poly_call_sites.rb
+++ b/test/initialize_param_poly_call_sites.rb
@@ -1,0 +1,20 @@
+# Regression test: when an `initialize` parameter is widened to "poly"
+# by conflicting Foo.new(...) call sites, the param type must stay poly
+# end-to-end. The extended merge logic explicitly returns existing_pt
+# when it is "poly" so that body inference (which can return a narrower
+# concrete type via super-call propagation or via the @ivar's type when
+# the ivar was seeded by a literal write elsewhere) does not silently
+# narrow the param back.
+
+class Box
+  def initialize(v)
+    @v = v
+  end
+
+  def show
+    puts @v
+  end
+end
+
+Box.new("hello").show
+Box.new(42).show

--- a/test/initialize_param_through_call.rb
+++ b/test/initialize_param_through_call.rb
@@ -1,0 +1,15 @@
+# Regression test: an initialize parameter that is never written to an
+# ivar must still pick up its type from `Foo.new(...)` call sites.
+#
+# Before the fix, body inference (which returns "int" when no `@x = x`
+# write is found) unconditionally overwrote the call-site-inferred type,
+# silently miscompiling code where the parameter was a string, array, or
+# any other concrete type.
+
+class Greeter
+  def initialize(name)
+    puts name
+  end
+end
+
+Greeter.new("hello")


### PR DESCRIPTION
## Reproduction

```ruby
class Greeter
  def initialize(name)
    puts name
  end
end

Greeter.new("hello")
```

Note that `name` is never assigned to an ivar — it is only read by `puts`.

## Expected behavior

```
hello
```

The call site `Greeter.new("hello")` provides enough evidence to infer
`name` as `string`, and the generated C should pass the literal through
to `sp_Greeter_new` and then to `puts`.

## Actual behavior

`spinel_parse` and `spinel_codegen` both succeed (exit 0), but `cc`
rejects the generated C:

```
$ cc -O2 -Ilib /tmp/out.c -lm -o /tmp/out
/tmp/out.c: In function 'main':
/tmp/out.c:33:21: error: passing argument 1 of 'sp_Greeter_new' makes integer from pointer without a cast [-Wint-conversion]
   33 |     sp_Greeter_new((&("\xff" "hello")[1]));
      |                    ~^~~~~~~~~~~~~~~~~~~~~
      |                     |
      |                     char *
/tmp/out.c:13:50: note: expected 'mrb_int' {aka 'long int'} but argument is of type 'char *'
   13 | static inline sp_Greeter *sp_Greeter_new(mrb_int lv_name) {
      |                                          ~~~~~~~~^~~~~~~
```

`sp_Greeter_new` is generated with `mrb_int lv_name`, but the call site
passes a `char *`. Under `make test` this surfaces as
`ERR: initialize_param_through_call`.

## Analysis

`Foo#initialize` parameter types are populated by two independent
inference sources that both write into `@cls_meth_ptypes`:

1. **`existing_pt`** — accumulated by `infer_constructor_types` while
   walking `Foo.new(arg)` call sites. `unify_call_types` widens this to
   `"poly"` when call sites disagree.
2. **`body_pt`** — returned by `infer_init_param_type`, which walks the
   initialize body for `@x = param` writes (returning the ivar type) or
   `super(param)` (returning the parent's ptype). Falls back to `"int"`
   ("no info") when no pattern matches.

The `mnames[j] == "initialize"` branch in `spinel_codegen.rb` (around
line 6378) overwrote `existing_pt` with `body_pt` unconditionally:

```ruby
while k < pnames.length
  pt = infer_init_param_type(i, pnames[k])
  if k < ptypes.length
    ptypes[k] = pt              # clobbers existing without consulting it
  end
  declare_var(pnames[k], pt)
  k = k + 1
end
```

In the repro, `existing_pt = "string"` and `body_pt = "int"` (the
fallback, since `name` is never written to an ivar). The overwrite
narrows the param to `int`, and the call site's `"hello"` argument no
longer matches.

Considering all combinations, the unconditional overwrite is wrong in
four cases:

| `existing_pt` | `body_pt` | current `pt` | should be |
|---|---|---|---|
| `int` / `nil` | anything | body | body (OK) |
| concrete | `int` / `nil` | body (`int`) ⚠ | existing — **the reported bug** |
| `poly` | concrete | body (concrete) ⚠ | `poly` — narrowing call-site widening |
| concrete A | concrete B | body (B) ⚠ | `poly` — conflicting concretes should demote |
| concrete | same concrete | body | body (OK) |
| `poly` | `poly` | body | body (OK) |

## Fix

Replace the unconditional overwrite with a four-case merge:

```ruby
existing_pt = "int"
if k < ptypes.length
  existing_pt = ptypes[k]
end
body_pt = infer_init_param_type(i, pnames[k])
pt = body_pt
if existing_pt != "int" && existing_pt != "nil"
  if body_pt == "int" || body_pt == "nil"
    pt = existing_pt              # body has no info; honor existing
  elsif existing_pt == "poly"
    pt = "poly"                   # already widened; don't narrow
  elsif body_pt != existing_pt && body_pt != "poly"
    @needs_rb_value = 1
    pt = "poly"                   # conflicting concretes demote
  end
end
```

When `existing_pt` is the no-info fallback (`int`/`nil`), `body_pt` is
taken verbatim — master-compatible. The merge only triggers when
`existing_pt` carries real call-site evidence.

### Notes

- The "concrete A vs. concrete B" demotion is added defensively. Current
  Spinel inference rarely produces this shape because
  `update_ivar_types_from_params` and `unify_call_types` tend to
  converge to the same answer first, but the case is included to keep
  the merge logic complete under future inference changes.
- The "`poly` + concrete" case occurs in larger programs (e.g.
  optcarrot): `super(param)` makes `infer_init_param_type` return the
  parent's concrete ptype as `body_pt` while the child's call sites
  widen `existing_pt` to `poly`. An isolated end-to-end repro hits
  independent codegen bugs (super-arg type propagation, string-literal
  → poly-ivar assignment), so a tighter test for that variant is left
  as a follow-up.

## Test plan

- [x] Added `test/initialize_param_through_call.rb` — the repro above.
      Verified that without the patch this test ERRORs in `make test`
      (`Tests: 137 pass, 0 fail, 1 error`) and passes with the patch.
- [x] Added `test/initialize_param_poly_call_sites.rb` — smoke test
      that a param widened to poly by conflicting `Box.new("hello")` /
      `Box.new(42)` call sites flows end-to-end without regression.
- [x] Bootstrap fixpoint holds (`gen2.c == gen3.c`).
- [x] `make test`: 138 pass / 0 fail / 0 error.