### PR TITLE
fix(codegen): resolve subclass parent through enclosing module chain

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -4979,7 +4979,34 @@ class Compiler
           end
         end
       else
-        parent = @nd_name[sp]
+        parent = const_ref_flat_name(sp)
+        if parent == ""
+          parent = @nd_name[sp]
+        end
+        # Resolve the parent class name against the same module-prefix
+        # chain that was used to register the child. `class Sub < Base`
+        # inside `module M` should land on `M_Base` (the registered
+        # name), not bare "Base", or `emit_class_fields` later fails
+        # `find_class_idx` and silently drops every inherited field.
+        if module_prefix != "" && const_ref_is_relative(sp) == 1
+          if find_class_idx(parent) < 0
+            mp = module_prefix
+            while mp != ""
+              cand = mp + "_" + parent
+              if find_class_idx(cand) >= 0
+                parent = cand
+                mp = ""
+              else
+                idx = mp.rindex("_")
+                if idx < 0
+                  mp = ""
+                else
+                  mp = mp[0, idx]
+                end
+              end
+            end
+          end
+        end
       end
     end
 

--- a/test/subclass_inherits_module_parent.rb
+++ b/test/subclass_inherits_module_parent.rb
@@ -1,0 +1,40 @@
+# `class Sub < Base` inside `module M` used to record `cls_parents`
+# as bare "Base" rather than "M_Base", so emit_class_fields' lookup
+# of the parent missed and Sub came out as an empty struct — every
+# field inherited from Base was dropped on the C side.
+
+module M
+  class Base
+    def initialize(x)
+      @x = x
+    end
+  end
+
+  class Sub < Base
+    def double
+      @x * 2
+    end
+    def x_plus(n)
+      @x + n
+    end
+  end
+
+  class Plain
+    def initialize
+      @y = 99
+    end
+  end
+
+  class PlainSub < Plain
+    def boost
+      @y + 1
+    end
+  end
+end
+
+s = M::Sub.new(7)
+puts s.double
+puts s.x_plus(100)
+
+ps = M::PlainSub.new
+puts ps.boost


### PR DESCRIPTION
## Reproduction

```ruby
module M
  class Base
    def initialize(x); @x = x; end
  end

  class Sub < Base
    def double; @x * 2; end
    def x_plus(n); @x + n; end
  end
end

s = M::Sub.new(5)
puts s.double      # 10
puts s.x_plus(3)   # 8
```

## Expected behavior

```
10
8
```

`M::Sub` inherits `Base`'s `@x` field. Methods on `Sub` reading `@x` should see the value set by `Base#initialize`.

## Actual behavior

`spinel_parse` and `spinel_codegen` succeed, but `cc` fails:

```
$ cc -O0 -Ilib /tmp/out.c -lm -o /tmp/out
/tmp/out.c: In function 'sp_M_Sub_double':
/tmp/out.c:NN:NN: error: 'sp_M_Sub' has no member named 'iv_x'
   NN |     return self->iv_x * 2;
      |                ^~~~~~
```

`sp_M_Sub`'s struct has no `iv_x` — the field was supposed to be inherited from `Base`, but the struct was emitted as if `Sub` had no parent.

## Analysis & fix

`collect_class_with_prefix` registers a class as `M_Sub` (combining the enclosing `module_prefix` with the class node name). For the parent class node — `class Sub < Base` — the recorded `cls_parents[Sub]` was just `@nd_name[sp]`, the bare leaf `"Base"`. The parent class itself is registered as `M_Base`, so `find_class_idx(@cls_parents[ci])` later returns -1, `emit_class_fields` silently emits no inherited fields, and the resulting struct lacks `iv_x`.

Resolve the superclass node the same way the child name is resolved:

1. `const_ref_flat_name(sp)` first — handles `class Sub < Outer::Inner`.
2. If that returns "" (e.g. `ConstantReadNode`), fall back to `@nd_name[sp]` as before.
3. If we're nested in a module (`module_prefix != ""`) AND the reference is relative (no leading `::`), and bare lookup misses, walk `module_prefix` upwards trying `<scope>_<bare>` until a registered class matches.

Mirrors the lookup chain already used for the child name and for ivar / local type resolution (the surrounding code).

Encountered while compiling optcarrot — `class MMC3 < ROM` lost ROM's full struct.

Test: `test/subclass_inherits_module_parent.rb`.