### PR TITLE
fix(codegen): bare `super` in initializer is silently dropped

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -12004,21 +12004,38 @@ class Compiler
         declare_method_locals(bid, pnames)
         stmts = get_stmts(bid)
         stmts.each { |sid|
-          if @nd_type[sid] == "SuperNode"
+          # Bare `super` parses as ForwardingSuperNode; `super(args)`
+          # parses as SuperNode. Both need to call the parent's
+          # initialize. For ForwardingSuperNode we forward the
+          # current method's params.
+          is_super = (@nd_type[sid] == "SuperNode" || @nd_type[sid] == "ForwardingSuperNode")
+          if is_super
             if @cls_parents[ci] != ""
               pi = find_class_idx(@cls_parents[ci])
               if pi >= 0
                 super_args = ""
-                args_id = @nd_arguments[sid]
-                if args_id >= 0
-                  arg_ids = get_args(args_id)
-                  ak = 0
-                  while ak < arg_ids.length
-                    if ak > 0
+                if @nd_type[sid] == "ForwardingSuperNode"
+                  # Forward the current init's params 1:1.
+                  fk = 0
+                  while fk < pnames.length
+                    if fk > 0
                       super_args = super_args + ", "
                     end
-                    super_args = super_args + compile_expr(arg_ids[ak])
-                    ak = ak + 1
+                    super_args = super_args + "lv_" + pnames[fk]
+                    fk = fk + 1
+                  end
+                else
+                  args_id = @nd_arguments[sid]
+                  if args_id >= 0
+                    arg_ids = get_args(args_id)
+                    ak = 0
+                    while ak < arg_ids.length
+                      if ak > 0
+                        super_args = super_args + ", "
+                      end
+                      super_args = super_args + compile_expr(arg_ids[ak])
+                      ak = ak + 1
+                    end
                   end
                 end
                 emit_raw("  sp_" + @cls_parents[ci] + "_initialize((sp_" + @cls_parents[ci] + " *)self" + (super_args != "" ? ", " + super_args : "") + ");")
@@ -12069,7 +12086,7 @@ class Compiler
               emit_raw("  " + self_arrow + ivar + " = " + val + ";")
             end
           else
-            if @nd_type[sid] != "SuperNode"
+            if is_super == false
               # Compile other statements (e.g., method calls like @arr[0] = val)
               compile_stmt(sid)
             end

--- a/test/super_forwarding.rb
+++ b/test/super_forwarding.rb
@@ -1,0 +1,25 @@
+# Bare `super` (no args, no parens) inside a constructor parses as
+# `ForwardingSuperNode`, not `SuperNode`. Without the
+# ForwardingSuperNode case, the call to the parent's `initialize`
+# was silently dropped — the parent's ivar setup never ran and the
+# child object was left in a half-initialized state.
+
+class Base
+  def initialize(x)
+    @x = x
+    @y = x * 10
+  end
+end
+
+class Child < Base
+  attr_reader :x, :y, :z
+  def initialize(x)
+    super              # bare — forwards x to Base#initialize
+    @z = x + 1
+  end
+end
+
+c = Child.new(3)
+puts c.x   # 3
+puts c.y   # 30
+puts c.z   # 4


### PR DESCRIPTION
## Reproduction

```ruby
class Base
  def initialize(x)
    @x = x
    @y = x * 10
  end
end

class Child < Base
  attr_reader :x, :y, :z
  def initialize(x)
    super              # bare — should forward `x` to Base#initialize
    @z = x + 1
  end
end

c = Child.new(3)
puts c.x   # 3
puts c.y   # 30
puts c.z   # 4
```

## Expected behavior

```
3
30
4
```

`super` with no parens forwards the current method's arguments to the parent's same-named method. `Child.new(3)` should run `Base#initialize(3)` first (setting `@x = 3` and `@y = 30`), then `Child#initialize`'s remaining body (setting `@z = 4`).

## Actual behavior

```
0
0
4
```

`@x` and `@y` are zero — `Base#initialize` never ran. Only `@z` was set, by `Child`'s own line.

## Analysis & fix

`emit_constructor` in `spinel_codegen.rb` walked the initializer body and looked for super calls with `@nd_type[sid] == "SuperNode"`. Prism parses the two `super` shapes into different node types:

- `super(args)` → `SuperNode` (with `@nd_arguments`)
- `super` (no parens) → `ForwardingSuperNode` (no `@nd_arguments`; the implicit semantics is to forward the current method's params 1:1)

The `ForwardingSuperNode` shape was never matched, so the bare-`super` statement was silently skipped over and the parent's `initialize` was never called.

Fix: treat both node types as super calls in the body walk. For `ForwardingSuperNode`, build the argument list by walking the current method's `pnames` and emitting `lv_<pname>` for each, so the parent's `initialize` receives the same locals 1:1. For `SuperNode`, the existing arg-walking branch is unchanged. The single-statement skip-list at the bottom of the loop is also widened from `!= "SuperNode"` to `is_super == false` so neither node type gets compiled twice.

Test: `test/super_forwarding.rb` — `Child < Base` with bare `super` in `Child#initialize`, asserts that `Base`'s ivar setup ran.