### PR TITLE
feat: add regression test for sym_array empty-then-push

### DIFF
--- a/test/sym_array_empty_push.rb
+++ b/test/sym_array_empty_push.rb
@@ -1,0 +1,19 @@
+# Issue #85 / PR #92: an empty `[]` followed by `push(:sym)` should
+# promote the local's tracked type to sym_array, so element access
+# emits the symbol-name path instead of printing the symbol id.
+# The literal-array form (`syms = [:tag, :more]`) was already passing
+# on master before PR #92, so this test exercises empty-then-push.
+
+syms = []
+syms.push(:tag)
+syms.push(:more)
+puts syms[0]      # tag
+puts syms[1]      # more
+puts syms.length  # 2
+
+# `<<` form should behave the same.
+syms2 = []
+syms2 << :alpha
+syms2 << :beta
+puts syms2[0]     # alpha
+puts syms2[1]     # beta


### PR DESCRIPTION

  Suggested PR description

  Closes #100. Follow-up to #92.

  ## Summary

Adds `test/sym_array_empty_push.rb` to lock in the fix from #92 for issue #85: an empty `[]` followed by `push(:sym)` (or `<< :sym`) must promote the local's tracked type from `int_array` to `sym_array` so element access emits `puts(sp_sym_to_s(...))` instead of `printf("%lld", ...)`.

The original #85 reproducer (`syms = [:tag, :more]; puts syms[0]`) was already passing on master before #92, so the test exercises the empty-then-push path specifically. Both `.push` and `<<` forms are covered — they hit the same `scan_locals` promotion site today, but keeping both guards against future refactors that split their handling.

  ## Test plan

1. `make test` — 137/137 pass (was 136 before this PR)
2. Verified earlier on a pre-#92 codegen that this exact pattern emitted `0` instead of `tag`, so the test would catch the regression if the promotion logic is reverted