### PR TITLE
feat(codegen): Process.clock_gettime

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -3143,6 +3143,11 @@ class Compiler
     if recv >= 0
       if @nd_type[recv] == "ConstantReadNode"
         rcname = @nd_name[recv]
+        if rcname == "Process"
+          if mname == "clock_gettime"
+            return "float"
+          end
+        end
         if rcname == "File"
           if mname == "read"
             return "string"
@@ -18572,6 +18577,13 @@ class Compiler
       if rcname == "Time"
         if mname == "now"
           return "((mrb_int)time(NULL))"
+        end
+      end
+      # Process.clock_gettime — assume CLOCK_MONOTONIC; the clock_id
+      # arg is not modeled. Returns seconds as a float.
+      if rcname == "Process"
+        if mname == "clock_gettime"
+          return "({ struct timespec _ts; clock_gettime(CLOCK_MONOTONIC, &_ts); (mrb_float)_ts.tv_sec + (mrb_float)_ts.tv_nsec / 1e9; })"
         end
       end
       # ENV

--- a/test/process_clock_gettime.rb
+++ b/test/process_clock_gettime.rb
@@ -1,0 +1,13 @@
+# Process.clock_gettime(Process::CLOCK_MONOTONIC) returns a Float.
+# We can't assert an exact value, but we can verify the call lowers
+# correctly (returns a float, monotonic non-decreasing across two
+# samples).
+
+t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+t2 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+# t1 and t2 must be Float-typed in spinel; arithmetic should work.
+diff = t2 - t1
+if diff >= 0
+  puts "monotonic"
+end


### PR DESCRIPTION
## Code example

```ruby
t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
t2 = Process.clock_gettime(Process::CLOCK_MONOTONIC)

diff = t2 - t1
if diff >= 0
  puts "monotonic"
end
```

## Expected behavior

```
monotonic
```

`Process.clock_gettime(Process::CLOCK_MONOTONIC)` returns the current monotonic time as a `Float` (seconds with fractional nanosecond resolution). Two consecutive calls produce a non-decreasing difference.

This PR maps the call to a C `({ ... })` statement-expression that wraps `clock_gettime(CLOCK_MONOTONIC, &ts)` and combines `tv_sec` + `tv_nsec / 1e9` into an `mrb_float`:

```c
({ struct timespec _ts; clock_gettime(CLOCK_MONOTONIC, &_ts); (mrb_float)_ts.tv_sec + (mrb_float)_ts.tv_nsec / 1e9; })
```

The argument (a `Process::CLOCK_*` constant) is not modeled — `CLOCK_MONOTONIC` is assumed unconditionally. Other clocks would need separate handling; the typical use case (timing/benchmark code) uses MONOTONIC, and that's what this PR supports.

`infer_constant_recv_type` is also extended so `Process.clock_gettime` is type-inferred as `float`, letting `t2 - t1` and other arithmetic pick up the float type without falling back to int.

Test: `test/process_clock_gettime.rb` (two consecutive samples must be non-decreasing).