### PR TITLE
test(codegen): pin endless method support (def foo(x) = expr)

### DIFF
--- a/test/endless_method.rb
+++ b/test/endless_method.rb
@@ -1,0 +1,61 @@
+# Endless methods (Ruby 3.0+): `def name(args) = expr` is shorthand for
+# a single-expression method body. Prism flattens this to the same
+# DefNode shape as a regular def with a one-statement StatementsNode
+# body, so the existing codegen path supports it transparently. This
+# test pins that contract — if a future Prism upgrade emits a distinct
+# node type (e.g. SingleLineMethodDefinitionNode), the test breaks
+# loudly instead of silently regressing.
+
+# 1. Plain integer return.
+def double(x) = x * 2
+puts double(21)
+# 42
+
+# 2. String return with interpolation.
+def greet(name) = "hello, #{name}"
+puts greet("world")
+# hello, world
+
+# 3. Self-recursive endless method (still expressible, since the body
+#    is one expression).
+def fact(n) = n <= 1 ? 1 : n * fact(n - 1)
+puts fact(5)
+# 120
+
+# 4. No-arg endless method.
+def answer = 42
+puts answer
+# 42
+
+# 5. Endless method using a block-passing call.
+def doubled_max(arr) = arr.map { |x| x * 2 }.max
+puts doubled_max([1, 4, 2])
+# 8
+
+# 6. Class endless method (instance + class methods).
+class Box
+  def self.unit = 1
+  def initialize(v); @v = v; end
+  def double = @v * 2
+  def name = "Box"
+end
+
+puts Box.unit
+# 1
+puts Box.new(7).double
+# 14
+puts Box.new(0).name
+# Box
+
+# 7. Boolean-returning endless method.
+def positive?(n) = n > 0
+puts positive?(10)
+# true
+puts positive?(-1)
+# false
+
+# 8. Method composition (one endless method calling another).
+def square(x) = x * x
+def square_of_sum(a, b) = square(a + b)
+puts square_of_sum(2, 3)
+# 25


### PR DESCRIPTION
## Summary

Pin the existing endless-method definition support (`def foo(x) = expr`, Ruby 3.0+) with a regression test. The shape already worked through the parser + codegen; this commit adds the test that locks it down.

## Reproducer

```ruby
def square(x) = x * x
puts square(7)

def greet(name) = "hello, #{name}"
puts greet("world")

def factorial(n) = n <= 1 ? 1 : n * factorial(n - 1)
puts factorial(5)
```

CRuby:
```
49
hello, world
120
```

Pre-test status: same output as CRuby (already worked) — but with no test gating, an accidental codegen regression could have stopped it silently. This commit pins the contract.

## Fix

This is a `test(codegen):` commit — no codegen change, only the regression test. The fact that it passes against the current codegen confirms the shape is supported.

## Out of scope

- Endless method with `rescue` modifier (`def parse(s) = Integer(s) rescue nil`) — covered by #30 (rs-endless-method-rescue).
- Endless method with explicit `return` — Ruby disallows it (parse error); inherits from Prism.

## Test plan

- [x] `make bootstrap` — `gen2.c == gen3.c (bootstrap OK)`
- [x] `make test` — `Tests: 200 pass, 0 fail, 0 error`
- [x] `test/endless_method.rb` covers:
  - simple arithmetic body (`x * x`)
  - string-interpolation body
  - recursive definition
  - integer comparison body
  - boolean-returning body
  - method composition (one endless method calling another)

