### PR TITLE
feat(parse,codegen): support hash shorthand ({ x:, y: })

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -8176,12 +8176,67 @@ class Compiler
     result
   end
 
+  # Map a simple-literal AST node to its canonical type name. Returns ""
+  # for anything that isn't a leaf-literal (hashes, arrays, calls, etc.).
+  # Used by pre_scan_simple_local_writes to seed @scope_names before
+  # scan_locals's first pass runs.
+  def simple_literal_type(nid)
+    if nid < 0
+      return ""
+    end
+    t = @nd_type[nid]
+    if t == "StringNode"
+      return "string"
+    end
+    if t == "IntegerNode"
+      return "int"
+    end
+    if t == "FloatNode"
+      return "float"
+    end
+    if t == "SymbolNode"
+      return "symbol"
+    end
+    if t == "TrueNode"
+      return "bool"
+    end
+    if t == "FalseNode"
+      return "bool"
+    end
+    if t == "NilNode"
+      return "nil"
+    end
+    ""
+  end
+
+  # Pre-populate @scope_names with simple-literal local writes so that
+  # scan_locals's pass-1 inference can resolve LocalVariableReadNode
+  # references during type inference. Without this, hash shorthand
+  # `{first:}` whose key resolves to a previously-written string-valued
+  # local mis-types because find_var_type runs against an empty scope and
+  # falls back to "int". Limited to leaf-literal initializers; method
+  # calls and composite literals still go through the regular passes.
+  def pre_scan_simple_local_writes(stmts)
+    stmts.each { |sid|
+      if @nd_type[sid] == "LocalVariableWriteNode"
+        lname = @nd_name[sid]
+        if find_var_type(lname) == ""
+          st = simple_literal_type(@nd_expression[sid])
+          if st != ""
+            declare_var(lname, st)
+          end
+        end
+      end
+    }
+  end
+
   # ---- Feature detection ----
   def detect_features
     # Set up a temporary scope with main-level locals so feature detection
     # can infer types of local variables correctly
     push_scope
     stmts = get_body_stmts(@root_id)
+    pre_scan_simple_local_writes(stmts)
     lnames = "".split(",")
     ltypes = "".split(",")
     empty_p = "".split(",")
@@ -13209,6 +13264,7 @@ class Compiler
     ltypes = "".split(",")
 
     empty_params = "".split(",")
+    pre_scan_simple_local_writes(stmts)
     stmts.each { |sid|
       if @nd_type[sid] != "DefNode"
         if @nd_type[sid] != "ClassNode"

--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -394,7 +394,15 @@ static int flatten(pm_node_t *node) {
     pm_assoc_node_t *n = (pm_assoc_node_t *)node;
     N("AssocNode");
     R("key", n->key);
-    R("value", n->value);
+    /* Hash shorthand `{ x: }` lowers to an AssocNode whose value is a
+       PM_IMPLICIT_NODE wrapping the actual LocalVariableReadNode (or
+       MethodCallNode for an undeclared name). Unwrap one level here so
+       the codegen never sees the implicit wrapper. */
+    pm_node_t *val = n->value;
+    if (val && PM_NODE_TYPE_P(val, PM_IMPLICIT_NODE)) {
+      val = ((pm_implicit_node_t *)val)->value;
+    }
+    R("value", val);
     break;
   }
   case PM_KEYWORD_HASH_NODE: {

--- a/test/hash_shorthand.rb
+++ b/test/hash_shorthand.rb
@@ -1,0 +1,37 @@
+# Hash shorthand `{ x:, y: }` (Ruby 3.1+): an AssocNode whose value is
+# implicit. Prism wraps the implicit value in a PM_IMPLICIT_NODE that
+# carries the actual LocalVariableReadNode (or MethodCallNode for an
+# undeclared name) as its `value` child. spinel_parse unwraps the
+# ImplicitNode at the AST boundary so the codegen never sees the
+# wrapper, which means the shorthand reuses the existing
+# AssocNode + LocalVariableReadNode compile path with zero codegen
+# change.
+
+# 1. Two-key shorthand from int-valued locals.
+x = 10
+y = 20
+nums = {x:, y:}
+puts nums[:x]
+# 10
+puts nums[:y]
+# 20
+
+# 2. Single-key shorthand returned from a method body.
+def make_pair(weight)
+  {weight:}
+end
+
+h = make_pair(42)
+puts h[:weight]
+# 42
+
+# 3. Mixing shorthand and explicit pair (same value type — int).
+n = 7
+m = 11
+total = {n:, m:, sum: 18}
+puts total[:n]
+# 7
+puts total[:m]
+# 11
+puts total[:sum]
+# 18

--- a/test/hash_shorthand_str.rb
+++ b/test/hash_shorthand_str.rb
@@ -1,0 +1,48 @@
+# Hash shorthand with string-valued local variable.
+# Regression: scan_locals's first pass infers the hash literal value type
+# before the local's type lands in @scope_names, so `{first:}` mis-types
+# as int. Pre-fix: declared sp_SymIntHash / sp_SymPolyHash but built with
+# string values -> incompatible-pointer C error or unknown-type error.
+
+# Single string-valued shorthand
+name = "ada"
+who1 = {name:}
+puts who1[:name]
+puts who1.length
+
+# Mixed string-valued shorthand and explicit string pair
+first = "ada"
+who2 = {first:, last: "lovelace"}
+puts who2[:first]
+puts who2[:last]
+puts who2.length
+
+# Compare against the explicit equivalent (both should produce the same output)
+who3 = {first: first, last: "lovelace"}
+puts who3[:first]
+puts who3[:last]
+puts who3.length
+
+# Three string-valued shorthand keys
+a = "alpha"
+b = "beta"
+c = "gamma"
+who4 = {a:, b:, c:}
+puts who4[:a]
+puts who4[:b]
+puts who4[:c]
+puts who4.length
+
+# Mixed shorthand and explicit pairs round-tripping a single value type
+x = "one"
+y = "two"
+who5 = {x:, y:, z: "three"}
+puts who5[:x]
+puts who5[:y]
+puts who5[:z]
+puts who5.length
+
+# Has-key membership over the inferred hash type
+puts who1.has_key?(:name)
+puts who2.has_key?(:first)
+puts who2.has_key?(:missing)


### PR DESCRIPTION
## Summary

Ruby 3.1+ hash shorthand `{ x:, y: }` lowers to an `AssocNode` whose value is a `PM_IMPLICIT_NODE` wrapping the actual `LocalVariableReadNode` (or `MethodCallNode` for an undeclared name). The serializer emitted `UnknownNode_69` for the implicit wrapper, leaving the value slot uncompiled (zero-valued output). A separate inference-ordering bug also surfaced: `infer_hash_val_type` ran before `scan_locals` populated `@scope_names`, so `{first:}` over a string-valued local mis-typed the hash as `sp_SymIntHash` / `sp_SymPolyHash` rather than `sp_SymStrHash`.

## Reproducer

```ruby
first = "ada"
who = {first:, last: "lovelace"}
puts who[:first]
puts who[:last]
puts who.length
```

CRuby:
```
ada
lovelace
2
```

Pre-fix Spinel: declared `who` as `sp_SymIntHash *` / `sp_SymPolyHash *` and built it with string values — incompatible-pointer C error or unknown-type error.

Post-fix Spinel matches CRuby.

## Fix

Two coordinated halves:

**1. AST serializer.** When the `AssocNode` value is `PM_IMPLICIT_NODE`, follow `(pm_implicit_node_t *)val->value` to the real expression. The codegen never sees the wrapper — the existing `AssocNode` + `LocalVariableReadNode` compile path handles shorthand with zero codegen change.

**2. Pre-scan locals before hash inference.** New helper `simple_literal_type` maps `StringNode`/`IntegerNode`/`FloatNode`/`SymbolNode`/`TrueNode`/`FalseNode`/`NilNode` to canonical type names. `pre_scan_simple_local_writes` walks each enclosing-scope statement and `declare_var`s any not-yet-declared `LocalVariableWriteNode` whose value is a leaf literal. Invoked at the top of both `detect_features` and `emit_main`, immediately after `push_scope`. With this in place, `{first:}` over a string-valued local correctly types as `sp_SymStrHash`. Composite initializers (hashes, arrays, method calls) still flow through the regular passes — only leaf-literal-then-shorthand is covered.

## Out of scope

- Method-body scopes (`scan_locals` at method-emission sites) are not pre-scanned. The bug pattern can manifest there too; the documented reproducer is at top level.

## Test plan

- [x] `make bootstrap` — `gen2.c == gen3.c (bootstrap OK)`
- [x] `make test` — `Tests: 201 pass, 0 fail, 0 error`
- [x] `test/hash_shorthand.rb` — int-valued shorthand:
  - two-key shorthand from int-valued locals (`{x:, y:}`)
  - single-key shorthand inside a method body (`{weight:}`)
  - mixed shorthand and explicit pair (`{n:, m:, sum: 18}`)
- [x] `test/hash_shorthand_str.rb` — string-valued shorthand (the inference fix):
  - single shorthand `{name:}` over a string-valued local
  - mixed shorthand and explicit (`{first:, last: "lovelace"}`)
  - explicit equivalent for byte-equal output
  - three-key all-shorthand (`{a:, b:, c:}`)
  - shorthand + explicit + shorthand mixed (`{x:, y:, z: "three"}`)

