### PR TITLE
feat(parser+codegen): support `a ||= b` and `a &&= b` for locals

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -13978,6 +13978,20 @@ class Compiler
       end
       return "(" + self_arrow + sanitize_ivar(iname_w) + " = " + val + ")"
     end
+    if t == "LocalVariableOrWriteNode"
+      # `local ||= expr` in expression context. Lower as
+      # `(local = local ? local : expr)` so the side effect runs
+      # only on a falsy current value.
+      vref = fiber_var_ref(@nd_name[nid])
+      val = compile_expr(@nd_expression[nid])
+      return "(" + vref + " = " + vref + " ? " + vref + " : (" + val + "))"
+    end
+    if t == "LocalVariableAndWriteNode"
+      # `local &&= expr` in expression context.
+      vref = fiber_var_ref(@nd_name[nid])
+      val = compile_expr(@nd_expression[nid])
+      return "(" + vref + " = " + vref + " ? (" + val + ") : " + vref + ")"
+    end
     if t == "ConstantReadNode"
       if @nd_name[nid] == "ARGV"
         return "sp_argv"
@@ -20747,6 +20761,18 @@ class Compiler
       if op == "^"
         emit("  " + vref + " ^= " + val + ";")
       end
+      return
+    end
+    if t == "LocalVariableOrWriteNode"
+      vref = fiber_var_ref(@nd_name[nid])
+      val = compile_expr(@nd_expression[nid])
+      emit("  if (!(" + vref + ")) " + vref + " = " + val + ";")
+      return
+    end
+    if t == "LocalVariableAndWriteNode"
+      vref = fiber_var_ref(@nd_name[nid])
+      val = compile_expr(@nd_expression[nid])
+      emit("  if (" + vref + ") " + vref + " = " + val + ";")
       return
     end
     if t == "InstanceVariableWriteNode"

--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -261,6 +261,20 @@ static int flatten(pm_node_t *node) {
     R("value", n->value);
     break;
   }
+  case PM_LOCAL_VARIABLE_OR_WRITE_NODE: {
+    pm_local_variable_or_write_node_t *n = (pm_local_variable_or_write_node_t *)node;
+    N("LocalVariableOrWriteNode");
+    NAME("name", n->name);
+    R("value", n->value);
+    break;
+  }
+  case PM_LOCAL_VARIABLE_AND_WRITE_NODE: {
+    pm_local_variable_and_write_node_t *n = (pm_local_variable_and_write_node_t *)node;
+    N("LocalVariableAndWriteNode");
+    NAME("name", n->name);
+    R("value", n->value);
+    break;
+  }
   case PM_LOCAL_VARIABLE_TARGET_NODE: {
     pm_local_variable_target_node_t *n = (pm_local_variable_target_node_t *)node;
     N("LocalVariableTargetNode");

--- a/test/local_or_and_write.rb
+++ b/test/local_or_and_write.rb
@@ -1,0 +1,33 @@
+# `LocalVariableOrWriteNode` (`a ||= b`) and
+# `LocalVariableAndWriteNode` (`a &&= b`) parse as their own
+# AST nodes — distinct from `LocalVariableOperatorWriteNode`
+# (which carries `+`, `-`, `*`, etc. via a binary_operator field).
+# Without dedicated parser cases the prism nodes were dropped on
+# the floor, so `a ||= b` produced no C output.
+
+# (1) Statement-form ||=
+a = nil
+a ||= 10
+puts a       # 10
+a ||= 99     # already truthy → no-op
+puts a       # 10
+
+# (2) Statement-form &&=
+b = 5
+b &&= b + 1
+puts b       # 6
+c = nil
+c &&= 99     # nil → no-op
+puts c.nil? ? "nil" : c.to_s   # nil
+
+# (3) Expression-form ||=
+x = nil
+y = (x ||= 7)
+puts x       # 7
+puts y       # 7
+
+# (4) Expression-form &&=
+p = 3
+q = (p &&= p * 2)
+puts p       # 6
+puts q       # 6


### PR DESCRIPTION
## Code example
```ruby
# Statement form
a = nil
a ||= 10
puts a       # 10
a ||= 99     # already truthy → no-op
puts a       # 10

b = 5
b &&= b + 1
puts b       # 6

# Expression form (chained)
x = nil
y = (x ||= 7)
puts x       # 7
puts y       # 7

p = 3
q = (p &&= p * 2)
puts p       # 6
puts q       # 6
```

## Expected behavior
`a ||= b` is a Ruby short-circuit assignment: `a = b` runs only when `a` is falsy. `a &&= b` is the dual: `a = b` runs only when `a` is truthy. Both forms should also work in expression position (the resulting value of the assignment can be used in a chain like `y = (x ||= 7)`).

Output:
```
10
10
6
7
7
6
6
```

## Notes
`LocalVariableOrWriteNode` and `LocalVariableAndWriteNode` parse as their own prism AST nodes — distinct from `LocalVariableOperatorWriteNode` (which carries `+`, `-`, etc. via a `binary_operator` field). Without dedicated parser cases the prism nodes were dropped on the floor, so `a ||= b` produced no C output.

Implementation:
- `spinel_parse.c`: emit the new node types alongside the existing `LocalVariableOperatorWriteNode` case.
- `spinel_codegen.rb` `compile_expr`: lower `||=` as `(local = local ? local : (val))` and `&&=` as the dual ternary.
- `spinel_codegen.rb` `compile_stmt`: lower `||=` as `if (!(local)) local = val;` (and the `&&=` dual).