### PR TITLE
fix(runtime): sp_file_basename returns fresh sp_str_alloc'd copy

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -781,7 +781,19 @@ static void sp_file_write(const char *path, const char *data) { FILE *f = fopen(
 static mrb_bool sp_file_exist(const char *path) { FILE *f = fopen(path, "r"); if (f) { fclose(f); return TRUE; } return FALSE; }
 static void sp_file_delete(const char *path) { remove(path); }
 static const char *sp_backtick(const char *cmd) { FILE *p = popen(cmd, "r"); if (!p) return sp_str_empty; char *buf = sp_str_alloc_raw(4096); size_t n = fread(buf, 1, 4095, p); buf[n] = 0; pclose(p); return buf; }
-static const char *sp_file_basename(const char *path) { const char *s = strrchr(path, '/'); if (s) return s + 1; return path; }
+static const char *sp_file_basename(const char *path) {
+  const char *s = strrchr(path, '/');
+  const char *base = s ? s + 1 : path;
+  /* sp_gc_mark looks at byte[-1] to distinguish heap strings (`\xfe`)
+     from literals (`\xff`). A `s+1` mid-path pointer has whatever the
+     '/' was before it — and for an arbitrary string that's not a tag,
+     so the GC tries to dereference it as a heap header and segfaults.
+     Return a fresh sp_str_alloc'd copy so the prefix marker is right. */
+  size_t n = strlen(base);
+  char *buf = sp_str_alloc(n);
+  memcpy(buf, base, n + 1);
+  return buf;
+}
 
 typedef struct sp_Proc { void *fn; void *cap; void (*cap_scan)(void *); } sp_Proc;
 static void sp_Proc_scan(void *p) { sp_Proc *pr = (sp_Proc *)p; if (pr->cap && pr->cap_scan) pr->cap_scan(pr->cap); }

--- a/test/file_basename_gc.rb
+++ b/test/file_basename_gc.rb
@@ -1,0 +1,59 @@
+# sp_file_basename used to return `path + offset` — a pointer into
+# the input path. Without keeping the underlying buffer rooted, the
+# GC could free the path string, leaving the held basename dangling.
+#
+# Triggering the bug requires:
+#  - A path constructed dynamically (heap string, not literal).
+#  - A basename returned from a helper, so the path goes out of scope.
+#  - GC pressure that actually fires `sp_gc_collect` so `sp_str_sweep`
+#    walks the string heap and reaps the unreferenced path. String
+#    allocations alone don't accrue to `sp_gc_bytes` (per the comment
+#    in `sp_str_alloc`); we need object allocations to push past the
+#    threshold.
+#
+# The fix returns a fresh sp_str_alloc'd copy whose own `\xfe` tag
+# byte makes mark_string take the right path, and which survives
+# independently of the original path.
+
+class Trash
+  def initialize(n)
+    @n = n
+    @s = "padding payload " * 64    # ~1 KB heap string per Trash
+  end
+  attr_reader :n
+end
+
+def name_of(i)
+  path = "/very/deep/parent/directory/with/many/segments/file" + i.to_s + ".rb"
+  File.basename(path)
+end
+
+names = []
+i = 0
+while i < 50
+  names << name_of(i)
+  i = i + 1
+end
+
+# Allocate ~5000 Trash instances (~5 MB) — far past the 256 KB GC
+# threshold — to force multiple sp_gc_collect cycles and reap the
+# unreferenced path strings via sp_str_sweep.
+junk = []
+j = 0
+while j < 5000
+  junk << Trash.new(j)
+  j = j + 1
+end
+puts junk.length     # 5000
+
+# Each names[i] should still resolve to "fileN.rb".
+ok = 1
+i = 0
+while i < 50
+  expected = "file" + i.to_s + ".rb"
+  if names[i] != expected
+    ok = 0
+  end
+  i = i + 1
+end
+puts(ok == 1 ? "ok" : "corrupt")    # ok


### PR DESCRIPTION
## Reproduction

```ruby
class Trash
  def initialize(n)
    @n = n
    @s = "padding payload " * 64    # ~1 KB heap string per Trash
  end
  attr_reader :n
end

def name_of(i)
  path = "/very/deep/parent/directory/with/many/segments/file" + i.to_s + ".rb"
  File.basename(path)
end

names = []
i = 0
while i < 50
  names << name_of(i)
  i = i + 1
end

# Allocate ~5000 Trash instances (~5 MB) — far past the 256 KB GC
# threshold — to force multiple sp_gc_collect cycles and reap the
# unreferenced path strings via sp_str_sweep.
junk = []
j = 0
while j < 5000
  junk << Trash.new(j)
  j = j + 1
end
puts junk.length     # 5000

ok = 1
i = 0
while i < 50
  expected = "file" + i.to_s + ".rb"
  if names[i] != expected
    ok = 0
  end
  i = i + 1
end
puts(ok == 1 ? "ok" : "corrupt")
```

## Expected behavior

```
5000
ok
```

After collecting basenames into the `names` array, each entry should still resolve to its original `"fileN.rb"` regardless of how much GC pressure the program puts on the heap afterward.

## Actual behavior

```
5000
corrupt
```

After GC fires, some entries in `names` no longer match `"fileN.rb"`. Pre-fix output is non-deterministic (depends on what malloc reuses the freed slot with) but `corrupt` is consistent — at least one of the 50 names has been overwritten by another allocation.

In adversarial layouts where the freed page itself is unmapped, the program segfaults at the comparison instead of printing `corrupt`.

## Analysis & fix

`sp_file_basename` was a single line that returned a pointer INTO the input path:

```c
static const char *sp_file_basename(const char *path) {
  const char *s = strrchr(path, '/');
  if (s) return s + 1;
  return path;
}
```

That `s + 1` is a mid-string pointer. Two separate things broken by it:

**1. The GC mark phase doesn't propagate reachability.**

`sp_mark_string` looks at the byte BEFORE the string pointer — `\xfe` means heap-allocated (mark it `\xfc`), `\xff` means literal (no-op). For a `s + 1` mid-path pointer that byte is whatever character happened to sit at `path[offset_of_basename - 1]`, which for our test path is `'/'` (`0x2F`). `sp_mark_string` finds neither tag and silently does nothing — so reaching `names[i]` from a GC root does NOT mark the underlying path string. `sp_str_sweep` then sees the path as unmarked and reaps it.

**2. After the path is reaped, the held basename is dangling.**

`names[i]` still points into the freed buffer. Subsequent malloc calls eventually reuse those bytes. Read after that produces whatever was written there, or a segfault if the page is unmapped or has been mprotect'd by the allocator.

The fix returns a fresh `sp_str_alloc`'d copy:

```c
static const char *sp_file_basename(const char *path) {
  const char *s = strrchr(path, '/');
  const char *base = s ? s + 1 : path;
  size_t n = strlen(base);
  char *buf = sp_str_alloc(n);
  memcpy(buf, base, n + 1);
  return buf;
}
```

The copy lives in its own `sp_str_hdr` slot with the right `\xfe` prefix tag, so `sp_mark_string` recognizes it and `sp_str_sweep` keeps it alive as long as anything roots it.

Test notes (`test/file_basename_gc.rb`): forcing the bug requires both heap-allocated paths (so the path strings can actually be reaped) and enough GC-tracked OBJECT allocations to push past the 256 KB threshold — string allocations alone don't accrue to `sp_gc_bytes` (per the comment in `sp_str_alloc` about issue #99), so a tight string-churn loop never crosses the threshold and `sp_str_sweep` never runs. The `Trash` class with its 1 KB ivar string drives 5000 `sp_gc_alloc` calls, which is what triggers the collector.