### PR TITLE
Add poly runtime operators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,10 +193,14 @@ test: spinel_parse$(EXE) $(SP_RT_LIB)
 	      expected=$$($(TIMEOUT10) ruby "$$f" 2>/dev/null); \
 	    fi; \
 	    actual=$$($(TIMEOUT10) /tmp/_sp_t_bin$(EXE) 2>/dev/null); \
+	    expected=$$(printf "%s" "$$expected" | tr -d '\r'); \
+	    actual=$$(printf "%s" "$$actual" | tr -d '\r'); \
 	    if [ "$$expected" = "$$actual" ]; then \
 	      pass=$$((pass+1)); \
 	    else \
-	      echo "FAIL: $$bn"; fail=$$((fail+1)); \
+	      echo "FAIL: $$bn"; \
+	      printf '%s\n%s\n%s\n%s\n' "--- expected ---" "$$expected" "--- actual ---" "$$actual"; \
+	      fail=$$((fail+1)); \
 	    fi; \
 	  else \
 	    echo "ERR:  $$bn"; err=$$((err+1)); \
@@ -226,10 +230,14 @@ bench: spinel_parse$(EXE) $(SP_RT_LIB)
 	      echo "SKIP: $$bn (ruby timeout)"; skip=$$((skip+1)); \
 	    else \
 	      actual=$$($(TIMEOUT60) /tmp/_sp_b_bin$(EXE) 2>/dev/null); \
+	      expected=$$(printf "%s" "$$expected" | tr -d '\r'); \
+	      actual=$$(printf "%s" "$$actual" | tr -d '\r'); \
 	      if [ "$$expected" = "$$actual" ]; then \
 	        pass=$$((pass+1)); \
 	      else \
-	        echo "FAIL: $$bn"; fail=$$((fail+1)); \
+	        echo "FAIL: $$bn"; \
+	        printf '%s\n%s\n%s\n%s\n' "--- expected ---" "$$expected" "--- actual ---" "$$actual"; \
+	        fail=$$((fail+1)); \
 	      fi; \
 	    fi; \
 	  else \

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -627,6 +627,8 @@ static sp_RbVal sp_box_bool(mrb_bool v) { sp_RbVal r; r.tag = SP_TAG_BOOL; r.cls
 static sp_RbVal sp_box_nil(void) { sp_RbVal r; r.tag = SP_TAG_NIL; r.cls_id = 0; r.v.i = 0; return r; }
 static sp_RbVal sp_box_obj(void *p, int cls_id) { sp_RbVal r; r.tag = SP_TAG_OBJ; r.cls_id = cls_id; r.v.p = p; return r; }
 static sp_RbVal sp_box_sym(sp_sym v) { sp_RbVal r; r.tag = SP_TAG_SYM; r.cls_id = 0; r.v.i = (mrb_int)v; return r; }
+static sp_RbVal sp_box_nullable_str(const char *v) { return v ? sp_box_str(v) : sp_box_nil(); }
+static sp_RbVal sp_box_nullable_obj(void *p, int cls_id) { return p ? sp_box_obj(p, cls_id) : sp_box_nil(); }
 /* Built-in pointer boxes — share SP_TAG_OBJ with a reserved negative
    cls_id so the dispatch path is uniform. */
 static sp_RbVal sp_box_int_array(void *p)   { return sp_box_obj(p, SP_BUILTIN_INT_ARRAY); }
@@ -662,6 +664,7 @@ static void sp_poly_puts(sp_RbVal v) {
   }
 }
 static mrb_bool sp_poly_nil_p(sp_RbVal v) { return v.tag == SP_TAG_NIL; }
+static mrb_bool sp_poly_truthy(sp_RbVal v) { return !(v.tag == SP_TAG_NIL || (v.tag == SP_TAG_BOOL && !v.v.b)); }
 static const char *sp_poly_to_s(sp_RbVal v) {
   switch (v.tag) {
     case SP_TAG_INT: return sp_int_to_s(v.v.i);
@@ -685,7 +688,24 @@ static const char *sp_poly_to_s(sp_RbVal v) {
 static sp_RbVal sp_poly_add(sp_RbVal a, sp_RbVal b) { if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return sp_box_int(a.v.i + b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f + b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((mrb_float)a.v.i + b.v.f); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f + (mrb_float)b.v.i); if (a.tag == SP_TAG_STR && b.tag == SP_TAG_STR) return sp_box_str(sp_str_concat(a.v.s, b.v.s)); return sp_box_int(0); }
 static sp_RbVal sp_poly_sub(sp_RbVal a, sp_RbVal b) { if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return sp_box_int(a.v.i - b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f - b.v.f); return sp_box_int(0); }
 static sp_RbVal sp_poly_mul(sp_RbVal a, sp_RbVal b) { if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return sp_box_int(a.v.i * b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f * b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((mrb_float)a.v.i * b.v.f); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f * (mrb_float)b.v.i); return sp_box_int(0); }
-static mrb_bool sp_poly_gt(sp_RbVal a, sp_RbVal b) { if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return a.v.i > b.v.i; if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return a.v.f > b.v.f; return FALSE; }
+static mrb_int sp_poly_to_i(sp_RbVal v) { if (v.tag == SP_TAG_INT || v.tag == SP_TAG_SYM) return v.v.i; if (v.tag == SP_TAG_STR) return (mrb_int)strtoll(v.v.s ? v.v.s : sp_str_empty, NULL, 10); if (v.tag == SP_TAG_FLT) return (mrb_int)v.v.f; if (v.tag == SP_TAG_BOOL) return v.v.b ? 1 : 0; return 0; }
+static mrb_float sp_poly_to_f(sp_RbVal v) { if (v.tag == SP_TAG_FLT) return v.v.f; if (v.tag == SP_TAG_INT || v.tag == SP_TAG_SYM) return (mrb_float)v.v.i; if (v.tag == SP_TAG_BOOL) return v.v.b ? 1.0 : 0.0; return 0.0; }
+static mrb_bool sp_poly_numeric_p(sp_RbVal v) { return v.tag == SP_TAG_INT || v.tag == SP_TAG_FLT; }
+static mrb_bool sp_poly_eq(sp_RbVal a, sp_RbVal b) { if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) return sp_poly_to_f(a) == sp_poly_to_f(b); if (a.tag != b.tag) return FALSE; switch (a.tag) { case SP_TAG_INT: return a.v.i == b.v.i; case SP_TAG_STR: return (a.v.s == NULL || b.v.s == NULL) ? (a.v.s == b.v.s) : (strcmp(a.v.s, b.v.s) == 0); case SP_TAG_FLT: return a.v.f == b.v.f; case SP_TAG_BOOL: return a.v.b == b.v.b; case SP_TAG_NIL: return TRUE; case SP_TAG_SYM: return a.v.i == b.v.i; case SP_TAG_OBJ: return a.cls_id == b.cls_id && a.v.p == b.v.p; default: return FALSE; } }
+static mrb_int sp_poly_cmp(sp_RbVal a, sp_RbVal b, mrb_bool *comparable) { if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) { mrb_float af = sp_poly_to_f(a), bf = sp_poly_to_f(b); *comparable = TRUE; return (af > bf) - (af < bf); } if (a.tag == SP_TAG_STR && b.tag == SP_TAG_STR) { if (a.v.s == NULL || b.v.s == NULL) { *comparable = (a.v.s == b.v.s); return 0; } *comparable = TRUE; return strcmp(a.v.s, b.v.s); } if (a.tag == SP_TAG_SYM && b.tag == SP_TAG_SYM) { *comparable = TRUE; return (a.v.i > b.v.i) - (a.v.i < b.v.i); } *comparable = FALSE; return 0; }
+static mrb_bool sp_poly_lt(sp_RbVal a, sp_RbVal b) { mrb_bool comparable; mrb_int cmp = sp_poly_cmp(a, b, &comparable); return comparable ? (cmp < 0) : FALSE; }
+static mrb_bool sp_poly_le(sp_RbVal a, sp_RbVal b) { mrb_bool comparable; mrb_int cmp = sp_poly_cmp(a, b, &comparable); return comparable ? (cmp <= 0) : FALSE; }
+static mrb_bool sp_poly_gt(sp_RbVal a, sp_RbVal b) { mrb_bool comparable; mrb_int cmp = sp_poly_cmp(a, b, &comparable); return comparable ? (cmp > 0) : FALSE; }
+static mrb_bool sp_poly_ge(sp_RbVal a, sp_RbVal b) { mrb_bool comparable; mrb_int cmp = sp_poly_cmp(a, b, &comparable); return comparable ? (cmp >= 0) : FALSE; }
+static sp_RbVal sp_poly_div(sp_RbVal a, sp_RbVal b) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) / sp_poly_to_f(b)); return sp_box_int(sp_idiv(sp_poly_to_i(a), sp_poly_to_i(b))); }
+static sp_RbVal sp_poly_mod(sp_RbVal a, sp_RbVal b) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(fmod(sp_poly_to_f(a), sp_poly_to_f(b))); return sp_box_int(sp_imod(sp_poly_to_i(a), sp_poly_to_i(b))); }
+static sp_RbVal sp_poly_pow(sp_RbVal a, sp_RbVal b) { double r = pow((double)sp_poly_to_f(a), (double)sp_poly_to_f(b)); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT && b.v.i >= 0) return sp_box_int((mrb_int)r); return sp_box_float((mrb_float)r); }
+static sp_RbVal sp_poly_shl(sp_RbVal a, sp_RbVal b) { return sp_box_int(sp_poly_to_i(a) << sp_poly_to_i(b)); }
+static sp_RbVal sp_poly_shr(sp_RbVal a, sp_RbVal b) { return sp_box_int(sp_poly_to_i(a) >> sp_poly_to_i(b)); }
+static sp_RbVal sp_poly_band(sp_RbVal a, sp_RbVal b) { return sp_box_int(sp_poly_to_i(a) & sp_poly_to_i(b)); }
+static sp_RbVal sp_poly_bor(sp_RbVal a, sp_RbVal b) { return sp_box_int(sp_poly_to_i(a) | sp_poly_to_i(b)); }
+static sp_RbVal sp_poly_bxor(sp_RbVal a, sp_RbVal b) { return sp_box_int(sp_poly_to_i(a) ^ sp_poly_to_i(b)); }
+static sp_RbVal sp_poly_neg(sp_RbVal a) { if (a.tag == SP_TAG_FLT) return sp_box_float(-a.v.f); return sp_box_int(-sp_poly_to_i(a)); }
 
 /* PolyArray: array of sp_RbVal */
 typedef struct { sp_RbVal *data; mrb_int len; mrb_int cap; } sp_PolyArray;

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -1533,7 +1533,7 @@ class Compiler
       return "bool"
     end
     if t == "OrNode"
-      return infer_type(@nd_left[nid])
+      return or_result_type(nid)
     end
     if t == "ParenthesesNode"
       body = @nd_body[nid]
@@ -1991,6 +1991,14 @@ class Compiler
     lt = ""
     if recv >= 0
       lt = infer_type(recv)
+      if lt == "poly"
+        if mname == "+" || mname == "-" || mname == "*" || mname == "/" || mname == "%" || mname == "**"
+          return "poly"
+        end
+        if mname == "<<" || mname == ">>" || mname == "&" || mname == "|" || mname == "^" || mname == "-@"
+          return "poly"
+        end
+      end
       # Bigint operators return bigint
       if lt == "bigint"
         if mname == "+" || mname == "-" || mname == "*" || mname == "/" || mname == "%"
@@ -2960,6 +2968,9 @@ class Compiler
         if rt == "mutable_str"
           return "string"
         end
+        if rt == "poly"
+          return "poly"
+        end
         if rt == "int_array"
           # a[range] / a[start, len] returns a slice (still int_array);
           # bare a[i] returns the element.
@@ -3311,6 +3322,9 @@ class Compiler
       if rt == "poly"
         if mname == "nil?"
           return "bool"
+        end
+        if mname == "[]"
+          return "poly"
         end
         # Scan every user class that defines this method. If they all
         # agree on the return type, the call has that concrete type.
@@ -13887,10 +13901,54 @@ class Compiler
   # side effects then yields 1.
   def compile_cond_expr(nid)
     expr = compile_expr(nid)
-    if nid >= 0 && is_value_type_obj(infer_type(nid)) == 1
+    t = infer_type(nid)
+    if t == "poly"
+      return "sp_poly_truthy(" + expr + ")"
+    end
+    if t == "nil"
+      return "FALSE"
+    end
+    if is_nullable_type(t) == 1
+      return "(" + expr + " != NULL)"
+    end
+    if nid >= 0 && is_value_type_obj(t) == 1
       return "((" + expr + "), 1)"
     end
     expr
+  end
+
+  def truthy_c_expr(t, expr)
+    if t == "poly"
+      return "sp_poly_truthy(" + expr + ")"
+    end
+    if t == "bool"
+      return expr
+    end
+    if t == "nil"
+      return "FALSE"
+    end
+    if is_nullable_type(t) == 1 || type_is_pointer(t) == 1
+      return "(" + expr + " != NULL)"
+    end
+    "((" + expr + "), TRUE)"
+  end
+
+  def or_result_type(nid)
+    lt = infer_type(@nd_left[nid])
+    rt = infer_type(@nd_right[nid])
+    if lt == rt
+      return lt
+    end
+    if lt == "nil"
+      return rt
+    end
+    if rt == "nil"
+      if is_nullable_pointer_type(lt) == 1 && is_nullable_type(lt) == 0
+        return lt + "?"
+      end
+      return lt
+    end
+    "poly"
   end
 
   # ---- Expression compiler ----
@@ -14078,7 +14136,32 @@ class Compiler
       return "(" + compile_expr(@nd_left[nid]) + " && " + compile_expr(@nd_right[nid]) + ")"
     end
     if t == "OrNode"
-      return "(" + compile_expr(@nd_left[nid]) + " || " + compile_expr(@nd_right[nid]) + ")"
+      left_nid = @nd_left[nid]
+      right_nid = @nd_right[nid]
+      lt = infer_type(left_nid)
+      rt = infer_type(right_nid)
+      ot = or_result_type(nid)
+      if ot != "bool" || lt != "bool" || rt != "bool"
+        if ot == "poly"
+          @needs_rb_value = 1
+        end
+        left_tmp = new_temp
+        emit("  " + c_type(lt) + " " + left_tmp + " = " + compile_expr(left_nid) + ";")
+        left_expr = left_tmp
+        right_expr = compile_expr(right_nid)
+        if ot == "poly"
+          left_expr = box_value_to_poly(lt, left_expr)
+          right_expr = box_value_to_poly(rt, right_expr)
+        elsif base_type(lt) != base_type(ot)
+          left_expr = c_default_val(ot)
+        elsif base_type(rt) != base_type(ot)
+          if rt == "nil"
+            right_expr = c_default_val(ot)
+          end
+        end
+        return "(" + truthy_c_expr(lt, left_tmp) + " ? " + left_expr + " : " + right_expr + ")"
+      end
+      return "(" + compile_expr(left_nid) + " || " + compile_expr(right_nid) + ")"
     end
     if t == "ParenthesesNode"
       body = @nd_body[nid]
@@ -15910,6 +15993,10 @@ class Compiler
     # Operators
     if mname == "**" || mname == "pow"
       lt = infer_type(recv)
+      if lt == "poly"
+        @needs_rb_value = 1
+        return "sp_poly_pow(" + compile_expr(recv) + ", " + box_expr_to_poly(get_args(@nd_arguments[nid])[0]) + ")"
+      end
       if lt == "int"
         return "((mrb_int)pow((double)" + compile_expr(recv) + ", (double)" + compile_arg0(nid) + "))"
       end
@@ -15921,6 +16008,13 @@ class Compiler
         return "sp_str_concat(" + compile_expr(recv) + "->data, " + compile_arg0(nid) + ")"
       end
       if lt == "string"
+        args_id = @nd_arguments[nid]
+        if args_id >= 0
+          arg_ids = get_args(args_id)
+          if arg_ids.length > 0 && infer_type(arg_ids[0]) == "poly"
+            return "sp_str_concat(" + compile_expr(recv) + ", sp_poly_to_s(" + compile_expr(arg_ids[0]) + "))"
+          end
+        end
         # Flatten chained string concat: a + b + c → sp_str_concat3(a,b,c)
         parts = collect_concat_chain(nid)
         if parts.length == 3
@@ -16018,6 +16112,10 @@ class Compiler
     end
     if mname == "/"
       lt = infer_type(recv)
+      if lt == "poly"
+        @needs_rb_value = 1
+        return "sp_poly_div(" + compile_expr(recv) + ", " + box_expr_to_poly(get_args(@nd_arguments[nid])[0]) + ")"
+      end
       if lt == "float"
         return "(" + compile_expr(recv) + " / " + compile_arg0(nid) + ")"
       end
@@ -16036,6 +16134,10 @@ class Compiler
     end
     if mname == "%"
       lt = infer_type(recv)
+      if lt == "poly"
+        @needs_rb_value = 1
+        return "sp_poly_mod(" + compile_expr(recv) + ", " + box_expr_to_poly(get_args(@nd_arguments[nid])[0]) + ")"
+      end
       if lt == "string" || lt == "mutable_str"
         args_id = @nd_arguments[nid]
         if args_id >= 0
@@ -16112,6 +16214,12 @@ class Compiler
     end
     if mname == "<"
       lt = infer_type(recv)
+      arg_id = get_args(@nd_arguments[nid])[0]
+      at = infer_type(arg_id)
+      if lt == "poly" || at == "poly"
+        @needs_rb_value = 1
+        return "sp_poly_lt(" + box_value_to_poly(lt, compile_expr(recv)) + ", " + box_value_to_poly(at, compile_expr(arg_id)) + ")"
+      end
       if lt == "string"
         cc = try_char_cmp(nid, "<")
         if cc != ""
@@ -16123,6 +16231,12 @@ class Compiler
     end
     if mname == ">"
       lt = infer_type(recv)
+      arg_id = get_args(@nd_arguments[nid])[0]
+      at = infer_type(arg_id)
+      if lt == "poly" || at == "poly"
+        @needs_rb_value = 1
+        return "sp_poly_gt(" + box_value_to_poly(lt, compile_expr(recv)) + ", " + box_value_to_poly(at, compile_expr(arg_id)) + ")"
+      end
       if lt == "string"
         cc = try_char_cmp(nid, ">")
         if cc != ""
@@ -16130,14 +16244,16 @@ class Compiler
         end
         return "(strcmp(" + compile_expr(recv) + ", " + compile_arg0(nid) + ") > 0)"
       end
-      if lt == "poly"
-        @needs_rb_value = 1
-        return "sp_poly_gt(" + compile_expr(recv) + ", " + box_expr_to_poly(get_args(@nd_arguments[nid])[0]) + ")"
-      end
       return "(" + compile_expr(recv) + " > " + compile_arg0(nid) + ")"
     end
     if mname == "<="
       lt = infer_type(recv)
+      arg_id = get_args(@nd_arguments[nid])[0]
+      at = infer_type(arg_id)
+      if lt == "poly" || at == "poly"
+        @needs_rb_value = 1
+        return "sp_poly_le(" + box_value_to_poly(lt, compile_expr(recv)) + ", " + box_value_to_poly(at, compile_expr(arg_id)) + ")"
+      end
       if lt == "string"
         cc = try_char_cmp(nid, "<=")
         if cc != ""
@@ -16149,6 +16265,12 @@ class Compiler
     end
     if mname == ">="
       lt = infer_type(recv)
+      arg_id = get_args(@nd_arguments[nid])[0]
+      at = infer_type(arg_id)
+      if lt == "poly" || at == "poly"
+        @needs_rb_value = 1
+        return "sp_poly_ge(" + box_value_to_poly(lt, compile_expr(recv)) + ", " + box_value_to_poly(at, compile_expr(arg_id)) + ")"
+      end
       if lt == "string"
         cc = try_char_cmp(nid, ">=")
         if cc != ""
@@ -16180,6 +16302,12 @@ class Compiler
       return compile_eq(nid, "!=")
     end
     if mname == "!"
+      lt = infer_type(recv)
+      if lt == "poly"
+        tmp = new_temp
+        emit("  sp_RbVal " + tmp + " = " + compile_expr(recv) + ";")
+        return "(!" + truthy_c_expr(lt, tmp) + ")"
+      end
       return "(!" + compile_expr(recv) + ")"
     end
     if mname == "between?"
@@ -16237,18 +16365,38 @@ class Compiler
         rc = compile_expr_gc_rooted(recv)
         return "(sp_PtrArray_push(" + rc + ", " + compile_arg0(nid) + "), " + rc + ")"
       end
+      if lt == "poly"
+        @needs_rb_value = 1
+        return "sp_poly_shl(" + compile_expr(recv) + ", " + box_expr_to_poly(get_args(@nd_arguments[nid])[0]) + ")"
+      end
       return "(" + compile_expr(recv) + " << " + compile_arg0(nid) + ")"
     end
     if mname == ">>"
+      if infer_type(recv) == "poly"
+        @needs_rb_value = 1
+        return "sp_poly_shr(" + compile_expr(recv) + ", " + box_expr_to_poly(get_args(@nd_arguments[nid])[0]) + ")"
+      end
       return "(" + compile_expr(recv) + " >> " + compile_arg0(nid) + ")"
     end
     if mname == "&"
+      if infer_type(recv) == "poly"
+        @needs_rb_value = 1
+        return "sp_poly_band(" + compile_expr(recv) + ", " + box_expr_to_poly(get_args(@nd_arguments[nid])[0]) + ")"
+      end
       return "(" + compile_expr(recv) + " & " + compile_arg0(nid) + ")"
     end
     if mname == "|"
+      if infer_type(recv) == "poly"
+        @needs_rb_value = 1
+        return "sp_poly_bor(" + compile_expr(recv) + ", " + box_expr_to_poly(get_args(@nd_arguments[nid])[0]) + ")"
+      end
       return "(" + compile_expr(recv) + " | " + compile_arg0(nid) + ")"
     end
     if mname == "^"
+      if infer_type(recv) == "poly"
+        @needs_rb_value = 1
+        return "sp_poly_bxor(" + compile_expr(recv) + ", " + box_expr_to_poly(get_args(@nd_arguments[nid])[0]) + ")"
+      end
       return "(" + compile_expr(recv) + " ^ " + compile_arg0(nid) + ")"
     end
     if mname == "~"
@@ -16256,6 +16404,10 @@ class Compiler
     end
     if mname == "-@"
       rt = infer_type(recv)
+      if rt == "poly"
+        @needs_rb_value = 1
+        return "sp_poly_neg(" + compile_expr(recv) + ")"
+      end
       if rt == "float"
         return "(-" + compile_expr(recv) + ")"
       end
@@ -19048,6 +19200,10 @@ class Compiler
   end
 
   def poly_dispatch_return_type(mname)
+    if mname == "[]"
+      @needs_rb_value = 1
+      return "poly"
+    end
     common = ""
     ci = 0
     while ci < @cls_names.length
@@ -19266,6 +19422,22 @@ class Compiler
     if arg_id >= 0
       rc = compile_expr(arg_id)
     end
+    if lt == "poly" || at == "poly"
+      @needs_rb_value = 1
+      left = lc
+      right = rc
+      if lt != "poly"
+        left = box_value_to_poly(lt, lc)
+      end
+      if at != "poly"
+        right = box_value_to_poly(at, rc)
+      end
+      if op == "=="
+        return "sp_poly_eq(" + left + ", " + right + ")"
+      else
+        return "(!sp_poly_eq(" + left + ", " + right + "))"
+      end
+    end
     # Symbol equality: distinct from all non-symbol types in Ruby.
     if lt == "symbol"
       if at == "symbol"
@@ -19330,6 +19502,44 @@ class Compiler
   # Mirrors box_expr_to_poly but operates on a raw (type, value) pair so
   # callers that already have temps don't have to re-emit the expr.
   def box_value_to_poly(at, val)
+    nullable = is_nullable_type(at)
+    raw_at = at
+    at = base_type(at)
+    if nullable == 1 && is_nullable_pointer_type(raw_at) == 1
+      if at == "string"
+        return "sp_box_nullable_str(" + val + ")"
+      end
+      if at == "int_array"
+        return "sp_box_nullable_obj(" + val + ", SP_BUILTIN_INT_ARRAY)"
+      end
+      if at == "float_array"
+        return "sp_box_nullable_obj(" + val + ", SP_BUILTIN_FLT_ARRAY)"
+      end
+      if at == "str_array"
+        return "sp_box_nullable_obj(" + val + ", SP_BUILTIN_STR_ARRAY)"
+      end
+      if at == "sym_array"
+        return "sp_box_nullable_obj(" + val + ", SP_BUILTIN_SYM_ARRAY)"
+      end
+      if is_ptr_array_type(at) == 1
+        return "sp_box_nullable_obj(" + val + ", SP_BUILTIN_PTR_ARRAY)"
+      end
+      if at == "proc" || at == "lambda"
+        return "sp_box_nullable_obj(" + val + ", SP_BUILTIN_PROC)"
+      end
+      if is_obj_type(at) == 1
+        cname = at[4, at.length - 4]
+        ci = find_class_idx(cname)
+        return "sp_box_nullable_obj(" + val + ", " + ci.to_s + ")"
+      end
+      if type_is_pointer(at) == 1
+        return "sp_box_nullable_obj((void *)(" + val + "), 0)"
+      end
+    end
+    box_non_nullable_value_to_poly(at, val)
+  end
+
+  def box_non_nullable_value_to_poly(at, val)
     if at == "poly"
       return val
     end
@@ -19351,8 +19561,6 @@ class Compiler
     if at == "symbol"
       return "sp_box_sym(" + val + ")"
     end
-    # Built-in pointer types route through sp_box_obj with a reserved
-    # negative cls_id (mirrors box_expr_to_poly).
     if at == "int_array"
       return "sp_box_int_array(" + val + ")"
     end
@@ -19375,6 +19583,9 @@ class Compiler
       cname = at[4, at.length - 4]
       ci = find_class_idx(cname)
       return "sp_box_obj(" + val + ", " + ci.to_s + ")"
+    end
+    if type_is_pointer(at) == 1
+      return "sp_box_obj((void *)(" + val + "), 0)"
     end
     "sp_box_int(" + val + ")"
   end
@@ -19420,110 +19631,11 @@ class Compiler
     end
     at = infer_type(nid)
     val = compile_expr(nid)
-    if at == "poly"
-      return val
-    end
-    if at == "int"
-      return "sp_box_int(" + val + ")"
-    end
-    if at == "string"
-      return "sp_box_str(" + val + ")"
-    end
-    if at == "float"
-      return "sp_box_float(" + val + ")"
-    end
-    if at == "bool"
-      return "sp_box_bool(" + val + ")"
-    end
-    if at == "nil"
-      return "sp_box_nil()"
-    end
-    if at == "symbol"
-      return "sp_box_sym(" + val + ")"
-    end
-    if is_obj_type(at) == 1
-      cname = at[4, at.length - 4]
-      ci = find_class_idx(cname)
-      return "sp_box_obj(" + val + ", " + ci.to_s + ")"
-    end
-    # Built-in pointer types: route through sp_box_obj with a reserved
-    # negative cls_id (SP_BUILTIN_*) so dispatch is uniform.
-    if at == "int_array"
-      return "sp_box_int_array(" + val + ")"
-    end
-    if at == "float_array"
-      return "sp_box_float_array(" + val + ")"
-    end
-    if at == "str_array"
-      return "sp_box_str_array(" + val + ")"
-    end
-    if at == "sym_array"
-      return "sp_box_sym_array(" + val + ")"
-    end
-    if is_ptr_array_type(at) == 1
-      return "sp_box_ptr_array(" + val + ")"
-    end
-    if at == "proc" || at == "lambda"
-      return "sp_box_proc(" + val + ")"
-    end
-    # Other pointer types (hashes, mutable strings, etc.) — box with a
-    # neutral cls_id of 0 rather than truncating the pointer to int.
-    if type_is_pointer(at) == 1
-      return "sp_box_obj((void *)(" + val + "), 0)"
-    end
-    "sp_box_int(" + val + ")"
+    box_value_to_poly(at, val)
   end
 
   def box_val_to_poly(val, at)
-    if at == "poly"
-      return val
-    end
-    if at == "int"
-      return "sp_box_int(" + val + ")"
-    end
-    if at == "string"
-      return "sp_box_str(" + val + ")"
-    end
-    if at == "float"
-      return "sp_box_float(" + val + ")"
-    end
-    if at == "bool"
-      return "sp_box_bool(" + val + ")"
-    end
-    if at == "nil"
-      return "sp_box_nil()"
-    end
-    if at == "symbol"
-      return "sp_box_sym(" + val + ")"
-    end
-    if at == "int_array"
-      return "sp_box_int_array(" + val + ")"
-    end
-    if at == "float_array"
-      return "sp_box_float_array(" + val + ")"
-    end
-    if at == "str_array"
-      return "sp_box_str_array(" + val + ")"
-    end
-    if at == "sym_array"
-      return "sp_box_sym_array(" + val + ")"
-    end
-    if is_ptr_array_type(at) == 1
-      return "sp_box_ptr_array(" + val + ")"
-    end
-    if is_obj_type(at) == 1
-      cname = at[4, at.length - 4]
-      ci = find_class_idx(cname)
-      return "sp_box_obj(" + val + ", " + ci.to_s + ")"
-    end
-    # Other pointer types (hashes, mutable strings, etc.) — box with a
-    # neutral cls_id of 0. Round-tripping back to the original concrete
-    # type is the caller's problem; this just makes the assignment
-    # type-check rather than silently truncating a pointer to mrb_int.
-    if type_is_pointer(at) == 1
-      return "sp_box_obj((void *)(" + val + "), 0)"
-    end
-    "sp_box_int(" + val + ")"
+    box_value_to_poly(at, val)
   end
 
   # Emit a runtime loop that pushes every element of the array `src_expr`

--- a/test/poly_equality_mixed_sites.rb
+++ b/test/poly_equality_mixed_sites.rb
@@ -1,0 +1,40 @@
+def same(a, b)
+  a == b
+end
+
+puts same(1, 1)
+puts same("x", "x")
+puts same(1, 1.0)
+
+def less_or_equal(a, b)
+  a <= b
+end
+
+puts less_or_equal(1, 2.0)
+begin
+  puts less_or_equal(1, "x")
+rescue
+  puts false
+end
+begin
+  puts less_or_equal(false, true)
+rescue
+  puts false
+end
+begin
+  puts less_or_equal(nil, nil)
+rescue
+  puts false
+end
+
+def maybe_string(flag)
+  if flag
+    "actual"
+  else
+    nil
+  end
+end
+
+puts same(maybe_string(false), nil)
+puts same(maybe_string(true), nil)
+puts same(maybe_string(false), "")

--- a/test/poly_or_returns_value.rb
+++ b/test/poly_or_returns_value.rb
@@ -1,0 +1,13 @@
+def pick(a, b)
+  a || b
+end
+
+puts pick(nil, "fallback")
+puts pick("actual", "fallback")
+
+def pick_int(a, b)
+  a || b
+end
+
+puts pick_int(0, 5)
+puts(nil || "direct")

--- a/test/system.rb
+++ b/test/system.rb
@@ -1,14 +1,14 @@
 # Test system features needed for ccm
 
+# system()
+system("echo hello_from_system")  # hello_from_system
+
 # ENV
 puts ENV['HOME'] != nil  # true
 
 # Dir.home
 home = Dir.home
 puts home.length > 0  # true
-
-# system()
-system("echo hello_from_system")  # hello_from_system
 
 # backtick
 result = `echo backtick_test`.strip


### PR DESCRIPTION
## Summary

Add runtime/codegen support for `poly` equality and value-returning truthiness.

Changes:
- compare `sp_RbVal` values through runtime helpers instead of raw C operators
- handle cross-type numeric equality/comparison and non-comparable poly comparisons
- compile non-boolean `||` as a value-select expression with coherent branch typing/boxing
- preserve nullable pointer semantics when boxing into `poly`, so NULL becomes `nil`
- handle NULL strings in poly equality/comparison without normalizing NULL to an empty string
- normalize captured test output before comparison and stabilize the `system` fixture for Windows/MSYS2
- add `sp_RbVal` truthiness and supporting poly operator helpers
- add regression tests for mixed-call-site equality, poly comparisons, and value-returning `||`

Fixes #171.
Fixes #172.

## Verification

```sh
make -B bootstrap
make test
# Tests: 233 pass, 0 fail, 0 error
```