### PR TITLE
fix(codegen): unbox poly elements when emitting an IntArray literal

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -20123,7 +20123,17 @@ class Compiler
     emit("  sp_IntArray *" + tmp + " = sp_IntArray_new();")
     k = 0
     while k < elems.length
-      emit("  sp_IntArray_push(" + tmp + ", " + compile_expr(elems[k]) + ");")
+      ev = compile_expr(elems[k])
+      et = infer_type(elems[k])
+      # Unbox poly values when pushing into a (concrete) IntArray.
+      # An ArrayNode literal whose elements are poly (e.g.
+      # `[addr]` where addr's recorded type is sp_RbVal) needs the
+      # int payload extracted via `.v.i`. Without this, the C
+      # compiler rejects the push with "incompatible type".
+      if et == "poly"
+        ev = "(" + ev + ").v.i"
+      end
+      emit("  sp_IntArray_push(" + tmp + ", " + ev + ");")
       k = k + 1
     end
     tmp

--- a/test/array_lit_unbox_poly.rb
+++ b/test/array_lit_unbox_poly.rb
@@ -1,0 +1,23 @@
+# `compile_array_literal`'s int-array fallback pushed elements
+# verbatim, including poly-typed ones. When a local was widened to
+# poly via cross-branch assignments and then wrapped in an `[x]`
+# literal, the generated C had `sp_IntArray_push(arr, <sp_RbVal
+# struct>)`, which gcc rejected with "incompatible type for
+# argument 2 of sp_IntArray_push". The fix unboxes the int payload
+# via `.v.i`. Caller code is responsible for keeping the poly slot
+# integer-tagged at the moment the literal is built.
+
+addr = 7
+flag = 0
+if flag > 0
+  # Dead path at runtime — only here to widen `addr` to poly so
+  # the array literal lands on the unboxing path.
+  addr = "x"
+end
+
+# `addr` is poly at compile time (sp_RbVal) but always int=7 at
+# runtime. The `[addr]` literal infers as int_array (a single poly
+# element falls through to the IntArray branch).
+arr = [addr]
+puts arr.length          # 1
+puts arr[0]              # 7


### PR DESCRIPTION
## Reproduction
```ruby
addr = 7
flag = 0
if flag > 0
  addr = "x"
end
arr = [addr]
puts arr.length
puts arr[0]
```

## Expected behavior
`addr` is widened to `poly` (`sp_RbVal`) by the cross-branch assignment of disjoint types, but at runtime is always `7` (int). The literal `[addr]` builds an int array. Output:
```
1
7
```

## Actual behavior
Compile error:
```
/tmp/_t.c: In function ‘main’:
/tmp/_t.c:23:27: error: incompatible type for argument 2 of ‘sp_IntArray_push’
   23 |     sp_IntArray_push(_t1, lv_addr);
      |                           ^~~~~~~
      |                           |
      |                           sp_RbVal
In file included from /tmp/_t.c:2:
lib/sp_runtime.h:220:59: note: expected ‘mrb_int’ {aka ‘long int’} but argument is of type ‘sp_RbVal’
  220 | static inline void sp_IntArray_push(sp_IntArray*a,mrb_int v){if(a->start+a->len>=a->cap)sp_IntArray_push_grow(a);a->data[a->start+a->len]=v;a->len++;}
      |                                                   ~~~~~~~~^
```

## Analysis & fix
`compile_array_literal`'s int-array fallback (the default branch when `infer_array_elem_type` doesn't return one of the specialized array types) emitted `sp_IntArray_push(arr, compile_expr(elem))` without consulting the element's inferred type. When the element was poly (an `sp_RbVal` struct), the push got handed the struct directly and gcc rejected with `incompatible type for argument 2 of sp_IntArray_push`.

For a single-element `[poly_var]` literal `infer_array_elem_type` returns `int_array` as the default, so this fallback fires.

Fix: when the element's `infer_type` is `poly`, extract the int payload via `.v.i` before pushing. The runtime tag is **not** checked; we trust the surrounding code to keep the array element typed correctly. A more thorough fix would either widen the array literal itself to a `poly_array` when any element is poly, or emit a runtime tag check — but the unboxing is the simpler match for the common case where the caller code knows the value is integer at runtime.