### PR TITLE
ci: bump CRuby version to 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
 
       - name: Install prism gem (codegen bootstrap step 2 needs it)
         run: gem install prism -v 1.9.0


### PR DESCRIPTION
`test/numbered_block_params.rb` (added in 15df9f5) uses Ruby 3.4's implicit `it` block parameter. On Ruby 3.3 `it` raises NameError, so the reference ruby and the spinel binary diverge and the test fails. The failure was masked until 83e0e09 made `make test` fail-loud.