### PR TITLE
fix(codegen): box polymorphic method returns as sp_RbVal

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -18488,6 +18488,18 @@ class Compiler
     if args_id >= 0
       arg_ids = get_args(args_id)
       if arg_ids.length > 0
+        if @current_method_return == "poly"
+          ret_expr = box_expr_to_poly(arg_ids[0])
+          if @in_gc_scope == 1
+            tmp = new_temp
+            emit("  sp_RbVal " + tmp + " = " + ret_expr + ";")
+            emit("  SP_GC_RESTORE();")
+            emit("  return " + tmp + ";")
+          else
+            emit("  return " + ret_expr + ";")
+          end
+          return
+        end
         rt = infer_type(arg_ids[0])
         # return nil in a nullable pointer method → return NULL
         if rt == "nil" && is_nullable_pointer_type(@current_method_return) == 1
@@ -23442,6 +23454,10 @@ class Compiler
       return
     end
     if return_type != "void"
+      if return_type == "poly"
+        emit("  return " + box_expr_to_poly(last) + ";")
+        return
+      end
       val = compile_expr(last)
       expr_type = infer_type(last)
       if expr_type == "lambda"

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -23455,7 +23455,15 @@ class Compiler
     end
     if return_type != "void"
       if return_type == "poly"
-        emit("  return " + box_expr_to_poly(last) + ";")
+        ret_expr = box_expr_to_poly(last)
+        if @in_gc_scope == 1
+          tmp = new_temp
+          emit("  sp_RbVal " + tmp + " = " + ret_expr + ";")
+          emit("  SP_GC_RESTORE();")
+          emit("  return " + tmp + ";")
+        else
+          emit("  return " + ret_expr + ";")
+        end
         return
       end
       val = compile_expr(last)

--- a/test/poly_dispatch_args_ret.rb
+++ b/test/poly_dispatch_args_ret.rb
@@ -21,7 +21,25 @@ class Builder
       B.new
     end
   end
+
+  def make_with_return(flag)
+    if flag == 0
+      return A.new
+    end
+    return B.new
+  end
 end
 
-obj = Builder.new.make(0)
-puts obj.read(41)
+b = Builder.new
+
+obj0 = b.make(0)
+puts obj0.read(41)
+
+obj1 = b.make(1)
+puts obj1.read(41)
+
+ret0 = b.make_with_return(0)
+puts ret0.read(41)
+
+ret1 = b.make_with_return(1)
+puts ret1.read(41)

--- a/test/poly_dispatch_args_ret.rb
+++ b/test/poly_dispatch_args_ret.rb
@@ -1,0 +1,27 @@
+# Regression test for polymorphic return flow:
+# a method returning different class instances from branches.
+
+class A
+  def read(v)
+    v + 1
+  end
+end
+
+class B
+  def read(v)
+    v + 2
+  end
+end
+
+class Builder
+  def make(flag)
+    if flag == 0
+      A.new
+    else
+      B.new
+    end
+  end
+end
+
+obj = Builder.new.make(0)
+puts obj.read(41)


### PR DESCRIPTION
## Summary
This PR fixes polymorphic method return codegen when a method returns different class instances across branches.

Previously, methods inferred as returning `poly` could still emit raw object returns in `return`/tail-return paths, causing C type mismatches instead of `sp_RbVal` returns.

## Changes
- In `compile_return_stmt`, when the current method return type is `poly`, return values are boxed via `box_expr_to_poly(...)`.
- In `compile_body_return`, when `return_type == "poly"`, the last expression is returned as a boxed `sp_RbVal`.
- Added/expanded regression test:
  - `test/poly_dispatch_args_ret.rb`
  - Covers:
    - branch return (`make(0) -> A.new`, `make(1) -> B.new`)
    - explicit `return` (`make_with_return`)

## Result
- New regression test passes.
- Full test suite passes (`make test`).
