### PR TITLE
feat(codegen): Array#difference for core typed arrays (int/sym/str/float)

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2984,6 +2984,13 @@ class Compiler
       end
       return ""
     end
+    if mname == "difference"
+      if recv >= 0
+        rt = infer_type(recv)
+        return rt if rt == "int_array" || rt == "sym_array" || rt == "str_array" || rt == "float_array"
+      end
+      return ""
+    end
     ""
   end
 
@@ -17100,6 +17107,19 @@ class Compiler
         emit("  }")
         return tmp
       end
+      # difference: elements of self NOT in other (deduplicated).
+      # Inverse of intersection.
+      if mname == "difference"
+        arg = compile_arg0(nid)
+        tmp = new_temp
+        itmp = new_temp
+        emit("  sp_IntArray *" + tmp + " = sp_IntArray_new();")
+        emit("  for (mrb_int " + itmp + " = 0; " + itmp + " < sp_IntArray_length(" + rc + "); " + itmp + "++) {")
+        emit("    mrb_int _v = sp_IntArray_get(" + rc + ", " + itmp + ");")
+        emit("    if (!sp_IntArray_include(" + arg + ", _v) && !sp_IntArray_include(" + tmp + ", _v)) sp_IntArray_push(" + tmp + ", _v);")
+        emit("  }")
+        return tmp
+      end
       if mname == "min_by"
         if @nd_block[nid] >= 0
           blk = @nd_block[nid]
@@ -17245,6 +17265,23 @@ class Compiler
         emit("  }")
         return tmp
       end
+      # difference: float elements of self not in other, dedup. Inline
+      # membership for the NaN-aware == semantics; mirror intersection.
+      if mname == "difference"
+        arg = compile_arg0(nid)
+        tmp = new_temp
+        itmp = new_temp
+        jtmp = new_temp
+        ktmp = new_temp
+        emit("  sp_FloatArray *" + tmp + " = sp_FloatArray_new();")
+        emit("  for (mrb_int " + itmp + " = 0; " + itmp + " < sp_FloatArray_length(" + rc + "); " + itmp + "++) {")
+        emit("    mrb_float _v = sp_FloatArray_get(" + rc + ", " + itmp + ");")
+        emit("    mrb_int _in_b = 0; for (mrb_int " + jtmp + " = 0; " + jtmp + " < sp_FloatArray_length(" + arg + "); " + jtmp + "++) { if (sp_FloatArray_get(" + arg + ", " + jtmp + ") == _v) { _in_b = 1; break; } }")
+        emit("    mrb_int _in_r = 0; for (mrb_int " + ktmp + " = 0; " + ktmp + " < sp_FloatArray_length(" + tmp + "); " + ktmp + "++) { if (sp_FloatArray_get(" + tmp + ", " + ktmp + ") == _v) { _in_r = 1; break; } }")
+        emit("    if (!_in_b && !_in_r) sp_FloatArray_push(" + tmp + ", _v);")
+        emit("  }")
+        return tmp
+      end
     end
     if is_ptr_array_type(recv_type) == 1
       elem_type = ptr_array_elem_type(recv_type)
@@ -17360,6 +17397,19 @@ class Compiler
         emit("  for (mrb_int " + itmp + " = 0; " + itmp + " < sp_StrArray_length(" + rc + "); " + itmp + "++) {")
         emit("    const char *_v = sp_StrArray_get(" + rc + ", " + itmp + ");")
         emit("    if (sp_StrArray_include(" + arg + ", _v) && !sp_StrArray_include(" + tmp + ", _v)) sp_StrArray_push(" + tmp + ", _v);")
+        emit("  }")
+        return tmp
+      end
+      # difference: str elements of self not in other, dedup. Mirrors
+      # int_array's branch with strcmp-backed membership.
+      if mname == "difference"
+        arg = compile_arg0(nid)
+        tmp = new_temp
+        itmp = new_temp
+        emit("  sp_StrArray *" + tmp + " = sp_StrArray_new();")
+        emit("  for (mrb_int " + itmp + " = 0; " + itmp + " < sp_StrArray_length(" + rc + "); " + itmp + "++) {")
+        emit("    const char *_v = sp_StrArray_get(" + rc + ", " + itmp + ");")
+        emit("    if (!sp_StrArray_include(" + arg + ", _v) && !sp_StrArray_include(" + tmp + ", _v)) sp_StrArray_push(" + tmp + ", _v);")
         emit("  }")
         return tmp
       end

--- a/test/array_difference.rb
+++ b/test/array_difference.rb
@@ -1,0 +1,28 @@
+# Array#difference for typed arrays (int/sym/str/float).
+# Mirrors Array#intersection (c31b618) and Array#union — keep only
+# elements of self NOT present in other (deduplicated).
+
+# int_array
+puts [1, 2, 3, 4].difference([2, 4]).inspect
+puts [1, 2, 3].difference([4, 5]).inspect
+puts [1, 2, 3].difference([1, 2, 3]).inspect
+puts [].difference([1, 2]).inspect
+puts [1, 2].difference([]).inspect
+puts [1, 1, 2, 3].difference([1]).inspect
+puts [].difference([]).inspect
+
+# str_array
+puts ["a", "b", "c"].difference(["b"]).inspect
+puts ["x", "y"].difference(["a"]).inspect
+puts ["a", "b"].difference(["a", "b"]).inspect
+puts ["a", "a", "b"].difference(["a"]).inspect
+
+# float_array
+puts [1.0, 2.0, 3.0].difference([2.0]).inspect
+puts [1.5, 2.5].difference([3.5]).inspect
+puts [1.0, 1.0, 2.0].difference([1.0]).inspect
+
+# sym_array
+puts [:a, :b, :c].difference([:b]).inspect
+puts [:x, :y].difference([:a]).inspect
+puts [:a, :a, :b].difference([:a]).inspect


### PR DESCRIPTION
## Summary

Add `Array#difference` for the four core typed-array variants (`int_array`, `sym_array`, `str_array`, `float_array`). Mirrors the c31b618 (Array#intersection) PR template — same dispatch shape, same per-receiver-type implementation pattern.

## Reproducer

```ruby
a = [1, 2, 3, 4, 5]
b = [2, 4]
puts a.difference(b).inspect
puts a.difference([]).inspect
puts [].difference(a).inspect
```

CRuby:
```
[1, 3, 5]
[1, 2, 3, 4, 5]
[]
```

Pre-add Spinel: `difference` was not in the `compile_array_method_expr` dispatch — call returned `0` / nil, `inspect` printed empty.

Post-add Spinel matches CRuby.

## Fix

Add a `difference` arm to `compile_array_method_expr` per receiver type (int/sym at one shared block, str at its own block, float at its own block) — total four parallel branches. Each:

1. Allocates a fresh result array of the same typed variant.
2. Iterates self; for each element, push to result iff it's NOT in the argument array AND not already in the result (dedup).

Membership uses the existing per-type include helper: `sp_IntArray_include` (int+sym), `sp_StrArray_include` (str, strcmp-based), inline `==` loop for float (NaN-aware, mirrors the intersection arm's handling).

Layer-1 type-inference entry in `infer_method_call_return_type` returns the receiver's own type (Array#difference preserves the array variant).

## Out of scope

- `Array#-` (the operator alias) — same semantics; would be one more dispatch alias.
- Multi-arg difference (`a.difference(b, c, d)`) — Ruby supports it; this PR is single-arg for parity with the existing `intersection`.

## Test plan

- [x] `make bootstrap` — `gen2.c == gen3.c (bootstrap OK)`
- [x] `make test` — `Tests: 200 pass, 0 fail, 0 error`
- [x] `test/array_difference.rb` covers per element type (int/sym/str/float):
  - basic difference with overlap
  - empty self difference non-empty other
  - non-empty self difference empty other
  - full-overlap (result is empty)
  - no-overlap (result equals self)
  - duplicate-input dedup verification

