### PR TITLE
fix(codegen): preserve namespace prefix in ivar / local types

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -4941,7 +4941,12 @@ class Compiler
           end
         end
       }
+      # Pin lexical scope while collecting ivars. See longer comment
+      # at the other collect_ivars call site below for rationale.
+      saved_idx = @current_class_idx
+      @current_class_idx = ci
       collect_ivars(ci)
+      @current_class_idx = saved_idx
       return
     end
 
@@ -5116,8 +5121,17 @@ class Compiler
       end
     }
 
-    # Collect ivars
+    # Collect ivars. Pin the lexical scope to this class so any
+    # `@x = Foo.new(...)` inside its methods resolves `Foo` against
+    # the same scope chain the call site sees — without this,
+    # current_lexical_scope_name returns "" and a `Config` reference
+    # inside `Optcarrot::NES` resolves to bare "Config" (no
+    # Optcarrot_ prefix), poisoning the ivar's recorded type and the
+    # eventual `sp_Config *` field declaration that fails to compile.
+    saved_idx = @current_class_idx
+    @current_class_idx = ci
     collect_ivars(ci)
+    @current_class_idx = saved_idx
   end
 
   def collect_module_methods_into_class(ci, mod_name)
@@ -7266,6 +7280,14 @@ class Compiler
     i = 0
     while i < @meth_names.length
       push_scope
+      # Pin @current_method_name so current_lexical_scope_name can pull
+      # the module prefix out of `<Mod>_cls_<m>` style names. Without
+      # this, a `Foo.new` inside e.g. `Optcarrot::Driver.load` resolves
+      # `Foo` against the empty scope and lands on bare `Foo` instead
+      # of `Optcarrot_Foo`, which then poisons the local variable's
+      # recorded type.
+      saved_meth = @current_method_name
+      @current_method_name = @meth_names[i]
       pnames = @meth_param_names[i].split(",")
       ptypes = @meth_param_types[i].split(",")
       j = 0
@@ -7289,6 +7311,7 @@ class Compiler
         end
         scan_writer_calls(@meth_body_ids[i])
       end
+      @current_method_name = saved_meth
       pop_scope
       i = i + 1
     end
@@ -13659,7 +13682,17 @@ class Compiler
       if @nd_type[sid] != "DefNode"
         if @nd_type[sid] != "ClassNode"
           if @nd_type[sid] != "ConstantWriteNode"
-            scan_locals(sid, lnames, ltypes, empty_params)
+            # Skip ModuleNode bodies — their nested classes/methods are
+            # collected separately, and recursing into them here would
+            # pull every nested method's locals into main()'s frame and
+            # also mis-resolve constants (no lexical scope is in effect
+            # at this scan, so e.g. `Video.new(...)` inside a module
+            # function lands on bare `Video` instead of the namespaced
+            # form). The other passes below already filter ModuleNode;
+            # this one was the outlier.
+            if @nd_type[sid] != "ModuleNode"
+              scan_locals(sid, lnames, ltypes, empty_params)
+            end
           end
         end
       end

--- a/test/nested_class_module_const_resolution.rb
+++ b/test/nested_class_module_const_resolution.rb
@@ -1,0 +1,38 @@
+# When a class lives inside a module and another class in the same
+# module is referenced via a bare name from one of its method bodies,
+# the inferred type of the resulting ivar/local must carry the same
+# namespace prefix that the class is registered under. Otherwise
+# `c_type` falls back to the short name and the C code references an
+# undeclared `sp_Foo *` that does not match the `sp_M_Foo *` typedef.
+#
+# Pre-fix, `Inner.new` inside `Outer#initialize` was scanned with no
+# lexical scope set on the compiler, so `Inner` resolved to bare and
+# the ivar got recorded as `obj_Inner` while the actual class is
+# registered under `sp_M_Inner`. The struct field declaration would
+# then read `sp_Inner * iv_inner` and the C compiler would reject it
+# with `unknown type name 'sp_Inner'`.
+
+module M
+  class Inner
+    def initialize(x)
+      @x = x
+    end
+    attr_reader :x
+  end
+
+  class Outer
+    def initialize
+      @inner = Inner.new(10)
+    end
+    def via_ivar
+      @inner.x
+    end
+    def via_local
+      tmp = Inner.new(20)
+      tmp.x
+    end
+  end
+end
+
+puts M::Outer.new.via_ivar
+puts M::Outer.new.via_local


### PR DESCRIPTION
## Reproduction

  ```ruby
  module M
    class Inner
      def initialize(x); @x = x; end
      attr_reader :x
    end

    class Outer
      def initialize
        @inner = Inner.new(10)     # bare-name reference
      end
      def via_ivar
        @inner.x
      end
      def via_local
        tmp = Inner.new(20)        # bare-name in local
        tmp.x
      end
    end
  end

  puts M::Outer.new.via_ivar
  puts M::Outer.new.via_local
  ```

  ## Expected behavior

  ```
  10
  20
  ```

  `Inner` and `Outer` both live under `module M`, registered as `M_Inner` and `M_Outer` in `@cls_names`. The bare-name reference `Inner.new(...)` from `Outer`'s body should resolve to `M_Inner` via the lexical scope chain.

  ## Actual behavior

  `spinel_parse` and `spinel_codegen` both succeed (exit 0), but `cc` rejects the generated C:

  ```
  $ cc -O0 -Ilib /tmp/out.c -lm -o /tmp/out
  /tmp/out.c: In function 'sp_M_Outer_new':
  /tmp/out.c:46:31: error: incompatible type for argument 1 of 'sp_box_obj'
     46 |   self->iv_inner = sp_box_obj(sp_M_Inner_new(10), 0);
        |                               ^~~~~~~~~~~~~~~~~~
        |                               |
        |                               sp_M_Inner {aka struct sp_M_Inner_s}
  In file included from /tmp/out.c:2:
  lib/sp_runtime.h:628:34: note: expected 'void *' but argument is of type 'sp_M_Inner' {aka 'struct sp_M_Inner_s'}
    628 | static sp_RbVal sp_box_obj(void *p, int cls_id) { sp_RbVal r; r.tag = SP_TAG_OBJ; r.cls_id = cls_id; r.v.p = p; return r; }
        |                            ~~~~~~^ = p; return r; }
      |                            ~~~~~~^
```

`iv_inner` was emitted as a poly (sp_RbVal) slot, and the assignment tries to box `sp_M_Inner_new(10)`'s **value-type return** through `sp_box_obj` which expects a `void *` — `cc` rejects passing a struct where a pointer is wanted.

## Analysis & fix

When `scan_ivars` walks `@inner = Inner.new(10)`, `infer_ivar_init_type` runs `constructor_class_name` on the receiver `Inner`. That calls `resolve_const_ref_name`, which walks `current_lexical_scope_name`'s chain trying `<scope>_Inner` at each level. `current_lexical_scope_name` returns `@cls_names[@current_class_idx]` if `@current_class_idx >= 0`.

But `collect_ivars(ci)` was called from `collect_class_with_prefix` with `@current_class_idx` still at its `-1` initial value — the field hadn't been pinned yet. So the scope chain is empty, the search falls through to bare `"Inner"`, the ivar's type tag is recorded as `obj_Inner`, and `find_class_idx("Inner")` later returns `-1` (the registered name is `M_Inner`).

Two cascading consequences:

1. **Value-type detection runs unsuspecting.** `M_Inner` gets marked as a value type (one ivar, no inheritance) — fine on its own. But `iv_inner` of `Outer` was recorded as `obj_Inner`, and the canonical-name lookup that's supposed to map that back to `M_Inner` fails. The codegen ends up treating `iv_inner` as a poly slot (because some path widened it after the name mismatch).

2. **The boxing site picks `sp_box_obj(value_struct, 0)`.** `sp_M_Inner_new(10)` returns the value struct; `sp_box_obj` wants `void *`. cc rejects.

Fix: pin the lexical scope before every ivar / local scan that may resolve constants. Three sites:

- `collect_class_with_prefix`'s **regular** class branch — save `@current_class_idx`, set it to `ci`, call `collect_ivars(ci)`, restore.
- The same function's **open-class** branch (class reopening) — same save/restore around its `collect_ivars(ci)` call.
- `infer_function_body_call_types`'s top-level method loop — pin `@current_method_name = @meth_names[i]` before `scan_writer_calls` so module class methods (`<Mod>_cls_<m>` flat names) get the module prefix peeled off via `current_lexical_scope_name`'s `_cls_` slicer.

Plus a small filter in `detect_poly_locals`: skip `ModuleNode` bodies. The other passes already filtered them, but this outer scan was the outlier — it would otherwise pull every nested method's locals into the main-frame walk with no scope set, again poisoning the resolution of constants like `Video.new(...)` inside a module function.

Test: `test/nested_class_module_const_resolution.rb` — `M::Outer.new.via_ivar` and `via_local` both reach `M::Inner` via bare-name references.