### PR TITLE
feat(codegen): collect class-nested classes (follow-up to #27)

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -3745,6 +3745,12 @@ class Compiler
             end
           end
         end
+        if @nd_type[sid] == "ClassNode"
+          collect_class_with_prefix(sid, cname)
+        end
+        if @nd_type[sid] == "ModuleNode"
+          collect_module_with_prefix(sid, cname)
+        end
       }
       body_stmts.each { |sid|
         if @nd_type[sid] == "CallNode"
@@ -3895,6 +3901,16 @@ class Compiler
             collect_attr_call(ci, sid)
           end
         end
+      end
+      # Nested class / module inside class. Mirroring the
+      # nested-in-module path, the inner type is registered at top
+      # level under its outer-class–prefixed name (e.g. `A::B` →
+      # `A_B`) so a `A::B.new` call resolves via the same flat lookup.
+      if @nd_type[sid] == "ClassNode"
+        collect_class_with_prefix(sid, cname)
+      end
+      if @nd_type[sid] == "ModuleNode"
+        collect_module_with_prefix(sid, cname)
       end
     }
     # Second pass: handle includes (after all own methods are known)

--- a/test/nested_class_in_class.rb
+++ b/test/nested_class_in_class.rb
@@ -1,0 +1,38 @@
+# Nested class definition inside another class.
+# Spinel has no namespace table; bare class names must be unique, so
+# `class A; class B; ... end; end` registers `B` at top level the same
+# way `module M; class B; ... end; end` does.
+
+class A
+  class B
+    def initialize(x)
+      @x = x
+    end
+    attr_reader :x
+  end
+
+  def make_b(x)
+    B.new(x)
+  end
+end
+
+# Direct construction via the path
+b = A::B.new(7)
+puts b.x
+
+# Construction via the outer class
+b2 = A.new.make_b(42)
+puts b2.x
+
+# A nested class with its own nested class
+class Outer
+  class Mid
+    class Inner
+      def hello
+        "hi"
+      end
+    end
+  end
+end
+
+puts Outer::Mid::Inner.new.hello


### PR DESCRIPTION
Follow-up to #27 (`fix(codegen): support module-nested classes and
ConstantPath .new`). That PR added the recursion for `module M;
class C; end; end` in `collect_module_with_prefix`, but didn't add the
symmetric path for `class A; class B; end; end` in
`collect_class_with_prefix`. This PR fills that gap.

## Reproducer

```ruby
class A
  class B
    def initialize(x); @x = x; end
    attr_reader :x
  end
end
puts A::B.new(7).x
```

## Expected

```
7
```

## Actual (master)

```
/tmp/_t.c: In function 'main':
/tmp/_t.c:36:5: error: unknown type name 'sp_A_B'; did you mean 'sp_A'?
   36 |     sp_A_B * _t1 = 0;
      |     ^~~~~~
      |     sp_A
```

`sp_A_B` is the C-level symbol that the existing
`resolve_const_ref_name` already produces for `A::B`. It just never
gets registered, because the body walk in `collect_class_with_prefix`
skips nested class declarations.

## Analysis & fix

`collect_class_with_prefix` only iterates `DefNode` /
`ConstantWriteNode` / attr-call `CallNode` inside the class body. A
nested `ClassNode` / `ModuleNode` is silently dropped — `B` never makes
it into `@cls_names`, so no struct or constructor is emitted, and the
later `A::B.new` lookup compiles to a use of the unregistered type.

The fix is the obvious mirror of #27's module-side recursion: inside
both the new-class branch and the class-reopen branch of
`collect_class_with_prefix`, also recurse into nested `ClassNode` /
`ModuleNode`, calling `collect_class_with_prefix(sid, cname)` /
`collect_module_with_prefix(sid, cname)` so the inner type registers
under its outer-prefixed flat name (`A::B` → `A_B`). The existing
`resolve_const_ref_name(A::B)` already returns `A_B`, and the existing
lexical walk in `resolve_const_read_name` (`scope = "A"` → candidate
`"A_B"`) makes a bare `B` reference inside `A`'s own methods resolve
to the same registered class.

## What's not in scope

Two limits exist for module-nested classes since #27 and aren't made
any worse here — flagging them so reviewers don't read the test as
claiming coverage:

- `class C < A::B` falls back to `parent = @nd_name[sp]` (the leaf
  name `"B"`), so the parent-class lookup will miss `A_B`. Same
  behavior as `class C < M::B` on master.
- A literal-underscore top-level `class A_B` collides with the flat
  name produced for `class A; class B`. Pre-existing for
  `module M; class B` too.

## Tests

`test/nested_class_in_class.rb` covers:
- direct `A::B.new(...)` construction,
- bare-`B` resolution from a method on the outer class
  (`A.new.make_b(x)`),
- a 3-deep `Outer::Mid::Inner` chain.