### PR TITLE
feat(codegen,runtime): add Integer#lcm

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -76,6 +76,7 @@ static inline mrb_int sp_imod(mrb_int a, mrb_int b) {
 }
 
 static mrb_int sp_gcd(mrb_int a,mrb_int b){if(a<0)a=-a;if(b<0)b=-b;while(b){mrb_int t=b;b=a%b;a=t;}return a;}
+static mrb_int sp_lcm(mrb_int a,mrb_int b){if(a==0||b==0)return 0;mrb_int g=sp_gcd(a,b);if(a<0)a=-a;if(b<0)b=-b;return (a/g)*b;}
 static mrb_int sp_int_clamp(mrb_int v,mrb_int lo,mrb_int hi){return v<lo?lo:v>hi?hi:v;}
 static inline char *sp_str_alloc_raw(size_t total_with_null);  /* fwd decl */
 static const char*sp_int_chr(mrb_int n){char*s=sp_str_alloc_raw(2);s[0]=(char)n;s[1]=0;return s;}

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2239,7 +2239,7 @@ class Compiler
     if mname == "chr"
       return "string"
     end
-    if mname == "gcd"
+    if mname == "gcd" || mname == "lcm"
       return "int"
     end
     if mname == "clamp"
@@ -16550,6 +16550,9 @@ class Compiler
     end
     if mname == "gcd"
       return "sp_gcd(" + rc + ", " + compile_arg0(nid) + ")"
+    end
+    if mname == "lcm"
+      return "sp_lcm(" + rc + ", " + compile_arg0(nid) + ")"
     end
     if mname == "clamp"
       args_id = @nd_arguments[nid]

--- a/test/integer_lcm.rb
+++ b/test/integer_lcm.rb
@@ -1,0 +1,36 @@
+# basic
+puts 6.lcm(4)
+puts 4.lcm(6)
+
+# zero
+puts 0.lcm(5)
+puts 5.lcm(0)
+puts 0.lcm(0)
+
+# negative
+puts((-4).lcm(6))
+puts 6.lcm(-4)
+puts((-3).lcm(-7))
+
+# same
+puts 7.lcm(7)
+
+# one
+puts 1.lcm(5)
+puts 5.lcm(1)
+
+# coprime
+puts 8.lcm(9)
+
+# divisor — one divides the other
+puts 3.lcm(9)
+puts 9.lcm(3)
+
+# primes
+puts 7.lcm(13)
+
+# one with one
+puts 1.lcm(1)
+
+# large
+puts 12345.lcm(67890)


### PR DESCRIPTION
This pull request adds support for the `lcm` (least common multiple) integer method to the codebase, alongside tests and type inference updates. The main changes involve implementing the `sp_lcm` function in C, updating the code generator to handle `.lcm` calls, and introducing tests to verify correct behavior.

**Support for the `lcm` integer method:**

* Added a new C function `sp_lcm` to compute the least common multiple of two integers in `lib/sp_runtime.h`.
* Updated the code generator to handle `.lcm` method calls in integer expressions and generate the appropriate C code.
* Updated type inference logic to recognize that `.lcm` returns an integer, similar to `.gcd`.

**Testing:**

* Added a new test file `test/integer_lcm.rb` with a comprehensive set of test cases for the `.lcm` method, covering positive, zero, negative, coprime, and large number cases