### PR TITLE
fix(codegen): widen implicit self call params

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -9236,11 +9236,7 @@ class Compiler
               while kk < arg_ids.length
                 at = infer_type(arg_ids[kk])
                 if kk < ptypes.length
-                  if ptypes[kk] == "int"
-                    if at != "int"
-                      ptypes[kk] = at
-                    end
-                  end
+                  ptypes[kk] = unify_call_types(ptypes[kk], at, arg_ids[kk])
                 end
                 kk = kk + 1
               end
@@ -19272,6 +19268,11 @@ class Compiler
         at = infer_type(arg_ids[k])
         if k < ptypes.length
           pt = ptypes[k]
+          if pt == "poly"
+            result = result + box_expr_to_poly(arg_ids[k])
+            k = k + 1
+            next
+          end
           if at == "int"
             if is_obj_type(pt) == 1
               # Cast int to object pointer

--- a/test/implicit_self_param_poly.rb
+++ b/test/implicit_self_param_poly.rb
@@ -1,0 +1,17 @@
+class TokenSink
+  def initialize
+    @value = ""
+  end
+
+  def set_token(value)
+    @value = value.to_s
+  end
+
+  def run
+    set_token(1)
+    set_token("done")
+    puts @value
+  end
+end
+
+TokenSink.new.run


### PR DESCRIPTION
## Summary

- merge implicit `self` method-call argument types with `unify_call_types`
- box arguments when a typed instance-method call targets a `poly` parameter
- add a regression test for same-class implicit calls with mixed argument types

## Validation

- `make all`
- `make test` (`200 pass, 0 fail, 0 error`)
- `make bench` (`56 pass, 0 fail, 0 skip`)

Fixes #135
