### PR TITLE
fix(codegen): forward &block at typed-receiver call sites

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -695,6 +695,14 @@ class Compiler
     result
   end
 
+  # Returns 1 if @nd_block[nid] is a literal BlockNode (do/end body),
+  # 0 otherwise. Used by &block-forwarding call sites to decide
+  # whether to emit a proc literal for the trailing block slot.
+  def has_literal_block(nid)
+    blk = @nd_block[nid]
+    (blk >= 0 && @nd_type[blk] == "BlockNode") ? 1 : 0
+  end
+
   # Flatten a constant reference into an internal name.
   #   C       -> C
   #   ::C     -> C
@@ -10260,6 +10268,24 @@ class Compiler
     0
   end
 
+  # Returns 1 if the (ci, midx) method declares a `&block` parameter,
+  # 0 otherwise. Ruby syntax requires `&block` to be the trailing
+  # param, so we check only the last slot — a proc-typed slot in any
+  # other position is a positional proc argument, not a block param.
+  # Mirrors cls_method_has_yield: call sites use it to decide whether
+  # to omit the trailing &block slot from default-padding.
+  def cls_method_has_block_param(ci, midx)
+    if ci < 0 || midx < 0
+      return 0
+    end
+    all_ptypes = @cls_meth_ptypes[ci].split("|")
+    if midx >= all_ptypes.length
+      return 0
+    end
+    pts = all_ptypes[midx].split(",")
+    (pts.length > 0 && pts.last == "proc") ? 1 : 0
+  end
+
   def cls_find_method_direct(ci, mname)
     mnames = @cls_meth_names[ci].split(";")
     j = 0
@@ -10879,6 +10905,21 @@ class Compiler
       end
       result = result + c_type(pt) + " lv_" + pnames[j]
       j = j + 1
+    end
+    result
+  end
+
+  # Builds the trailing portion of a call-args list — each non-empty
+  # piece prefixed with ", ", empties skipped. Returns "" when both
+  # are empty. Mirrors build_params_str: callers concatenate the
+  # result onto a self/recv prefix to form the full arg list.
+  def build_call_tail(ca, bp)
+    result = ""
+    if ca != ""
+      result = result + ", " + ca
+    end
+    if bp != ""
+      result = result + ", " + bp
     end
     result
   end
@@ -13804,7 +13845,7 @@ class Compiler
         end
         ca = ""
         if owner_midx >= 0
-          ca = compile_typed_call_args(nid, owner_ci, owner_midx)
+          ca = compile_typed_call_args(nid, owner_ci, owner_midx, 0)
         else
           ca = compile_call_args(nid)
         end
@@ -16672,24 +16713,34 @@ class Compiler
           if oci2 >= 0
             midx2 = cls_find_method_direct(oci2, mname)
           end
+          # Omit the trailing &block slot from default-padding when the
+          # callee declares one — we'll fill it explicitly from the
+          # call site's literal block below.
+          has_proc = cls_method_has_block_param(oci2, midx2)
           ca = ""
           if midx2 >= 0
-            ca = compile_typed_call_args(nid, oci2, midx2)
+            ca = compile_typed_call_args(nid, oci2, midx2, has_proc)
           else
             ca = compile_call_args(nid)
           end
+          bp = ""
+          if has_proc == 1
+            if has_literal_block(nid) == 1
+              @needs_proc = 1
+              bp = compile_proc_literal(nid)
+            else
+              # The callee declares &block but the call site provides
+              # none — fill the slot with NULL so the C call has the
+              # right arity (compile_typed_call_args has already been
+              # told to skip default-padding for this slot).
+              bp = "0"
+            end
+          end
+          tail = build_call_tail(ca, bp)
           if owner == cname
-            if ca != ""
-              return "sp_" + owner + "_" + sanitize_name(mname) + "(" + rc + ", " + ca + ")"
-            else
-              return "sp_" + owner + "_" + sanitize_name(mname) + "(" + rc + ")"
-            end
+            return "sp_" + owner + "_" + sanitize_name(mname) + "(" + rc + tail + ")"
           else
-            if ca != ""
-              return "sp_" + owner + "_" + sanitize_name(mname) + "((sp_" + owner + " *)" + rc + ", " + ca + ")"
-            else
-              return "sp_" + owner + "_" + sanitize_name(mname) + "((sp_" + owner + " *)" + rc + ")"
-            end
+            return "sp_" + owner + "_" + sanitize_name(mname) + "((sp_" + owner + " *)" + rc + tail + ")"
           end
         end
       end
@@ -16740,7 +16791,7 @@ class Compiler
           end
           ca2 = ""
           if midx3 >= 0
-            ca2 = compile_typed_call_args(nid, oci3, midx3)
+            ca2 = compile_typed_call_args(nid, oci3, midx3, 0)
           else
             ca2 = compile_call_args(nid)
           end
@@ -17209,7 +17260,7 @@ class Compiler
       if init_ci >= 0
         init_idx = cls_find_method_direct(init_ci, "initialize")
         if init_idx >= 0
-          return compile_typed_call_args(nid, init_ci, init_idx)
+          return compile_typed_call_args(nid, init_ci, init_idx, 0)
         end
       end
       return ""
@@ -17409,11 +17460,16 @@ class Compiler
     result
   end
 
-  def compile_typed_call_args(nid, target_ci, target_midx)
+  def compile_typed_call_args(nid, target_ci, target_midx, omit_trailing)
     # Like compile_call_args but casts arguments to match target method param
     # types AND fills in defaults from @cls_meth_defaults for trailing
     # parameters the caller omitted (issue #49). Returns "" only when the
     # method takes no parameters at all.
+    #
+    # `omit_trailing` is the number of trailing param slots to leave out
+    # entirely — block-forwarding call sites pass 1 so the &block slot
+    # isn't default-padded with "0" (the actual proc is appended by the
+    # caller after this returns).
     args_id = @nd_arguments[nid]
     arg_ids = []
     if args_id >= 0
@@ -17428,6 +17484,24 @@ class Compiler
     end
     if target_midx < all_defaults.length
       defaults = all_defaults[target_midx].split(",")
+    end
+    # Drop the trailing slots the caller will fill explicitly (the
+    # &block slot when block-forwarding) — otherwise a surplus
+    # positional arg would mis-cast against the omitted slot's type
+    # and the loop's default-padding would emit "0" for the slot the
+    # caller is about to fill itself.
+    if omit_trailing > 0
+      kept = []
+      pk = 0
+      limit = ptypes.length - omit_trailing
+      if limit < 0
+        limit = 0
+      end
+      while pk < limit
+        kept.push(ptypes[pk])
+        pk = pk + 1
+      end
+      ptypes = kept
     end
     total = ptypes.length
     if arg_ids.length > total

--- a/test/block_forward_recv_typed.rb
+++ b/test/block_forward_recv_typed.rb
@@ -1,0 +1,82 @@
+# Typed-receiver `recv.m { ... }` &block forwarding (Site B).
+#
+# Pre-fix `compile_object_method_expr` dropped the literal block: the
+# call site emitted `sp_Cls_m(rc, 0)` and the binary segfaulted inside
+# `sp_proc_call(NULL, ...)`. Fix: precompute `has_proc` from the
+# callee's param types, pass it to `compile_typed_call_args` as the
+# new `omit_trailing` 4th arg so the &block slot isn't padded with
+# "0", then build a `bp`/`tail` that appends the proc literal after
+# the regular args.
+
+# 1. Basic: `recv.m { ... }` with arity-0 block.call.
+class App
+  def run(&block)
+    block.call
+  end
+end
+
+App.new.run { puts "1-basic" }
+
+# 2. block.call with one int arg, return value used.
+class Doubler
+  def apply(x, &block)
+    block.call(x)
+  end
+end
+
+puts Doubler.new.apply(21) { |n| n * 2 }
+
+# 3. Mixed: regular arg + &block, multiple stmts in method body.
+class Logger
+  def log(label, &block)
+    puts label
+    block.call
+  end
+end
+
+Logger.new.log("3-mixed") { puts "  body" }
+
+# 4. Block invoked multiple times from inside the method.
+class Repeater
+  def thrice(&block)
+    block.call
+    block.call
+    block.call
+  end
+end
+
+Repeater.new.thrice { puts "4-thrice" }
+
+# 5. Block uses interpolation of its own argument. (Closure capture
+#    over outer locals is a separate subsystem — out of scope here.)
+class Wrapper
+  def go(n, &block)
+    block.call(n)
+  end
+end
+
+Wrapper.new.go(7) { |i| puts "5-arg=#{i}" }
+
+# 6. Block returns a value used by the method.
+class Picker
+  def pick(&block)
+    block.call(10) + block.call(20)
+  end
+end
+
+puts Picker.new.pick { |n| n * 5 }
+
+# 7. Method declares &block, call site provides none. The &block
+#    slot must be filled with NULL — pre-fix `omit_trailing` dropped
+#    the slot from the C call entirely, leaving an arity mismatch
+#    between sp_Optional_maybe(sp_Optional *, sp_Proc *) and
+#    sp_Optional_maybe(_t1).
+class Optional
+  def maybe(&block)
+    puts "7-no-block"
+  end
+end
+
+Optional.new.maybe
+
+puts "done"


### PR DESCRIPTION
## Summary

`recv.m { ... }` silently dropped the literal block — the call site
emitted `sp_Cls_m(rc, 0)` and the binary segfaulted inside
`sp_proc_call(NULL, ...)`. The typed-receiver dispatch in
`compile_object_method_expr` (Site B) had no &block forwarding at
all — it always emitted `sp_Cls_m(rc, ca)` regardless of whether
the callee declared `&block`.

## Reproducer (pre-fix segfault)

```ruby
class App
  def run(&block)
    block.call
  end
end

App.new.run { puts "hi" }
# Ruby:           hi
# pre-fix Spinel: SIGSEGV inside sp_proc_call(NULL, ...)
```

## Pieces

**`has_literal_block(nid)` helper.** Returns 1 when `@nd_block[nid]`
is a literal `BlockNode` (do/end body), 0 otherwise.

**`cls_method_has_block_param(ci, midx)` predicate.** Mirrors the
existing `cls_method_has_yield`: returns 1 when the (ci, midx)
method declares any `proc`-typed param.

**`compile_typed_call_args` 4th arg `omit_trailing`.** The issue-#49
default-padding logic emitted `"0"` for any omitted trailing param,
including the &block slot. The block-forwarding code then appended
the actual proc, producing `sp_App_run(_t1, 0, sp_proc_new(...))` —
three args where two were expected. Fix: callers compute `has_proc`
before `ca` and pass it as `omit_trailing`; the &block slot is
excluded from default-padding and filled explicitly by the
forwarding logic. The three non-block callers (current-class
self-call, int-class fallback, constructor path) pass `0`.

**`build_call_tail(ca, bp)` helper.** Concatenates a comma-prefixed
tail from non-empty pieces — mirrors `build_params_str`.

**Site B `bp`/`tail` template.** `compile_object_method_expr`
precomputes `has_proc`, resolves the literal block via
`has_literal_block`, then concatenates `(rc, ca, bp)` via
`build_call_tail`.

## Out of scope

- Self-calls and `&block` argument forwarding land separately.
- Class-method dispatch (`Cls.method { ... }`) at the
  `@cls_cmeth_names`-walking site (~line 16493) — separate code
  path.
- Multi-arg `block.call(a, b, ...)` — needs a matching change in
  `compile_proc_literal` to emit fns with arity matching the block's
  params (currently hardcoded to one `mrb_int lv_<bp>`).

## Test plan

- [x] `make bootstrap` (gen2.c == gen3.c)
- [x] `make test` 160/160 pass (159 at base + 1 new)
- [x] `test/block_forward_recv_typed.rb` covers 6 cases — basic
      receivered, return-value-used, mixed regular+&block, multiple
      block invocations, block-arg interpolation, value-used-twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
