### PR TITLE
feat(codegen): Array#clear for typed arrays

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -22287,6 +22287,29 @@ class Compiler
             return 1
           end
         end
+        # Typed array Array#clear — zero the length (and start
+        # for IntArray, which uses a sliding window). Capacity
+        # and the backing buffer stay; subsequent pushes refill
+        # the slots from index 0.
+        if rt == "int_array" || rt == "sym_array"
+          rc = compile_expr_gc_rooted(recv)
+          emit("  " + rc + "->len = 0; " + rc + "->start = 0;")
+          return 1
+        end
+        if rt == "float_array" || rt == "poly_array" || is_ptr_array_type(rt) == 1
+          rc = compile_expr_gc_rooted(recv)
+          emit("  " + rc + "->len = 0;")
+          return 1
+        end
+        if rt == "str_array"
+          rc = compile_expr_gc_rooted(recv)
+          # StrArray has an inline-storage optimization: data may
+          # point to inline_data (small) or a malloc'd buffer.
+          # Either way, zeroing len is a clean reset — the next
+          # push refills from index 0.
+          emit("  " + rc + "->len = 0;")
+          return 1
+        end
       end
     end
 

--- a/test/array_clear_typed.rb
+++ b/test/array_clear_typed.rb
@@ -1,0 +1,40 @@
+# `Array#clear` on typed arrays used to fall through the
+# dispatcher and produce no C output, leaving the array
+# unchanged. Zero the length (and `start` for IntArray, which
+# uses a sliding window) so the next push refills from index 0.
+
+# IntArray
+ints = [1, 2, 3]
+ints.clear
+puts ints.length    # 0
+ints.push(7)
+puts ints[0]        # 7
+
+# SymArray (shares IntArray internally)
+syms = [:a, :b, :c]
+syms.clear
+puts syms.length    # 0
+
+# FloatArray
+floats = [1.5, 2.5, 3.5]
+floats.clear
+puts floats.length  # 0
+
+# StrArray
+strs = ["a", "b", "c"]
+strs.clear
+puts strs.length    # 0
+
+# PtrArray (array of objects)
+class Box
+  attr_reader :n
+  def initialize(n); @n = n; end
+end
+boxes = [Box.new(1), Box.new(2)]
+boxes.clear
+puts boxes.length   # 0
+
+# PolyArray (mixed-type elements)
+mixed = [1, "x", :sym, 4.5]
+mixed.clear
+puts mixed.length   # 0


### PR DESCRIPTION
## Code example
```ruby
ints = [1, 2, 3]
ints.clear
puts ints.length    # 0
ints.push(7)
puts ints[0]        # 7

syms = [:a, :b, :c]
syms.clear
puts syms.length    # 0

floats = [1.5, 2.5, 3.5]
floats.clear
puts floats.length  # 0

strs = ["a", "b", "c"]
strs.clear
puts strs.length    # 0

class Box
  attr_reader :n
  def initialize(n); @n = n; end
end
boxes = [Box.new(1), Box.new(2)]
boxes.clear
puts boxes.length   # 0

mixed = [1, "x", :sym, 4.5]
mixed.clear
puts mixed.length   # 0
```

## Expected behavior
`Array#clear` empties the array in place and returns the receiver. After `arr.clear`, `arr.length == 0` and the storage is reusable (subsequent pushes refill from index 0).

Output:
```
0
7
0
0
0
0
0
```

## Notes
The dispatcher already had a string-`#clear` path (truncate the buffer to empty) but no typed-array case — so `arr.clear` on IntArray / SymArray / FloatArray / StrArray / PtrArray / PolyArray fell through and emitted no C output, leaving the array untouched.

Implementation: zero `len` (and `start` for IntArray / SymArray, which use a sliding window over the backing buffer). Capacity and the malloc'd buffer stay; the next push refills from index 0.