### PR TITLE
fix(codegen): walk @nd_parts in scan_new_calls

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -6435,6 +6435,16 @@ class Compiler
       scan_new_calls(conds[k])
       k = k + 1
     end
+    # InterpolatedStringNode and friends carry their components in @nd_parts.
+    # Without this, an EmbeddedStatementsNode inside `"#{...}"` is the only
+    # call site for a method whose param type would otherwise widen, and
+    # the param keeps its default `int` => C error at the call site.
+    parts = parse_id_list(@nd_parts[nid])
+    k = 0
+    while k < parts.length
+      scan_new_calls(parts[k])
+      k = k + 1
+    end
   end
 
   def update_ivar_types_from_params

--- a/test/interp_method_widening.rb
+++ b/test/interp_method_widening.rb
@@ -1,0 +1,39 @@
+# Method called only inside string interpolation should still anchor its
+# parameter type. Pre-fix: scan_features didn't visit EmbeddedStatementsNode
+# bodies, so `cap(name)` inside `"#{...}"` was the only call site for `cap`,
+# its `s` param defaulted to int, and codegen produced a C compile error.
+
+def cap(s)
+  s + "_cap"
+end
+
+name = "frob"
+puts "lv_#{cap(name)}"
+
+# Same shape with two args, one of which is also a method call
+def join_with(a, b)
+  a + "_" + b
+end
+
+x = "hello"
+y = "world"
+puts "wrapped(#{join_with(x, y)})"
+
+# Nested interpolation containing a method call whose param widens to int
+def inc(n)
+  n + 1
+end
+
+puts "next=#{inc(10)}"
+
+# Method whose param widens to bool via interpolated boolean call
+def bang(p)
+  if p
+    "YES"
+  else
+    "no"
+  end
+end
+
+flag = true
+puts "answer: #{bang(flag)}"


### PR DESCRIPTION
## Summary

Pre-fix, `scan_features` did not visit `EmbeddedStatementsNode` bodies, so methods called only inside `"#{...}"` interpolation were missed by feature detection. Their parameter types fell back to `int`, and codegen emitted a C compile error on string-typed argument passing.

## Reproducer

```ruby
def cap(s)
  s + "_cap"
end

name = "frob"
puts "lv_#{cap(name)}"
```

CRuby:
```
lv_frob_cap
```

Pre-fix Spinel: C compile error. `cap`'s `s` parameter inferred as `mrb_int`; the call site `cap(name)` passes a `const char *` into an int slot.

Post-fix Spinel matches CRuby.

## Fix

`scan_new_calls` (the helper that anchors method-parameter types from observed call sites) now walks `@nd_parts[nid]` for the embedded-statement node so call sites inside interpolations are seen by the same widening pass that handles top-level call sites. The existing `compile_interpolated` already emitted the body correctly at codegen time; the fix is purely on the inference side.

## Out of scope

- Nested `eval`-style strings (Spinel does not model dynamic eval).
- Dynamic-receiver method calls inside interpolation where the receiver type is not statically resolvable — those still hit the same fallbacks as outside-interpolation dynamic calls.

## Test plan

- [x] `make bootstrap` — `gen2.c == gen3.c (bootstrap OK)`
- [x] `make test` — `Tests: 200 pass, 0 fail, 0 error`
- [x] `test/interp_method_widening.rb` covers four shapes:
  - one-arg method (`cap(s)`) called only inside `#{}`
  - two-arg method (`join_with(a, b)`) inside `#{}`
  - integer-arg method (`inc(n)`) inside `#{}` (regression — no widening drift)
  - bool-returning method (`bang(p)`) inside `#{}` whose return value flows through interpolation

