### PR TITLE
fix(codegen): pin lexical scope while walking class bodies in scan_new_calls

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -1029,7 +1029,9 @@ class Compiler
       return ""
     end
     idx = name.rindex("_")
-    if idx < 0
+    # CRuby returns nil when not found; spinel runtime returns -1.
+    # Treat both as "no underscore — root scope".
+    if idx == nil || idx < 0
       return ""
     end
     name[0, idx]
@@ -6344,8 +6346,92 @@ class Compiler
     "poly"
   end
 
+  # Resolve a ClassNode AST id to its registered index in
+  # @cls_names, walking the same module-prefix chain that
+  # `resolve_const_read_name` / `find_class_idx` use at emit
+  # time. Returns -1 when the class isn't in @cls_names (e.g. a
+  # nested `class << self` body that hasn't been registered as a
+  # regular class).
+  def class_node_to_idx(nid)
+    cp = @nd_constant_path[nid]
+    if cp < 0
+      return -1
+    end
+    flat = const_ref_flat_name(cp)
+    if flat == ""
+      return -1
+    end
+    resolved = resolve_const_read_name(flat)
+    ci = find_class_idx(resolved)
+    if ci >= 0
+      return ci
+    end
+    find_class_idx(flat)
+  end
+
+  # Set @current_class_idx / @current_lexical_scope to the class
+  # introduced by `nid` (a ClassNode). No-op when the class isn't
+  # registered. Caller is responsible for save/restore.
+  def enter_class_scope_from_node(nid)
+    ci = class_node_to_idx(nid)
+    if ci >= 0
+      @current_class_idx = ci
+      @current_lexical_scope = @cls_names[ci]
+    end
+  end
+
+  # Append the module name introduced by `nid` (a ModuleNode) to
+  # `@current_lexical_scope`. Caller is responsible for save/
+  # restore. Mirrors the prefix pattern that
+  # `collect_module_with_prefix` uses for nested module names.
+  def enter_module_scope_from_node(nid)
+    cp = @nd_constant_path[nid]
+    if cp < 0
+      return
+    end
+    mname_s = const_ref_flat_name(cp)
+    if mname_s == ""
+      return
+    end
+    if @current_lexical_scope != ""
+      @current_lexical_scope = @current_lexical_scope + "_" + mname_s
+    else
+      @current_lexical_scope = mname_s
+    end
+  end
+
   def scan_new_calls(nid)
     if nid < 0
+      return
+    end
+    # When we descend into a class body, pin @current_class_idx so
+    # any `infer_type(@ivar)` in the args of a nested .new call
+    # resolves against this class's ivar table. Without this scope
+    # set-up, arguments like `@cpu` inside `Foo.initialize`'s
+    # body that contains `Bar.new(@cpu, ...)` infer as "int" (the
+    # default for an InstanceVariableReadNode with no scope), which
+    # then wedges Bar.initialize's first param at int even after
+    # multiple iterations of the fixpoint loop.
+    if @nd_type[nid] == "ClassNode"
+      saved_ci = @current_class_idx
+      saved_scope = @current_lexical_scope
+      enter_class_scope_from_node(nid)
+      body = @nd_body[nid]
+      if body >= 0
+        scan_new_calls(body)
+      end
+      @current_class_idx = saved_ci
+      @current_lexical_scope = saved_scope
+      return
+    end
+    if @nd_type[nid] == "ModuleNode"
+      saved_scope2 = @current_lexical_scope
+      enter_module_scope_from_node(nid)
+      body = @nd_body[nid]
+      if body >= 0
+        scan_new_calls(body)
+      end
+      @current_lexical_scope = saved_scope2
       return
     end
     if @nd_type[nid] == "CallNode"

--- a/test/scan_new_calls_class_scope.rb
+++ b/test/scan_new_calls_class_scope.rb
@@ -1,0 +1,35 @@
+# `scan_new_calls` walks the AST looking for `Foo.new(args)` and
+# propagates each arg's inferred type into Foo's initialize param-
+# type table. The arg inference uses `infer_type`, which for an
+# `InstanceVariableReadNode` consults `@current_class_idx` —
+# previously the scan never set it.
+#
+# Result: `Bar.new(@x, ...)` inside `Foo#initialize` resolved
+# `@x` against an empty scope (returned the int default), so
+# Bar.initialize's first param wedged at mrb_int. The fix pins
+# `@current_class_idx` while recursing into ClassNode bodies.
+
+class A
+  attr_reader :n
+  def initialize(n)
+    @n = n
+  end
+end
+
+class B
+  attr_reader :a
+  def initialize(a_arg)
+    @a = a_arg
+  end
+end
+
+class C
+  attr_reader :b
+  def initialize
+    @inner = A.new(7)
+    @b = B.new(@inner)
+  end
+end
+
+c = C.new
+puts c.b.a.n   # 7


### PR DESCRIPTION
## Reproduction
```ruby
class Helper
  attr_reader :n
  def initialize(n)
    @n = n
  end
end

class Box
  attr_reader :h
  def initialize(h_arg)
    @h = h_arg
  end
end

class Outer
  attr_reader :b
  def initialize
    @inner = Helper.new(7)
    @b = Box.new(@inner)
  end
end

puts Outer.new.b.h.n
```

## Expected behavior
`Box#initialize`'s `h_arg` parameter should be inferred as `obj_Helper` (a `sp_Helper *`) because the only call site `Box.new(@inner)` passes a `Helper` instance. Output:
```
7
```

## Actual behavior
gcc rejects `Box.new(@inner)` — `Box#initialize` was typed with a `mrb_int` first param while the call site passes `sp_Helper *`:
```
/tmp/_t.c: In function ‘sp_Outer_new’:
error: passing argument 2 of ‘sp_Box_new’ makes integer from pointer without a cast [-Wint-conversion]
       sp_Box_new(self->iv_inner)
                  ^~~~~~~~~~~~~~
note: expected ‘mrb_int’ {aka ‘long int’} but argument is of type ‘sp_Helper *’
```

## Analysis & fix
`scan_new_calls` walks the entire AST collecting `Foo.new(args)` patterns and propagates each arg's inferred type into `Foo#initialize`'s param-type table. For an `InstanceVariableReadNode` arg, the inference consults `@current_class_idx` (the surrounding class) to look up the ivar's recorded type — but the scan never set it.

So `@inner` inside `Outer#initialize` resolved against an empty scope (the int default for unresolved ivar reads) and `Box#initialize`'s first param wedged at `mrb_int`. The fixpoint loop ran multiple iterations but each one re-discovered the same `int` via the same scopeless lookup.

Fix: recurse explicitly into `ClassNode` / `ModuleNode` bodies in `scan_new_calls`, setting `@current_class_idx` (and `@current_lexical_scope` for nested module names) to the enclosing class's registered name first, then restoring on exit.

The class-name lookup walks the same module-prefix chain that emit-time uses (`resolve_const_read_name` → `find_class_idx`), so the search hits e.g. `Optcarrot_APU` for a `class APU` declared inside `module Optcarrot`. The lookup is extracted into a small helper `class_node_to_idx(nid)`, plus a parallel `enter_class_scope_from_node` / `enter_module_scope_from_node` for the actual scope-set so future scope-pinning passes can share the resolution logic.

Side fix: `trim_const_scope_once` hardened against `name.rindex("_")` returning `nil` under CRuby (the spinel runtime returns `-1`). The two-arg form `if idx == nil || idx < 0` covers both.