### PR TITLE
Fix GC marking for poly arrays and poly ivars

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -711,8 +711,11 @@ static sp_RbVal sp_poly_neg(sp_RbVal a) { if (a.tag == SP_TAG_FLT) return sp_box
 
 /* PolyArray: array of sp_RbVal */
 typedef struct { sp_RbVal *data; mrb_int len; mrb_int cap; } sp_PolyArray;
-static sp_PolyArray *sp_PolyArray_new(void) { sp_PolyArray *a = (sp_PolyArray *)sp_gc_alloc(sizeof(sp_PolyArray), NULL, NULL); a->cap = 16; a->data = (sp_RbVal *)malloc(sizeof(sp_RbVal) * a->cap); a->len = 0; return a; }
-static void sp_PolyArray_push(sp_PolyArray *a, sp_RbVal v) { if (a->len >= a->cap) { a->cap = a->cap * 2 + 1; a->data = (sp_RbVal *)realloc(a->data, sizeof(sp_RbVal) * a->cap); } a->data[a->len++] = v; }
+static inline void sp_mark_rbval(sp_RbVal v);
+static void sp_PolyArray_scan(void *p) { sp_PolyArray *a = (sp_PolyArray *)p; for (mrb_int i = 0; i < a->len; i++) sp_mark_rbval(a->data[i]); }
+static void sp_PolyArray_fin(void *p) { sp_PolyArray *a = (sp_PolyArray *)p; sp_gc_hdr *h = (sp_gc_hdr *)((char *)a - sizeof(sp_gc_hdr)); sp_gc_bytes -= sizeof(sp_RbVal) * a->cap; h->size -= sizeof(sp_RbVal) * a->cap; free(a->data); }
+static sp_PolyArray *sp_PolyArray_new(void) { sp_PolyArray *a = (sp_PolyArray *)sp_gc_alloc(sizeof(sp_PolyArray), sp_PolyArray_fin, sp_PolyArray_scan); a->cap = 16; a->data = (sp_RbVal *)malloc(sizeof(sp_RbVal) * a->cap); a->len = 0; { sp_gc_hdr *h = (sp_gc_hdr *)((char *)a - sizeof(sp_gc_hdr)); h->size += sizeof(sp_RbVal) * a->cap; sp_gc_bytes += sizeof(sp_RbVal) * a->cap; } return a; }
+static void sp_PolyArray_push(sp_PolyArray *a, sp_RbVal v) { if (a->len >= a->cap) { sp_gc_hdr *h = (sp_gc_hdr *)((char *)a - sizeof(sp_gc_hdr)); sp_gc_bytes -= sizeof(sp_RbVal) * a->cap; h->size -= sizeof(sp_RbVal) * a->cap; a->cap = a->cap * 2 + 1; a->data = (sp_RbVal *)realloc(a->data, sizeof(sp_RbVal) * a->cap); h->size += sizeof(sp_RbVal) * a->cap; sp_gc_bytes += sizeof(sp_RbVal) * a->cap; } a->data[a->len++] = v; }
 static mrb_int sp_PolyArray_length(sp_PolyArray *a) { return a->len; }
 static sp_RbVal sp_PolyArray_get(sp_PolyArray *a, mrb_int i) { if (i < 0) i += a->len; return a->data[i]; }
 static sp_PolyArray *sp_PolyArray_slice(sp_PolyArray *a, mrb_int start, mrb_int len) { if (start < 0) start += a->len; if (start < 0) start = 0; sp_PolyArray *b = sp_PolyArray_new(); if (start >= a->len || len <= 0) return b; if (start + len > a->len) len = a->len - start; for (mrb_int i = 0; i < len; i++) sp_PolyArray_push(b, a->data[start + i]); return b; }

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -11858,6 +11858,9 @@ class Compiler
   end
 
   def ivar_is_gc_ptr(t)
+    if t == "poly"
+      return 1
+    end
     if is_obj_type(t) == 1
       if is_value_type_obj(t) == 1
         return 0
@@ -11891,6 +11894,14 @@ class Compiler
     0
   end
 
+  def emit_gc_mark_ivar(field, t)
+    if t == "poly"
+      emit_raw("  sp_mark_rbval(" + field + ");")
+    else
+      emit_raw("  if (" + field + ") sp_gc_mark((void *)" + field + ");")
+    end
+  end
+
   def emit_gc_scan_functions
     i = 0
     while i < @cls_names.length
@@ -11904,7 +11915,7 @@ class Compiler
         while j < names.length
           if j < types.length
             if ivar_is_gc_ptr(types[j]) == 1
-              emit_raw("  if (self->" + sanitize_ivar(names[j]) + ") sp_gc_mark((void *)self->" + sanitize_ivar(names[j]) + ");")
+              emit_gc_mark_ivar("self->" + sanitize_ivar(names[j]), types[j])
             end
           end
           j = j + 1
@@ -11919,7 +11930,7 @@ class Compiler
             while pj < pnames.length
               if pj < ptypes.length
                 if ivar_is_gc_ptr(ptypes[pj]) == 1
-                  emit_raw("  if (self->" + sanitize_ivar(pnames[pj]) + ") sp_gc_mark((void *)self->" + sanitize_ivar(pnames[pj]) + ");")
+                  emit_gc_mark_ivar("self->" + sanitize_ivar(pnames[pj]), ptypes[pj])
                 end
               end
               pj = pj + 1
@@ -12521,9 +12532,9 @@ class Compiler
             ivar_name = @nd_name[sid]
             ivar = sanitize_ivar(ivar_name)
             expr_id_iv = @nd_expression[sid]
-            # Match the special-case in compile_stmt: an empty `{}`
+            # Match the special-case in compile_stmt: empty `{}` / `[]`
             # assigned to an ivar promoted by scan_writer_calls needs
-            # the matching `sp_*Hash_new()` constructor (issue #64).
+            # the matching container constructor.
             ivt = cls_ivar_type(@current_class_idx, ivar_name)
             iv_ctor = ""
             if is_empty_hash_literal(expr_id_iv) == 1 && ivt != "" && ivt != "str_int_hash"
@@ -12544,6 +12555,9 @@ class Compiler
               elsif ivt == "sym_poly_hash"
                 iv_ctor = "sp_SymPolyHash_new()"
               end
+            end
+            if iv_ctor == "" && is_empty_array_literal(expr_id_iv) == 1 && ivt != ""
+              iv_ctor = empty_array_new_for_type(ivt)
             end
             if iv_ctor != ""
               @needs_gc = 1
@@ -21439,11 +21453,10 @@ class Compiler
     if t == "InstanceVariableWriteNode"
       iname = @nd_name[nid]
       expr_id = @nd_expression[nid]
-      # Empty `{}` literal assigned to an ivar that scan_writer_calls
-      # has promoted to a non-default hash type. compile_hash_literal
-      # always returns `sp_StrIntHash_new()` for empty `{}`, so without
-      # this special-case the ivar slot's type and the initializer's
-      # type disagree (issue #64).
+      # Empty `{}` / `[]` literal assigned to an ivar that scan_writer_calls
+      # has promoted to a non-default container type. The literal emitters use
+      # default empty container types, so without this special-case the ivar
+      # slot's type and the initializer's type can disagree.
       ivt = ""
       if @current_class_idx >= 0
         ivt = cls_ivar_type(@current_class_idx, iname)
@@ -21467,6 +21480,14 @@ class Compiler
         elsif ivt == "sym_poly_hash"
           ctor = "sp_SymPolyHash_new()"
         end
+        if ctor != ""
+          @needs_gc = 1
+          emit("  " + self_arrow + sanitize_ivar(iname) + " = " + ctor + ";")
+          return
+        end
+      end
+      if is_empty_array_literal(expr_id) == 1 && ivt != ""
+        ctor = empty_array_new_for_type(ivt)
         if ctor != ""
           @needs_gc = 1
           emit("  " + self_arrow + sanitize_ivar(iname) + " = " + ctor + ";")

--- a/test/poly_gc.rb
+++ b/test/poly_gc.rb
@@ -1,0 +1,39 @@
+class Trash
+  def initialize(n)
+    @n = n
+    @s = "padding payload " * 64
+  end
+end
+
+class Holder
+  def initialize(value)
+    @value = value
+  end
+
+  attr_reader :value
+end
+
+def make_poly_array
+  value = "array-" + 123.to_s
+  [value, 1]
+end
+
+def make_holder
+  value = "ivar-" + 456.to_s
+  Holder.new(value)
+end
+
+values = make_poly_array
+holder = make_holder
+Holder.new(1)
+
+junk = []
+i = 0
+while i < 5000
+  junk << Trash.new(i)
+  i = i + 1
+end
+
+puts junk.length
+puts values[0]
+puts holder.value


### PR DESCRIPTION
## Summary

Fix GC and constructor correctness for polymorphic container/slot paths:

- mark every boxed element in `sp_PolyArray`
- add a `sp_PolyArray` finalizer and account its backing buffer in `sp_gc_bytes`
- emit `sp_mark_rbval` for instance variables inferred as `poly`
- emit the resolved container constructor for empty `[]` ivar initializers after type promotion
- add a regression test covering poly arrays and poly ivars under GC pressure

## Root Cause

`sp_PolyArray_new()` allocated arrays with `scan = NULL`, so the collector did not traverse boxed elements. The backing buffer was also allocated with `malloc` but had no finalizer or byte accounting, unlike the other runtime array types.

Generated GC scanners also skipped ivars whose type was `poly`, even though those slots can hold boxed strings and objects.

Separately, empty array ivar initializers kept emitting the default `sp_IntArray_new()` constructor even after later writes promoted the ivar to a more specific array type. That produced generated C where the struct field and initializer disagreed.

Closes #196.
Closes #200.

## Validation

```text
make
gen2.c == gen3.c (bootstrap OK)

make test
Tests: 243 pass, 0 fail, 0 error
```

I also checked the strict compile repro from #200 with `-Werror=incompatible-pointer-types`; it now emits `sp_FloatArray_new()` for the promoted empty-array ivar and compiles successfully.
