### PR TITLE
feat(codegen+runtime): File.binread + binread(path).bytes

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -783,6 +783,28 @@ static void sp_file_delete(const char *path) { remove(path); }
 static const char *sp_backtick(const char *cmd) { FILE *p = popen(cmd, "r"); if (!p) return sp_str_empty; char *buf = sp_str_alloc_raw(4096); size_t n = fread(buf, 1, 4095, p); buf[n] = 0; pclose(p); return buf; }
 static const char *sp_file_basename(const char *path) { const char *s = strrchr(path, '/'); if (s) return s + 1; return path; }
 
+/* Read a file's bytes into a fresh IntArray. Distinct from
+   `sp_str_bytes(sp_file_read(path))` because plain sp_str_bytes uses
+   null-termination and stops at the first 0x00 byte — wrong for
+   binary data (e.g. .nes ROM files). */
+static sp_IntArray *sp_file_binread_bytes(const char *path) {
+  FILE *f = fopen(path, "rb");
+  sp_IntArray *a = sp_IntArray_new();
+  if (!f) return a;
+  fseek(f, 0, SEEK_END);
+  long sz = ftell(f);
+  fseek(f, 0, SEEK_SET);
+  unsigned char *buf = (unsigned char *)malloc(sz > 0 ? (size_t)sz : 1);
+  if (sz > 0) {
+    size_t r = fread(buf, 1, sz, f);
+    (void)r;
+    for (long i = 0; i < sz; i++) sp_IntArray_push(a, (mrb_int)buf[i]);
+  }
+  free(buf);
+  fclose(f);
+  return a;
+}
+
 typedef struct sp_Proc { void *fn; void *cap; void (*cap_scan)(void *); } sp_Proc;
 static void sp_Proc_scan(void *p) { sp_Proc *pr = (sp_Proc *)p; if (pr->cap && pr->cap_scan) pr->cap_scan(pr->cap); }
 static sp_Proc *sp_proc_new(void *fn, void *cap, void (*cap_scan)(void *)) { sp_Proc *p = (sp_Proc *)sp_gc_alloc(sizeof(sp_Proc), NULL, sp_Proc_scan); p->fn = fn; p->cap = cap; p->cap_scan = cap_scan; return p; }

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -3156,7 +3156,7 @@ class Compiler
       if @nd_type[recv] == "ConstantReadNode"
         rcname = @nd_name[recv]
         if rcname == "File"
-          if mname == "read"
+          if mname == "read" || mname == "binread"
             return "string"
           end
           if mname == "exist?"
@@ -16818,6 +16818,28 @@ class Compiler
     if mname == "bytes"
       @needs_int_array = 1
       @needs_gc = 1
+      # `File.binread(path).bytes` — sp_str_bytes uses null-termination
+      # so it stops at the first 0x00 byte, which is wrong for binary
+      # data (e.g. .nes ROM files). Pattern-match the chained call
+      # and emit a single binread-to-IntArray helper that reads with
+      # the file's actual byte count.
+      r = @nd_receiver[nid]
+      if r >= 0 && @nd_type[r] == "CallNode"
+        rmname = @nd_name[r]
+        if rmname == "binread"
+          rr = @nd_receiver[r]
+          if rr >= 0 && @nd_type[rr] == "ConstantReadNode" && @nd_name[rr] == "File"
+            rargs = @nd_arguments[r]
+            if rargs >= 0
+              ras = get_args(rargs)
+              if ras.length >= 1
+                @needs_file_io = 1
+                return "sp_file_binread_bytes(" + compile_expr(ras[0]) + ")"
+              end
+            end
+          end
+        end
+      end
       return "sp_str_bytes(" + rc + ")"
     end
     if mname == "hex"
@@ -18662,7 +18684,7 @@ class Compiler
       end
       # File operations
       if rcname == "File"
-        if mname == "read"
+        if mname == "read" || mname == "binread"
           return "sp_file_read(" + compile_arg0(nid) + ")"
         end
         if mname == "exist?"

--- a/test/file_binread.rb
+++ b/test/file_binread.rb
@@ -1,0 +1,32 @@
+# `File.binread(path).bytes` — sp_str_bytes uses null-termination
+# and stops at the first 0x00 byte, so for binary data (e.g. .nes
+# ROM files where 0x00 appears mid-file) we need a dedicated
+# helper that reads with the actual file size.
+#
+# `File.binread(path)` standalone is aliased to File.read.
+
+# Set up a binary file with embedded NULs via a shell command.
+# spinel's File.write uses fputs and would stop at the first NUL.
+path = "/tmp/spinel_binread_test.bin"
+`printf 'AB\\000CD\\000EF' > #{path}`
+
+# Pattern-matched: emits sp_file_binread_bytes(path) which reads
+# the file by its actual byte count, NOT through sp_str_bytes.
+arr = File.binread(path).bytes
+puts arr.length               # 8
+puts arr[0]                   # 65 (A)
+puts arr[1]                   # 66 (B)
+puts arr[2]                   # 0  (NUL)
+puts arr[3]                   # 67 (C)
+puts arr[4]                   # 68 (D)
+puts arr[5]                   # 0  (NUL)
+puts arr[6]                   # 69 (E)
+puts arr[7]                   # 70 (F)
+
+# `File.binread` standalone aliases `File.read`. spinel's strings
+# are null-terminated so any NUL in the result is a hard stop —
+# this branch is just verifying the alias resolves and returns
+# something string-shaped.
+puts File.binread(path)[0, 2] # AB
+
+File.delete(path) if File.exist?(path)


### PR DESCRIPTION
# Reproduction

```ruby
# Set up a binary file with embedded NUL bytes via shell
# (spinel's File.write uses fputs and would stop at the first NUL).
path = "/tmp/binread_test.bin"
`printf 'AB\\000CD\\000EF' > #{path}`

arr = File.binread(path).bytes
puts arr.length    # expected: 8
puts arr[2]        # expected: 0
puts arr[5]        # expected: 0
puts arr[7]        # expected: 70 (F)
```

## Expected

```
8
0
0
70
```

## Actual

```
warning: cannot resolve call to 'binread' on class_File (emitting 0)
0
0
0
0
```

`File.binread` was unresolved, so the chained `.bytes` operated
on `0` and returned an empty IntArray.

Even after wiring `File.binread` to `sp_file_read` (the same path
as `File.read`), the chained `.bytes` would still be wrong: plain
`sp_str_bytes` walks until the C-string NUL terminator, so for
binary data with embedded `0x00` bytes (e.g. `.nes` ROM files) it
returns a truncated array.

## Fix

Two pieces:

1. **`File.binread` aliased to `File.read`**. Both lower to
   `sp_file_read`. Wired in `infer_method_name_type` (returns
   `"string"`) and the `File`-constant codegen dispatcher.

2. **`File.binread(path).bytes` pattern-matched** in the `bytes`
   codegen path and lowered to a new `sp_file_binread_bytes`
   runtime helper. The helper opens the file, `fseek`s to the
   end to learn the actual byte count, then reads the full
   payload into a fresh `IntArray` — no NUL truncation.

Test: `test/file_binread.rb` writes a file with embedded NULs
via shell `printf`, reads it back through both forms, and checks
that the IntArray contains all 8 bytes including the NULs.