### PR TITLE
fix(codegen): scope class-body bare-call return inference to no-recv

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -1885,8 +1885,12 @@ class Compiler
       return @meth_return_types[mi]
     end
 
-    # Bare method call in class context
-    if @current_class_idx >= 0
+    # Bare (no-receiver) method call resolved against the enclosing
+    # class's method table. Only for `recv < 0` — without that guard,
+    # a `Fiber.yield ...` (which has a receiver) inside a class body
+    # would short-circuit here returning the int default and never
+    # reach the Fiber.yield → poly branch further down.
+    if recv < 0 && @current_class_idx >= 0
       mr = cls_method_return(@current_class_idx, mname)
       return mr
     end

--- a/test/class_method_open_class_call.rb
+++ b/test/class_method_open_class_call.rb
@@ -1,0 +1,31 @@
+# `infer_call_type`'s class-body fallback used to short-circuit on
+# any call inside a class body — including those with a receiver.
+# A `recv.method(...)` whose method isn't on the enclosing class
+# resolved as the default `int`, and the receiver-aware branches
+# below (Fiber.yield → poly, infer_open_class_type → user open-
+# class return) never ran. The fix gates the fallback on
+# `recv < 0`.
+#
+# Reproducer here: an open-class method on Integer that returns a
+# hash. Without the fix, `C#wrap`'s body calls `x.to_pair` whose
+# inferred return came out as `int` (the enclosing C class has no
+# `to_pair`), but the actual emit returns `sp_SymIntHash *` →
+# "returning sp_SymIntHash * from a function with return type
+# mrb_int" -Wint-conversion error.
+
+class Integer
+  def to_pair
+    {a: self, b: self * 2, c: self * 3}
+  end
+end
+
+class C
+  def wrap(x)
+    x.to_pair
+  end
+end
+
+h = C.new.wrap(5)
+puts h[:a]   # 5
+puts h[:b]   # 10
+puts h[:c]   # 15


### PR DESCRIPTION
## Reproduction
```ruby
class Integer
  def to_pair
    {a: self, b: self * 2, c: self * 3}
  end
end

class C
  def wrap(x)
    x.to_pair
  end
end

h = C.new.wrap(5)
puts h[:a]
puts h[:b]
puts h[:c]
```

## Expected behavior
`x.to_pair` dispatches to the open-class `Integer#to_pair`, which returns a hash. `C#wrap` propagates that hash. Output:
```
5
10
15
```

## Actual behavior
Compile error:
```
warning: cannot resolve call to '[]' on int (emitting 0)
/tmp/_t.c: In function ‘sp_C_wrap’:
/tmp/_t.c:46:12: error: returning ‘sp_SymIntHash *’ from a function with return type ‘mrb_int’ {aka ‘long int’} makes integer from pointer without a cast [-Wint-conversion]
   46 |     return sp___oc_Integer_to_pair(lv_x);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Analysis & fix
`infer_call_type` had a fallback that resolved the return type via `cls_method_return(@current_class_idx, mname)` whenever `@current_class_idx >= 0`. The check fired for **any** call inside a class body, including those with an explicit receiver. So for `x.to_pair` inside `class C`, the fallback ran first, found no `to_pair` method on C, returned the default `int`, and the receiver-aware branches further down — including `infer_open_class_type`, which would have returned `sym_int_hash` from `__oc_Integer_to_pair` — never ran.

`C#wrap` ended up with a signature `mrb_int sp_C_wrap(...)` while the body returns `sp_SymIntHash *`. gcc rejects.

Fix: gate the fallback on `recv < 0`. Same-class self calls (no explicit receiver) still resolve through it; calls with an explicit receiver fall through to the receiver-aware branches.