### PR TITLE
fix(codegen): avoid duplicate SP_GC_SAVE in constructor initialize path

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -10481,6 +10481,7 @@ class Compiler
   end
 
   def emit_constructor(ci)
+    saved_gc_scope = @in_gc_scope
     cname = @cls_names[ci]
     init_idx = cls_find_method_direct(ci, "initialize")
     if @cls_is_value_type[ci] == 1
@@ -10489,6 +10490,7 @@ class Compiler
     else
       emit_raw("static inline sp_" + cname + " *sp_" + cname + "_new(" + constructor_params_decl(ci) + ") {")
       emit_raw("  SP_GC_SAVE();")
+      @in_gc_scope = 1
       scan_fn = "NULL"
       if class_has_ptr_ivars(ci) == 1
         scan_fn = "sp_" + cname + "_gc_scan"
@@ -10641,6 +10643,7 @@ class Compiler
     emit_raw("  return self;")
     emit_raw("}")
     emit_raw("")
+    @in_gc_scope = saved_gc_scope
 
     # Initialize function (for super calls) - always uses *self (pointer)
     if init_idx >= 0
@@ -11025,8 +11028,10 @@ class Compiler
     end
     if has_gc_locals == 1
       if @needs_gc == 1
-        emit("  SP_GC_SAVE();")
-        @in_gc_scope = 1
+        if @in_gc_scope == 0
+          emit("  SP_GC_SAVE();")
+          @in_gc_scope = 1
+        end
       end
     end
     j = 0

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -11027,11 +11027,9 @@ class Compiler
       j = j + 1
     end
     if has_gc_locals == 1
-      if @needs_gc == 1
-        if @in_gc_scope == 0
-          emit("  SP_GC_SAVE();")
-          @in_gc_scope = 1
-        end
+      if @needs_gc == 1 && @in_gc_scope == 0
+        emit("  SP_GC_SAVE();")
+        @in_gc_scope = 1
       end
     end
     j = 0

--- a/test/gc_save_double_in_new.rb
+++ b/test/gc_save_double_in_new.rb
@@ -1,0 +1,13 @@
+class GcSaveDoubleInNew
+  def initialize(path)
+    data = [1, 2, 3]
+    @x = data
+  end
+
+  def step
+    @x.length
+  end
+end
+
+o = GcSaveDoubleInNew.new("a")
+puts o.step


### PR DESCRIPTION
## Summary

Fix duplicate `SP_GC_SAVE()` emission in generated constructor code when `new` inlines `initialize` logic for pointer classes.

This caused C compilation failures due to `_gc_saved` redefinition in the same scope.

## Changes

- Track/restore `@in_gc_scope` in `emit_constructor`.
- Mark GC scope as active after emitting constructor-level `SP_GC_SAVE()`.
- Guard local-level `SP_GC_SAVE()` emission in `declare_method_locals` so it only emits when no GC scope is already active.

## Test

Added `test/gc_save_double_in_new.rb`, a minimal repro that previously failed with:

- `redefinition of '_gc_saved'`

and now compiles/runs correctly.

## Notes

This PR is intentionally scoped to duplicate GC-save emission in constructor/initialize codegen path.
EOF