### PR TITLE
Support class method dispatch on ConstantPath receivers

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -16138,9 +16138,10 @@ class Compiler
   end
 
   def compile_constant_recv_expr(nid, mname, recv, rc)
-    # ARGV methods
-    if @nd_type[recv] == "ConstantReadNode"
-      if @nd_name[recv] == "ARGV"
+    rcname = constructor_class_name(recv)
+    if rcname != ""
+      # ARGV methods
+      if rcname == "ARGV"
         if mname == "length"
           return "sp_argv.len"
         end
@@ -16149,10 +16150,6 @@ class Compiler
           return "((" + idx_expr + " < sp_argv.len) ? sp_argv.data[(int)" + idx_expr + "] : NULL)"
         end
       end
-    end
-
-    rcname = constructor_class_name(recv)
-    if rcname != ""
       # Math
       if rcname == "Math"
         if mname == "sqrt"

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -16151,9 +16151,9 @@ class Compiler
       end
     end
 
-    # Math
-    if @nd_type[recv] == "ConstantReadNode"
-      rcname = @nd_name[recv]
+    rcname = constructor_class_name(recv)
+    if rcname != ""
+      # Math
       if rcname == "Math"
         if mname == "sqrt"
           return "sqrt(" + compile_arg0(nid) + ")"

--- a/test/constant_path_argv.rb
+++ b/test/constant_path_argv.rb
@@ -1,0 +1,6 @@
+# Test ConstantPath access to ARGV methods.
+
+puts ARGV.length
+puts ::ARGV.length
+puts(ARGV[0] == nil)
+puts(::ARGV[0] == nil)

--- a/test/constant_path_class_method.rb
+++ b/test/constant_path_class_method.rb
@@ -1,0 +1,14 @@
+# Test ConstantPath class method dispatch:
+#   A::B.create(...)
+#   ::A::B.create(...)
+
+module A
+  class B
+    def self.create(x)
+      x + 1
+    end
+  end
+end
+
+puts A::B.create(41)
+puts ::A::B.create(99)


### PR DESCRIPTION
## Summary
This PR fixes class method dispatch when the receiver is a constant path (e.g. `A::B.create` or `::A::B.create`).

Previously, this path was treated as unsupported in `compile_constant_recv_expr`, which caused fallback code generation (`0`) instead of emitting the class method call.

## Changes
- Updated constant-receiver dispatch to resolve receiver class names via `constructor_class_name(recv)` instead of only accepting `ConstantReadNode`.
- Kept existing dispatch behavior for `Math`, `File`, `Time`, `ENV`, `Dir`, module class methods, and class methods; expanded it to work with `ConstantPathNode` receivers.

## Tests
- Added `test/constant_path_class_method.rb` to cover:
  - `A::B.create(41)`
  - `::A::B.create(99)`

## Result
- New test passes.
- Full test suite passes (`make test`).
