### PR TITLE
feat(codegen): Array#take_while and #drop_while for int/sym arrays

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2984,6 +2984,13 @@ class Compiler
       end
       return ""
     end
+    if mname == "take_while" || mname == "drop_while"
+      if recv >= 0
+        rt = infer_type(recv)
+        return rt if rt == "int_array" || rt == "sym_array"
+      end
+      return ""
+    end
     ""
   end
 
@@ -17039,6 +17046,58 @@ class Compiler
           return tmp
         end
         return "sp_IntArray_sort(" + rc + ")"
+      end
+      # take_while / drop_while: block-driven prefix scan. take_while
+      # collects elements from the front while the block stays truthy;
+      # drop_while skips them and returns the rest. Mirrors the
+      # existing take/drop arms but with per-element block evaluation.
+      # `bp`'s C type and the metadata `declare_var` records both come
+      # from `elem_type_of_array(recv_type)` so sym_array gets `sp_sym`
+      # rather than a hardcoded `mrb_int`. Multi-stmt blocks compile
+      # preceding statements before extracting the predicate expr from
+      # the last — same shape as the partition arm.
+      if (mname == "take_while" || mname == "drop_while") && @nd_block[nid] >= 0
+        blk = @nd_block[nid]
+        bp = get_block_param(nid, 0)
+        if bp == ""
+          bp = "_x"
+        end
+        elem_t = elem_type_of_array(recv_type)
+        tmp = new_temp
+        itmp = new_temp
+        ktmp = new_temp
+        emit("  sp_IntArray *" + tmp + " = sp_IntArray_new();")
+        emit("  { mrb_int " + ktmp + " = sp_IntArray_length(" + rc + ");")
+        emit("    mrb_int " + itmp + " = 0;")
+        emit("    while (" + itmp + " < " + ktmp + ") {")
+        emit("      " + c_type(elem_t) + " lv_" + bp + " = sp_IntArray_get(" + rc + ", " + itmp + ");")
+        push_scope
+        declare_var(bp, elem_t)
+        bbody = @nd_body[blk]
+        bexpr = "0"
+        if bbody >= 0
+          bs = get_stmts(bbody)
+          if bs.length > 0
+            k = 0
+            while k < bs.length - 1
+              compile_stmt(bs[k])
+              k = k + 1
+            end
+            bexpr = compile_expr(bs.last)
+          end
+        end
+        emit("      if (!(" + bexpr + ")) break;")
+        if mname == "take_while"
+          emit("      sp_IntArray_push(" + tmp + ", lv_" + bp + ");")
+        end
+        emit("      " + itmp + "++;")
+        emit("    }")
+        if mname == "drop_while"
+          emit("    while (" + itmp + " < " + ktmp + ") { sp_IntArray_push(" + tmp + ", sp_IntArray_get(" + rc + ", " + itmp + ")); " + itmp + "++; }")
+        end
+        emit("  }")
+        pop_scope
+        return tmp
       end
       if mname == "first"
         return "sp_IntArray_get(" + rc + ", 0)"

--- a/test/array_take_drop_while.rb
+++ b/test/array_take_drop_while.rb
@@ -1,0 +1,29 @@
+# Array#take_while and Array#drop_while for int_array (the common case).
+# take_while collects elements from the front while the block stays
+# truthy; drop_while skips them and returns the rest.
+
+# take_while
+puts [1, 2, 3, 1].take_while { |x| x < 3 }.inspect
+puts [1, 2, 3].take_while { |x| x < 10 }.inspect
+puts [5, 6, 7].take_while { |x| x < 0 }.inspect
+puts [].take_while { |x| x > 0 }.inspect
+
+# drop_while
+puts [1, 2, 3, 1].drop_while { |x| x < 3 }.inspect
+puts [1, 2, 3].drop_while { |x| x < 10 }.inspect
+puts [5, 6, 7].drop_while { |x| x < 0 }.inspect
+puts [].drop_while { |x| x > 0 }.inspect
+
+# take_while + drop_while round-trip preserves total count
+arr = [1, 2, 3, 4, 5, 1, 2]
+puts(arr.take_while { |x| x < 4 }.length + arr.drop_while { |x| x < 4 }.length)
+
+# Multi-stmt block — preceding statements must execute (regression for the
+# "only last expr is compiled" bug).
+counter = 0
+[1, 2, 3, 4].take_while { |x| counter = counter + 1; x < 3 }
+puts counter
+
+# sym_array path (regression for the bp-hardcoded-int bug).
+puts [:a, :b, :c, :d].take_while { |s| s != :c }.inspect
+puts [:a, :b, :c, :d].drop_while { |s| s != :c }.inspect


### PR DESCRIPTION
## Summary

Add `Array#take_while` and `Array#drop_while` for `int_array` and `sym_array` (the variants that are backed by `sp_IntArray` — same shape, single helper). Both are block-driven prefix-scan methods.

## Reproducer

```ruby
puts [1, 2, 3, 4, 5].take_while { |x| x < 3 }.inspect
puts [1, 2, 3, 4, 5].drop_while { |x| x < 3 }.inspect
puts [10, 20, 30].take_while { |x| x > 100 }.inspect  # all-false
puts [10, 20, 30].drop_while { |x| x < 100 }.inspect  # all-true
```

CRuby:
```
[1, 2]
[3, 4, 5]
[]
[]
```

Pre-add Spinel: `take_while` / `drop_while` were not in the `compile_array_method_expr` dispatch — call returned `0` / nil, `inspect` printed empty.

Post-add Spinel matches CRuby.

## Fix

Combined arm in `compile_array_method_expr`:

```ruby
if (mname == "take_while" || mname == "drop_while") && @nd_block[nid] >= 0
  # ... block-param binding + per-element predicate eval + early break
end
```

Implementation:
1. Allocate result `sp_IntArray`.
2. Walk self while predicate stays truthy. For `take_while`: push each element into the result. For `drop_while`: skip and increment index only.
3. Once predicate goes false (or end-of-array): for `drop_while` only, copy remaining elements unconditionally into the result.

Layer-1 type-inference returns the receiver's own type (preserves `int_array` / `sym_array`).

## Out of scope

- `str_array#take_while` / `drop_while` — different backing helper (`sp_StrArray`); separate per-type dispatch needed.
- `float_array#take_while` / `drop_while` — same situation.
- `Enumerator`-returning no-block forms (`a.take_while`) — Spinel doesn't model Enumerator.

## Test plan

- [x] `make bootstrap` — `gen2.c == gen3.c (bootstrap OK)`
- [x] `make test` — `Tests: 200 pass, 0 fail, 0 error`
- [x] `test/array_take_drop_while.rb` covers:
  - basic predicate truthy-prefix
  - all-false predicate (empty result for take_while; full input for drop_while)
  - all-true predicate (full input for take_while; empty for drop_while)
  - sym_array variant
  - empty receiver

