### PR TITLE
fix(codegen): don't drop return value of user methods named like mutators

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -26979,11 +26979,39 @@ class Compiler
     if lt == "CallNode"
       lm = @nd_name[last]
       if lm == "[]=" || lm == "push" || lm == "pop" || lm == "emit" || lm == "emit_raw" || lm == "puts" || lm == "print" || lm == "p" || lm == "printf" || lm == "warn" || lm == "raise" || lm == "exit" || lm == "abort" || lm == "sleep" || lm == "delete" || lm == "clear" || lm == "concat" || lm == "prepend" || lm == "fill" || lm == "insert" || lm == "update" || lm == "merge!" || lm == "store" || lm == "reverse!" || lm == "sort!" || lm == "each" || lm == "times" || lm == "upto" || lm == "downto"
-        compile_stmt(last)
-        if return_type != "void"
-          emit("  return " + c_return_default(return_type) + ";")
+        # The hardcoded list above is meant to catch builtin Array/Hash
+        # mutators conventionally called for side-effect. But several of
+        # these names (update, clear, concat, delete, each, pop, push, ...)
+        # are equally plausible on user classes — and there returning the
+        # call's value is the only correct behavior. If the receiver
+        # resolves to a user class and that class defines a method with
+        # the same name, treat the call as an ordinary expression.
+        last_recv = @nd_receiver[last]
+        is_user_method = 0
+        if last_recv < 0
+          if @current_class_idx >= 0
+            if cls_find_method_direct(@current_class_idx, lm) >= 0
+              is_user_method = 1
+            end
+          end
+        else
+          last_rt = base_type(infer_type(last_recv))
+          if is_obj_type(last_rt) == 1
+            recv_ci = find_class_idx(last_rt[4, last_rt.length - 4])
+            if recv_ci >= 0
+              if cls_find_method_direct(recv_ci, lm) >= 0
+                is_user_method = 1
+              end
+            end
+          end
         end
-        return
+        if is_user_method == 0
+          compile_stmt(last)
+          if return_type != "void"
+            emit("  return " + c_return_default(return_type) + ";")
+          end
+          return
+        end
       end
       # Receiver-based setter calls (obj.attr = val)
       if lm.end_with?("=") && lm != "==" && lm != "!=" && lm != "<=" && lm != ">="

--- a/test/user_method_named_like_mutator.rb
+++ b/test/user_method_named_like_mutator.rb
@@ -1,0 +1,30 @@
+# compile_body_return treats certain method names (`update`, `clear`,
+# `concat`, `delete`, `each`, `pop`, `push`, `merge!`, ...) as
+# statement-only because Hash and Array mutators are conventionally
+# called for side-effect. That's right when the receiver IS a Hash
+# or Array, but it silently throws away the value when a user class
+# happens to define a method with one of those names — including the
+# implicit `self.update(...)` form, since the receiver chain isn't
+# even consulted before the name match fires.
+#
+# Pre-fix, `C.new.f(7)` returned 0 (correct: 8) and
+# `D.new.run(C.new)` returned 0 (correct: 30). Both follow Ruby
+# semantics now.
+
+class C
+  def update(target)
+    target
+  end
+  def f(n)
+    update(n + 1)   # implicit self.update — was discarded
+  end
+end
+
+class D
+  def run(c)
+    c.update(30)    # explicit recv on user class — was discarded
+  end
+end
+
+puts C.new.f(7)
+puts D.new.run(C.new)


### PR DESCRIPTION
## Reproduction
```ruby
class C
  def update(target)
    target
  end
  def f(n)
    update(n + 1)
  end
end

class D
  def run(c)
    c.update(30)
  end
end

puts C.new.f(7)
puts D.new.run(C.new)
```

## Expected behavior
Both `update` calls return their argument. Output:
```
8
30
```

## Actual behavior
Compiles cleanly, but the values are silently dropped:
```
0
0
```

## Analysis & fix
`compile_body_return` had a hardcoded list of method names — `update`, `clear`, `concat`, `delete`, `each`, `pop`, `push`, `merge!`, `times`, `upto`, ... — that get treated as statement-only when they appear as the final expression of a method body. The intent was to discard the return value of `Hash#update` / `Array#concat` / etc., which are conventionally called for side-effect.

The check fires purely on method name, ignoring the receiver. So when a user class defines `def update(x)` and another method ends with `update(x + 1)` (or `c.update(x)` with `c : MyClass`), the value is silently dropped and the method's `return ...` becomes `return 0`. No compile error, just wrong output.

Fix: resolve the receiver before matching the name list. If the receiver (or `self` for no-recv calls) resolves to a user class that defines a method by that name, fall through to the normal expression path. Builtin Hash / Array recvs still hit the statement path as before.