### PR TITLE
fix(codegen): dispatch [] / length on poly recv that's a PtrArray

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -19327,13 +19327,13 @@ class Compiler
     if at == "symbol"
       return "sp_box_sym(" + val + ")"
     end
-    if is_obj_type(at) == 1
-      cname = at[4, at.length - 4]
-      ci = find_class_idx(cname)
-      return "sp_box_obj(" + val + ", " + ci.to_s + ")"
-    end
     # Built-in pointer types: route through sp_box_obj with a reserved
-    # negative cls_id (SP_BUILTIN_*) so dispatch is uniform.
+    # negative cls_id (SP_BUILTIN_*) so dispatch is uniform. These
+    # checks run BEFORE is_obj_type because an `obj_X_ptr_array` type
+    # tag both starts with "obj_" and ends with "_ptr_array" — the
+    # is_obj_type branch would otherwise feed a "Foo_ptr_array" name
+    # to find_class_idx, get -1 (= SP_BUILTIN_INT_ARRAY by accident),
+    # and emit `sp_box_obj(p, -1)` which mis-tags the runtime value.
     if at == "int_array"
       return "sp_box_int_array(" + val + ")"
     end
@@ -19348,6 +19348,11 @@ class Compiler
     end
     if is_ptr_array_type(at) == 1
       return "sp_box_ptr_array(" + val + ")"
+    end
+    if is_obj_type(at) == 1
+      cname = at[4, at.length - 4]
+      ci = find_class_idx(cname)
+      return "sp_box_obj(" + val + ", " + ci.to_s + ")"
     end
     if at == "proc" || at == "lambda"
       return "sp_box_proc(" + val + ")"

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -19056,9 +19056,12 @@ class Compiler
         yc = "(sp_sym)sp_IntArray_get((sp_IntArray *)" + recv_tmp + ".v.p, " + a0 + ")"
         emit("    if (" + recv_tmp + ".cls_id == SP_BUILTIN_SYM_ARRAY) " + result_tmp + " = sp_box_sym(" + yc + ");")
       end
-      # PtrArray's element type is class-specific (sp_<C> *) so a
-      # uniform poly result needs sp_box_obj — but we don't have a
-      # cls_id here. Defer (the issue notes this is more involved).
+      # PtrArray dispatch — get returns a void* which we cast to
+      # mrb_int when the receiver is poly. Callers that immediately
+      # do `<obj>.reset`-style dispatch expect a pointer back.
+      pc = "(mrb_int)sp_PtrArray_get((sp_PtrArray *)" + recv_tmp + ".v.p, " + a0 + ")"
+      prhs = is_poly_ret == 1 ? "sp_box_obj((void *)" + pc + ", 0)" : pc
+      emit("    if (" + recv_tmp + ".cls_id == SP_BUILTIN_PTR_ARRAY) " + result_tmp + " = " + prhs + ";")
     end
     # `length` / `size` — every built-in array exposes its own
     # `_length` helper (sym_array shares IntArray's). PtrArray is

--- a/test/poly_dispatch_ptr_array.rb
+++ b/test/poly_dispatch_ptr_array.rb
@@ -1,0 +1,57 @@
+# Polymorphic `[]` and `length` dispatch must reach a PtrArray
+# receiver. Pre-fix, two things were wrong:
+#
+# 1. `emit_poly_builtin_dispatch` had no SP_BUILTIN_PTR_ARRAY branch
+#    for `[]` (the in-source comment said "Defer (the issue notes
+#    this is more involved)"). The dispatch result silently stayed at
+#    its default 0 / NULL when the runtime tag was a PtrArray.
+#
+# 2. `box_expr_to_poly` checked `is_obj_type` *before*
+#    `is_ptr_array_type`. Both predicates fire on `obj_Foo_ptr_array`
+#    (it starts with `obj_` AND ends with `_ptr_array`), so the
+#    is_obj_type branch ran first and emitted
+#    `sp_box_obj(p, find_class_idx("Foo_ptr_array"))`
+#    = `sp_box_obj(p, -1)`. -1 happens to equal SP_BUILTIN_INT_ARRAY,
+#    so the runtime cls_id mis-tagged a PtrArray as an IntArray.
+#    Subsequent dispatch then fell into the IntArray branch and read
+#    garbage out of the PtrArray's layout.
+#
+# `lenof([Foo.new(1), Foo.new(2)])` previously printed 16 (a bogus
+# byte interpreted as IntArray length); now it prints 2.
+
+class Foo
+  def initialize(n)
+    @n = n
+  end
+  attr_reader :n
+end
+
+class Bar
+  def length
+    99
+  end
+
+  def [](_)
+    77
+  end
+end
+
+def lenof(a)
+  a.length
+end
+
+def first(a)
+  a[0]
+end
+
+# `length` over mixed call sites — IntArray, PtrArray<Foo>, and a
+# user class. The PtrArray branch is the new one for this PR.
+puts lenof([1, 2, 3])                  # 3
+puts lenof([Foo.new(1), Foo.new(2)])   # 2
+puts lenof(Bar.new)                    # 99
+
+# `[]` over the same shapes.
+puts first([10, 20, 30])               # 10
+foo = first([Foo.new(42)])
+puts foo.n                             # 42
+puts first(Bar.new)                    # 77


### PR DESCRIPTION
## Reproduction

```ruby
class Foo
  def initialize(n); @n = n; end
  attr_reader :n
end

def lenof(a)
  a.length
end

def first(a)
  a[0]
end

# Mixed call sites — IntArray, PtrArray<Foo>, user class — widen
# the param to poly via the existing param-widening pass.
puts lenof([1, 2, 3])                  # 3
puts lenof([Foo.new(1), Foo.new(2)])   # 2
puts first([10, 20, 30])               # 10
puts first([Foo.new(42)]).n            # 42
```

## Expected behavior

```
3
2
10
42
```

A polymorphic receiver carrying a PtrArray (an array of class instances) should respond to `[]` and `length` the same way it does for IntArray / StrArray / FloatArray / SymArray, all of which already worked.

## Actual behavior

```
3
16
10
Segmentation fault (core dumped)
```

(Where `16` is a stray byte interpreted as IntArray length, and the segfault comes from calling `.n` on a 0-typed result.)

## Analysis & fix

Two bugs entangled:

**1. The dispatch table is missing the PtrArray branch.**

`emit_poly_builtin_dispatch`'s `[]` arm handled `SP_BUILTIN_INT_ARRAY`, `_FLT_ARRAY`, `_STR_ARRAY`, `_SYM_ARRAY` — but PtrArray was deferred with the comment:

> PtrArray's element type is class-specific (sp_<C> *) so a uniform poly result needs sp_box_obj — but we don't have a cls_id here. Defer (the issue notes this is more involved).

Result: when the runtime tag was `SP_BUILTIN_PTR_ARRAY`, the result temp stayed at its default 0 / NULL.

Fix: emit a branch that casts `sp_PtrArray_get`'s `void *` result to `mrb_int` (and wraps with `sp_box_obj(p, 0)` when the dispatch's overall result type is poly). cls_id 0 loses concrete-class dispatch on the resulting poly value, but callers that immediately do `arr[i].some_method` get back the pointer they need (commit `f34ad56`).

**2. Call-site boxing of `obj_X_ptr_array` produces the wrong runtime cls_id.**

Even with the dispatch arm in place, `lenof([Foo.new(1), Foo.new(2)])` still printed `16` instead of `2`. The reason was in `box_expr_to_poly`: the type-tag dispatch checked `is_obj_type` BEFORE `is_ptr_array_type`. Both predicates fire on `obj_<Class>_ptr_array` (it both starts with `obj_` and ends with `_ptr_array`), so the `is_obj_type` branch ran first, fed `<Class>_ptr_array` to `find_class_idx` (which returned `-1` for "no such class"), and emitted `sp_box_obj(p, -1)`. `-1` happens to equal `SP_BUILTIN_INT_ARRAY`, so the runtime dispatch landed in the IntArray branch and read garbage out of the PtrArray's struct layout.

Fix: reorder the checks in `box_expr_to_poly` so the built-in pointer types (`int_array`, `float_array`, `str_array`, `sym_array`, `*_ptr_array` via `is_ptr_array_type`) are checked before the catch-all `is_obj_type` branch. Mirrors the ordering already used by `box_value_to_poly` and `box_val_to_poly`. This is in commit `572aa46`.

Without (2), (1) is unreachable — the runtime tag never lands on `SP_BUILTIN_PTR_ARRAY`.

Test: `test/poly_dispatch_ptr_array.rb` exercises `length` and `[]` for IntArray, PtrArray<Foo>, and a user class through the same poly dispatch site. Pre-fix the PtrArray case prints `16`/segfaults; post-fix it prints `2`/`42`.