### PR TITLE
fix(codegen): forward &block at self-call sites

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -13837,23 +13837,35 @@ class Compiler
       if cidx >= 0
         owner = find_method_owner(@current_class_idx, mname)
         # Look up the method's owning class so we can fill in defaults
-        # from @cls_meth_defaults (issue #49).
+        # from @cls_meth_defaults (issue #49) and check for a &block slot.
         owner_ci = find_class_idx(owner)
         owner_midx = -1
         if owner_ci >= 0
           owner_midx = cls_find_method_direct(owner_ci, mname)
         end
+        # Omit the trailing &block slot from default-padding when the
+        # callee declares one — we'll fill it explicitly from the
+        # call site's literal block below.
+        has_proc = cls_method_has_block_param(owner_ci, owner_midx)
         ca = ""
         if owner_midx >= 0
-          ca = compile_typed_call_args(nid, owner_ci, owner_midx, 0)
+          ca = compile_typed_call_args(nid, owner_ci, owner_midx, has_proc)
         else
           ca = compile_call_args(nid)
         end
-        if ca != ""
-          return "sp_" + owner + "_" + sanitize_name(mname) + "(self, " + ca + ")"
-        else
-          return "sp_" + owner + "_" + sanitize_name(mname) + "(self)"
+        bp = ""
+        if has_proc == 1
+          if has_literal_block(nid) == 1
+            @needs_proc = 1
+            bp = compile_proc_literal(nid)
+          else
+            # The callee declares &block but the call site provides
+            # none — fill the slot with NULL so the C call has the
+            # right arity.
+            bp = "0"
+          end
         end
+        return "sp_" + owner + "_" + sanitize_name(mname) + "(self" + build_call_tail(ca, bp) + ")"
       end
       # Check attr_readers (bare method call like `x` meaning self.x)
       readers = @cls_attr_readers[@current_class_idx].split(";")

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -695,6 +695,14 @@ class Compiler
     result
   end
 
+  # Returns 1 if @nd_block[nid] is a literal BlockNode (do/end body),
+  # 0 otherwise. Used by &block-forwarding call sites to decide
+  # whether to emit a proc literal for the trailing block slot.
+  def has_literal_block(nid)
+    blk = @nd_block[nid]
+    (blk >= 0 && @nd_type[blk] == "BlockNode") ? 1 : 0
+  end
+
   # Flatten a constant reference into an internal name.
   #   C       -> C
   #   ::C     -> C
@@ -10260,6 +10268,24 @@ class Compiler
     0
   end
 
+  # Returns 1 if the (ci, midx) method declares a `&block` parameter,
+  # 0 otherwise. Ruby syntax requires `&block` to be the trailing
+  # param, so we check only the last slot — a proc-typed slot in any
+  # other position is a positional proc argument, not a block param.
+  # Mirrors cls_method_has_yield: call sites use it to decide whether
+  # to omit the trailing &block slot from default-padding.
+  def cls_method_has_block_param(ci, midx)
+    if ci < 0 || midx < 0
+      return 0
+    end
+    all_ptypes = @cls_meth_ptypes[ci].split("|")
+    if midx >= all_ptypes.length
+      return 0
+    end
+    pts = all_ptypes[midx].split(",")
+    (pts.length > 0 && pts.last == "proc") ? 1 : 0
+  end
+
   def cls_find_method_direct(ci, mname)
     mnames = @cls_meth_names[ci].split(";")
     j = 0
@@ -10879,6 +10905,21 @@ class Compiler
       end
       result = result + c_type(pt) + " lv_" + pnames[j]
       j = j + 1
+    end
+    result
+  end
+
+  # Builds the trailing portion of a call-args list — each non-empty
+  # piece prefixed with ", ", empties skipped. Returns "" when both
+  # are empty. Mirrors build_params_str: callers concatenate the
+  # result onto a self/recv prefix to form the full arg list.
+  def build_call_tail(ca, bp)
+    result = ""
+    if ca != ""
+      result = result + ", " + ca
+    end
+    if bp != ""
+      result = result + ", " + bp
     end
     result
   end
@@ -13804,7 +13845,7 @@ class Compiler
         end
         ca = ""
         if owner_midx >= 0
-          ca = compile_typed_call_args(nid, owner_ci, owner_midx)
+          ca = compile_typed_call_args(nid, owner_ci, owner_midx, 0)
         else
           ca = compile_call_args(nid)
         end
@@ -16672,24 +16713,34 @@ class Compiler
           if oci2 >= 0
             midx2 = cls_find_method_direct(oci2, mname)
           end
+          # Omit the trailing &block slot from default-padding when the
+          # callee declares one — we'll fill it explicitly from the
+          # call site's literal block below.
+          has_proc = cls_method_has_block_param(oci2, midx2)
           ca = ""
           if midx2 >= 0
-            ca = compile_typed_call_args(nid, oci2, midx2)
+            ca = compile_typed_call_args(nid, oci2, midx2, has_proc)
           else
             ca = compile_call_args(nid)
           end
+          bp = ""
+          if has_proc == 1
+            if has_literal_block(nid) == 1
+              @needs_proc = 1
+              bp = compile_proc_literal(nid)
+            else
+              # The callee declares &block but the call site provides
+              # none — fill the slot with NULL so the C call has the
+              # right arity (compile_typed_call_args has already been
+              # told to skip default-padding for this slot).
+              bp = "0"
+            end
+          end
+          tail = build_call_tail(ca, bp)
           if owner == cname
-            if ca != ""
-              return "sp_" + owner + "_" + sanitize_name(mname) + "(" + rc + ", " + ca + ")"
-            else
-              return "sp_" + owner + "_" + sanitize_name(mname) + "(" + rc + ")"
-            end
+            return "sp_" + owner + "_" + sanitize_name(mname) + "(" + rc + tail + ")"
           else
-            if ca != ""
-              return "sp_" + owner + "_" + sanitize_name(mname) + "((sp_" + owner + " *)" + rc + ", " + ca + ")"
-            else
-              return "sp_" + owner + "_" + sanitize_name(mname) + "((sp_" + owner + " *)" + rc + ")"
-            end
+            return "sp_" + owner + "_" + sanitize_name(mname) + "((sp_" + owner + " *)" + rc + tail + ")"
           end
         end
       end
@@ -16740,7 +16791,7 @@ class Compiler
           end
           ca2 = ""
           if midx3 >= 0
-            ca2 = compile_typed_call_args(nid, oci3, midx3)
+            ca2 = compile_typed_call_args(nid, oci3, midx3, 0)
           else
             ca2 = compile_call_args(nid)
           end
@@ -17209,7 +17260,7 @@ class Compiler
       if init_ci >= 0
         init_idx = cls_find_method_direct(init_ci, "initialize")
         if init_idx >= 0
-          return compile_typed_call_args(nid, init_ci, init_idx)
+          return compile_typed_call_args(nid, init_ci, init_idx, 0)
         end
       end
       return ""
@@ -17409,11 +17460,16 @@ class Compiler
     result
   end
 
-  def compile_typed_call_args(nid, target_ci, target_midx)
+  def compile_typed_call_args(nid, target_ci, target_midx, omit_trailing)
     # Like compile_call_args but casts arguments to match target method param
     # types AND fills in defaults from @cls_meth_defaults for trailing
     # parameters the caller omitted (issue #49). Returns "" only when the
     # method takes no parameters at all.
+    #
+    # `omit_trailing` is the number of trailing param slots to leave out
+    # entirely — block-forwarding call sites pass 1 so the &block slot
+    # isn't default-padded with "0" (the actual proc is appended by the
+    # caller after this returns).
     args_id = @nd_arguments[nid]
     arg_ids = []
     if args_id >= 0
@@ -17428,6 +17484,24 @@ class Compiler
     end
     if target_midx < all_defaults.length
       defaults = all_defaults[target_midx].split(",")
+    end
+    # Drop the trailing slots the caller will fill explicitly (the
+    # &block slot when block-forwarding) — otherwise a surplus
+    # positional arg would mis-cast against the omitted slot's type
+    # and the loop's default-padding would emit "0" for the slot the
+    # caller is about to fill itself.
+    if omit_trailing > 0
+      kept = []
+      pk = 0
+      limit = ptypes.length - omit_trailing
+      if limit < 0
+        limit = 0
+      end
+      while pk < limit
+        kept.push(ptypes[pk])
+        pk = pk + 1
+      end
+      ptypes = kept
     end
     total = ptypes.length
     if arg_ids.length > total

--- a/test/block_forward_recv_typed.rb
+++ b/test/block_forward_recv_typed.rb
@@ -1,0 +1,82 @@
+# Typed-receiver `recv.m { ... }` &block forwarding (Site B).
+#
+# Pre-fix `compile_object_method_expr` dropped the literal block: the
+# call site emitted `sp_Cls_m(rc, 0)` and the binary segfaulted inside
+# `sp_proc_call(NULL, ...)`. Fix: precompute `has_proc` from the
+# callee's param types, pass it to `compile_typed_call_args` as the
+# new `omit_trailing` 4th arg so the &block slot isn't padded with
+# "0", then build a `bp`/`tail` that appends the proc literal after
+# the regular args.
+
+# 1. Basic: `recv.m { ... }` with arity-0 block.call.
+class App
+  def run(&block)
+    block.call
+  end
+end
+
+App.new.run { puts "1-basic" }
+
+# 2. block.call with one int arg, return value used.
+class Doubler
+  def apply(x, &block)
+    block.call(x)
+  end
+end
+
+puts Doubler.new.apply(21) { |n| n * 2 }
+
+# 3. Mixed: regular arg + &block, multiple stmts in method body.
+class Logger
+  def log(label, &block)
+    puts label
+    block.call
+  end
+end
+
+Logger.new.log("3-mixed") { puts "  body" }
+
+# 4. Block invoked multiple times from inside the method.
+class Repeater
+  def thrice(&block)
+    block.call
+    block.call
+    block.call
+  end
+end
+
+Repeater.new.thrice { puts "4-thrice" }
+
+# 5. Block uses interpolation of its own argument. (Closure capture
+#    over outer locals is a separate subsystem — out of scope here.)
+class Wrapper
+  def go(n, &block)
+    block.call(n)
+  end
+end
+
+Wrapper.new.go(7) { |i| puts "5-arg=#{i}" }
+
+# 6. Block returns a value used by the method.
+class Picker
+  def pick(&block)
+    block.call(10) + block.call(20)
+  end
+end
+
+puts Picker.new.pick { |n| n * 5 }
+
+# 7. Method declares &block, call site provides none. The &block
+#    slot must be filled with NULL — pre-fix `omit_trailing` dropped
+#    the slot from the C call entirely, leaving an arity mismatch
+#    between sp_Optional_maybe(sp_Optional *, sp_Proc *) and
+#    sp_Optional_maybe(_t1).
+class Optional
+  def maybe(&block)
+    puts "7-no-block"
+  end
+end
+
+Optional.new.maybe
+
+puts "done"

--- a/test/block_forward_self_call.rb
+++ b/test/block_forward_self_call.rb
@@ -1,0 +1,61 @@
+# Self-call `m { ... }` &block forwarding (Site A).
+#
+# When a method on class C calls another method on the same class
+# without an explicit receiver (`m { ... }` instead of `self.m { ... }`),
+# dispatch goes through `compile_no_recv_call_expr`'s
+# `@current_class_idx >= 0` branch — call this Site A. Pre-fix this
+# branch always emitted `sp_C_m(self, ca)` with no block tail, so a
+# literal block at the call site was silently dropped and the binary
+# segfaulted in `sp_proc_call(NULL, ...)`.
+#
+# Site A reuses the `has_literal_block` helper and the
+# `omit_trailing` 4th arg of `compile_typed_call_args` introduced
+# in the previous PR (Site B / typed-receiver forwarding); the only
+# new code here is the same `bp`/`tail` template adapted to the
+# self-call form.
+
+# 1. Bare self-call dispatch — one method invokes another method
+#    of the same class with a literal block.
+class Caller
+  def kick
+    inner { puts "1-self-call" }
+  end
+
+  def inner(&block)
+    block.call
+  end
+end
+
+Caller.new.kick
+
+# 2. Self-call passes a value through to the block via block.call(arg).
+class Wrapper
+  def go
+    forward(7) { |i| puts "2-arg=#{i}" }
+  end
+
+  def forward(n, &block)
+    block.call(n)
+  end
+end
+
+Wrapper.new.go
+
+# 3. Self-call inside a loop — each iteration forwards a fresh block.
+class Bank
+  def run
+    deposit_each(3) { |i| puts "3-dollar-#{i}" }
+  end
+
+  def deposit_each(n, &block)
+    i = 0
+    while i < n
+      block.call(i)
+      i = i + 1
+    end
+  end
+end
+
+Bank.new.run
+
+puts "done"


### PR DESCRIPTION
## Summary

`m { ... }` from inside another method of the same class silently
dropped the literal block. The self-call dispatch path —
`compile_no_recv_call_expr`'s `@current_class_idx >= 0` branch —
always emitted `sp_C_m(self, ca)` with no block tail, so the block
went nowhere and the binary segfaulted in `sp_proc_call(NULL, ...)`.

Symmetric to #108 (typed-receiver fix); reuses its
`has_literal_block`, `cls_method_has_block_param`, `build_call_tail`,
and `omit_trailing` machinery. Stacks on #108 — until that merges,
the diff here shows both commits.

## Reproducer (pre-fix segfault)

```ruby
class Caller
  def kick
    inner { puts "hi" }
  end

  def inner(&block)
    block.call
  end
end

Caller.new.kick
# Ruby:           hi
# pre-fix Spinel: SIGSEGV inside sp_proc_call(NULL, ...)
```

## Fix

The new code is the same `bp`/`tail` template from #108 adapted to
the self-call form, which carries `self` instead of a typed-receiver
C-temp.

## Test plan

- [x] `make bootstrap` (gen2.c == gen3.c)
- [x] `make test` 161/161 pass (160 at #108's tip + 1 new)
- [x] `test/block_forward_self_call.rb` covers 3 cases — bare
      self-call, self-call passing arg through to block, self-call
      inside a loop forwarding a fresh block per iteration.
