### PR TITLE
fix(codegen+runtime): FloatArray#shift was silently a no-op

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -272,6 +272,7 @@ static mrb_float sp_FloatArray_max(sp_FloatArray*a){if(a->len==0)return 0;mrb_fl
 static mrb_float sp_FloatArray_sum(sp_FloatArray*a){mrb_float s=0;for(mrb_int i=0;i<a->len;i++)s+=a->data[i];return s;}
 static void sp_FloatArray_replace(sp_FloatArray*dst,sp_FloatArray*src){dst->len=0;if(src->len>dst->cap){sp_gc_hdr*h=(sp_gc_hdr*)((char*)dst-sizeof(sp_gc_hdr));sp_gc_bytes-=sizeof(mrb_float)*dst->cap;h->size-=sizeof(mrb_float)*dst->cap;void*nd=realloc(dst->data,sizeof(mrb_float)*src->len);if(!nd){perror("realloc");exit(1);}dst->data=(mrb_float*)nd;dst->cap=src->len;h->size+=sizeof(mrb_float)*dst->cap;sp_gc_bytes+=sizeof(mrb_float)*dst->cap;}memcpy(dst->data,src->data,sizeof(mrb_float)*src->len);dst->len=src->len;}
 static inline mrb_float sp_FloatArray_pop(sp_FloatArray*a){return a->data[--a->len];}
+static inline mrb_float sp_FloatArray_shift(sp_FloatArray*a){if(a->len==0)return 0.0;mrb_float v=a->data[0];for(mrb_int i=0;i+1<a->len;i++)a->data[i]=a->data[i+1];a->len--;return v;}
 static inline mrb_int sp_FloatArray_length(sp_FloatArray*a){return a->len;}
 static inline mrb_bool sp_FloatArray_empty(sp_FloatArray*a){return a->len==0;}
 static inline mrb_float sp_FloatArray_get(sp_FloatArray*a,mrb_int i){if(i<0)i+=a->len;return a->data[i];}

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2669,6 +2669,9 @@ class Compiler
         if rt == "sym_array"
           return "symbol"
         end
+        if rt == "float_array"
+          return "float"
+        end
       end
       return "int"
     end
@@ -17877,6 +17880,9 @@ class Compiler
       end
       if mname == "pop"
         return "sp_FloatArray_pop(" + rc + ")"
+      end
+      if mname == "shift"
+        return "sp_FloatArray_shift(" + rc + ")"
       end
       if mname == "empty?"
         return "sp_FloatArray_empty(" + rc + ")"

--- a/test/float_array_shift.rb
+++ b/test/float_array_shift.rb
@@ -1,0 +1,14 @@
+# FloatArray#shift removes and returns the first element. The
+# IntArray helper existed; FloatArray's was missing and the codegen
+# fell through to the unknown-method 0 fallback.
+
+arr = [1.5, 2.5, 3.5, 4.5]
+puts arr.shift     # 1.5
+puts arr.length    # 3
+puts arr[0]        # 2.5
+
+# Drain via repeated shift.
+while arr.length > 0
+  puts arr.shift
+end
+puts arr.length    # 0


### PR DESCRIPTION
## Reproduction

```ruby
arr = [1.5, 2.5, 3.5, 4.5]
puts arr.shift     # 1.5
puts arr.length    # 3
puts arr[0]        # 2.5

while arr.length > 0
  puts arr.shift
end
puts arr.length    # 0
```

## Expected behavior

```
1.5
3
2.5
2.5
3.5
4.5
0
```

`Array#shift` removes and returns the first element. Spinel already supports this for `IntArray`, `StrArray`, `SymArray`, and `FloatArray#pop` works — so `FloatArray#shift` should behave the same way.

## Actual behavior

`spinel_codegen` emits a warning at compile time:

```
warning: cannot resolve call to 'shift' on float_array (emitting 0)
```

Then the program runs and:

```
0       # arr.shift returned 0 instead of 1.5
4       # arr.length is still 4 — array was not modified
1.5     # arr[0] is still 1.5
0
0
0
... (infinite loop: arr.length stays at 4 forever, shift keeps returning 0)
```

The `while arr.length > 0` loop never terminates because `shift` returns `0` without modifying the array.

## Analysis & fix

The FloatArray method handler in `spinel_codegen.rb` had no `shift` arm — only `pop`, `length`, `empty?`, `[]`, and a few others. With no match, dispatch fell through to the unknown-method `0` fallback (with the warning shown above), so the Ruby-level call became literally `0` in the generated C and the array was untouched.

`infer_call_type`'s `shift` branch was likewise missing the `float_array → float` mapping, so even if the runtime helper had existed, the call expression would have been typed as the default `int`.

Three small additions, parallel to what already exists for `pop` / for the other typed arrays:

1. Runtime helper `sp_FloatArray_shift` in `lib/sp_runtime.h`, alongside `sp_FloatArray_pop`. Removes `data[0]`, shifts the rest down, decrements `len`, returns the removed value (or `0.0` on empty).
2. Codegen dispatch arm in the FloatArray method handler that emits `sp_FloatArray_shift(rc)`.
3. `infer_call_type` entry so `arr.shift` on a `float_array` is typed as `float` (not the int default), matching the existing `int_array → int`, `str_array → string`, `sym_array → symbol` arms.

Test: `test/float_array_shift.rb` (single shift, length / index check after, full drain via repeated shift).