### PR TITLE
feat(codegen): support multi-argument yield + zero-unset block params fix

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -155,6 +155,7 @@ class Compiler
     @hoisted_strlen_var = ""
     @hoisted_strlen_recv = ""
     @in_yield_method = 0
+    @current_method_yield_arity = 1
     @in_gc_scope = 0
 
     # Yield/block tracking (parallel with meth_names / cls_meth_names)
@@ -5231,6 +5232,80 @@ class Compiler
       end
     end
     0
+  end
+
+  # Walks `nid` for YieldNodes and returns max(`current`, max_args_of_yields).
+  # Mirrors body_has_yield's recursion shape. `current` carries the running
+  # max so callers can seed a floor (1, since every yield-using method needs
+  # at least one mrb_int slot in `_block`'s signature).
+  def body_max_yield_arity(nid, current)
+    if nid < 0
+      return current
+    end
+    if @nd_type[nid] == "YieldNode"
+      n = 0
+      if @nd_arguments[nid] >= 0
+        n = get_args(@nd_arguments[nid]).length
+      end
+      if n < 1
+        n = 1
+      end
+      if n > current
+        current = n
+      end
+    end
+    if @nd_type[nid] == "DefNode"
+      return current
+    end
+    if @nd_body[nid] >= 0
+      current = body_max_yield_arity(@nd_body[nid], current)
+    end
+    stmts = parse_id_list(@nd_stmts[nid])
+    k = 0
+    while k < stmts.length
+      current = body_max_yield_arity(stmts[k], current)
+      k = k + 1
+    end
+    if @nd_expression[nid] >= 0
+      current = body_max_yield_arity(@nd_expression[nid], current)
+    end
+    if @nd_predicate[nid] >= 0
+      current = body_max_yield_arity(@nd_predicate[nid], current)
+    end
+    if @nd_subsequent[nid] >= 0
+      current = body_max_yield_arity(@nd_subsequent[nid], current)
+    end
+    if @nd_else_clause[nid] >= 0
+      current = body_max_yield_arity(@nd_else_clause[nid], current)
+    end
+    if @nd_left[nid] >= 0
+      current = body_max_yield_arity(@nd_left[nid], current)
+    end
+    if @nd_right[nid] >= 0
+      current = body_max_yield_arity(@nd_right[nid], current)
+    end
+    if @nd_block[nid] >= 0
+      current = body_max_yield_arity(@nd_block[nid], current)
+    end
+    conds = parse_id_list(@nd_conditions[nid])
+    k = 0
+    while k < conds.length
+      current = body_max_yield_arity(conds[k], current)
+      k = k + 1
+    end
+    args = parse_id_list(@nd_args[nid])
+    k = 0
+    while k < args.length
+      current = body_max_yield_arity(args[k], current)
+      k = k + 1
+    end
+    if @nd_arguments[nid] >= 0
+      current = body_max_yield_arity(@nd_arguments[nid], current)
+    end
+    if @nd_receiver[nid] >= 0
+      current = body_max_yield_arity(@nd_receiver[nid], current)
+    end
+    current
   end
 
   # ---- Return type inference ----
@@ -10421,16 +10496,18 @@ class Compiler
   end
 
   def yield_params_suffix(mi)
+    csig = block_params_csig(method_yield_arity(mi))
     pd = method_params_decl(mi)
     if pd == ""
-      return "void (*_block)(mrb_int, void*), void *_benv"
+      return "void (*_block)(" + csig + ", void*), void *_benv"
     end
-    return ", void (*_block)(mrb_int, void*), void *_benv"
+    return ", void (*_block)(" + csig + ", void*), void *_benv"
   end
 
   def yield_params_suffix_cls(ci, midx)
     # For class instance methods (always have self first)
-    return ", void (*_block)(mrb_int, void*), void *_benv"
+    csig = block_params_csig(cls_method_yield_arity(ci, midx))
+    return ", void (*_block)(" + csig + ", void*), void *_benv"
   end
 
   def cls_method_has_yield(ci, midx)
@@ -10441,6 +10518,42 @@ class Compiler
       end
     end
     0
+  end
+
+  # Max number of args used in any `yield` inside the top-level method
+  # at @meth_body_ids[mi]. Floor of 1 — yield-using methods always have
+  # at least one mrb_int slot (the no-arg `yield` form is padded to 0).
+  def method_yield_arity(mi)
+    if mi < 0 || mi >= @meth_body_ids.length
+      return 1
+    end
+    body_max_yield_arity(@meth_body_ids[mi], 1)
+  end
+
+  # Same as method_yield_arity, but resolved through the class method
+  # body table @cls_meth_bodies (parallel to @cls_meth_has_yield).
+  def cls_method_yield_arity(ci, midx)
+    if ci < 0 || midx < 0
+      return 1
+    end
+    bodies = @cls_meth_bodies[ci].split(";")
+    if midx >= bodies.length
+      return 1
+    end
+    bid = bodies[midx].to_i
+    body_max_yield_arity(bid, 1)
+  end
+
+  # Comma-joined string of `arity` mrb_int slots — the variable-arity
+  # portion of the `_block` function-pointer signature.
+  def block_params_csig(arity)
+    csig = "mrb_int"
+    k = 1
+    while k < arity
+      csig = csig + ", mrb_int"
+      k = k + 1
+    end
+    csig
   end
 
   # Returns 1 if the (ci, midx) method declares a `&block` parameter,
@@ -11004,6 +11117,7 @@ class Compiler
     if midx >= 0
       if cls_method_has_yield(ci, midx) == 1
         @in_yield_method = 1
+        @current_method_yield_arity = cls_method_yield_arity(ci, midx)
       else
         @in_yield_method = 0
       end
@@ -11061,6 +11175,7 @@ class Compiler
     @current_method_name = ""
     @current_method_block_param = ""
     @in_yield_method = 0
+    @current_method_yield_arity = 1
     @indent = 0
     emit_raw("  return " + c_return_default(rt) + ";")
     emit_raw("}")
@@ -11184,6 +11299,7 @@ class Compiler
 
     if @meth_has_yield[mi] == 1
       @in_yield_method = 1
+      @current_method_yield_arity = method_yield_arity(mi)
     else
       @in_yield_method = 0
     end
@@ -11254,6 +11370,7 @@ class Compiler
     @current_method_name = ""
     @current_method_block_param = ""
     @in_yield_method = 0
+    @current_method_yield_arity = 1
     @indent = 0
     emit_raw("  return " + c_return_default(rt) + ";")
     emit_raw("}")
@@ -24147,23 +24264,21 @@ class Compiler
 
   def compile_yield_stmt(nid)
     args_id = @nd_arguments[nid]
-    arg_exprs = ""
+    emitted = "".split(",")
     if args_id >= 0
       aids = get_args(args_id)
       k = 0
       while k < aids.length
-        if k > 0
-          arg_exprs = arg_exprs + ", "
-        end
-        arg_exprs = arg_exprs + compile_expr(aids[k])
+        emitted.push(compile_expr(aids[k]))
         k = k + 1
       end
     end
-    if arg_exprs != ""
-      emit("  if (_block) _block(" + arg_exprs + ", _benv);")
-    else
-      emit("  if (_block) _block(0, _benv);")
+    # Pad to the enclosing method's max yield arity so the call matches
+    # the function-pointer signature emitted by yield_params_suffix.
+    while emitted.length < @current_method_yield_arity
+      emitted.push("0")
     end
+    emit("  if (_block) _block(" + emitted.join(", ") + ", _benv);")
   end
 
   def compile_yield_call_stmt(nid, mi)
@@ -24258,15 +24373,25 @@ class Compiler
     if t == "YieldNode"
       # Replace yield with the block body
       args_id = @nd_arguments[nid]
+      assigned = 0
       if args_id >= 0
         aids = get_args(args_id)
         k = 0
         while k < aids.length
           if k < bp_names.length
             emit("  lv_" + bp_names[k] + " = " + compile_expr_remap(aids[k], map_from, map_to) + ";")
+            assigned = assigned + 1
           end
           k = k + 1
         end
+      end
+      # Reset any block params that didn't receive a yield arg so a
+      # later smaller-arity yield in the same method doesn't leak the
+      # previous yield's values. Mirrors compile_yield_stmt's "0"
+      # padding on the function-pointer dispatch path.
+      while assigned < bp_names.length
+        emit("  lv_" + bp_names[assigned] + " = 0;")
+        assigned = assigned + 1
       end
       body = @nd_body[blk]
       if body >= 0

--- a/test/multi_arg_yield.rb
+++ b/test/multi_arg_yield.rb
@@ -1,0 +1,70 @@
+# Multi-argument `yield` in a method body (issue #98).
+#
+# Pre-fix, every `yield` lowered against a single-arg `_block`
+# function pointer (`void (*_block)(mrb_int, void*)`), so any
+# `yield x, y[, ...]` emitted `_block(x, y, _benv)` against the
+# wrong signature and `cc` rejected it. The yield-inlined path
+# (`compile_stmt_with_block`'s YieldNode branch) had a parallel
+# bug: smaller-arity yields in a multi-arity method only assigned
+# the args that were passed, so unset block-local C vars leaked
+# whatever value the previous yield had set.
+#
+# Fix scans each yield-using method's body for the max yield arity
+# and threads that count through `yield_params_suffix*` (so the
+# function-pointer signature gets N `mrb_int` slots) and through
+# `compile_yield_stmt` (function-pointer-path emit). The inlined
+# path is fixed by zeroing remaining `lv_<bp>` slots after each
+# yield's args are assigned.
+
+# 1. Basic 2-arg yield.
+def add_pair
+  yield 1, 2
+end
+
+add_pair { |a, b| puts a + b }
+
+# 2. 3-arg yield with block returning to a local.
+def sum_triple
+  yield 10, 20, 30
+end
+
+sum_triple { |a, b, c| puts a + b + c }
+
+# 3. Mixed-arity yields in the same method. The smaller yields
+#    must not leak values from the larger ones. Pre-fix, the second
+#    yield's `b` would carry 999 from the first yield; post-fix it's
+#    0. Test uses `b.to_i` so the CRuby-side `nil` and Spinel-side
+#    mrb_int 0 both produce the same numeric value.
+def mixed_yield
+  yield 100, 999
+  yield 200
+end
+
+total = 0
+mixed_yield { |a, b| total = total + a + b.to_i }
+puts total
+
+# 4. Multi-arg yield from a class instance method.
+class Dispatcher
+  def emit
+    yield 100, 200
+    yield 300, 400
+  end
+end
+
+Dispatcher.new.emit { |x, y| puts x + y }
+
+# 5. Three different yield arities in one method. Max-arity detection
+#    must find 3 so the function-pointer signature has 3 slots; the
+#    smaller yields must zero-pad their unused slots. Test uses
+#    `b.to_i` / `c.to_i` so CRuby's `nil` for missing block params
+#    and Spinel's `mrb_int 0` produce the same numeric sum.
+def varied
+  yield 1, 2, 3
+  yield 10, 20
+  yield 100
+end
+
+acc = 0
+varied { |a, b, c| acc = acc + a + b.to_i + c.to_i }
+puts acc


### PR DESCRIPTION
Two related codegen fixes for inlined yield paths.

## Multi-argument yield (matz/spinel#98)

`def f; yield 1, 2; end; f { |a, b| puts a + b }` failed at C compile because the function-pointer signature for `_block` hardcoded a single `mrb_int` slot, while `compile_yield_stmt` emitted however many args the source carried.

Fix scans each yield-using method's body for the max yield arity and threads that count through `yield_params_suffix` (top-level) and `yield_params_suffix_cls` (instance methods) so the function-pointer signature gets N `mrb_int` slots, then through `compile_yield_stmt` so the call-site emit pads to N args with `0` for unused slots.

## Zero unset block params in inlined mixed-arity yield

The inlined call-site path (`compile_stmt_with_block`'s `YieldNode` branch) only assigned block-local C vars for the args that the yield actually passed. When a smaller-arity yield followed a larger one in the same method, the unset slots leaked the previous yield's values.

Reproducer pre-fix:

```ruby
def f
  yield 100, 999
  yield 200
end
f { |a, b| puts a + b.to_i }
```

CRuby: `1099`, `200`. Spinel pre-fix: `1099`, `1199` (`b` held `999` from the first yield). Spinel post-fix: `1099`, `200`.

Fix tracks how many block params received a value at each yield and emits `lv_<bp> = 0;` for the remaining ones.

## Out of scope

- Yields with non-`mrb_int` block-param types (the function-pointer signature is still int-only). The most common case for AOT-able yield blocks is integer arithmetic; non-int block params today fall through to the inlined path which uses the source-typed `lv_<bp>` directly.

## Test plan

- [x] `make bootstrap` (gen2.c == gen3.c)
- [x] `make test` passes (182 tests)
- [x] `test/multi_arg_yield.rb` covers 2-arg yield, 3-arg yield, mixed-arity (smaller-after-larger), class-instance-method yield, and three-different-arity yields in one method.
