### PR TITLE
[codex] Fail make targets when tests report errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,12 +195,13 @@ test: spinel_parse$(EXE) $(SP_RT_LIB)
 	  fi; \
 	done; \
 	rm -f /tmp/_sp_t.ast /tmp/_sp_t.c /tmp/_sp_t_bin$(EXE); \
-	echo "Tests: $$pass pass, $$fail fail, $$err error"
+	echo "Tests: $$pass pass, $$fail fail, $$err error"; \
+	if [ $$fail -ne 0 ] || [ $$err -ne 0 ]; then exit 1; fi
 
 bench: spinel_parse$(EXE) $(SP_RT_LIB)
 	@if [ ! -f spinel_codegen$(EXE) ]; then echo "Run 'make bootstrap' first"; exit 1; fi
 	@if [ -z "$(TIMEOUT_BIN)" ]; then echo "Note: no 'timeout' command found; running without time limits."; fi
-	@pass=0; fail=0; skip=0; \
+	@pass=0; fail=0; err=0; skip=0; \
 	for f in benchmark/*.rb; do \
 	  bn=$$(basename "$$f" .rb); \
 	  $(TIMEOUT10) ./spinel_parse$(EXE) "$$f" /tmp/_sp_b.ast 2>/dev/null && \
@@ -224,11 +225,12 @@ bench: spinel_parse$(EXE) $(SP_RT_LIB)
 	      fi; \
 	    fi; \
 	  else \
-	    echo "ERR:  $$bn"; \
+	    echo "ERR:  $$bn"; err=$$((err+1)); \
 	  fi; \
 	done; \
 	rm -f /tmp/_sp_b.ast /tmp/_sp_b.c /tmp/_sp_b_bin$(EXE); \
-	echo "Benchmarks: $$pass pass, $$fail fail, $$skip skip"
+	echo "Benchmarks: $$pass pass, $$fail fail, $$err error, $$skip skip"; \
+	if [ $$fail -ne 0 ] || [ $$err -ne 0 ]; then exit 1; fi
 
 # ---- Install ----
 


### PR DESCRIPTION
## Summary

- Make make test exit non-zero when the test summary reports failures or errors.
- Track benchmark errors in make bench and make that target exit non-zero on failures or errors as well.

## Why

The test and benchmark recipes currently print non-zero fail/error counts but still finish successfully because the final command is the summary echo. That lets GitHub Actions report a successful check even when individual tests reported FAIL or ERR.

This PR intentionally makes the current CI fail so the existing reported failures are visible in the check status.

## Validation

- Ran make test locally. It now exits non-zero after reporting the existing array_tally_sym error:

    Tests: 220 pass, 0 fail, 1 error
    make: *** [Makefile:176: test] Error 1
