### PR TITLE
feat(codegen): Symbol#upcase and Symbol#downcase

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2174,10 +2174,10 @@ class Compiler
     if mname == "round"
       return "int"
     end
-    if mname == "upcase"
-      return "string"
-    end
-    if mname == "downcase"
+    if mname == "upcase" || mname == "downcase"
+      if recv >= 0 && infer_type(recv) == "symbol"
+        return "symbol"
+      end
       return "string"
     end
     if mname == "swapcase"
@@ -8388,6 +8388,16 @@ class Compiler
         if @nd_receiver[nid] >= 0
           rt = infer_type(@nd_receiver[nid])
           if rt == "string"
+            @needs_sym_intern = 1
+          end
+        end
+      end
+      # `:foo.upcase` / `:foo.downcase` lower to sp_str_upcase /
+      # sp_str_downcase on the symbol's name string and re-intern via
+      # sp_sym_intern. Mark the dynamic-pool path so it gets emitted.
+      if mname == "upcase" || mname == "downcase"
+        if @nd_receiver[nid] >= 0
+          if infer_type(@nd_receiver[nid]) == "symbol"
             @needs_sym_intern = 1
           end
         end
@@ -16442,6 +16452,12 @@ class Compiler
     end
     if mname == "to_sym" || mname == "intern"
       return rc
+    end
+    # Symbol#upcase / Symbol#downcase: lower-case via the str case helper
+    # then re-intern. Naming convention `sp_str_<mname>` lets one branch
+    # handle both — and slots in cleanly for capitalize/swapcase later.
+    if mname == "upcase" || mname == "downcase"
+      return "sp_sym_intern(sp_str_" + mname + "(sp_sym_to_s(" + rc + ")))"
     end
     if mname == "inspect"
       return "sp_str_concat(\":\", sp_sym_to_s(" + rc + "))"

--- a/test/symbol_upcase_downcase.rb
+++ b/test/symbol_upcase_downcase.rb
@@ -1,0 +1,26 @@
+# Symbol#upcase and Symbol#downcase return symbols by upper/lower-casing
+# the symbol's name string and re-interning. Mirrors the existing
+# String#upcase / #downcase plumbing — the only delta is `sp_sym_to_s`
+# in front of the case helper and `sp_sym_intern` wrapping the result.
+
+# Symbol#upcase
+puts :hello.upcase
+puts :HELLO.upcase
+puts :MixedCase.upcase
+puts :a.upcase
+puts :_.upcase
+
+# Symbol#downcase
+puts :HELLO.downcase
+puts :hello.downcase
+puts :MixedCase.downcase
+puts :Z.downcase
+
+# Round trip — sym -> upper -> lower returns to original lower form
+puts :foo.upcase.downcase
+puts :BAR.downcase.upcase
+
+# Re-intern stability — equal pre/post-case symbols stay equal
+puts :Hello.upcase == :HELLO
+puts :Hello.downcase == :hello
+puts :a.upcase != :A.downcase


### PR DESCRIPTION
## Summary

Add `Symbol#upcase` and `Symbol#downcase`. Both return a new `Symbol` whose name is the case-transformed version of the receiver's name.

## Reproducer

```ruby
puts :hello.upcase
puts :HELLO.downcase
puts :MixedCase.upcase
puts :MixedCase.downcase
```

CRuby:
```
HELLO
hello
MIXEDCASE
mixedcase
```

Pre-add Spinel: `upcase`/`downcase` on a `Symbol` receiver was not in the `compile_symbol_method_expr` dispatch — fell through to the string-method path, which fails with a type error against the symbol receiver.

Post-add Spinel matches CRuby.

## Fix

Two arms added to `compile_symbol_method_expr`:

- **`#upcase`** — calls `sp_str_upcase` on the symbol's name string, then re-interns via the existing dynamic-symbol pool path (`sp_sym_intern`).
- **`#downcase`** — same shape with `sp_str_downcase`.

Layer-1 type-inference for `upcase`/`downcase` on a `symbol` receiver returns `symbol` (preserves the type — distinct from the same methods on `string` which return `string`). The matching `@needs_sym_intern` flag is set in `scan_features` so the dynamic-symbol pool ships into the generated C.

## Out of scope

- `Symbol#capitalize`, `Symbol#swapcase` — same shape; defer for follow-up.
- Locale-aware case folding (`upcase :turkic` etc.) — Spinel uses ASCII case folding via `sp_str_upcase` / `sp_str_downcase`, which matches CRuby's default.

## Test plan

- [x] `make bootstrap` — `gen2.c == gen3.c (bootstrap OK)`
- [x] `make test` — `Tests: 200 pass, 0 fail, 0 error`
- [x] `test/symbol_upcase_downcase.rb` covers:
  - all-lowercase upcased
  - all-uppercase downcased
  - mixed-case upcased and downcased
  - already-correct-case (no-op)
  - single-char and multi-char symbols

