### PR TITLE
feat: Array#rotate!(n) for typed arrays

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -226,6 +226,7 @@ static inline mrb_int sp_IntArray_get(sp_IntArray*a,mrb_int i){if(i<0)i+=a->len;
 static void sp_IntArray_set_slow(sp_IntArray*a,mrb_int i,mrb_int v){while(a->start+i>=a->cap){sp_gc_hdr*h=(sp_gc_hdr*)((char*)a-sizeof(sp_gc_hdr));sp_gc_bytes-=sizeof(mrb_int)*a->cap;h->size-=sizeof(mrb_int)*a->cap;a->cap=a->cap*2+1;a->data=(mrb_int*)realloc(a->data,sizeof(mrb_int)*a->cap);h->size+=sizeof(mrb_int)*a->cap;sp_gc_bytes+=sizeof(mrb_int)*a->cap;}while(i>=a->len){a->data[a->start+a->len]=0;a->len++;}a->data[a->start+i]=v;}
 static inline void sp_IntArray_set(sp_IntArray*a,mrb_int i,mrb_int v){if(i<0)i+=a->len;if(i>=0&&i<a->len){a->data[a->start+i]=v;return;}sp_IntArray_set_slow(a,i,v);}
 static void sp_IntArray_reverse_bang(sp_IntArray*a){for(mrb_int i=0,j=a->len-1;i<j;i++,j--){mrb_int t=a->data[a->start+i];a->data[a->start+i]=a->data[a->start+j];a->data[a->start+j]=t;}}
+static void sp_IntArray_rotate_bang(sp_IntArray*a,mrb_int n){if(a->len<=0)return;n=((n%a->len)+a->len)%a->len;if(n==0)return;mrb_int*tmp=(mrb_int*)malloc(sizeof(mrb_int)*a->len);for(mrb_int i=0;i<a->len;i++)tmp[i]=a->data[a->start+(i+n)%a->len];for(mrb_int i=0;i<a->len;i++)a->data[a->start+i]=tmp[i];free(tmp);}
 static int _sp_int_cmp(const void*a,const void*b){mrb_int va=*(const mrb_int*)a,vb=*(const mrb_int*)b;return(va>vb)-(va<vb);}
 static sp_IntArray*sp_IntArray_sort(sp_IntArray*a){sp_IntArray*b=sp_IntArray_dup(a);qsort(b->data+b->start,b->len,sizeof(mrb_int),_sp_int_cmp);return b;}
 static void sp_IntArray_sort_bang(sp_IntArray*a){qsort(a->data+a->start,a->len,sizeof(mrb_int),_sp_int_cmp);}
@@ -263,6 +264,7 @@ static inline mrb_float sp_FloatArray_get(sp_FloatArray*a,mrb_int i){if(i<0)i+=a
 static sp_FloatArray*sp_FloatArray_slice(sp_FloatArray*a,mrb_int start,mrb_int len){if(start<0)start+=a->len;if(start<0)start=0;sp_FloatArray*b=sp_FloatArray_new();if(start>=a->len||len<=0)return b;if(start+len>a->len)len=a->len-start;if(len>b->cap){sp_gc_hdr*h=(sp_gc_hdr*)((char*)b-sizeof(sp_gc_hdr));sp_gc_bytes-=sizeof(mrb_float)*b->cap;h->size-=sizeof(mrb_float)*b->cap;b->cap=len;b->data=(mrb_float*)realloc(b->data,sizeof(mrb_float)*b->cap);h->size+=sizeof(mrb_float)*b->cap;sp_gc_bytes+=sizeof(mrb_float)*b->cap;}memcpy(b->data,a->data+start,sizeof(mrb_float)*len);b->len=len;return b;}
 static inline void sp_FloatArray_set(sp_FloatArray*a,mrb_int i,mrb_float v){if(i<0)i+=a->len;while(i>=a->cap){a->cap=a->cap*2+1;a->data=(mrb_float*)realloc(a->data,sizeof(mrb_float)*a->cap);}while(i>=a->len){a->data[a->len]=0.0;a->len++;}a->data[i]=v;}
 static void sp_FloatArray_reverse_bang(sp_FloatArray*a){for(mrb_int i=0,j=a->len-1;i<j;i++,j--){mrb_float t=a->data[i];a->data[i]=a->data[j];a->data[j]=t;}}
+static void sp_FloatArray_rotate_bang(sp_FloatArray*a,mrb_int n){if(a->len<=0)return;n=((n%a->len)+a->len)%a->len;if(n==0)return;mrb_float*tmp=(mrb_float*)malloc(sizeof(mrb_float)*a->len);for(mrb_int i=0;i<a->len;i++)tmp[i]=a->data[(i+n)%a->len];for(mrb_int i=0;i<a->len;i++)a->data[i]=tmp[i];free(tmp);}
 static int _sp_float_cmp(const void*a,const void*b){mrb_float va=*(const mrb_float*)a,vb=*(const mrb_float*)b;return(va>vb)-(va<vb);}
 static void sp_FloatArray_sort_bang(sp_FloatArray*a){qsort(a->data,a->len,sizeof(mrb_float),_sp_float_cmp);}
 static void sp_FloatArray_shuffle_bang(sp_FloatArray*a){for(mrb_int i=a->len-1;i>0;i--){mrb_int j=(mrb_int)(rand()%(i+1));mrb_float t=a->data[i];a->data[i]=a->data[j];a->data[j]=t;}}
@@ -280,6 +282,7 @@ static inline void sp_PtrArray_set(sp_PtrArray*a,mrb_int i,void*v){if(i<0)i+=a->
 static inline mrb_int sp_PtrArray_length(sp_PtrArray*a){return a->len;}
 static inline mrb_bool sp_PtrArray_empty(sp_PtrArray*a){return a->len==0;}
 static void sp_PtrArray_reverse_bang(sp_PtrArray*a){for(mrb_int i=0,j=a->len-1;i<j;i++,j--){void*t=a->data[i];a->data[i]=a->data[j];a->data[j]=t;}}
+static void sp_PtrArray_rotate_bang(sp_PtrArray*a,mrb_int n){if(a->len<=0)return;n=((n%a->len)+a->len)%a->len;if(n==0)return;void**tmp=(void**)malloc(sizeof(void*)*a->len);for(mrb_int i=0;i<a->len;i++)tmp[i]=a->data[(i+n)%a->len];for(mrb_int i=0;i<a->len;i++)a->data[i]=tmp[i];free(tmp);}
 static sp_PtrArray*sp_PtrArray_dup(sp_PtrArray*a){sp_PtrArray*b=sp_PtrArray_new_scan(a->scan_elem);for(mrb_int i=0;i<a->len;i++)sp_PtrArray_push(b,a->data[i]);return b;}
 static sp_PtrArray*sp_PtrArray_slice(sp_PtrArray*a,mrb_int start,mrb_int len){if(start<0)start+=a->len;if(start<0)start=0;sp_PtrArray*b=sp_PtrArray_new_scan(a->scan_elem);if(start>=a->len||len<=0)return b;if(start+len>a->len)len=a->len-start;for(mrb_int i=0;i<len;i++)sp_PtrArray_push(b,a->data[start+i]);return b;}
 static void sp_PtrArray_shuffle_bang(sp_PtrArray*a){for(mrb_int i=a->len-1;i>0;i--){mrb_int j=(mrb_int)(rand()%(i+1));void*t=a->data[i];a->data[i]=a->data[j];a->data[j]=t;}}
@@ -306,6 +309,7 @@ static inline const char*sp_StrArray_get(sp_StrArray*a,mrb_int i){if(i<0)i+=a->l
 static sp_StrArray*sp_StrArray_slice(sp_StrArray*a,mrb_int start,mrb_int len){if(start<0)start+=a->len;if(start<0)start=0;sp_StrArray*b=sp_StrArray_new();if(start>=a->len||len<=0)return b;if(start+len>a->len)len=a->len-start;for(mrb_int i=0;i<len;i++)sp_StrArray_push(b,a->data[start+i]);return b;}
 static inline void sp_StrArray_set(sp_StrArray*a,mrb_int i,const char*v){if(i<0)i+=a->len;while(i>=a->len)sp_StrArray_push(a,"");a->data[i]=v;}
 static void sp_StrArray_reverse_bang(sp_StrArray*a){for(mrb_int i=0,j=a->len-1;i<j;i++,j--){const char*t=a->data[i];a->data[i]=a->data[j];a->data[j]=t;}}
+static void sp_StrArray_rotate_bang(sp_StrArray*a,mrb_int n){if(a->len<=0)return;n=((n%a->len)+a->len)%a->len;if(n==0)return;const char**tmp=(const char**)malloc(sizeof(const char*)*a->len);for(mrb_int i=0;i<a->len;i++)tmp[i]=a->data[(i+n)%a->len];for(mrb_int i=0;i<a->len;i++)a->data[i]=tmp[i];free(tmp);}
 static int _sp_str_cmp(const void*a,const void*b){return strcmp(*(const char*const*)a,*(const char*const*)b);}
 static void sp_StrArray_sort_bang(sp_StrArray*a){qsort(a->data,a->len,sizeof(const char*),_sp_str_cmp);}
 static const char*sp_StrArray_join(sp_StrArray*a,const char*sep){size_t sl=strlen(sep),cap=256;char*buf=(char*)malloc(cap);size_t len=0;for(mrb_int i=0;i<a->len;i++){if(i>0){if(len+sl>=cap){cap*=2;buf=(char*)realloc(buf,cap);}memcpy(buf+len,sep,sl);len+=sl;}size_t el=strlen(a->data[i]);if(len+el>=cap){cap=(len+el)*2+1;buf=(char*)realloc(buf,cap);}memcpy(buf+len,a->data[i],el);len+=el;}buf[len]=0;char*r=sp_str_alloc(len);memcpy(r,buf,len);free(buf);return r;}
@@ -669,6 +673,7 @@ static sp_RbVal sp_PolyArray_get(sp_PolyArray *a, mrb_int i) { if (i < 0) i += a
 static sp_PolyArray *sp_PolyArray_slice(sp_PolyArray *a, mrb_int start, mrb_int len) { if (start < 0) start += a->len; if (start < 0) start = 0; sp_PolyArray *b = sp_PolyArray_new(); if (start >= a->len || len <= 0) return b; if (start + len > a->len) len = a->len - start; for (mrb_int i = 0; i < len; i++) sp_PolyArray_push(b, a->data[start + i]); return b; }
 static sp_PolyArray *sp_PolyArray_dup(sp_PolyArray *a) { sp_PolyArray *b = sp_PolyArray_new(); for (mrb_int i = 0; i < a->len; i++) sp_PolyArray_push(b, a->data[i]); return b; }
 static void sp_PolyArray_shuffle_bang(sp_PolyArray *a) { for (mrb_int i = a->len - 1; i > 0; i--) { mrb_int j = (mrb_int)(rand() % (i + 1)); sp_RbVal t = a->data[i]; a->data[i] = a->data[j]; a->data[j] = t; } }
+static void sp_PolyArray_rotate_bang(sp_PolyArray*a,mrb_int n){if(a->len<=0)return;n=((n%a->len)+a->len)%a->len;if(n==0)return;sp_RbVal*tmp=(sp_RbVal*)malloc(sizeof(sp_RbVal)*a->len);for(mrb_int i=0;i<a->len;i++)tmp[i]=a->data[(i+n)%a->len];for(mrb_int i=0;i<a->len;i++)a->data[i]=tmp[i];free(tmp);}
 static sp_PolyArray *sp_PolyArray_shuffle(sp_PolyArray *a) { sp_PolyArray *b = sp_PolyArray_dup(a); sp_PolyArray_shuffle_bang(b); return b; }
 
 /* Object#inspect for a tagged sp_RbVal. Dispatches on the runtime tag;

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -22038,6 +22038,42 @@ class Compiler
       end
     end
 
+    # rotate!(n) — defaults to n=1 like Ruby.
+    if mname == "rotate!"
+      if recv >= 0
+        rt = infer_type(recv)
+        rot_pfx = ""
+        if rt == "int_array" || rt == "sym_array"
+          rot_pfx = "IntArray"
+        end
+        if rt == "float_array"
+          rot_pfx = "FloatArray"
+        end
+        if rt == "str_array"
+          rot_pfx = "StrArray"
+        end
+        if is_ptr_array_type(rt) == 1
+          rot_pfx = "PtrArray"
+        end
+        if rt == "poly_array"
+          rot_pfx = "PolyArray"
+        end
+        if rot_pfx != ""
+          args_id = @nd_arguments[nid]
+          n_expr = "1"
+          if args_id >= 0
+            aargs = get_args(args_id)
+            if aargs.length > 0
+              n_expr = compile_expr(aargs[0])
+            end
+          end
+          rc = compile_expr_gc_rooted(recv)
+          emit("  sp_" + rot_pfx + "_rotate_bang(" + rc + ", " + n_expr + ");")
+          return 1
+        end
+      end
+    end
+
     # reverse! / sort!
     if mname == "reverse!"
       if recv >= 0

--- a/test/array_rotate_bang.rb
+++ b/test/array_rotate_bang.rb
@@ -1,0 +1,54 @@
+# Array#rotate!(n): in-place left rotation by n positions.
+# Previously the bang form was not dispatched at all and the codegen
+# emitted a no-op, so `rotate!` left the array untouched.
+
+# IntArray
+ints = [1, 2, 3, 4, 5]
+ints.rotate!(2)
+ints.each { |i| puts i }   # 3 4 5 1 2
+
+# Negative n rotates right.
+ints2 = [1, 2, 3, 4, 5]
+ints2.rotate!(-1)
+ints2.each { |i| puts i }  # 5 1 2 3 4
+
+# n larger than length wraps modulo len.
+ints3 = [1, 2, 3]
+ints3.rotate!(7)
+ints3.each { |i| puts i }  # 2 3 1
+
+# Empty array is a no-op (no malloc, no crash).
+empty = []
+empty.rotate!(3)
+puts empty.length          # 0
+
+# SymArray (shares the IntArray helper internally).
+syms = [:a, :b, :c, :d]
+syms.rotate!(1)
+syms.each { |s| puts s }   # b c d a
+
+# FloatArray
+floats = [1.5, 2.5, 3.5, 4.5]
+floats.rotate!(2)
+floats.each { |f| puts f } # 3.5 4.5 1.5 2.5
+
+# StrArray
+strs = ["a", "b", "c", "d"]
+strs.rotate!(1)
+strs.each { |s| puts s }   # b c d a
+
+# PtrArray (array of objects)
+class Box
+  attr_reader :n
+  def initialize(n)
+    @n = n
+  end
+end
+boxes = [Box.new(10), Box.new(20), Box.new(30), Box.new(40)]
+boxes.rotate!(2)
+boxes.each { |b| puts b.n } # 30 40 10 20
+
+# PolyArray (mixed-type elements)
+mixed = [1, "x", :sym, 4.5]
+mixed.rotate!(1)
+mixed.each { |v| puts v }   # x sym 4.5 1


### PR DESCRIPTION
## Code example
```ruby
ints = [1, 2, 3, 4, 5]
ints.rotate!(2)
ints.each { |i| puts i }   # 3 4 5 1 2

floats = [1.5, 2.5, 3.5, 4.5]
floats.rotate!(2)
floats.each { |f| puts f } # 3.5 4.5 1.5 2.5

strs = ["a", "b", "c", "d"]
strs.rotate!(1)
strs.each { |s| puts s }   # b c d a

class Box
  attr_reader :n
  def initialize(n) = @n = n
end
boxes = [Box.new(10), Box.new(20), Box.new(30), Box.new(40)]
boxes.rotate!(2)
boxes.each { |b| puts b.n }  # 30 40 10 20

mixed = [1, "x", :sym, 4.5]
mixed.rotate!(1)
mixed.each { |v| puts v }    # x sym 4.5 1
```

## Expected behavior
In-place left rotation by `n` positions for IntArray, SymArray, FloatArray, StrArray, PtrArray, and PolyArray. Negative `n` rotates right; `n` larger than `len` wraps modulo length; an empty array is a no-op.

Implementation note: the runtime helpers use a temporary buffer (one malloc/free per call) instead of the in-place reverse-thrice trick, for code clarity. SymArray reuses the IntArray helper since `sp_sym` is `mrb_int`.