### PR TITLE
fix(codegen): ParenthesesNode multi-stmt + LocalVariableWriteNode in expr context

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -13978,6 +13978,25 @@ class Compiler
       end
       return "(" + self_arrow + sanitize_ivar(iname_w) + " = " + val + ")"
     end
+    if t == "LocalVariableWriteNode"
+      # `local = expr` used as an expression (e.g. inside a chained
+      # `@a = local = expr` write). Without this branch compile_expr
+      # falls through and returns the default "0", which silently
+      # zeroed the outer write — every `@_p_nz = ___a__ = __data__`
+      # in optcarrots OptimizedCodeBuilder CPU output became
+      # `iv__p_nz = 0`. Lower as a parenthesized C-style assignment.
+      val = compile_expr(@nd_expression[nid])
+      return "(" + fiber_var_ref(@nd_name[nid]) + " = " + val + ")"
+    end
+    if t == "LocalVariableOperatorWriteNode"
+      # `local OP= expr` used as an expression (e.g. ORA's
+      # `@_p_nz = ___a__ |= __data__`). Same shape as the chained
+      # write above — without this, the op-assign drops out and the
+      # outer write zeroes the ivar.
+      op = @nd_binop[nid]
+      val = compile_expr(@nd_expression[nid])
+      return "(" + fiber_var_ref(@nd_name[nid]) + " " + op + "= " + val + ")"
+    end
     if t == "ConstantReadNode"
       if @nd_name[nid] == "ARGV"
         return "sp_argv"
@@ -14072,8 +14091,37 @@ class Compiler
       body = @nd_body[nid]
       if body >= 0
         stmts = get_stmts(body)
-        if stmts.length > 0
-          return compile_expr(stmts.last)
+        if stmts.length == 1
+          return compile_expr(stmts[0])
+        end
+        if stmts.length > 1
+          # Multi-statement parens like `(stmt1; stmt2; ... ; expr)`
+          # in expression context. We must NOT lower this to a C
+          # comma-expression `(a, b, c)` because Cs `expr1 + expr2`
+          # has unspecified evaluation order between operands, and
+          # if either side has side effects (e.g. RTSs `(___sp__ =
+          # ___sp__+1 & 0xff; __ram__[0x100+sp])`), GCC can reorder
+          # so the increments fire out of order and the byte pulls
+          # come from the wrong stack slots.
+          # Strategy: emit the leading statements via emit() so they
+          # are sequenced C statements. Then evaluate the final
+          # expression and BIND it to a temp before returning, so
+          # that an enclosing expression (e.g. `parens1 + parens2`)
+          # cant interleave additional side effects from another
+          # parens between this ones evaluation and use.
+          k = 0
+          while k < stmts.length - 1
+            v = compile_expr(stmts[k])
+            if v != "" && v != "0"
+              emit("  " + v + ";")
+            end
+            k = k + 1
+          end
+          last_expr = compile_expr(stmts.last)
+          last_t = infer_type(stmts.last)
+          tmp = new_temp
+          emit("  " + c_type(last_t) + " " + tmp + " = " + last_expr + ";")
+          return tmp
         end
       end
       return "0"

--- a/test/parens_multi_stmt_and_local_write_expr.rb
+++ b/test/parens_multi_stmt_and_local_write_expr.rb
@@ -1,0 +1,23 @@
+# Verify two expression-context constructs:
+# - `(stmt1; stmt2; ...; expr)` — leading statements run for
+#   side effects; the value of the parens is the last expression.
+# - `local = expr` and `local OP= expr` used as expressions —
+#   they assign and yield the new value of the local.
+
+# (1) Multi-stmt parens — leading side effects must run.
+x = 0
+y = (x = x + 1; x = x + 1; x)
+puts x      # 2
+puts y      # 2
+
+# (2) `local = expr` as the value of an outer expression.
+a = 0
+b = (a = 5)
+puts a      # 5
+puts b      # 5
+
+# (3) `local OP= expr` as the value of an outer expression.
+c = 10
+d = (c += 3)
+puts c      # 13
+puts d      # 13


### PR DESCRIPTION
## Reproduction
  ```ruby
  # (1) Multi-stmt parens — leading side effects
  x = 0
  y = (x = x + 1; x = x + 1; x)
  puts x
  puts y

  # (2) `local = expr` used as the value of an outer expression
  a = 0
  b = (a = 5)
  puts a
  puts b
  ```

  ## Expected behavior
  ```
  2
  2
  5
  5
  ```

  ## Actual behavior
  Both compile cleanly (no warnings) but produce wrong runtime output:
  ```
  0
  0
  0
  0
  ```

  (1) The `x = x + 1` side effects in the leading parens never ran, so `x` stayed at 0 and the parens evaluated to 0.
  (2) `b = (a = 5)` neither assigned `a` nor produced 5 — `b` stayed at 0.

  ## Analysis & fix
  Two compile_expr gaps:

  1. **`ParenthesesNode` with multiple statements** — `compile_expr` emitted only the LAST statement of `(s1; s2; ...; expr)`, dropping the leading ones. The `;`-separated form is rare in idiomatic Ruby but appears in mechanical translations (e.g. optcarrot's optimized PPU template) where each stmt is a side effect. We can't lower as a C comma-expression `(a, b)` because the parens may sit inside a larger expression like `expr1 + expr2`, and C leaves the evaluation order between `+`'s operands unspecified — interleaving two parens-with-side-effects would change semantics. Instead, emit the leading statements via `emit()` and bind the final value to a fresh temp before returning, so the C compiler can't interleave with another parens's side effects.

  2. **`LocalVariableWriteNode` / `LocalVariableOperatorWriteNode`** were missing from `compile_expr` — fell through to the default `"0"` return. So `@a = local = expr` and `@a = local OP= expr` chains silently zeroed the outer write. Lower as `(local = ...)` and `(local OP= ...)` parenthesized C-style assignments.