### PR TITLE
fix(codegen): SP_GC_ROOT map accumulators against deep-nested allocation

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -25867,6 +25867,12 @@ class Compiler
       if block_ret == "string"
         @needs_str_array = 1
         emit("  sp_StrArray *" + tmp_arr + " = sp_StrArray_new();")
+        # Root the accumulator: a nested map block (e.g. each
+        # iteration allocates many inner objects via sp_*_new) can
+        # trigger GC between pushes; without rooting, the outer
+        # accumulator is collected mid-loop and the next push
+        # corrupts the freed buffer.
+        emit("  SP_GC_ROOT(" + tmp_arr + ");")
         emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_IntArray_length(" + rc + "); " + tmp_i + "++) {")
         if bp_is_lambda == 1
           emit("    sp_Val * lv_" + bp1 + " = (sp_Val *)sp_IntArray_get(" + rc + ", " + tmp_i + ");")
@@ -25892,6 +25898,7 @@ class Compiler
         return tmp_arr
       else
         emit("  sp_IntArray *" + tmp_arr + " = sp_IntArray_new();")
+        emit("  SP_GC_ROOT(" + tmp_arr + ");")
         emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_IntArray_length(" + rc + "); " + tmp_i + "++) {")
         if bp_is_lambda == 1
           emit("    sp_Val * lv_" + bp1 + " = (sp_Val *)sp_IntArray_get(" + rc + ", " + tmp_i + ");")
@@ -25938,6 +25945,7 @@ class Compiler
       if block_ret == "int"
         @needs_int_array = 1
         emit("  sp_IntArray *" + tmp_arr + " = sp_IntArray_new();")
+        emit("  SP_GC_ROOT(" + tmp_arr + ");")
         emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_StrArray_length(" + rc + "); " + tmp_i + "++) {")
         # Declare lv_<bp> with the block-local type inside the for body
         # so it C-shadows any outer same-named local (Ruby block-local
@@ -25967,6 +25975,7 @@ class Compiler
       end
       @needs_str_array = 1
       emit("  sp_StrArray *" + tmp_arr + " = sp_StrArray_new();")
+      emit("  SP_GC_ROOT(" + tmp_arr + ");")
       emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_StrArray_length(" + rc + "); " + tmp_i + "++) {")
       # Block-local C decl, see note in the int-block branch above.
       emit("    const char *lv_" + bp1 + " = sp_StrArray_get(" + rc + ", " + tmp_i + ");")

--- a/test/gc_root_map_accumulator.rb
+++ b/test/gc_root_map_accumulator.rb
@@ -1,0 +1,61 @@
+# A nested map block — outer iteration allocates plenty of inner
+# objects via sp_*_new — can trigger a GC pass between pushes
+# into the outer accumulator. Without rooting the accumulator,
+# GC frees it as unreachable; the next push then writes into
+# freed memory and corrupts malloc bookkeeping, surfacing as a
+# SIGSEGV in _int_malloc on the next allocation.
+#
+# Each .map below crosses spinel's 256KB GC threshold mid-loop
+# (each block iteration allocates a discarded scratch string
+# alongside the kept result), so the outer accumulator must be
+# rooted to survive a collection.
+
+# (1) int_array recv → StrArray accumulator (string-return block).
+ints = []
+i = 0
+while i < 20000
+  ints << i
+  i += 1
+end
+
+r1 = ints.map do |x|
+  _scratch = "scratch-#{x}-discarded-inner-allocation-padding"
+  "kept-string-value-#{x}"
+end
+puts r1.length            # 20000
+puts r1[0]                # kept-string-value-0
+puts r1[19999][-3, 3]     # 999
+
+# (2) int_array recv → IntArray accumulator (int-return block).
+r2 = ints.map do |x|
+  _scratch = "scratch-#{x}-discarded-inner-allocation-padding"
+  x * 2
+end
+puts r2.length            # 20000
+puts r2[0]                # 0
+puts r2[19999]            # 39998
+
+# (3) str_array recv → StrArray accumulator (string-return block).
+strs = []
+i = 0
+while i < 20000
+  strs << "src-#{i}"
+  i += 1
+end
+
+r3 = strs.map do |s|
+  _scratch = "scratch-#{s}-discarded-inner-allocation-padding"
+  "out-#{s}"
+end
+puts r3.length            # 20000
+puts r3[0]                # out-src-0
+puts r3[19999][-3, 3]     # 999
+
+# (4) str_array recv → IntArray accumulator (int-return block).
+r4 = strs.map do |s|
+  _scratch = "scratch-#{s}-discarded-inner-allocation-padding"
+  s.length
+end
+puts r4.length            # 20000
+puts r4[0]                # 5  (out-0 → "src-0")
+puts r4[19999]            # 9  ("src-19999")


### PR DESCRIPTION
## What

`compile_map_expr`'s int_array and str_array recv branches build
a fresh `IntArray` / `StrArray` accumulator, then loop pushing
each block result. The accumulator was not registered as a GC
root, so a GC pass triggered mid-loop (by allocations inside the
block, e.g. string interpolation) freed the buffer as
unreachable; the next push wrote into freed memory and corrupted
malloc bookkeeping, surfacing as a SIGSEGV in `_int_malloc` on
the next allocation.

Originally hit while generating optcarrot's `TILE_LUT`, where
each outer iteration allocates ~64K inner `IntArray`s — well
past spinel's 256KB GC threshold, so a collection inside the
block was guaranteed.

## Fix

Emit `SP_GC_ROOT(<accumulator>)` immediately after the
`sp_*Array_new` call in every `compile_map_expr` branch that
builds an accumulator on a master-supported recv:

| recv type                    | accum   | block return |
|------------------------------|---------|--------------|
| int_array / sym_array        | StrArray | string       |
| int_array / sym_array        | IntArray | int          |
| str_array                    | IntArray | int          |
| str_array                    | StrArray | string       |

```c
sp_StrArray *_t1 = sp_StrArray_new();
SP_GC_ROOT(_t1);                              // ← added
for (mrb_int _t2 = 0; _t2 < ...; _t2++) {
    ...
    sp_StrArray_push(_t1, val);
}
```

`SP_GC_ROOT` uses a `cleanup`-attribute sentinel so the root is
auto-popped at scope end — no manual `SP_GC_RESTORE` needed,
matches the variable's actual lifetime.

Future map branches added by other PRs (Range, ptr_array,
poly_array) should apply the same one-liner.

## Note on the test

`test/gc_root_map_accumulator.rb` covers all four affected
shapes (int_array×{int,string}, str_array×{int,string}) with a
20K-element receiver and a string-allocating scratch in each
block iteration — comfortably crossing the 256KB GC threshold.
It verifies the output is correct, but does **not**
deterministically reproduce the SIGSEGV without the fix —
whether the freed buffer's memory has been reclaimed by the
next push depends on `malloc` bookkeeping, and the dangling
pointer often "works" in isolation. The fix is still the right
behavior; the test guards against regressions in the
accumulator's GC-rooting and exercises the heavy-allocation
shape that originally triggered the SIGSEGV in optcarrot.