### PR TITLE
fix(codegen): default-arg inlining honors callee class scope

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -177,6 +177,12 @@ class Compiler
     @instance_eval_self_var = ""
     @instance_eval_self_type = ""
 
+    # During default-arg substitution, when the callee's default
+    # expression is inlined into the caller, `self_arrow` consults
+    # this override to route `self->iv_X` against the call's
+    # explicit receiver instead of the caller's self.
+    @self_override = ""
+
     # Yield/block tracking (parallel with meth_names / cls_meth_names)
     @meth_has_yield = []
     @cls_meth_has_yield = "".split(",")
@@ -10553,12 +10559,35 @@ class Compiler
   end
 
   def self_arrow
+    # `@self_override` lets default-arg substitution redirect `self`
+    # to an explicit receiver expression: when a callee's default
+    # expression is inlined into the caller, `self` would otherwise
+    # resolve to the caller's `self`, but the default was authored
+    # against the callee's instance. Store the bare expression
+    # (e.g. `lv_f`) and append the arrow / dot here.
+    if @self_override != nil && @self_override != ""
+      if @current_class_idx >= 0 && @cls_is_value_type[@current_class_idx] == 1
+        return @self_override + "."
+      end
+      return @self_override + "->"
+    end
     if @current_class_idx >= 0
       if @cls_is_value_type[@current_class_idx] == 1
         return "self."
       end
     end
     "self->"
+  end
+
+  # The C expression that should be used wherever bare `self`
+  # would normally appear (e.g. as the first arg to a same-class
+  # method dispatch). Defaults to `"self"`; default-arg inlining
+  # overrides it via `@self_override`.
+  def self_expr
+    if @self_override != nil && @self_override != ""
+      return @self_override
+    end
+    "self"
   end
 
   def subtree_has_ivar_write(nid)
@@ -15651,7 +15680,7 @@ class Compiler
             bp = "0"
           end
         end
-        return "sp_" + owner + "_" + sanitize_name(mname) + "(self" + build_call_tail(ca, bp) + ")"
+        return "sp_" + owner + "_" + sanitize_name(mname) + "(" + self_expr + build_call_tail(ca, bp) + ")"
       end
       # Check attr_readers (bare method call like `x` meaning self.x)
       readers = @cls_attr_readers[@current_class_idx].split(";")
@@ -20246,11 +20275,31 @@ class Compiler
         end
         result = result + aexpr
       else
-        # Caller omitted this trailing arg — emit the method's default.
+        # Caller omitted this trailing arg — emit the method's
+        # default expression. The default was authored in the
+        # callee's class scope, so any `self` / `@ivar` references
+        # need to resolve against the call's receiver, not the
+        # caller's self. Switch @current_class_idx and override
+        # `self_arrow` for the duration of the inline expansion.
         if k < defaults.length
           def_id = defaults[k].to_i
           if def_id >= 0
+            recv_for_default = @nd_receiver[nid]
+            saved_ci = @current_class_idx
+            saved_override = @self_override
+            if recv_for_default >= 0
+              # Materialize the recv into a C expression. Wrap in
+              # parens so any cast/operator chain stays self-
+              # contained when consumed as `(<recv>)->iv_X` (via
+              # `self_arrow`) or as the first arg of a same-class
+              # method call (via `self_expr`).
+              recv_c = compile_expr_gc_rooted(recv_for_default)
+              @self_override = "(" + recv_c + ")"
+              @current_class_idx = target_ci
+            end
             result = result + compile_expr(def_id)
+            @current_class_idx = saved_ci
+            @self_override = saved_override
           else
             result = result + "0"
           end

--- a/test/default_arg_callee_scope.rb
+++ b/test/default_arg_callee_scope.rb
@@ -1,0 +1,52 @@
+# When a callee method's default-arg expression reads from an
+# instance variable OR calls a same-class method without an
+# explicit receiver, the inlined expansion at the caller's site
+# must resolve against the call's *receiver* (and the callee's
+# class), not the caller's `self`. Naive inlining either fails to
+# compile or routes through the wrong vtable.
+
+# (1) Default reads `@ivar` — must resolve against the recv's
+# instance, not the caller's.
+class Wrapper
+  def initialize(seed)
+    @base = seed
+  end
+  def grab(target = @base * 10)
+    target
+  end
+end
+
+class Caller
+  def initialize
+    @w = Wrapper.new(3)
+  end
+  def go
+    @w.grab        # default `@base * 10` → 3 * 10 = 30
+  end
+end
+
+puts Caller.new.go      # 30
+
+# (2) Default calls a same-class bare method — must dispatch to
+# the *callee's* class, not the caller's. Caller defines its own
+# method by the same name, but Foo's default should still call
+# Foo's version.
+class Foo
+  def target
+    1
+  end
+  def foo(opt = target)
+    opt
+  end
+end
+
+class Bar
+  def target
+    2          # different value — must NOT be picked up
+  end
+  def check
+    Foo.new.foo
+  end
+end
+
+puts Bar.new.check       # 1 (Foo#target, not Bar#target)


### PR DESCRIPTION
## Reproduction

```ruby
class Wrapper
  def initialize(seed)
    @base = seed
  end
  def grab(target = @base * 10)
    target
  end
end

class Caller
  def initialize
    @w = Wrapper.new(3)
  end
  def go
    @w.grab            # default `@base * 10` should read Wrapper#@base
  end
end

puts Caller.new.go     # expected: 30


class Foo
  def target; 1; end
  def foo(opt = target)
    opt
  end
end

class Bar
  def target; 2; end   # different value — must NOT be picked up
  def check
    Foo.new.foo        # default `target` should dispatch to Foo#target
  end
end

puts Bar.new.check     # expected: 1
```

## Expected

```
30
1
```

## Actual

The first case fails to compile:

```
sp_t.c: In function ‘sp_Caller_go’:
sp_t.c:65:44: error: ‘sp_Caller’ {aka ‘struct sp_Caller_s’} has no member named ‘iv_base’
   65 |     return sp_Wrapper_grab(self.iv_w, (self.iv_base * 10));
      |                                            ^
```

The second case compiles but prints `2` instead of `1`:

```c
static inline mrb_int sp_Bar_check(sp_Bar *self) {
    sp_Foo *_t1 = sp_Foo_new();
    return sp_Foo_foo(_t1, sp_Bar_target(self));   // Bar#target, not Foo#target
}
```

## Analysis

`compile_typed_call_args` substitutes the callee's default-arg expression
inline at the caller's site for omitted trailing args. The default was
authored in the callee's class scope (`@base`, bare `target`), so its
`self` should bind to the call's receiver, but the inlined expression
was being compiled under the caller's `@current_class_idx` and emitting
references against the caller's `self`.

## Fix

For the inline expansion only:

- Switch `@current_class_idx` to the callee class so bare-call resolution
  (`compile_call_expr`'s lexical-scope branch) finds the callee's methods.
- Set a new `@self_override` to the explicit receiver expression.
  `self_arrow` (used by ivar reads) consults it to emit `(<recv>)->iv_X`,
  and `self_expr` (used as the first arg of same-class method calls)
  returns `<recv>` instead of `"self"`.
- Materialize the receiver via `compile_expr_gc_rooted` once and wrap it
  in parens so any cast or operator chain stays self-contained when
  consumed as `(<recv>)->iv_X` or `<recv>` in arg position.

After the fix, the same callsites emit:

```c
return sp_Wrapper_grab(self.iv_w, ((self.iv_w).iv_base * 10));
return sp_Foo_foo(_t1, sp_Foo_target((_t2)));
```

The receiver is reused (no double-eval), the ivar is read against the
callee's instance, and the bare call dispatches to the callee's class.

Test: `test/default_arg_callee_scope.rb` covers both the ivar-read and
bare-method-call patterns.