### PR TITLE
fix(codegen): infer array-returning result for non-array recv on #map

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2855,10 +2855,23 @@ class Compiler
               if is_obj_type(bret) == 1
                 return bret + "_ptr_array"
               end
+              # Block returns a non-trivial type (an array literal,
+              # poly value, ...). The map's overall result is still an
+              # Array — fall through to the recv-based default below
+              # only when recv is already array-shaped, otherwise
+              # return int_array as a generic placeholder.
             end
           end
         end
-        return infer_type(recv)
+        rt_recv = infer_type(recv)
+        # Range#map / Integer#step.map / non-array recv → result is
+        # an Array, not a Range/IntArray. Without this, an
+        # `@x = (0...n).map {...}` recorded the ivar as `range` and
+        # later `@x = something_else` writes failed to type-check.
+        if rt_recv == "range" || rt_recv == "int"
+          return "int_array"
+        end
+        return rt_recv
       end
       return "int_array"
     end

--- a/test/map_range_recv_array_block.rb
+++ b/test/map_range_recv_array_block.rb
@@ -1,0 +1,25 @@
+# `infer_method_name_type` for `map` used to fall through to
+# `infer_type(recv)` when the block returned a non-trivial shape
+# (an array literal, poly, etc.). For a Range recv that yielded
+# `range`, poisoning any ivar holding the result; an
+# `@x = something_else` assignment then failed to type-check
+# (`@x = 0` against an `sp_Range` slot). The fix returns
+# `int_array` as a generic placeholder for non-array recvs.
+
+class C
+  def initialize
+    # Block returns an array literal — non-trivial bret. recv is
+    # Range. Without the fix, @rows is typed as `range`, and the
+    # follow-up assignment below produces a C compile error
+    # ("incompatible types when assigning to type sp_Range").
+    @rows = (0...3).map { |i| [i, i * 10] }
+    @rows = [10, 20, 30]
+  end
+
+  def show
+    @rows.each { |v| puts v }
+  end
+end
+
+C.new.show
+# Expected: 10 / 20 / 30


### PR DESCRIPTION
## Reproduction
```ruby
class C
  def initialize
    @rows = (0...3).map { |i| [i, i * 10] }
    @rows = [10, 20, 30]
  end
  def show
    @rows.each { |v| puts v }
  end
end

C.new.show
```

## Expected behavior
The first assignment to `@rows` is the result of mapping a Range; the second overwrites it with a literal int array. `each` iterates the int array. Output:
```
10
20
30
```

## Actual behavior
The program compiles cleanly but produces no output (the empty stdout is the bug):
```
(no output)
```

`@rows` is inferred as `sp_RbVal` (poly), since spinel can't reconcile "Range from `.map`" with "IntArray from literal". Both assignments box through `sp_box_*`, but `@rows.each { |v| puts v }` lands on the dispatch for poly recv, where `each` has no implementation — the codegen silently emits nothing.

Without the cross-branch reassignment (just the bare `@rows = (0...n).map { [...] }` form) the failure is loud: `incompatible types when assigning to type sp_Range from type int`. The reassignment hides the type clash but the resulting silent miscompile is arguably worse.

## Analysis & fix
`infer_method_name_type` for `map` consulted the block's return type for the standard cases (string → str_array, int → int_array, etc.) and otherwise fell through to `infer_type(recv)`. That's right when recv is itself an Array (e.g. `[1,2,3].map { foo }` — the recv's array type carries through), but wrong when recv is a Range or other non-array enumerable: `(0...3).map { [...] }` came back as `range`, the ivar holding it was typed `sp_Range`, and the subsequent `@rows = something_else` assignment failed to type-check (or, with disjoint subsequent assignments, got widened to poly and silently lost dispatch).

Fix: treat `range` / `int` recv as array-returning. The exact element type is unknown when the block returns an array literal or other non-trivial shape, so use `int_array` as a generic placeholder — better than poisoning the ivar with the recv's type.