### PR TITLE
fix(codegen): SplatNode inside Array literal — `[*range]` / `[*arr]`

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -20442,8 +20442,35 @@ class Compiler
     emit("  sp_IntArray *" + tmp + " = sp_IntArray_new();")
     k = 0
     while k < elems.length
-      ev = compile_expr(elems[k])
-      et = infer_type(elems[k])
+      eid = elems[k]
+      # SplatNode in an Array literal — `[*range]` or `[*arr]` —
+      # expands the inner expression's elements into the array.
+      # Without this branch, compile_expr lowered the splat to a
+      # default value (e.g., the lower bound of a Range), so
+      # `[*0..4096]` ended up as just `[0]`.
+      if @nd_type[eid] == "SplatNode"
+        inner = @nd_expression[eid]
+        it = infer_type(inner)
+        if @nd_type[inner] == "RangeNode"
+          lo = compile_expr(@nd_left[inner])
+          hi = compile_expr(@nd_right[inner])
+          cmp = range_excl_end(inner) == 1 ? "<" : "<="
+          ii = new_temp
+          emit("  for (mrb_int " + ii + " = " + lo + "; " + ii + " " + cmp + " " + hi + "; " + ii + "++) {")
+          emit("    sp_IntArray_push(" + tmp + ", " + ii + ");")
+          emit("  }")
+        elsif it == "int_array"
+          src = compile_expr(inner)
+          ii = new_temp
+          emit("  for (mrb_int " + ii + " = 0; " + ii + " < sp_IntArray_length(" + src + "); " + ii + "++) {")
+          emit("    sp_IntArray_push(" + tmp + ", sp_IntArray_get(" + src + ", " + ii + "));")
+          emit("  }")
+        end
+        k = k + 1
+        next
+      end
+      ev = compile_expr(eid)
+      et = infer_type(eid)
       # Unbox poly values when pushing into a (concrete) IntArray.
       # An ArrayNode literal whose elements are poly (e.g.
       # `[addr]` where addr's recorded type is sp_RbVal) needs the

--- a/test/array_splat_range.rb
+++ b/test/array_splat_range.rb
@@ -1,0 +1,23 @@
+# `[*0..n]` and `[*arr]` are array literals with a SplatNode element.
+# Without SplatNode handling in compile_array_literal, the splat was
+# lowered to a single default value (e.g., just the range's lower
+# bound), so `[*0..4096]` produced a 1-element array. This broke
+# optcarrot's dummy palette and made every `palette[i]` for i > 0
+# read out-of-bounds garbage.
+
+a = [*0..5]
+puts a.length
+puts a[0]
+puts a[3]
+puts a[5]
+
+b = [*0...4]
+puts b.length
+puts b[0]
+puts b[3]
+
+src = [10, 20, 30]
+c = [*src]
+puts c.length
+puts c[0]
+puts c[2]


### PR DESCRIPTION
## Reproduction

```ruby
a = [*0..5]
puts a.length    # expected: 6
puts a[3]        # expected: 3
puts a[5]        # expected: 5

src = [10, 20, 30]
b = [*src]
puts b.length    # expected: 3
puts b[2]        # expected: 30
```

## Expected

```
6
3
5
3
30
```

## Actual

```
1
0
0
1
10
```

`[*range]` and `[*arr]` both lowered to a single-element array
holding whatever `compile_expr` returned for the `SplatNode` —
the lower bound of the Range, or just the array's first element.

## Fix

`compile_array_literal` had no `SplatNode` branch — `compile_expr`
on the splat node returned the inner expression's default value.
Detect `SplatNode` in array-literal elements and expand it inline:

- `RangeNode` source: emit a C `for` loop bounded by the
  inclusive (`..`) / exclusive (`...`) endpoints, push each `i`
  into the accumulator.
- `int_array` source: walk with `sp_IntArray_get` and push.

Optcarrot hit this in `@palette = [*0..4096]` — the palette
ended up as just `[0]`, breaking every `palette[i]` lookup
later in the rendering path.

Test: `test/array_splat_range.rb` covers inclusive range,
exclusive range, and a splat-of-existing-IntArray.