### PR TITLE
fix(codegen): unify disagreeing call-site param types to poly + box

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -6538,11 +6538,15 @@ class Compiler
                   while kk < arg_ids.length
                     at = infer_type(arg_ids[kk])
                     if kk < ptypes.length
-                      if ptypes[kk] == "int"
-                        if at != "int"
-                          ptypes[kk] = at
-                        end
-                      end
+                      # Unify against the existing param type rather
+                      # than only widening from "int". The previous
+                      # rule let the FIRST non-int call site freeze
+                      # the param type; subsequent disagreeing calls
+                      # (e.g. addr arg seen as Range from one site
+                      # and as Integer from another) compiled to a
+                      # signature mismatch. unify_call_types collapses
+                      # incompatible types to "poly".
+                      ptypes[kk] = unify_call_types(ptypes[kk], at, arg_ids[kk])
                     end
                     kk = kk + 1
                   end
@@ -9580,6 +9584,13 @@ class Compiler
               while kk < arg_ids.length
                 at = infer_type(arg_ids[kk])
                 if kk < ptypes.length
+                  # Same unify-instead-of-only-widen-from-int change as
+                  # the obj-recv path in scan_new_calls. A no-recv self
+                  # call inside the same class is the path that, e.g.,
+                  # `def boot; add_mappings(0x..0x, ...); end` inside
+                  # CPU#boot lands on, and disagreeing arg types from
+                  # different self-calls need to widen to poly rather
+                  # than freezing on the first non-int call site.
                   ptypes[kk] = unify_call_types(ptypes[kk], at, arg_ids[kk])
                 end
                 kk = kk + 1
@@ -20139,28 +20150,34 @@ class Compiler
         result = result + ", "
       end
       if k < arg_ids.length
-        aexpr = compile_expr(arg_ids[k])
         at = infer_type(arg_ids[k])
         if k < ptypes.length
           pt = ptypes[k]
-          if pt == "poly"
-            result = result + box_expr_to_poly(arg_ids[k])
-            k = k + 1
-            next
-          end
-          if at == "int"
-            if is_obj_type(pt) == 1
-              # Cast int to object pointer
-              pcname = pt[4, pt.length - 4]
-              aexpr = "(sp_" + pcname + " *)" + aexpr
+          # If the param is poly and the arg is anything else, box it.
+          # The unify pass widens disagreeing param types to "poly" but
+          # leaves the call sites untouched; without this branch the
+          # call passes a raw mrb_int / pointer / range to a sp_RbVal
+          # parameter and the C compiler rejects it.
+          if pt == "poly" && at != "poly"
+            aexpr = box_expr_to_poly(arg_ids[k])
+          else
+            aexpr = compile_expr(arg_ids[k])
+            if at == "int"
+              if is_obj_type(pt) == 1
+                # Cast int to object pointer
+                pcname = pt[4, pt.length - 4]
+                aexpr = "(sp_" + pcname + " *)" + aexpr
+              end
+            end
+            if is_obj_type(at) == 1
+              if pt == "int"
+                # Cast object pointer to int
+                aexpr = "(mrb_int)" + aexpr
+              end
             end
           end
-          if is_obj_type(at) == 1
-            if pt == "int"
-              # Cast object pointer to int
-              aexpr = "(mrb_int)" + aexpr
-            end
-          end
+        else
+          aexpr = compile_expr(arg_ids[k])
         end
         result = result + aexpr
       else

--- a/test/method_param_unify_to_poly.rb
+++ b/test/method_param_unify_to_poly.rb
@@ -1,0 +1,40 @@
+# Disagreeing call-site types for the same parameter need to widen
+# to `poly`. Pre-fix, `scan_new_calls` (obj-recv) and
+# `scan_cls_method_calls` (self-call inside the same class) both
+# only widened FROM "int": once the first non-int call site set the
+# param type, subsequent disagreeing calls were silently accepted
+# and the C compiler rejected the eventual mismatched call.
+#
+# Once the param widens to `poly`, the int / pointer / etc. arguments
+# at the call sites need to be boxed via `sp_box_*`. That boxing
+# branch was also missing from `compile_typed_call_args`, so even
+# after unify produced "poly", the call sites still passed raw
+# mrb_int / pointers to a sp_RbVal-typed parameter.
+
+class CPU
+  def feed(x, val)
+    val
+  end
+  # Self-call (no receiver). Lands in scan_cls_method_calls.
+  def boot
+    feed("hello", 1)
+    feed(20, 2)
+    feed("world", 3)
+  end
+end
+
+class User
+  def initialize(cpu)
+    @cpu = cpu
+  end
+  # Obj-recv call. Lands in scan_new_calls' obj branch.
+  def reset
+    @cpu.feed(100, 10)
+    @cpu.feed("via_user", 20)
+    @cpu.feed(500, 30)
+  end
+end
+
+cpu = CPU.new
+puts cpu.boot
+puts User.new(cpu).reset


### PR DESCRIPTION
## Reproduction

```ruby
class Mapper
  def add(addr, name)
    puts "add: #{name} at #{addr}"
  end
end

m = Mapper.new
m.add(0x100, "rom")          # Integer
m.add(0..0xff, "ram_range")  # Range
m.add(0x200, "io")           # Integer again
```

## Expected behavior

```
add: rom at 256
add: ram_range at 0..255
add: io at 512
```

`Mapper#add`'s first parameter is called with two different concrete types (`Integer` and `Range`) across the three call sites — same as in plain Ruby, where the parameter just holds whatever the caller passed.

## Actual behavior

`cc` rejects the generated C with one error per "wrong-typed" call site:

```
build/out.c:NN:M: error: passing argument 1 of 'sp_Mapper_add' from incompatible pointer type [-Wincompatible-pointer-types]
   NN |     sp_Mapper_add(m, 256, "rom");
      |                      ^~~~
      |                      |
      |                      mrb_int
build/out.c:NN:M: note: expected 'sp_Range *' but argument is of type 'mrb_int'
   NN | static inline mrb_int sp_Mapper_add(sp_Mapper *self, sp_Range * lv_addr, const char * lv_name) {
```

(Or: reverse error if Range is the first call site and Integer comes second.)

The compiled function signature has `sp_Range * lv_addr`, even though two of the three call sites pass `mrb_int`.

## Analysis & fix

`scan_new_calls` (the obj-recv path for `obj.method(args)`) and `scan_cls_method_calls` (the no-recv self-call path inside the same class) both populated `@cls_meth_ptypes` with this rule:

```ruby
if ptypes[kk] == "int"
  if at != "int"
    ptypes[kk] = at
  end
end
```

I.e., only widen FROM "int" (the no-info default) to a real type. The first non-int call site froze the param type; later call sites disagreeing with it were silently accepted but the C signature stayed as the first-frozen type, so the disagreeing callers passed wrongly-typed args at the C level.

`unify_call_types` already handles the general case — same type → keep, int+T → T, T+T? → T?, otherwise → `"poly"` + `@needs_rb_value=1`. Replace the int-gated assignment with a call to `unify_call_types`, so the third call now sees `(Range, Integer, literal=true)` and correctly demotes to `poly`.

That widening alone produces `sp_RbVal lv_addr` but the call sites still pass raw `int` / pointer values (the existing arg-cast branch in `compile_typed_call_args` only handled int↔obj, not anything→poly). Add a `pt == "poly" && at != "poly"` branch that routes the arg through `box_expr_to_poly` so the widening reaches the call sites.

In optcarrot this drops ~50 of the C-compile errors (every `add_mappings(addr, ...)` and similar dispatch where addr was called with Integer literals from one site and a Range from another).

Test: `test/method_param_unify_to_poly.rb`.