### PR TITLE
fix(codegen): scan const-init expressions for block-param locals

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -13446,6 +13446,18 @@ class Compiler
         end
       end
     }
+    # Constant initializer expressions get compiled into main() right
+    # before the user statements run, but the block params they
+    # introduce (e.g. \`FRAME = [...].map { |n| ... }\`) need
+    # declarations in the same scope. Scan each const's RHS so the
+    # block param names land in lnames alongside the user-stmt locals.
+    ci_lc = 0
+    while ci_lc < @const_expr_ids.length
+      if @const_expr_ids[ci_lc] >= 0
+        scan_locals(@const_expr_ids[ci_lc], lnames, ltypes, empty_params)
+      end
+      ci_lc = ci_lc + 1
+    end
 
     # Declare vars for second pass to resolve dependent types
     j = 0

--- a/test/const_init_block_param_scan.rb
+++ b/test/const_init_block_param_scan.rb
@@ -1,0 +1,13 @@
+# A constant initializer's RHS can introduce block params (here
+# `n`) whose declarations need to land at main()'s frame. The
+# top-level-stmt scan in `emit_main` previously skipped const-init
+# expressions, so iterations whose body assigns `lv_n` without a
+# preceding `mrb_int lv_n;` (e.g. the `Array#sum { |n| ... }`
+# emit path uses `emit_iter_open`, which does plain `elem_var =
+# idx_var;`) failed C compilation with "undeclared identifier".
+
+TOTAL = [1, 2, 3].sum { |n| n * 2 }
+puts TOTAL                         # 12
+
+DOUBLED = [4, 5, 6].sum { |m| m * 3 }
+puts DOUBLED                       # 45


### PR DESCRIPTION
## Reproduction
```ruby
TOTAL = [1, 2, 3].sum { |n| n * 2 }
puts TOTAL
```

## Expected behavior
Output:
```
12
```

## Actual behavior
Compile error:
```
/tmp/_t.c: In function ‘main’:
/tmp/_t.c:20:7: error: ‘lv_n’ undeclared (first use in this function)
   20 |       lv_n = sp_IntArray_get(_t1, _t3);
      |       ^~~~
/tmp/_t.c:20:7: note: each undeclared identifier is reported only once for each function it appears in
```

## Analysis & fix
`Array#sum { |n| ... }` lowers via `emit_iter_open`, which emits a bare `lv_n = idx;` and relies on `lv_n` being declared **outside** the loop body. The matching `mrb_int lv_n;` declaration normally comes from `emit_main`'s top-level scan, which walks every top-level statement and accumulates locals.

That scan explicitly skipped `ConstantWriteNode`. So a block param introduced inside a const initializer's RHS (`TOTAL = ...sum { |n| ... }`) had no place where `lv_n` got declared. The const-init code was emitted into `main()` right after the locals block, so `lv_n = ...` referenced an undeclared identifier.

Fix: walk `@const_expr_ids` alongside the existing top-level statement scan in `emit_main`, so locals introduced inside any const RHS land in the same `lnames` / `ltypes` arrays as ordinary top-level locals.