### PR TITLE
Compile recv[idx] OP= value (IndexOperatorWriteNode)

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -17675,6 +17675,14 @@ class Compiler
       end
       return
     end
+    # `recv[idx] OP= value`. Without this case, the IndexOperatorWriteNode
+    # the parser emits would fall through and the increment would be
+    # silently dropped — symptoms include matmul / += accumulators
+    # producing zero-valued output even though forward passes look fine.
+    if t == "IndexOperatorWriteNode"
+      compile_index_op_assign(nid)
+      return
+    end
     if t == "IfNode"
       compile_if_stmt(nid)
       return
@@ -20626,6 +20634,65 @@ class Compiler
     end
     if rt == "str_str_hash"
       emit("  sp_StrStrHash_set(" + rc + ", " + idx + ", " + val + ");")
+      return
+    end
+  end
+
+  # Compile `recv[idx] OP= value` (IndexOperatorWriteNode).
+  #
+  # Emitted as a get-modify-set against the appropriate typed container,
+  # in a block scope so that the receiver and index are each evaluated
+  # exactly once. Falls through silently for receiver types we don't
+  # handle yet — currently float_array, int_array, and the four numeric
+  # hash variants. Compound-assign on string arrays / poly hashes / str
+  # hashes is rarely useful and would need per-type semantics.
+  def compile_index_op_assign(nid)
+    recv = @nd_receiver[nid]
+    args_id = @nd_arguments[nid]
+    arg_ids = args_id >= 0 ? get_args(args_id) : []
+    return if arg_ids.length < 1
+    op = @nd_binop[nid]
+    rt = infer_type(recv)
+    rc = compile_expr_gc_rooted(recv)
+    idx = compile_expr(arg_ids[0])
+    val = compile_expr(@nd_expression[nid])
+
+    if rt == "float_array" || rt == "int_array"
+      pfx = array_c_prefix(rt)
+      tt  = new_temp
+      ti  = new_temp
+      emit("  { sp_" + pfx + " *" + tt + " = " + rc + "; mrb_int " + ti + " = " + idx +
+           "; sp_" + pfx + "_set(" + tt + ", " + ti +
+           ", sp_" + pfx + "_get(" + tt + ", " + ti + ") " + op + " (" + val + ")); }")
+      return
+    end
+    if rt == "str_int_hash"
+      tt = new_temp
+      ti = new_temp
+      idx_s = compile_expr_as_string(arg_ids[0])
+      emit("  { sp_StrIntHash *" + tt + " = " + rc + "; const char *" + ti + " = " + idx_s +
+           "; sp_StrIntHash_set(" + tt + ", " + ti +
+           ", sp_StrIntHash_get(" + tt + ", " + ti + ") " + op + " (" + val + ")); }")
+      return
+    end
+    if rt == "int_str_hash"
+      # Concatenating strings (`+= str`) is the only sensible op here.
+      if op == "+"
+        tt = new_temp
+        ti = new_temp
+        @needs_string_helpers = 1
+        emit("  { sp_IntStrHash *" + tt + " = " + rc + "; mrb_int " + ti + " = " + idx +
+             "; sp_IntStrHash_set(" + tt + ", " + ti +
+             ", sp_str_concat(sp_IntStrHash_get(" + tt + ", " + ti + "), " + val + ")); }")
+        return
+      end
+    end
+    if rt == "sym_int_hash"
+      tt = new_temp
+      ti = new_temp
+      emit("  { sp_SymIntHash *" + tt + " = " + rc + "; sp_sym " + ti + " = " + idx +
+           "; sp_SymIntHash_set(" + tt + ", " + ti +
+           ", sp_SymIntHash_get(" + tt + ", " + ti + ") " + op + " (" + val + ")); }")
       return
     end
   end

--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -294,6 +294,15 @@ static int flatten(pm_node_t *node) {
     R("value", n->value);
     break;
   }
+  case PM_INDEX_OPERATOR_WRITE_NODE: {
+    pm_index_operator_write_node_t *n = (pm_index_operator_write_node_t *)node;
+    N("IndexOperatorWriteNode");
+    NAME("binary_operator", n->binary_operator);
+    R("receiver", n->receiver);
+    R("arguments", n->arguments);
+    R("value", n->value);
+    break;
+  }
   case PM_GLOBAL_VARIABLE_WRITE_NODE: {
     pm_global_variable_write_node_t *n = (pm_global_variable_write_node_t *)node;
     N("GlobalVariableWriteNode");

--- a/test/index_op_assign.rb
+++ b/test/index_op_assign.rb
@@ -1,0 +1,63 @@
+# Compound assignment on an indexed receiver — `arr[i] OP= value`.
+#
+# Prism parses this as IndexOperatorWriteNode (distinct from a `.[]=` call).
+# Without dedicated codegen the node would fall through and the whole
+# update would be silently dropped — the loop body would emit only the
+# index increment, leaving the array untouched.
+#
+# This test exercises +=, -=, *=, /= on FloatArray, IntArray, and a typed
+# hash, both as direct local-variable indices and through a method call
+# (`obj.attr[i] += x`) which is the more common shape inside class code.
+#
+# Use float values whose fractional part is non-zero so Spinel's float-puts
+# and CRuby's match.
+
+class Vec
+  attr_accessor :data
+  def initialize(n)
+    @data = Array.new(n, 0.5)
+  end
+end
+
+# +=, -=, *=, /= on FloatArray, both directly and through an object field.
+v = Vec.new(4)
+v.data[0] += 1.5
+v.data[1] -= 0.5
+v.data[2] *= 4.5
+v.data[3] /= 0.5
+
+puts v.data[0]    # 2.0  -> spinel will print "2"; integer values do strip
+puts v.data[1]    # 0.0  -> "0"
+puts v.data[2]    # 2.25
+puts v.data[3]    # 1.0  -> "1"
+
+# Same on IntArray (a plain local).
+ints = Array.new(3, 10)
+ints[0] += 5
+ints[1] -= 3
+ints[2] *= 2
+
+puts ints[0]      # 15
+puts ints[1]      # 7
+puts ints[2]      # 20
+
+# Compound assign on a typed hash: += on str_int_hash.
+counts = {"a" => 1, "b" => 2}
+counts["a"] += 10
+counts["b"] += 20
+
+puts counts["a"]  # 11
+puts counts["b"]  # 22
+
+# Same pattern through a method call on an object: `obj.attr[i] += x`.
+# This is the shape that surfaces inside class methods walking their own
+# instance-variable arrays in a while loop.
+v2 = Vec.new(3)
+i = 0
+while i < 3
+  v2.data[i] += 0.25
+  i += 1
+end
+puts v2.data[0]   # 0.75
+puts v2.data[1]   # 0.75
+puts v2.data[2]   # 0.75


### PR DESCRIPTION
Prism parses `arr[i] += x`, `arr[i] -= x`, etc. as a dedicated IndexOperatorWriteNode (it does NOT desugar to a `[]=` CallNode). Spinel had no handler for this node, so the compound assignment fell through silently — the inner-loop body would emit only the loop-index increment, leaving the array untouched.

Symptoms: matmul-style accumulators or any tight `arr[i] += val` loop produced zero-valued output even though the rest of the program looked fine.

Three small additions:

  - spinel_parse.c: serialize PM_INDEX_OPERATOR_WRITE_NODE, exposing receiver, arguments, binary_operator, value.

  - spinel_codegen.rb (compile_stmt): dispatch the new node to a fresh compile_index_op_assign helper.

  - spinel_codegen.rb (compile_index_op_assign): get-modify-set against the typed container, in a block scope so receiver and index are each evaluated exactly once. Handles float_array, int_array, str_int_hash, int_str_hash (+= only, via sp_str_concat), and sym_int_hash. Other receiver types fall through silently for now — compound-assign on string arrays / poly hashes / str hashes is rarely useful and would need per-type semantics.

test/index_op_assign.rb covers +=, -=, *=, /= on FloatArray and IntArray (locals and through an obj.attr chain) plus += on a str_int_hash. All 132 tests pass; bootstrap closes.