### PR TITLE
fix(codegen): Array#<< in expression context emits push, not bit-shift

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2088,6 +2088,10 @@ class Compiler
         if lt == "mutable_str"
           return "mutable_str"
         end
+        # Array `<<` returns the recv (so `(arr << x) << y` chains).
+        if is_array_type(lt) == 1
+          return lt
+        end
       end
       return "int"
     end
@@ -15978,6 +15982,34 @@ class Compiler
       end
       if lt == "string"
         return "sp_str_concat(" + compile_expr(recv) + ", " + compile_arg0(nid) + ")"
+      end
+      # Array `<<` is push, not bit-shift. The compile_call_expr path
+      # also has a push branch for direct `arr.push(x)` style calls,
+      # but the operator form lands here.
+      if lt == "int_array"
+        @needs_int_array = 1
+        rc = compile_expr_gc_rooted(recv)
+        return "(sp_IntArray_push(" + rc + ", " + compile_arg0(nid) + "), " + rc + ")"
+      end
+      if lt == "float_array"
+        @needs_float_array = 1
+        rc = compile_expr_gc_rooted(recv)
+        return "(sp_FloatArray_push(" + rc + ", " + compile_arg0(nid) + "), " + rc + ")"
+      end
+      if lt == "str_array"
+        @needs_str_array = 1
+        rc = compile_expr_gc_rooted(recv)
+        return "(sp_StrArray_push(" + rc + ", " + compile_arg0(nid) + "), " + rc + ")"
+      end
+      if lt == "sym_array"
+        @needs_int_array = 1
+        rc = compile_expr_gc_rooted(recv)
+        return "(sp_IntArray_push(" + rc + ", " + compile_arg0(nid) + "), " + rc + ")"
+      end
+      if is_ptr_array_type(lt) == 1
+        @needs_ptr_array = 1
+        rc = compile_expr_gc_rooted(recv)
+        return "(sp_PtrArray_push(" + rc + ", " + compile_arg0(nid) + "), " + rc + ")"
       end
       return "(" + compile_expr(recv) + " << " + compile_arg0(nid) + ")"
     end

--- a/test/array_shovel.rb
+++ b/test/array_shovel.rb
@@ -1,0 +1,33 @@
+# `arr << x` used in expression context (not a top-level statement)
+# fell through to a literal C `<<` (bit shift). The stmt-level path
+# already lowered `arr << x` to push for typed arrays; the operator/
+# expression form did not. gcc rejected the result with "invalid
+# operands to binary <<" on a pointer LHS.
+#
+# Chaining `(arr << x) << y` is the natural expression-context use
+# case: the inner `<<` returns the recv, which the outer `<<`
+# mutates again. Both the codegen path and `infer_call_type` need
+# to know the result is the recv's array type so the outer operand
+# type-checks.
+
+ints = [1]
+(ints << 2) << 3
+puts ints.length    # 3
+puts ints[0]        # 1
+puts ints[1]        # 2
+puts ints[2]        # 3
+
+floats = [1.5]
+(floats << 2.5) << 3.5
+puts floats.length  # 3
+puts floats[2]      # 3.5
+
+strs = ["a"]
+(strs << "b") << "c"
+puts strs.length    # 3
+puts strs[2]        # c
+
+syms = [:x]
+(syms << :y) << :z
+puts syms.length    # 3
+puts syms[2]        # z


### PR DESCRIPTION
## Reproduction
  ```ruby
  ints = [1]
  (ints << 2) << 3
  puts ints.length
  puts ints[0]
  puts ints[1]
  puts ints[2]
  ```

  ## Expected behavior
  `Array#<<` is an alias for `Array#push` and returns the receiver, so `(arr << x) << y` chains naturally. Output:
  ```
  3
  1
  2
  3
  ```

  ## Actual behavior
  Compile error:
  ```
  /tmp/_t.c: In function ‘main’:
  /tmp/_t.c:18:15: error: invalid operands to binary << (have ‘sp_IntArray *’ and ‘int’)
     18 |     ((lv_ints << 2) << 3);
        |               ^~
  ```

  ## Analysis & fix
  The statement-level `arr << x` (a bare `<<` statement) was already lowered to `sp_IntArray_push` by the existing code, but the expression-context `<<` handler (`compile_operator_expr`) had no typed-array branch — it emitted the literal C `<<` operator. With a pointer LHS, gcc rejects this.

  Two changes:

  1. **`compile_operator_expr`**: after the existing `mutable_str` / string-concat branches, add cases for `int_array` / `float_array` / `str_array` / `sym_array` / `ptr_array_type` that emit `(sp_<X>Array_push(rooted_recv, val), rooted_recv)`. Returning the GC-rooted recv lets the outer `<<` chain.

  2. **`infer_call_type` `<<` branch**: previously returned the recv type only for `mutable_str`, otherwise `int`. The outer `<<` of a chain sees the inner `<<`'s result as `int`, which retriggers the same compile error. Extend the branch so that when `is_array_type(lt) == 1`, the recv type is returned.