### PR TITLE
fix(codegen): box pointer-typed values to poly via sp_box_obj

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -19179,6 +19179,11 @@ class Compiler
     if at == "proc" || at == "lambda"
       return "sp_box_proc(" + val + ")"
     end
+    # Other pointer types (hashes, mutable strings, etc.) — box with a
+    # neutral cls_id of 0 rather than truncating the pointer to int.
+    if type_is_pointer(at) == 1
+      return "sp_box_obj((void *)(" + val + "), 0)"
+    end
     "sp_box_int(" + val + ")"
   end
 
@@ -19203,6 +19208,33 @@ class Compiler
     end
     if at == "symbol"
       return "sp_box_sym(" + val + ")"
+    end
+    if at == "int_array"
+      return "sp_box_int_array(" + val + ")"
+    end
+    if at == "float_array"
+      return "sp_box_float_array(" + val + ")"
+    end
+    if at == "str_array"
+      return "sp_box_str_array(" + val + ")"
+    end
+    if at == "sym_array"
+      return "sp_box_sym_array(" + val + ")"
+    end
+    if is_ptr_array_type(at) == 1
+      return "sp_box_ptr_array(" + val + ")"
+    end
+    if is_obj_type(at) == 1
+      cname = at[4, at.length - 4]
+      ci = find_class_idx(cname)
+      return "sp_box_obj(" + val + ", " + ci.to_s + ")"
+    end
+    # Other pointer types (hashes, mutable strings, etc.) — box with a
+    # neutral cls_id of 0. Round-tripping back to the original concrete
+    # type is the caller's problem; this just makes the assignment
+    # type-check rather than silently truncating a pointer to mrb_int.
+    if type_is_pointer(at) == 1
+      return "sp_box_obj((void *)(" + val + "), 0)"
     end
     "sp_box_int(" + val + ")"
   end

--- a/test/box_pointer_to_poly.rb
+++ b/test/box_pointer_to_poly.rb
@@ -1,0 +1,27 @@
+# `box_val_to_poly` and `box_expr_to_poly` previously fell through
+# to `sp_box_int(val)` for any pointer-typed expression they didn't
+# explicitly recognize (hashes, mutable strings, etc.), yielding
+# -Wint-conversion errors and silently truncating the pointer to a
+# 64-bit int. The fix routes pointer types through `sp_box_obj`.
+#
+# Triggers the path: a method whose return type is widened to poly
+# across branches (here: hash and string). The hash branch's
+# `return {a: 1, ...}` runs through `box_expr_to_poly`, which
+# without the fix emitted `sp_box_int(<sp_SymIntHash *>)` and gcc
+# rejected with "passing argument 1 of sp_box_int makes integer
+# from pointer without a cast".
+#
+# The test only verifies the program compiles and runs — round-
+# tripping the hash back out of the poly slot is the caller's
+# problem since the cls_id of 0 erases the concrete type.
+
+def get(flag)
+  if flag > 0
+    return {a: 1, b: 2, c: 3}
+  end
+  "hello"
+end
+
+x = get(0)
+y = get(1)
+puts "ok"


### PR DESCRIPTION
## Reproduction
```ruby
def get(flag)
  if flag > 0
    return {a: 1, b: 2, c: 3}
  end
  "hello"
end

x = get(0)
y = get(1)
puts "ok"
```

## Expected behavior
`get`'s return type is the union of hash and string, so it widens to poly (`sp_RbVal`). Each branch's return value is boxed with the appropriate `sp_box_*` helper. Output:
```
ok
```

## Actual behavior
Compile error:
```
/tmp/_t.c: In function ‘sp_get’:
/tmp/_t.c:35:33: error: passing argument 1 of ‘sp_box_int’ makes integer from pointer without a cast [-Wint-conversion]
   35 |       sp_RbVal _t2 = sp_box_int(_t1);
      |                                 ^~~
      |                                 |
      |                                 sp_SymIntHash *
In file included from /tmp/_t.c:2:
lib/sp_runtime.h:596:36: note: expected ‘mrb_int’ {aka ‘long int’} but argument is of type ‘sp_SymIntHash *’
  596 | static sp_RbVal sp_box_int(mrb_int v) { sp_RbVal r; r.tag = SP_TAG_INT; r.cls_id = 0; r.v.i = v; return r; }
      |                            ~~~~~~~~^
```

## Analysis & fix
`box_val_to_poly` and `box_expr_to_poly` both ended in a fallback that emitted `sp_box_int(val)` for any type they didn't explicitly enumerate. Pointer-typed values (hashes, mutable strings, ptr arrays, `obj_X`, etc.) landed there, and `sp_box_int` takes `mrb_int` — gcc rejected with `-Wint-conversion`, and even if it had compiled, the pointer would have been silently truncated to a 64-bit int.

Fix:
- Add explicit branches for the typed-array variants (`int_array` / `float_array` / `str_array` / `sym_array` / `ptr_array`) and `obj_X`, dispatching to the matching `sp_box_*` or `sp_box_obj(val, ci)`.
- For any other pointer type (`type_is_pointer(at) == 1`), route to `sp_box_obj((void *)(val), 0)`. The neutral `cls_id = 0` means the poly value can't be dispatched back to the original concrete type, but that's the caller's problem — at least the boxing produces a well-formed `sp_RbVal` instead of a silently-truncated int.

The same fallback is added to both `box_val_to_poly` (used at `val`-level call sites) and `box_expr_to_poly` (used at `expr_id`-level call sites such as fiber `yielded_value`).