### PR TITLE
feat(codegen): Integer#[idx] (bit indexing)

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -17135,6 +17135,17 @@ class Compiler
     if mname == "itself"
       return rc
     end
+    # Integer#[idx] — bit indexing. `n[k]` returns bit k of n.
+    if mname == "[]"
+      args_id = @nd_arguments[nid]
+      if args_id >= 0
+        aargs = get_args(args_id)
+        if aargs.length > 0
+          idx = compile_expr(aargs[0])
+          return "(((" + rc + ") >> (" + idx + ")) & 1)"
+        end
+      end
+    end
     ""
   end
 

--- a/test/integer_bit_index.rb
+++ b/test/integer_bit_index.rb
@@ -1,0 +1,22 @@
+# `Integer#[N]` returns bit N (0-indexed from the LSB) of the
+# integer. `data[5]` was previously falling through to the
+# unknown-method 0-fallback. Lower as `((rc >> idx) & 1)`.
+
+# Static index
+n = 0b10110100
+puts n[0]    # 0
+puts n[1]    # 0
+puts n[2]    # 1
+puts n[3]    # 0
+puts n[4]    # 1
+puts n[5]    # 1
+puts n[6]    # 0
+puts n[7]    # 1
+
+# Dynamic index
+i = 0
+while i < 4
+  puts n[i]
+  i += 1
+end
+# 0 0 1 0


### PR DESCRIPTION
## Code example
```ruby
n = 0b10110100
puts n[0]    # 0
puts n[1]    # 0
puts n[2]    # 1
puts n[3]    # 0
puts n[4]    # 1
puts n[5]    # 1
puts n[6]    # 0
puts n[7]    # 1

# Dynamic index
i = 0
while i < 4
  puts n[i]
  i += 1
end
```

## Expected behavior
`n[k]` returns bit `k` (0-indexed from the LSB) of integer `n`. Output:
```
0
0
1
0
1
1
0
1
0
0
1
0
```

## Notes
Previously the call fell through `compile_int_method_expr`'s dispatcher to the unknown-method 0-fallback, so every `n[k]` came out as `0`. Lower as `(((rc) >> (idx)) & 1)`.