### PR TITLE
fix(codegen): escape \n \t \r in emitted regex literals

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -8848,12 +8848,19 @@ class Compiler
         ch = pat[pi]
         if ch == 92.chr
           cpat = cpat + 92.chr + 92.chr
+        elsif ch == 34.chr
+          cpat = cpat + 92.chr + 34.chr
+        elsif ch == 10.chr
+          # Embedded newlines / tabs / CRs in /x patterns must be
+          # encoded as escape sequences; emitting them raw produces an
+          # unterminated C string literal.
+          cpat = cpat + 92.chr + "n"
+        elsif ch == 13.chr
+          cpat = cpat + 92.chr + "r"
+        elsif ch == 9.chr
+          cpat = cpat + 92.chr + "t"
         else
-          if ch == 34.chr
-            cpat = cpat + 92.chr + 34.chr
-          else
-            cpat = cpat + ch
-          end
+          cpat = cpat + ch
         end
         pi = pi + 1
       end

--- a/test/regex_multiline_pattern.rb
+++ b/test/regex_multiline_pattern.rb
@@ -1,0 +1,39 @@
+# A regex whose source contains literal newlines, tabs, or CRs must be
+# emitted as a properly escaped C string literal. Otherwise the embedded
+# raw character closes the C string mid-token and the generated
+# `re_compile` call doesn't parse at all (a C compile error, not a
+# runtime mismatch).
+
+# Multi-line /x pattern. The match itself is regex-engine business; the
+# point of the test is that the binary builds and the matcher runs at
+# all.
+re = /
+  bar
+/x
+if re =~ "barbar"
+  puts "ok1"
+else
+  puts "no1"
+end
+
+# Tab / CR / newline escapes anywhere in the source.
+re_t = /a\tb/
+if re_t =~ "a\tb"
+  puts "ok2"
+else
+  puts "no2"
+end
+
+re_n = /a\nb/
+if re_n =~ "a\nb"
+  puts "ok3"
+else
+  puts "no3"
+end
+
+re_r = /a\rb/
+if re_r =~ "a\rb"
+  puts "ok4"
+else
+  puts "no4"
+end


### PR DESCRIPTION
## Reproducer

```ruby
re = /
  hello
  world
/x
puts(re =~ "helloworld" ? "match" : "miss")
```

## Expected

```
match
```

## Actual (master)

```
/tmp/_t.c:8:28: warning: missing terminating " character
    8 |   sp_re_pat_0 = re_compile("
      |                            ^
/tmp/_t.c:8:28: error: missing terminating " character
/tmp/_t.c:9:3: error: 'hello' undeclared (first use in this function); did you mean 'ftello'?
    9 |   hello
      |   ^~~~~
      |   ftello
/tmp/_t.c:11:1: warning: missing terminating " character
   11 | ", 17, 0);
      | ^
/tmp/_t.c:11:1: error: missing terminating " character
/tmp/_t.c:8:17: error: too few arguments to function 're_compile'; expected 3, have 1
```

The C output errors out before linking — this isn't a runtime
mismatch, it's a generated-source mismatch.

## Analysis & fix

The pattern→C-string emit loop only escaped `\` and `"`. A raw newline,
tab, or CR in the pattern source flowed through to the emitted
`re_compile("...", N, F)` call unescaped, closing the C string literal
mid-line.

Extend the substitution loop to also rewrite raw `\n`, `\t`, `\r` in
the pattern bytes to their corresponding C escape sequences. The byte
length passed to `re_compile` stays the original `pat.length`, so the
regex engine still sees the same raw bytes at runtime — only the
C-source representation of the literal changes.

## Tests

`test/regex_multiline_pattern.rb` — multi-line `/x` literal plus
single-character `\t` / `\n` / `\r` escapes in the pattern source.