### PR TITLE
fix(codegen): collect ivars from MultiWriteNode (`@a, @b = ...`)

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -5679,8 +5679,54 @@ class Compiler
         add_ivar(ci, iname, "int")
       end
     end
+    # Multi-write to ivars: `@a, @b = expr1, expr2` (or `[expr1, expr2]`).
+    # Without this branch, ivars assigned only via destructuring never get
+    # registered and the struct comes out missing them.
+    if @nd_type[nid] == "MultiWriteNode"
+      targets = parse_id_list(@nd_targets[nid])
+      val_id = @nd_expression[nid]
+      ti = 0
+      while ti < targets.length
+        tid = targets[ti]
+        if @nd_type[tid] == "InstanceVariableTargetNode"
+          iname = @nd_name[tid]
+          vtype = scan_ivars_multi_target_type(val_id, ti)
+          if ivar_exists(ci, iname) == 0
+            add_ivar(ci, iname, vtype)
+          else
+            if vtype != "int" && vtype != "nil"
+              update_ivar_type(ci, iname, vtype)
+            end
+          end
+        end
+        ti = ti + 1
+      end
+    end
     # Recurse into children
     scan_ivars_children(ci, nid)
+  end
+
+  # i-th element type when scanning ivar destructuring writes. Mirrors
+  # multi_write_target_type but also handles array literals on the RHS
+  # (ivar collection runs before tuple inference, so `@a, @b = 1, 2`
+  # gets its types from positional ArrayNode elements rather than a
+  # tuple return).
+  def scan_ivars_multi_target_type(val_id, ti)
+    if val_id < 0
+      return "int"
+    end
+    if @nd_type[val_id] == "ArrayNode"
+      elems = parse_id_list(@nd_elements[val_id])
+      if ti < elems.length
+        return infer_ivar_init_type(elems[ti])
+      end
+      return "int"
+    end
+    rt = infer_type(val_id)
+    if is_tuple_type(rt) == 1
+      return tuple_elem_type_at(rt, ti)
+    end
+    "int"
   end
 
   def scan_ivars_children(ci, nid)

--- a/test/multi_write_ivar.rb
+++ b/test/multi_write_ivar.rb
@@ -1,0 +1,34 @@
+# `@a, @b = expr1, expr2` (multi-write to ivars) was not picked up by
+# `scan_ivars`, so the ivars were never registered and the struct
+# came out missing them. The emit-time path in compile_stmt already
+# handled InstanceVariableTargetNode; the gap was only in the
+# collection pass.
+
+class Inner
+  def initialize(x); @x = x; end
+  attr_reader :x
+end
+
+class HasObjects
+  def initialize
+    @left, @right = Inner.new(7), Inner.new(8)
+  end
+  def sum
+    @left.x + @right.x
+  end
+end
+
+class Holder
+  def initialize
+    @a, @b = 1, 2
+  end
+  attr_reader :a, :b
+  def has_obj
+    HasObjects.new.sum
+  end
+end
+
+h = Holder.new
+puts h.a
+puts h.b
+puts h.has_obj


### PR DESCRIPTION
## Reproduction

```ruby
class Pair
  def initialize(x, y)
    @a, @b = x, y         # destructuring assign
  end
  attr_reader :a, :b
end

p = Pair.new(10, 20)
puts p.a   # 10
puts p.b   # 20
```

## Expected behavior

```
10
20
```

`@a, @b = x, y` is parallel assignment to ivars — the standard Ruby way of destructuring. The fields should both be registered on the class struct.

## Actual behavior

`spinel_parse` and `spinel_codegen` succeed, but `cc` fails:

```
$ cc -O0 -Ilib /tmp/out.c -lm -o /tmp/out
/tmp/out.c: In function 'sp_Pair_a':
/tmp/out.c:NN:NN: error: 'sp_Pair' has no member named 'iv_a'
   NN |     return self->iv_a;
      |                ^~~~~
```

(Same for `iv_b`.) The struct has neither field — both ivars were dropped.

## Analysis & fix

`scan_ivars` recursed through method bodies looking for ivar writes, but only matched `InstanceVariableWriteNode` (single write) and `InstanceVariableOperatorWriteNode` (`@x += n`). The multi-write shape `@a, @b = expr1, expr2` parses as `MultiWriteNode` with `InstanceVariableTargetNode` entries in its `targets` list; with no matching branch, those ivars never reached `add_ivar` and were missing from the struct.

Add a `MultiWriteNode` arm to `scan_ivars`. Walk `targets`, pick out `InstanceVariableTargetNode` entries, register each one. The element-type lookup is factored into `scan_ivars_multi_target_type(val_id, ti)`:

- If RHS is `ArrayNode` (`[expr1, expr2]` or the bare `expr1, expr2` form), return `infer_ivar_init_type` of the i-th element.
- Otherwise infer the RHS as a tuple type (`tuple:T1,T2,...`) and return the i-th element's tuple slot.
- Fallback to `int`.

This mirrors the existing emit-time `multi_write_target_type` but adds the ArrayNode branch since ivar collection runs before tuple inference.

Encountered while compiling optcarrot — APU's `@pulse_0, @pulse_1 = Pulse.new(self), Pulse.new(self)` left both ivars unregistered.

Test: `test/multi_write_ivar.rb`.