### PR TITLE
feat(codegen,runtime): add two-argument Integer#pow(exp, mod)

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -77,6 +77,7 @@ static inline mrb_int sp_imod(mrb_int a, mrb_int b) {
 
 static mrb_int sp_gcd(mrb_int a,mrb_int b){if(a<0)a=-a;if(b<0)b=-b;while(b){mrb_int t=b;b=a%b;a=t;}return a;}
 static mrb_int sp_lcm(mrb_int a,mrb_int b){if(a==0||b==0)return 0;mrb_int g=sp_gcd(a,b);if(a<0)a=-a;if(b<0)b=-b;return (a/g)*b;}
+static mrb_int sp_powmod(mrb_int base,mrb_int exp,mrb_int mod){mrb_int r=1;mrb_int m=mod<0?-mod:mod;if(m==1){r=0;}else{base=base%m;if(base<0)base+=m;while(exp>0){if(exp%2==1)r=r*base%m;exp=exp/2;base=base*base%m;}}if(mod<0&&r>0)r-=m;return r;}
 static mrb_int sp_int_clamp(mrb_int v,mrb_int lo,mrb_int hi){return v<lo?lo:v>hi?hi:v;}
 static inline char *sp_str_alloc_raw(size_t total_with_null);  /* fwd decl */
 static const char*sp_int_chr(mrb_int n){char*s=sp_str_alloc_raw(2);s[0]=(char)n;s[1]=0;return s;}

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -15898,6 +15898,15 @@ class Compiler
     # Operators
     if mname == "**" || mname == "pow"
       lt = infer_type(recv)
+      if lt == "int" && mname == "pow"
+        args_id = @nd_arguments[nid]
+        if args_id >= 0
+          a = get_args(args_id)
+          if a.length >= 2
+            return "sp_powmod(" + compile_expr(recv) + ", " + compile_expr(a[0]) + ", " + compile_expr(a[1]) + ")"
+          end
+        end
+      end
       if lt == "int"
         return "((mrb_int)pow((double)" + compile_expr(recv) + ", (double)" + compile_arg0(nid) + "))"
       end

--- a/test/integer_powmod.rb
+++ b/test/integer_powmod.rb
@@ -1,0 +1,43 @@
+# basic
+puts 2.pow(10, 1000)
+puts 5.pow(2, 3)
+puts 3.pow(3, 8)
+
+# exp zero
+puts 2.pow(0, 5)
+puts 0.pow(0, 5)
+
+# mod one — always zero
+puts 2.pow(100, 1)
+puts 999.pow(999, 1)
+
+# negative base
+puts((-2).pow(3, 5))
+puts((-3).pow(2, 7))
+
+# large exponent
+puts 2.pow(20, 1000000)
+puts 7.pow(15, 100)
+
+# base larger than mod
+puts 100.pow(3, 7)
+
+# base zero
+puts 0.pow(5, 3)
+
+# base one
+puts 1.pow(999, 7)
+
+# mod two
+puts 7.pow(3, 2)
+
+# exp one
+puts 5.pow(1, 3)
+
+# negative mod
+puts 2.pow(2, -3)
+puts 2.pow(3, -5)
+
+# one-arg pow
+puts 2.pow(10)
+puts 3.pow(3)


### PR DESCRIPTION
This adds the two-argument form of `Integer#pow(exp, mod)` for modular exponentiation. The one-argument form is unchanged.

The implementation uses binary exponentiation (repeated squaring) — the same algorithm CRuby uses via `rb_int_powm()`. Each intermediate result is taken `% mod` so values stay small regardless of exponent size.

Tests covering edge cases (zero base, mod=1, negative base, large exponent, base>mod, one-arg fallback) are in `test/integer_powmod.rb`.