### PR TITLE
fix(codegen): isolate block param scope so infer_type ignores outer same-named locals

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -1982,7 +1982,9 @@ class Compiler
       return "int"
     end
     if mname == "then" || mname == "yield_self"
-      # Return type is the block's return type
+      # Return type is the block's return type. Bind the block param to
+      # the receiver's type so infer_type sees the inner shadow, not any
+      # outer same-named local of a different type.
       if recv >= 0
         blk = @nd_block[nid]
         if blk >= 0
@@ -1990,7 +1992,16 @@ class Compiler
           if bbody >= 0
             bbs = get_stmts(bbody)
             if bbs.length > 0
-              return infer_type(bbs.last)
+              bp = get_block_param(nid, 0)
+              if bp == ""
+                bp = "_x"
+              end
+              recv_t = infer_type(recv)
+              push_scope
+              declare_var(bp, recv_t)
+              rt = infer_type(bbs.last)
+              pop_scope
+              return rt
             end
           end
         end
@@ -2529,14 +2540,21 @@ class Compiler
     end
     if mname == "map"
       if recv >= 0
-        # Determine result array type from block return type
+        # Declare bp inside a scope so infer_type sees the inner element type, not a shadowed outer local.
         blk = @nd_block[nid]
         if blk >= 0
           bbody = @nd_body[blk]
           if bbody >= 0
             bbs = get_stmts(bbody)
             if bbs.length > 0
+              recv_t = infer_type(recv)
+              bp1 = get_block_param(nid, 0)
+              push_scope
+              if bp1 != ""
+                declare_var(bp1, iter_elem_type(recv_t))
+              end
               bret = infer_type(bbs.last)
+              pop_scope
               if bret == "string"
                 return "str_array"
               end
@@ -15319,7 +15337,6 @@ class Compiler
         bp1 = "_x"
       end
       et = elem_type_of_array(recv_type)
-      declare_var(bp1, et)
       tmp_t = new_temp
       tmp_f = new_temp
       tmp_res = new_temp
@@ -15327,7 +15344,9 @@ class Compiler
       emit("  " + c_type(recv_type) + " " + tmp_t + " = sp_" + pfx + "_new();")
       emit("  " + c_type(recv_type) + " " + tmp_f + " = sp_" + pfx + "_new();")
       emit("  for (mrb_int " + itmp + " = 0; " + itmp + " < sp_" + pfx + "_length(" + rc + "); " + itmp + "++) {")
-      emit("    lv_" + bp1 + " = sp_" + pfx + "_get(" + rc + ", " + itmp + ");")
+      emit("    " + c_type(et) + " lv_" + bp1 + " = sp_" + pfx + "_get(" + rc + ", " + itmp + ");")
+      push_scope
+      declare_var(bp1, et)
       blk = @nd_block[nid]
       bexpr = "0"
       if @nd_body[blk] >= 0
@@ -15342,6 +15361,7 @@ class Compiler
         end
       end
       emit("    if (" + bexpr + ") sp_" + pfx + "_push(" + tmp_t + ", lv_" + bp1 + "); else sp_" + pfx + "_push(" + tmp_f + ", lv_" + bp1 + ");")
+      pop_scope
       emit("  }")
       emit("  " + name + " *" + tmp_res + " = (" + name + " *)sp_gc_alloc(sizeof(" + name + "), NULL, " + tuple_scan_name(tt) + ");")
       emit("  " + tmp_res + "->_0 = " + tmp_t + ";")
@@ -15946,11 +15966,12 @@ class Compiler
         if @nd_block[nid] >= 0
           blk = @nd_block[nid]
           bp = get_block_param(nid, 0)
-          declare_var(bp, "int")
           tmp = new_temp
           emit("  sp_StrIntHash *" + tmp + " = sp_StrIntHash_new();")
           emit("  for (mrb_int _i = 0; _i < " + rc + "->len; _i++) {")
           emit("    mrb_int lv_" + bp + " = sp_StrIntHash_get(" + rc + ", " + rc + "->order[_i]);")
+          push_scope
+          declare_var(bp, "int")
           bbody = @nd_body[blk]
           bexpr = "0"
           if bbody >= 0
@@ -15960,6 +15981,7 @@ class Compiler
             end
           end
           emit("    sp_StrIntHash_set(" + tmp + ", " + rc + "->order[_i], " + bexpr + ");")
+          pop_scope
           emit("  }")
           return tmp
         end
@@ -19448,7 +19470,6 @@ class Compiler
           if bp == ""
             bp = "_c"
           end
-          declare_var(bp, "string")
           tmp = new_temp
           src = rc
           if rt == "mutable_str"
@@ -19463,9 +19484,12 @@ class Compiler
           emit("    char *" + char_buf + " = sp_str_alloc_raw(" + cn_tmp + " + 1);")
           emit("    memcpy(" + char_buf + ", " + src_tmp + " + " + tmp + ", " + cn_tmp + ");")
           emit("    " + char_buf + "[" + cn_tmp + "] = 0;")
-          emit("    lv_" + bp + " = " + char_buf + ";")
+          emit("    const char *lv_" + bp + " = " + char_buf + ";")
           @indent = @indent + 1
+          push_scope
+          declare_var(bp, "string")
           compile_stmts_body(@nd_body[@nd_block[nid]])
+          pop_scope
           @indent = @indent - 1
           emit("    " + tmp + " += " + cn_tmp + ";")
           emit("  }")
@@ -19483,7 +19507,6 @@ class Compiler
           if bp == ""
             bp = "_b"
           end
-          declare_var(bp, "int")
           tmp = new_temp
           src = rc
           if rt == "mutable_str"
@@ -19492,9 +19515,12 @@ class Compiler
           src_tmp = new_temp
           emit("  const char *" + src_tmp + " = " + src + ";")
           emit("  for (mrb_int " + tmp + " = 0; " + src_tmp + "[" + tmp + "]; " + tmp + "++) {")
-          emit("    lv_" + bp + " = (unsigned char)" + src_tmp + "[" + tmp + "];")
+          emit("    mrb_int lv_" + bp + " = (unsigned char)" + src_tmp + "[" + tmp + "];")
           @indent = @indent + 1
+          push_scope
+          declare_var(bp, "int")
           compile_stmts_body(@nd_body[@nd_block[nid]])
+          pop_scope
           @indent = @indent - 1
           emit("  }")
           return 1
@@ -19511,7 +19537,6 @@ class Compiler
           if bp == ""
             bp = "_l"
           end
-          declare_var(bp, "string")
           @needs_str_array = 1
           tmp_arr = new_temp
           tmp_i = new_temp
@@ -19521,9 +19546,12 @@ class Compiler
           end
           emit("  sp_StrArray *" + tmp_arr + " = sp_str_split(" + src + ", \"\\n\");")
           emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < " + tmp_arr + "->len; " + tmp_i + "++) {")
-          emit("    lv_" + bp + " = " + tmp_arr + "->data[" + tmp_i + "];")
+          emit("    const char *lv_" + bp + " = " + tmp_arr + "->data[" + tmp_i + "];")
           @indent = @indent + 1
+          push_scope
+          declare_var(bp, "string")
           compile_stmts_body(@nd_body[@nd_block[nid]])
+          pop_scope
           @indent = @indent - 1
           emit("  }")
           return 1
@@ -19561,13 +19589,18 @@ class Compiler
           bp2 = "_b"
         end
         pfx = array_c_prefix(rt)
-        et = c_type(elem_type_of_array(rt))
+        elem_t = elem_type_of_array(rt)
+        et = c_type(elem_t)
         tmp_i = new_temp
         emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_" + pfx + "_length(" + rc + "); " + tmp_i + "++) {")
         emit("    " + et + " lv_" + bp1 + " = sp_" + pfx + "_get(" + rc + ", " + tmp_i + ");")
         emit("    " + et + " lv_" + bp2 + " = sp_" + pfx + "_get(" + arg + ", " + tmp_i + ");")
         @indent = @indent + 1
+        push_scope
+        declare_var(bp1, elem_t)
+        declare_var(bp2, elem_t)
         compile_stmts_body(@nd_body[@nd_block[nid]])
+        pop_scope
         @indent = @indent - 1
         emit("  }")
         @in_loop = old
@@ -19608,7 +19641,10 @@ class Compiler
         end
         emit("  for (lv_" + bp1 + " = " + rc + "; lv_" + bp1 + " <= " + limit_val + "; lv_" + bp1 + " += " + step_val + ") {")
         @indent = @indent + 1
+        push_scope
+        declare_var(bp1, "int")
         compile_stmts_body(@nd_body[@nd_block[nid]])
+        pop_scope
         @indent = @indent - 1
         emit("  }")
         if synth == 1
@@ -19631,13 +19667,17 @@ class Compiler
           bp1 = "_x"
         end
         pfx = array_c_prefix(rt)
+        et = elem_type_of_array(rt)
         tmp_c = new_temp
         tmp_i = new_temp
         emit("  for (mrb_int " + tmp_c + " = 0; " + tmp_c + " < " + n + "; " + tmp_c + "++)")
         emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_" + pfx + "_length(" + rc + "); " + tmp_i + "++) {")
-        emit("    lv_" + bp1 + " = sp_" + pfx + "_get(" + rc + ", " + tmp_i + ");")
+        emit("    " + c_type(et) + " lv_" + bp1 + " = sp_" + pfx + "_get(" + rc + ", " + tmp_i + ");")
         @indent = @indent + 1
+        push_scope
+        declare_var(bp1, et)
         compile_stmts_body(@nd_body[@nd_block[nid]])
+        pop_scope
         @indent = @indent - 1
         emit("  }")
         @in_loop = old
@@ -19666,12 +19706,14 @@ class Compiler
                 tmp_i = new_temp
                 emit("  sp_StrArray *" + tmp_arr + " = sp_re_scan(sp_re_pat_" + ridx.to_s + ", " + rc + ");")
                 emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < " + tmp_arr + "->len; " + tmp_i + "++) {")
-                set_var_type(bp, "string")
-                emit("    lv_" + bp + " = " + tmp_arr + "->data[" + tmp_i + "];")
+                emit("    const char *lv_" + bp + " = " + tmp_arr + "->data[" + tmp_i + "];")
+                push_scope
+                declare_var(bp, "string")
                 blk = @nd_block[nid]
                 if @nd_body[blk] >= 0
                   compile_stmts_body(@nd_body[blk])
                 end
+                pop_scope
                 emit("  }")
                 return 1
               end
@@ -20027,11 +20069,12 @@ class Compiler
               if @nd_block[nid] >= 0
                 lblk = @nd_block[nid]
                 lbp = get_block_param(nid, 0)
-                declare_var(lbp, "string")
                 ltmp = new_temp
                 emit("  { char " + ltmp + "[4096];")
                 emit("  while (fgets(" + ltmp + ", sizeof(" + ltmp + "), " + ftmp + ")) {")
                 emit("    const char *lv_" + lbp + " = " + ltmp + ";")
+                push_scope
+                declare_var(lbp, "string")
                 # Compile block body
                 lbbody = @nd_body[lblk]
                 if lbbody >= 0
@@ -20042,6 +20085,7 @@ class Compiler
                     lbk = lbk + 1
                   end
                 end
+                pop_scope
                 emit("  } }")
                 return
               end
@@ -21474,15 +21518,28 @@ class Compiler
     tmp_j = new_temp
     tmp_len = new_temp
     pfx = array_c_prefix(rt)
-    declare_var(bp1, rt)
     @needs_gc = 1
     emit("  mrb_int " + tmp_len + " = sp_" + pfx + "_length(" + rc + ");")
     emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < " + tmp_len + "; " + tmp_i + " += " + n + ") {")
-    emit("    lv_" + bp1 + " = sp_" + pfx + "_new();")
+    # When bp1 shadows an outer same-named local of a different C type, the
+    # function-level lv_<bp1> has the outer type. Emit a block-scoped fresh
+    # declaration with its own GC root so the slice survives allocations in
+    # the user block body.
+    outer_t = find_var_type(bp1)
+    if outer_t != "" && outer_t != rt
+      emit("    SP_GC_SAVE();")
+      emit("    " + c_type(rt) + " lv_" + bp1 + " = sp_" + pfx + "_new();")
+      emit("    SP_GC_ROOT(lv_" + bp1 + ");")
+    else
+      emit("    lv_" + bp1 + " = sp_" + pfx + "_new();")
+    end
     emit("    for (mrb_int " + tmp_j + " = 0; " + tmp_j + " < " + n + " && " + tmp_i + " + " + tmp_j + " < " + tmp_len + "; " + tmp_j + "++)")
     emit("      sp_" + pfx + "_push(lv_" + bp1 + ", sp_" + pfx + "_get(" + rc + ", " + tmp_i + " + " + tmp_j + "));")
     @indent = @indent + 1
+    push_scope
+    declare_var(bp1, rt)
     compile_stmts_body(@nd_body[@nd_block[nid]])
+    pop_scope
     @indent = @indent - 1
     emit("  }")
     @in_loop = old
@@ -21502,15 +21559,26 @@ class Compiler
     tmp_j = new_temp
     tmp_len = new_temp
     pfx = array_c_prefix(rt)
-    declare_var(bp1, rt)
     @needs_gc = 1
     emit("  mrb_int " + tmp_len + " = sp_" + pfx + "_length(" + rc + ");")
     emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " + " + n + " <= " + tmp_len + "; " + tmp_i + "++) {")
-    emit("    lv_" + bp1 + " = sp_" + pfx + "_new();")
+    # See compile_each_slice_block: shadow case needs a fresh typed slot with
+    # its own GC root.
+    outer_t = find_var_type(bp1)
+    if outer_t != "" && outer_t != rt
+      emit("    SP_GC_SAVE();")
+      emit("    " + c_type(rt) + " lv_" + bp1 + " = sp_" + pfx + "_new();")
+      emit("    SP_GC_ROOT(lv_" + bp1 + ");")
+    else
+      emit("    lv_" + bp1 + " = sp_" + pfx + "_new();")
+    end
     emit("    for (mrb_int " + tmp_j + " = 0; " + tmp_j + " < " + n + "; " + tmp_j + "++)")
     emit("      sp_" + pfx + "_push(lv_" + bp1 + ", sp_" + pfx + "_get(" + rc + ", " + tmp_i + " + " + tmp_j + "));")
     @indent = @indent + 1
+    push_scope
+    declare_var(bp1, rt)
     compile_stmts_body(@nd_body[@nd_block[nid]])
+    pop_scope
     @indent = @indent - 1
     emit("  }")
     @in_loop = old
@@ -21561,7 +21629,10 @@ class Compiler
       emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_" + pfx + "_length(" + rc + "); " + tmp_i + "++) {")
       emit("    " + c_type(elem_type_of_array(rt)) + " lv_" + bp1 + " = sp_" + pfx + "_get(" + rc + ", " + tmp_i + ");")
       @indent = @indent + 1
+      push_scope
+      declare_var(bp1, elem_type_of_array(rt))
       compile_stmts_body(@nd_body[@nd_block[nid]])
+      pop_scope
       @indent = @indent - 1
       emit("  }")
       emit("  " + result + " = lv_" + bp2 + ";")
@@ -21591,7 +21662,11 @@ class Compiler
     emit("    " + c_type(elem_type_of_array(rt)) + " lv_" + bp1 + " = sp_" + pfx + "_get(" + rc + ", " + tmp + ");")
     emit("    mrb_int lv_" + bp2 + " = " + tmp + ";")
     @indent = @indent + 1
+    push_scope
+    declare_var(bp1, elem_type_of_array(rt))
+    declare_var(bp2, "int")
     compile_stmts_body(@nd_body[@nd_block[nid]])
+    pop_scope
     @indent = @indent - 1
     emit("  }")
     @in_loop = old
@@ -21618,7 +21693,12 @@ class Compiler
         emit("    " + c_type(elem_type_of_array(rt)) + " lv_" + bp1 + " = sp_" + pfx + "_get(" + rc + ", " + tmp + ");")
       end
       @indent = @indent + 1
+      push_scope
+      if has_bp == 1
+        declare_var(bp1, elem_type_of_array(rt))
+      end
       compile_stmts_body(@nd_body[@nd_block[nid]])
+      pop_scope
       @indent = @indent - 1
       emit("  }")
     end
@@ -21629,7 +21709,12 @@ class Compiler
         emit("    lv_" + bp1 + " = (sp_sym)sp_IntArray_get(" + rc + ", " + tmp + ");")
       end
       @indent = @indent + 1
+      push_scope
+      if has_bp == 1
+        declare_var(bp1, "symbol")
+      end
       compile_stmts_body(@nd_body[@nd_block[nid]])
+      pop_scope
       @indent = @indent - 1
       emit("  }")
     end
@@ -21643,7 +21728,12 @@ class Compiler
         emit("    lv_" + bp1 + " = " + bp_tmp + ";")
       end
       @indent = @indent + 1
+      push_scope
+      if has_bp == 1
+        declare_var(bp1, elem_type)
+      end
       compile_stmts_body(@nd_body[@nd_block[nid]])
+      pop_scope
       @indent = @indent - 1
       emit("  }")
     end
@@ -21655,7 +21745,13 @@ class Compiler
         emit("    lv_" + bp2 + " = sp_StrIntHash_get(" + rc + ", " + rc + "->order[" + tmp + "]);")
       end
       @indent = @indent + 1
+      push_scope
+      declare_var(bp1, "string")
+      if bp2 != ""
+        declare_var(bp2, "int")
+      end
       compile_stmts_body(@nd_body[@nd_block[nid]])
+      pop_scope
       @indent = @indent - 1
       emit("  }")
     end
@@ -21667,7 +21763,13 @@ class Compiler
         emit("    lv_" + bp2 + " = sp_IntStrHash_get(" + rc + ", " + rc + "->order[" + tmp + "]);")
       end
       @indent = @indent + 1
+      push_scope
+      declare_var(bp1, "int")
+      if bp2 != ""
+        declare_var(bp2, "string")
+      end
       compile_stmts_body(@nd_body[@nd_block[nid]])
+      pop_scope
       @indent = @indent - 1
       emit("  }")
     end
@@ -21679,7 +21781,13 @@ class Compiler
         emit("    lv_" + bp2 + " = sp_StrStrHash_get(" + rc + ", " + rc + "->order[" + tmp + "]);")
       end
       @indent = @indent + 1
+      push_scope
+      declare_var(bp1, "string")
+      if bp2 != ""
+        declare_var(bp2, "string")
+      end
       compile_stmts_body(@nd_body[@nd_block[nid]])
+      pop_scope
       @indent = @indent - 1
       emit("  }")
     end
@@ -21691,7 +21799,13 @@ class Compiler
         emit("    lv_" + bp2 + " = sp_SymIntHash_get(" + rc + ", " + rc + "->order[" + tmp + "]);")
       end
       @indent = @indent + 1
+      push_scope
+      declare_var(bp1, "symbol")
+      if bp2 != ""
+        declare_var(bp2, "int")
+      end
       compile_stmts_body(@nd_body[@nd_block[nid]])
+      pop_scope
       @indent = @indent - 1
       emit("  }")
     end
@@ -21703,7 +21817,13 @@ class Compiler
         emit("    lv_" + bp2 + " = sp_SymStrHash_get(" + rc + ", " + rc + "->order[" + tmp + "]);")
       end
       @indent = @indent + 1
+      push_scope
+      declare_var(bp1, "symbol")
+      if bp2 != ""
+        declare_var(bp2, "string")
+      end
       compile_stmts_body(@nd_body[@nd_block[nid]])
+      pop_scope
       @indent = @indent - 1
       emit("  }")
     end
@@ -21715,7 +21835,13 @@ class Compiler
         emit("    lv_" + bp2 + " = sp_SymPolyHash_get(" + rc + ", " + rc + "->order[" + tmp + "]);")
       end
       @indent = @indent + 1
+      push_scope
+      declare_var(bp1, "symbol")
+      if bp2 != ""
+        declare_var(bp2, "poly")
+      end
       compile_stmts_body(@nd_body[@nd_block[nid]])
+      pop_scope
       @indent = @indent - 1
       emit("  }")
     end
@@ -21727,7 +21853,13 @@ class Compiler
         emit("    lv_" + bp2 + " = sp_StrPolyHash_get(" + rc + ", " + rc + "->order[" + tmp + "]);")
       end
       @indent = @indent + 1
+      push_scope
+      declare_var(bp1, "string")
+      if bp2 != ""
+        declare_var(bp2, "poly")
+      end
       compile_stmts_body(@nd_body[@nd_block[nid]])
+      pop_scope
       @indent = @indent - 1
       emit("  }")
     end
@@ -21737,7 +21869,12 @@ class Compiler
       emit("  sp_Range " + tmp2 + " = " + rc + ";")
       emit("  for (lv_" + bp1 + " = " + tmp2 + ".first; lv_" + bp1 + " <= " + tmp2 + ".last; lv_" + bp1 + "++) {")
       @indent = @indent + 1
+      push_scope
+      if has_bp == 1
+        declare_var(bp1, "int")
+      end
       compile_stmts_body(@nd_body[@nd_block[nid]])
+      pop_scope
       @indent = @indent - 1
       emit("  }")
     end
@@ -21746,7 +21883,12 @@ class Compiler
       emit("  for (mrb_int " + tmp + " = 0; " + tmp + " < sp_PolyArray_length(" + rc + "); " + tmp + "++) {")
       emit("    lv_" + bp1 + " = sp_PolyArray_get(" + rc + ", " + tmp + ");")
       @indent = @indent + 1
+      push_scope
+      if has_bp == 1
+        declare_var(bp1, "poly")
+      end
       compile_stmts_body(@nd_body[@nd_block[nid]])
+      pop_scope
       @indent = @indent - 1
       emit("  }")
     end
@@ -21764,7 +21906,12 @@ class Compiler
       emit("    lv_" + bp1 + " = " + tmp + ";")
     end
     @indent = @indent + 1
+    push_scope
+    if bp1 != ""
+      declare_var(bp1, "int")
+    end
     compile_stmts_body(@nd_body[@nd_block[nid]])
+    pop_scope
     @indent = @indent - 1
     emit("  }")
     @in_loop = old
@@ -21782,7 +21929,12 @@ class Compiler
       emit("    lv_" + bp1 + " = " + tmp + ";")
     end
     @indent = @indent + 1
+    push_scope
+    if bp1 != ""
+      declare_var(bp1, "int")
+    end
     compile_stmts_body(@nd_body[@nd_block[nid]])
+    pop_scope
     @indent = @indent - 1
     emit("  }")
     @in_loop = old
@@ -21800,24 +21952,34 @@ class Compiler
       emit("    lv_" + bp1 + " = " + tmp + ";")
     end
     @indent = @indent + 1
+    push_scope
+    if bp1 != ""
+      declare_var(bp1, "int")
+    end
     compile_stmts_body(@nd_body[@nd_block[nid]])
+    pop_scope
     @indent = @indent - 1
     emit("  }")
     @in_loop = old
   end
 
   def compile_tap_expr(nid)
-    # Execute block with receiver bound to block param, return receiver
+    # Execute block with receiver bound to block param, return receiver.
+    # Open a C block so the param is a fresh local that shadows any
+    # outer same-named lv_<bp> without clobbering its value or type.
     rt = infer_type(@nd_receiver[nid])
     rc = compile_expr_gc_rooted(@nd_receiver[nid])
     bp = get_block_param(nid, 0)
     if bp == ""
       bp = "_x"
     end
-    declare_var(bp, rt)
     tmp = new_temp
     emit("  " + c_type(rt) + " " + tmp + " = " + rc + ";")
-    emit("  lv_" + bp + " = " + tmp + ";")
+    emit("  {")
+    emit("    " + c_type(rt) + " lv_" + bp + " = " + tmp + ";")
+    @indent = @indent + 1
+    push_scope
+    declare_var(bp, rt)
     blk = @nd_block[nid]
     bbody = @nd_body[blk]
     if bbody >= 0
@@ -21828,33 +21990,62 @@ class Compiler
         k = k + 1
       end
     end
+    pop_scope
+    @indent = @indent - 1
+    emit("  }")
     tmp
   end
 
   def compile_then_expr(nid)
-    # Execute block with receiver bound to block param, return block result
+    # Execute block with receiver bound to block param, return block result.
+    # Open a C block so the param is a fresh local that shadows any outer
+    # same-named lv_<bp>. The block's last-expression value is funneled
+    # through a result tmp declared in the enclosing scope so callers can
+    # still consume it after the C block closes.
     rt = infer_type(@nd_receiver[nid])
     rc = compile_expr_gc_rooted(@nd_receiver[nid])
     bp = get_block_param(nid, 0)
     if bp == ""
       bp = "_x"
     end
-    declare_var(bp, rt)
-    emit("  lv_" + bp + " = " + rc + ";")
     blk = @nd_block[nid]
     bbody = @nd_body[blk]
+
+    # Peek at the last expression's type under the inner binding so the
+    # result tmp is declared with the type that infer_type sees inside
+    # the block, not the type of any outer same-named local.
+    ret_t = "int"
+    bs = []
     if bbody >= 0
       bs = get_stmts(bbody)
+      if bs.length > 0
+        push_scope
+        declare_var(bp, rt)
+        ret_t = infer_type(bs.last)
+        pop_scope
+      end
+    end
+
+    result_tmp = new_temp
+    emit("  " + c_type(ret_t) + " " + result_tmp + " = " + c_default_val(ret_t) + ";")
+    emit("  {")
+    emit("    " + c_type(rt) + " lv_" + bp + " = " + rc + ";")
+    @indent = @indent + 1
+    push_scope
+    declare_var(bp, rt)
+    if bs.length > 0
       k = 0
       while k < bs.length - 1
         compile_stmt(bs[k])
         k = k + 1
       end
-      if bs.length > 0
-        return compile_expr(bs.last)
-      end
+      last_expr = compile_expr(bs.last)
+      emit("  " + result_tmp + " = " + last_expr + ";")
     end
-    "0"
+    pop_scope
+    @indent = @indent - 1
+    emit("  }")
+    result_tmp
   end
 
   # Emit the loop-open lines for iterating over a receiver expression.
@@ -21888,11 +22079,12 @@ class Compiler
     if bp1 == ""
       bp1 = "_x"
     end
-    declare_var(bp1, iter_elem_type(recv_type))
     tmp_sum = new_temp
     tmp_i = new_temp
     emit("  mrb_int " + tmp_sum + " = 0;")
     emit_iter_open(rc, recv_type, "lv_" + bp1, tmp_i)
+    push_scope
+    declare_var(bp1, iter_elem_type(recv_type))
     blk = @nd_block[nid]
     bexpr = "0"
     if @nd_body[blk] >= 0
@@ -21907,6 +22099,7 @@ class Compiler
       end
     end
     emit("    " + tmp_sum + " += " + bexpr + ";")
+    pop_scope
     emit("  }")
     tmp_sum
   end
@@ -21916,11 +22109,12 @@ class Compiler
     if bp1 == ""
       bp1 = "_x"
     end
-    declare_var(bp1, iter_elem_type(recv_type))
     tmp_cnt = new_temp
     tmp_i = new_temp
     emit("  mrb_int " + tmp_cnt + " = 0;")
     emit_iter_open(rc, recv_type, "lv_" + bp1, tmp_i)
+    push_scope
+    declare_var(bp1, iter_elem_type(recv_type))
     blk = @nd_block[nid]
     bexpr = "0"
     if @nd_body[blk] >= 0
@@ -21935,6 +22129,7 @@ class Compiler
       end
     end
     emit("    if (" + bexpr + ") " + tmp_cnt + "++;")
+    pop_scope
     emit("  }")
     tmp_cnt
   end
@@ -21950,7 +22145,6 @@ class Compiler
     elsif recv_type == "float_array"
       elem_type = "float"
     end
-    set_var_type(bp1, elem_type)
     tmp_res = new_temp
     tmp_key = new_temp
     tmp_i = new_temp
@@ -21960,6 +22154,8 @@ class Compiler
     emit("  " + c_type(elem_type) + " " + bp_tmp + " = " + c_default_val(elem_type) + ";")
     emit_iter_open(rc, recv_type, "lv_" + bp1, tmp_i)
     emit("    " + bp_tmp + " = lv_" + bp1 + ";")
+    push_scope
+    declare_var(bp1, elem_type)
     blk = @nd_block[nid]
     bexpr = "0"
     if @nd_body[blk] >= 0
@@ -21979,6 +22175,7 @@ class Compiler
     end
     emit("    mrb_int _k = " + bexpr + ";")
     emit("    if (" + tmp_i + " == 0 || _k " + cmp + " " + tmp_key + ") { " + tmp_res + " = " + bp_tmp + "; " + tmp_key + " = _k; }")
+    pop_scope
     emit("  }")
     tmp_res
   end
@@ -21988,8 +22185,9 @@ class Compiler
     if bp1 == ""
       bp1 = "_x"
     end
-    declare_var(bp1, iter_elem_type(recv_type))
-    # Determine result type from block return
+    elem_t = iter_elem_type(recv_type)
+    push_scope
+    declare_var(bp1, elem_t)
     blk = @nd_block[nid]
     block_ret = "int"
     if blk >= 0
@@ -22034,6 +22232,7 @@ class Compiler
     emit("  " + c_type(block_ret) + " " + tmp_val + " = " + bexpr + ";")
     emit("  if (" + tmp_val + ") sp_" + pfx_dst + "_push(" + tmp_arr + ", " + tmp_val + ");")
     @indent = @indent - 1
+    pop_scope
     emit("  }")
     tmp_arr
   end
@@ -22044,11 +22243,12 @@ class Compiler
       bp1 = "_x"
     end
     elem_type = iter_elem_type(recv_type)
-    declare_var(bp1, elem_type)
     tmp_res = new_temp
     tmp_i = new_temp
     emit("  " + c_type(elem_type) + " " + tmp_res + " = " + c_default_val(elem_type) + ";")
     emit_iter_open(rc, recv_type, "lv_" + bp1, tmp_i)
+    push_scope
+    declare_var(bp1, elem_type)
     blk = @nd_block[nid]
     bbody = @nd_body[blk]
     bexpr = "0"
@@ -22064,6 +22264,7 @@ class Compiler
       end
     end
     emit("    if (" + bexpr + ") { " + tmp_res + " = lv_" + bp1 + "; break; }")
+    pop_scope
     emit("  }")
     tmp_res
   end
@@ -22074,7 +22275,6 @@ class Compiler
     if bp1 == ""
       bp1 = "_x"
     end
-    declare_var(bp1, iter_elem_type(recv_type))
     tmp_res = new_temp
     tmp_i = new_temp
     init_val = "FALSE"
@@ -22083,6 +22283,8 @@ class Compiler
     end
     emit("  mrb_bool " + tmp_res + " = " + init_val + ";")
     emit_iter_open(rc, recv_type, "lv_" + bp1, tmp_i)
+    push_scope
+    declare_var(bp1, iter_elem_type(recv_type))
     blk = @nd_block[nid]
     bbody = @nd_body[blk]
     bexpr = "0"
@@ -22107,6 +22309,7 @@ class Compiler
       # none?
       emit("    if (" + bexpr + ") { " + tmp_res + " = FALSE; break; }")
     end
+    pop_scope
     emit("  }")
     tmp_res
   end
@@ -22139,14 +22342,15 @@ class Compiler
       @needs_str_str_hash = 1
     end
     @needs_gc = 1
-    declare_var(bp1, "string")
-    declare_var(bp2, val_type)
     tmp = new_temp
     itmp = new_temp
     emit("  " + c_type(hash_type) + tmp + " = " + ctor + "();")
     emit("  for (mrb_int " + itmp + " = 0; " + itmp + " < " + rc + "->len; " + itmp + "++) {")
     emit("    lv_" + bp1 + " = " + rc + "->order[" + itmp + "];")
     emit("    lv_" + bp2 + " = " + getter + "(" + rc + ", lv_" + bp1 + ");")
+    push_scope
+    declare_var(bp1, "string")
+    declare_var(bp2, val_type)
     blk = @nd_block[nid]
     bbody = @nd_body[blk]
     bexpr = "0"
@@ -22167,6 +22371,7 @@ class Compiler
       cond = "!(" + bexpr + ")"
     end
     emit("    if (" + cond + ") " + setter + "(" + tmp + ", lv_" + bp1 + ", lv_" + bp2 + ");")
+    pop_scope
     emit("  }")
     tmp
   end
@@ -22186,6 +22391,7 @@ class Compiler
       val_type = "string"
       getter = "sp_StrStrHash_get"
     end
+    push_scope
     declare_var(bp1, "string")
     declare_var(bp2, val_type)
     itmp = new_temp
@@ -22224,6 +22430,7 @@ class Compiler
       end
       emit("    if (" + bexpr + ") " + tmp_c + "++;")
       emit("  }")
+      pop_scope
       return tmp_c
     end
     if mname == "any?"
@@ -22245,6 +22452,7 @@ class Compiler
       end
       emit("    if (" + bexpr + ") { " + tmp_r + " = TRUE; break; }")
       emit("  }")
+      pop_scope
       return tmp_r
     end
     if mname == "all?"
@@ -22266,6 +22474,7 @@ class Compiler
       end
       emit("    if (!(" + bexpr + ")) { " + tmp_r + " = FALSE; break; }")
       emit("  }")
+      pop_scope
       return tmp_r
     end
     # find / detect — return key of first match
@@ -22288,8 +22497,10 @@ class Compiler
       end
       emit("    if (" + bexpr + ") { " + tmp_r + " = lv_" + bp1 + "; break; }")
       emit("  }")
+      pop_scope
       return tmp_r
     end
+    pop_scope
     "0"
   end
 
@@ -22301,7 +22512,18 @@ class Compiler
     if bp1 == ""
       bp1 = "_x"
     end
-    # Determine result array type from block return type
+    elem_type = "int"
+    if rt == "str_array"
+      elem_type = "string"
+    elsif rt == "float_array"
+      elem_type = "float"
+    elsif rt == "poly_array"
+      elem_type = "poly"
+    elsif is_ptr_array_type(rt) == 1
+      elem_type = ptr_array_elem_type(rt)
+    end
+    push_scope
+    declare_var(bp1, elem_type)
     blk = @nd_block[nid]
     block_ret = "int_array"
     if blk >= 0
@@ -22325,18 +22547,6 @@ class Compiler
     tmp_inner = new_temp
     tmp_j = new_temp
     emit("  " + c_type(block_ret) + tmp_arr + " = sp_" + pfx_dst + "_new();")
-    # Declare block param type from receiver element type
-    elem_type = "int"
-    if rt == "str_array"
-      elem_type = "string"
-    elsif rt == "float_array"
-      elem_type = "float"
-    elsif rt == "poly_array"
-      elem_type = "poly"
-    elsif is_ptr_array_type(rt) == 1
-      elem_type = ptr_array_elem_type(rt)
-    end
-    declare_var(bp1, elem_type)
     emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_" + pfx_src + "_length(" + rc + "); " + tmp_i + "++) {")
     emit("    lv_" + bp1 + " = sp_" + pfx_src + "_get(" + rc + ", " + tmp_i + ");")
     @indent = @indent + 1
@@ -22357,6 +22567,7 @@ class Compiler
     end
     @indent = @indent - 1
     emit("  }")
+    pop_scope
     tmp_arr
   end
 
@@ -22369,6 +22580,10 @@ class Compiler
       bpn = get_block_param(nid, 0)
       res_type = "int"
       blk_n = @nd_block[nid]
+      push_scope
+      if bpn != ""
+        declare_var(bpn, "int")
+      end
       if blk_n >= 0
         body_n = @nd_body[blk_n]
         if body_n >= 0
@@ -22417,6 +22632,7 @@ class Compiler
       end
       @indent = @indent - 1
       emit("  }")
+      pop_scope
       return tmp_arrn
     end
     rt = infer_type(@nd_receiver[nid])
@@ -22434,19 +22650,9 @@ class Compiler
     if rt == "int_array" || rt == "sym_array"
       @needs_int_array = 1
       @needs_gc = 1
-      # Check if block body returns string (for map that produces StrArray)
-      block_ret = "int"
-      blk = @nd_block[nid]
-      if blk >= 0
-        body = @nd_body[blk]
-        if body >= 0
-          stmts = get_stmts(body)
-          if stmts.length > 0
-            block_ret = infer_type(stmts.last)
-          end
-        end
-      end
+      bp_t = elem_type_of_array(rt)
       # Check if block param is used as lambda (elements are lambda pointers in IntArray)
+      blk = @nd_block[nid]
       bp_is_lambda = 0
       if blk >= 0
         bp_is_lambda = param_used_as_lambda(bp1, @nd_body[blk])
@@ -22476,15 +22682,29 @@ class Compiler
           end
         end
       end
+      if bp_is_lambda == 1
+        bp_t = "lambda"
+      end
+      push_scope
+      declare_var(bp1, bp_t)
+      block_ret = "int"
+      if blk >= 0
+        body = @nd_body[blk]
+        if body >= 0
+          stmts = get_stmts(body)
+          if stmts.length > 0
+            block_ret = infer_type(stmts.last)
+          end
+        end
+      end
       if block_ret == "string"
         @needs_str_array = 1
         emit("  sp_StrArray *" + tmp_arr + " = sp_StrArray_new();")
         emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_IntArray_length(" + rc + "); " + tmp_i + "++) {")
         if bp_is_lambda == 1
-          declare_var(bp1, "lambda")
-          emit("    lv_" + bp1 + " = (sp_Val *)sp_IntArray_get(" + rc + ", " + tmp_i + ");")
+          emit("    sp_Val * lv_" + bp1 + " = (sp_Val *)sp_IntArray_get(" + rc + ", " + tmp_i + ");")
         else
-          emit("    lv_" + bp1 + " = sp_IntArray_get(" + rc + ", " + tmp_i + ");")
+          emit("    mrb_int lv_" + bp1 + " = sp_IntArray_get(" + rc + ", " + tmp_i + ");")
         end
         @indent = @indent + 1
         blk2 = @nd_block[nid]
@@ -22501,15 +22721,15 @@ class Compiler
         end
         @indent = @indent - 1
         emit("  }")
+        pop_scope
         return tmp_arr
       else
         emit("  sp_IntArray *" + tmp_arr + " = sp_IntArray_new();")
         emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_IntArray_length(" + rc + "); " + tmp_i + "++) {")
         if bp_is_lambda == 1
-          declare_var(bp1, "lambda")
-          emit("    lv_" + bp1 + " = (sp_Val *)sp_IntArray_get(" + rc + ", " + tmp_i + ");")
+          emit("    sp_Val * lv_" + bp1 + " = (sp_Val *)sp_IntArray_get(" + rc + ", " + tmp_i + ");")
         else
-          emit("    lv_" + bp1 + " = sp_IntArray_get(" + rc + ", " + tmp_i + ");")
+          emit("    mrb_int lv_" + bp1 + " = sp_IntArray_get(" + rc + ", " + tmp_i + ");")
         end
         @indent = @indent + 1
         blk2 = @nd_block[nid]
@@ -22526,6 +22746,7 @@ class Compiler
         end
         @indent = @indent - 1
         emit("  }")
+        pop_scope
         return tmp_arr
       end
     end
@@ -22534,6 +22755,8 @@ class Compiler
       # `tt = foo.map { ... }` silently became `lv_tt = 0` and the
       # subsequent iteration crashed. Issue #43.
       @needs_gc = 1
+      push_scope
+      declare_var(bp1, "string")
       block_ret = "string"
       blk = @nd_block[nid]
       if blk >= 0
@@ -22545,7 +22768,6 @@ class Compiler
           end
         end
       end
-      declare_var(bp1, "string")
       if block_ret == "int"
         @needs_int_array = 1
         emit("  sp_IntArray *" + tmp_arr + " = sp_IntArray_new();")
@@ -22573,6 +22795,7 @@ class Compiler
         end
         @indent = @indent - 1
         emit("  }")
+        pop_scope
         return tmp_arr
       end
       @needs_str_array = 1
@@ -22598,6 +22821,7 @@ class Compiler
       end
       @indent = @indent - 1
       emit("  }")
+      pop_scope
       return tmp_arr
     end
     "0"
@@ -22615,10 +22839,13 @@ class Compiler
     if rt == "int_array" || rt == "sym_array"
       @needs_int_array = 1
       @needs_gc = 1
+      bp_t = elem_type_of_array(rt)
       emit("  sp_IntArray *" + tmp_arr + " = sp_IntArray_new();")
       emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_IntArray_length(" + rc + "); " + tmp_i + "++) {")
       emit("    mrb_int lv_" + bp1 + " = sp_IntArray_get(" + rc + ", " + tmp_i + ");")
       @indent = @indent + 1
+      push_scope
+      declare_var(bp1, bp_t)
       blk = @nd_block[nid]
       if blk >= 0
         body = @nd_body[blk]
@@ -22631,6 +22858,7 @@ class Compiler
           end
         end
       end
+      pop_scope
       @indent = @indent - 1
       emit("  }")
       return tmp_arr
@@ -22662,10 +22890,14 @@ class Compiler
     emit("  lv_" + bp1 + " = " + init_val + ";")
     rt = infer_type(@nd_receiver[nid])
     pfx = array_c_prefix(rt)
+    elem_t = elem_type_of_array(rt)
     tmp = new_temp
     emit("  for (mrb_int " + tmp + " = 0; " + tmp + " < sp_" + pfx + "_length(" + rc + "); " + tmp + "++) {")
-    emit("    " + c_type(elem_type_of_array(rt)) + " lv_" + bp2 + " = sp_" + pfx + "_get(" + rc + ", " + tmp + ");")
+    emit("    " + c_type(elem_t) + " lv_" + bp2 + " = sp_" + pfx + "_get(" + rc + ", " + tmp + ");")
     @indent = @indent + 1
+    push_scope
+    declare_var(bp1, elem_t)
+    declare_var(bp2, elem_t)
     blk = @nd_block[nid]
     if blk >= 0
       body = @nd_body[blk]
@@ -22678,6 +22910,7 @@ class Compiler
         end
       end
     end
+    pop_scope
     @indent = @indent - 1
     emit("  }")
   end
@@ -22691,12 +22924,15 @@ class Compiler
     rt = infer_type(@nd_receiver[nid])
     if rt == "int_array" || rt == "sym_array"
       @needs_int_array = 1
+      bp_t = elem_type_of_array(rt)
       tmp_arr = new_temp
       emit("  sp_IntArray *" + tmp_arr + " = sp_IntArray_new();")
       tmp_i = new_temp
       emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_IntArray_length(" + rc + "); " + tmp_i + "++) {")
       emit("    mrb_int lv_" + bp1 + " = sp_IntArray_get(" + rc + ", " + tmp_i + ");")
       @indent = @indent + 1
+      push_scope
+      declare_var(bp1, bp_t)
       blk = @nd_block[nid]
       if blk >= 0
         body = @nd_body[blk]
@@ -22709,6 +22945,7 @@ class Compiler
           end
         end
       end
+      pop_scope
       @indent = @indent - 1
       emit("  }")
       return tmp_arr
@@ -22731,6 +22968,8 @@ class Compiler
       emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_IntArray_length(" + rc + "); " + tmp_i + "++) {")
       emit("    mrb_int lv_" + bp1 + " = sp_IntArray_get(" + rc + ", " + tmp_i + ");")
       @indent = @indent + 1
+      push_scope
+      declare_var(bp1, "int")
       blk = @nd_block[nid]
       if blk >= 0
         body = @nd_body[blk]
@@ -22743,6 +22982,7 @@ class Compiler
           end
         end
       end
+      pop_scope
       @indent = @indent - 1
       emit("  }")
     end
@@ -23534,7 +23774,10 @@ class Compiler
       bpn = get_block_param(nid, 0)
       tmp_arrn = new_temp
       tmp_in = new_temp
-      # infer block result type
+      push_scope
+      if bpn != ""
+        declare_var(bpn, "int")
+      end
       res_type = "int"
       blk_n = @nd_block[nid]
       if blk_n >= 0
@@ -23582,6 +23825,7 @@ class Compiler
       end
       @indent = @indent - 1
       emit("  }")
+      pop_scope
       @in_loop = old
       return
     end
@@ -23598,6 +23842,8 @@ class Compiler
       emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_IntArray_length(" + rc + "); " + tmp_i + "++) {")
       emit("    mrb_int lv_" + bp1 + " = sp_IntArray_get(" + rc + ", " + tmp_i + ");")
       @indent = @indent + 1
+      push_scope
+      declare_var(bp1, "int")
       blk = @nd_block[nid]
       if blk >= 0
         body = @nd_body[blk]
@@ -23610,6 +23856,7 @@ class Compiler
           end
         end
       end
+      pop_scope
       @indent = @indent - 1
       emit("  }")
     end
@@ -23619,6 +23866,8 @@ class Compiler
       emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_StrArray_length(" + rc + "); " + tmp_i + "++) {")
       emit("    const char *lv_" + bp1 + " = sp_StrArray_get(" + rc + ", " + tmp_i + ");")
       @indent = @indent + 1
+      push_scope
+      declare_var(bp1, "string")
       blk = @nd_block[nid]
       if blk >= 0
         body = @nd_body[blk]
@@ -23631,6 +23880,7 @@ class Compiler
           end
         end
       end
+      pop_scope
       @indent = @indent - 1
       emit("  }")
     end
@@ -23651,10 +23901,13 @@ class Compiler
     tmp_arr = new_temp
     tmp_i = new_temp
     if rt == "int_array" || rt == "sym_array"
+      bp_t = elem_type_of_array(rt)
       emit("  sp_IntArray *" + tmp_arr + " = sp_IntArray_new();")
       emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_IntArray_length(" + rc + "); " + tmp_i + "++) {")
       emit("    mrb_int lv_" + bp1 + " = sp_IntArray_get(" + rc + ", " + tmp_i + ");")
       @indent = @indent + 1
+      push_scope
+      declare_var(bp1, bp_t)
       blk = @nd_block[nid]
       if blk >= 0
         body = @nd_body[blk]
@@ -23667,6 +23920,7 @@ class Compiler
           end
         end
       end
+      pop_scope
       @indent = @indent - 1
       emit("  }")
     end

--- a/test/block_param_shadow.rb
+++ b/test/block_param_shadow.rb
@@ -1,0 +1,246 @@
+# Block parameters shadow outer differently-typed locals correctly.
+# Without push_scope/declare_var around the block body compile, infer_type
+# returned the outer scope's type for the block param, dispatching the
+# wrong runtime call (e.g. sp_str_repeat for an int param).
+
+# --- each on int_array, outer string v (the original report) ---
+def f1
+  v = "hello"
+  [1, 2, 3].each do |v|
+    puts v * 10
+  end
+  puts v
+end
+f1
+# 10
+# 20
+# 30
+# hello
+
+# --- each_with_index, outer string i ---
+def f2
+  i = "outer"
+  ["a", "b"].each_with_index do |s, i|
+    puts s + i.to_s
+  end
+  puts i
+end
+f2
+# a0
+# b1
+# outer
+
+# --- each_with_index on str_array, outer int i ---
+def f3
+  i = 99
+  ["a", "b", "c"].each_with_index do |s, i|
+    puts s + ":" + i.to_s
+  end
+  puts i
+end
+f3
+# a:0
+# b:1
+# c:2
+# 99
+
+# --- map on int_array, outer string i ---
+def f4
+  i = "outer"
+  out = [10, 20, 30].map { |i| i + 1 }
+  puts out[0]               # 11
+  puts out[1]               # 21
+  puts out[2]               # 31
+  puts i                    # outer
+end
+f4
+
+# --- map on str_array, outer int s ---
+def f5
+  s = 42
+  words = ["a", "b", "c"]
+  up = words.map { |s| s.upcase }
+  puts up[0]                # A
+  puts up[1]                # B
+  puts up[2]                # C
+  puts s                    # 42
+end
+f5
+
+# --- select on int_array, outer string n ---
+def f6
+  n = "kept"
+  out = [1, 2, 3, 4].select { |n| n > 2 }
+  puts out.length           # 2
+  puts out[0]               # 3
+  puts out[1]               # 4
+  puts n                    # kept
+end
+f6
+
+# --- reject on int_array, outer string n ---
+def f7
+  n = "drop"
+  out = [1, 2, 3, 4].reject { |n| n > 2 }
+  puts out.length           # 2
+  puts out[0]               # 1
+  puts out[1]               # 2
+  puts n                    # drop
+end
+f7
+
+# --- partition on int_array, outer string n ---
+def f8
+  n = "outer"
+  parts = [1, 2, 3, 4, 5].partition { |n| n > 2 }
+  puts parts[0].length      # 3
+  puts parts[0][0]          # 3
+  puts parts[0][1]          # 4
+  puts parts[0][2]          # 5
+  puts parts[1].length      # 2
+  puts parts[1][0]          # 1
+  puts parts[1][1]          # 2
+  puts n                    # outer
+end
+f8
+
+# --- partition on str_array, outer int x ---
+def f9
+  x = 99
+  parts = ["a", "bb", "ccc"].partition { |x| x.length > 1 }
+  puts parts[0].length      # 2
+  puts parts[0][0]          # bb
+  puts parts[0][1]          # ccc
+  puts parts[1].length      # 1
+  puts parts[1][0]          # a
+  puts x                    # 99
+end
+f9
+
+# --- each_char on string, outer int c ---
+def f10
+  c = 7
+  "abc".each_char do |c|
+    puts c + "!"
+  end
+  puts c
+end
+f10
+# a!
+# b!
+# c!
+# 7
+
+# --- each_byte on string, outer string b ---
+def f11
+  b = "kept"
+  "AB".each_byte do |b|
+    puts b + 1
+  end
+  puts b
+end
+f11
+# 66
+# 67
+# kept
+
+# --- cycle on int_array with count, outer string x ---
+def f12
+  x = "outer"
+  [1, 2].cycle(2) do |x|
+    puts x * 10
+  end
+  puts x
+end
+f12
+# 10
+# 20
+# 10
+# 20
+# outer
+
+# --- scan with block on string, outer int m ---
+def f13
+  m = 99
+  "a1b2c3".scan(/\d+/) do |m|
+    puts m + "!"
+  end
+  puts m
+end
+f13
+# 1!
+# 2!
+# 3!
+# 99
+
+# --- each_slice on int_array, outer string v ---
+def f14
+  v = "hello"
+  [1, 2, 3, 4].each_slice(2) do |v|
+    puts v.length
+  end
+  puts v
+end
+f14
+# 2
+# 2
+# hello
+
+# --- each_cons on str_array, outer int c ---
+def f15
+  c = 7
+  ["a", "b", "c", "d"].each_cons(3) do |c|
+    puts c.length
+  end
+  puts c
+end
+f15
+# 3
+# 3
+# 7
+
+# --- tap on int receiver, outer string v ---
+def f16
+  v = "hello"
+  42.tap do |v|
+    puts v + 1
+  end
+  puts v
+end
+f16
+# 43
+# hello
+
+# --- tap on string receiver, outer int s ---
+def f17
+  s = 99
+  "abc".tap do |s|
+    puts s + "!"
+  end
+  puts s
+end
+f17
+# abc!
+# 99
+
+# --- then on int receiver, outer string v ---
+def f18
+  v = "hello"
+  out = 42.then { |v| v + 1 }
+  puts out
+  puts v
+end
+f18
+# 43
+# hello
+
+# --- yield_self with int receiver returning string, outer float v ---
+def f19
+  v = 3.14
+  out = 42.yield_self { |v| v.to_s + "!" }
+  puts out
+  puts v
+end
+f19
+# 42!
+# 3.14


### PR DESCRIPTION
## Summary

Follow up: https://github.com/matz/spinel/issues/77

- Wrap block bodies in \`push_scope\`/\`declare_var\`/\`pop_scope\` across iterator helpers (each, map, select, reject, each_with_index, each_with_object, partition, step, zip, each_slice, each_cons, each_pair, each_char/byte/line, min_by/max_by/sort_by, take_while, drop_while, chunk_while, group_by, count/sum/any?/all?/none?/find, hash iterators, and more) so \`infer_type\` resolves block params against the inner binding rather than a shadowed outer local of a different type.
- Without this, the wrong runtime dispatch was emitted (e.g. \`sp_str_repeat\` for an int block param when an outer string of the same name existed).
- Add \`test/block_param_shadow.rb\` covering the regression on \`each\`, \`each_with_index\`, \`map\`, \`select\`, and \`reject\`.

Note: the seed-driven accumulator type inference for \`inject\`/\`reduce\` and \`each_with_object\` is intentionally left out and will be handled in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)