### PR TITLE
feat(codegen): support anonymous & block forwarding (Ruby 3.1+)

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -744,6 +744,17 @@ class Compiler
       @needs_proc = 1
       return compile_proc_literal(nid)
     end
+    # Anonymous `&` forwarding (Ruby 3.1+): `inner(&)` where the
+    # enclosing method declared `def outer(&)`. The BlockArgumentNode
+    # carries no expression, so `find_block_arg` returns -1; we forward
+    # the enclosing method's anon-block param directly.
+    blk = @nd_block[nid]
+    if blk >= 0 && @nd_type[blk] == "BlockArgumentNode" && @nd_expression[blk] < 0
+      if @current_method_block_param != ""
+        @needs_proc = 1
+        return "lv_" + @current_method_block_param
+      end
+    end
     ba = find_block_arg(nid)
     if ba >= 0
       @needs_proc = 1
@@ -4332,7 +4343,16 @@ class Compiler
         if result != ""
           result = result + ","
         end
-        result = result + @nd_name[blk]
+        # Anonymous `&` (Ruby 3.1+) — `def m(&); inner(&); end` —
+        # produces a BlockParameterNode with no name. Synthesize a
+        # stable internal name so the param gets a proper `lv_` slot
+        # and downstream lookups (find_block_param_name,
+        # @current_method_block_param) work the same as for `&block`.
+        bn = @nd_name[blk]
+        if bn == ""
+          bn = "__anon_block"
+        end
+        result = result + bn
       end
     end
     result

--- a/test/anon_block_forward.rb
+++ b/test/anon_block_forward.rb
@@ -1,0 +1,47 @@
+# Anonymous `&` block forwarding (Ruby 3.1+).
+#
+# `def outer(&); inner(&); end` declares an unnamed block parameter
+# and forwards it via the matching anonymous `&` in the call. Pre-fix,
+# the parameter `BlockParameterNode { name: nil }` was registered with
+# an empty name, leaving the method without a `_block`/`lv_` slot, and
+# the forwarding `BlockArgumentNode { expression: -1 }` got dropped at
+# the call site (it slipped through `find_block_arg`'s -1 return).
+#
+# Fix synthesizes the internal name `__anon_block` for unnamed block
+# params so they flow through `find_block_param_name` and
+# `@current_method_block_param` like any other `&block`, and extends
+# `block_forward_expr` to forward the current method's anon-block
+# slot when it sees a BlockArgumentNode with no expression.
+
+# 1. Top-level outer/inner with anonymous & forwarding.
+def outer(&)
+  inner(&)
+end
+
+def inner(&block)
+  block.call
+end
+
+outer { puts "1-top-level" }
+
+# 2. Anonymous & with a body that does work before forwarding.
+def with_prefix(label, &)
+  puts label
+  inner(&)
+end
+
+with_prefix("2-prefix") { puts "  body" }
+
+# 3. Anonymous & on a class instance method, forwarding to another
+#    class instance method via typed-receiver dispatch.
+class Outer
+  def kick(&)
+    sink(&)
+  end
+
+  def sink(&block)
+    block.call
+  end
+end
+
+Outer.new.kick { puts "3-class-method" }


### PR DESCRIPTION
## Summary

`def outer(&); inner(&); end` declares an unnamed block parameter and forwards it via the matching anonymous `&` in the call. Pre-fix, two gaps dropped the block:

1. `collect_pnames_str` read `@nd_name[blk]` directly, so an anonymous `BlockParameterNode` (name = nil) registered as an empty pname — no `lv_` slot, no entry in `pnames` for `find_block_param_name` to spot.
2. `block_forward_expr` only handled `BlockArgumentNode`s whose expression was a `LocalVariableReadNode` (the `&proc_var` shape). The anonymous form (`expression: -1`) fell through to the no-block path.

## Fix

Synthesizes the stable internal name `__anon_block` whenever the `BlockParameterNode` is unnamed, so the param flows through `find_block_param_name` and `@current_method_block_param` like a regular `&block`. `block_forward_expr` gains a new branch that detects `BlockArgumentNode { expression < 0 }` and forwards the enclosing method's anon-block slot (`lv___anon_block`).

## Out of scope

- Anonymous-`&` forwarded from a method that has no `&` param at all (`def m; n(&); end`). Today this silently no-ops; emitting a compile-time error would need new error infrastructure that doesn't exist in the codegen.

## Test plan

- [x] `make bootstrap` (gen2.c == gen3.c)
- [x] `make test` passes (182 tests)
- [x] `test/anon_block_forward.rb` covers top-level forwarding, anonymous-`&` with a prefix statement before the forward, and class-instance-method forwarding via typed-receiver dispatch.
