### PR TITLE
feat(codegen): Range#map { |i| ... }

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -25814,6 +25814,93 @@ class Compiler
     end
     tmp_arr = new_temp
     tmp_i = new_temp
+    # Range#map: iterate i from first to last (inclusive when ..,
+    # exclusive when ...). The receiver isn't a Range value-type
+    # we can hold in a temp the way arrays are — recompile the
+    # endpoints directly. ParenthesesNode (e.g. `(1..8).map {...}`)
+    # is unwrapped first, since it parses as
+    # CallNode(recv=ParenthesesNode(stmt=RangeNode), name=map).
+    if rt == "range"
+      block_ret_r = "int"
+      blk_r = @nd_block[nid]
+      if blk_r >= 0
+        body_r = @nd_body[blk_r]
+        if body_r >= 0
+          stmts_r = get_stmts(body_r)
+          if stmts_r.length > 0
+            block_ret_r = infer_type(stmts_r.last)
+          end
+        end
+      end
+      # Only handle scalar block returns inline; an array-returning
+      # block (`(0..n).map { |i| [i, ...] }`) would make this an
+      # array-of-arrays, which the int/str/float push helpers can't
+      # express. Fall through to the "0" placeholder for those — the
+      # generic int_array typing keeps any follow-up `@x = [...]`
+      # assignment to the same slot type-checking.
+      if block_ret_r != "int" && block_ret_r != "string" && block_ret_r != "float"
+        return "0"
+      end
+      @needs_int_array = 1
+      @needs_gc = 1
+      if block_ret_r == "string"
+        @needs_str_array = 1
+        emit("  sp_StrArray *" + tmp_arr + " = sp_StrArray_new();")
+      elsif block_ret_r == "float"
+        @needs_float_array = 1
+        emit("  sp_FloatArray *" + tmp_arr + " = sp_FloatArray_new();")
+      else
+        emit("  sp_IntArray *" + tmp_arr + " = sp_IntArray_new();")
+      end
+      rng_id = @nd_receiver[nid]
+      while rng_id >= 0 && @nd_type[rng_id] == "ParenthesesNode"
+        body_pn = @nd_body[rng_id]
+        if body_pn >= 0
+          ps = get_stmts(body_pn)
+          if ps.length > 0
+            rng_id = ps.last
+          else
+            rng_id = -1
+          end
+        else
+          rng_id = -1
+        end
+      end
+      first_e = compile_expr(@nd_left[rng_id])
+      last_e = compile_expr(@nd_right[rng_id])
+      excl = range_excl_end(rng_id) == 1 ? "<" : "<="
+      emit("  for (mrb_int " + tmp_i + " = " + first_e + "; " + tmp_i + " " + excl + " " + last_e + "; " + tmp_i + "++) {")
+      have_bp_r = (get_block_param(nid, 0) != "")
+      if have_bp_r
+        declare_var(bp1, "int")
+        emit("    lv_" + bp1 + " = " + tmp_i + ";")
+      end
+      @indent = @indent + 1
+      if blk_r >= 0
+        body_r2 = @nd_body[blk_r]
+        if body_r2 >= 0
+          stmts_r2 = get_stmts(body_r2)
+          k_r = 0
+          while k_r < stmts_r2.length - 1
+            compile_stmt(stmts_r2[k_r])
+            k_r = k_r + 1
+          end
+          if stmts_r2.length > 0
+            lastv_r = compile_expr(stmts_r2.last)
+            if block_ret_r == "string"
+              emit("  sp_StrArray_push(" + tmp_arr + ", " + lastv_r + ");")
+            elsif block_ret_r == "float"
+              emit("  sp_FloatArray_push(" + tmp_arr + ", " + lastv_r + ");")
+            else
+              emit("  sp_IntArray_push(" + tmp_arr + ", " + lastv_r + ");")
+            end
+          end
+        end
+      end
+      @indent = @indent - 1
+      emit("  }")
+      return tmp_arr
+    end
     if rt == "int_array" || rt == "sym_array"
       @needs_int_array = 1
       @needs_gc = 1

--- a/test/range_map.rb
+++ b/test/range_map.rb
@@ -1,0 +1,20 @@
+# Range#map (and the parenthesised form `(a..b).map { ... }`,
+# which is what Ruby parsers usually produce). The compile path
+# in spinel used to fall through to the default `"0"` return for
+# Range receivers, so `tt = (0..3).map { |i| i * 10 }` silently
+# became `tt = 0` and any subsequent `.each` / `[i]` was a bit
+# shift, not an array op.
+
+# Inclusive range, simple body
+puts (0..3).map { |i| i * 10 }.length      # 4
+puts (0..3).map { |i| i * 10 }[2]          # 20
+
+# Exclusive range
+puts (0...3).map { |i| i }.length          # 3
+puts (0...3).map { |i| i }[2]              # 2
+
+# String result
+puts ((1..3).map { |i| "x#{i}" }.join(","))   # x1,x2,x3
+
+# Float result
+puts ((0...3).map { |i| i * 0.5 }.length)     # 3


### PR DESCRIPTION
## Reproduction

```ruby
puts (0..3).map { |i| i * 10 }.length      # expected: 4
puts (0..3).map { |i| i * 10 }[2]          # expected: 20
puts (0...3).map { |i| i }.length          # expected: 3
puts ((1..3).map { |i| "x#{i}" }.join(",")) # expected: x1,x2,x3
```

## Expected

```
4
20
3
x1,x2,x3
```

## Actual

```
0
0
0
```

`compile_map_expr` had no Range branch, so `(0..N).map { ... }`
fell through to the default `"0"` return. The result silently
became an `int` placeholder and any follow-up `.length`, `[i]`,
`.join(...)` lowered to bit shifts on `0`.

## Fix

Add a Range branch in `compile_map_expr` that emits a plain C
`for` loop and pushes each block result into a fresh `IntArray`
/ `StrArray` / `FloatArray`.

Two details:

- ParenthesesNode is unwrapped before reading the range
  endpoints — `(1..8).map { ... }` parses as
  `CallNode(recv=ParenthesesNode(stmt=RangeNode))`, so reading
  `@nd_left` / `@nd_right` directly off the recv would return
  garbage.
- Block returns that aren't `int` / `string` / `float` (e.g. an
  array literal — `(0..n).map { |i| [i, i*10] }`) fall through
  to the original `"0"` placeholder. The outer map's result type
  in those cases is array-of-arrays, which the int/str/float
  push helpers can't express; preserving the placeholder keeps
  the existing typing where a follow-up `@x = [...]`
  re-assignment to the same slot still type-checks.

Test: `test/range_map.rb` covers inclusive / exclusive range,
`int` / `string` / `float` block returns. The existing
`test/map_range_recv_array_block.rb` continues to exercise the
fall-through case.