### PR TITLE
feat(codegen+runtime): Array#slice!(from, n) for every typed array

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -694,6 +694,18 @@ static void sp_PolyArray_push(sp_PolyArray *a, sp_RbVal v) { if (a->len >= a->ca
 static mrb_int sp_PolyArray_length(sp_PolyArray *a) { return a->len; }
 static sp_RbVal sp_PolyArray_get(sp_PolyArray *a, mrb_int i) { if (i < 0) i += a->len; return a->data[i]; }
 static sp_PolyArray *sp_PolyArray_slice(sp_PolyArray *a, mrb_int start, mrb_int len) { if (start < 0) start += a->len; if (start < 0) start = 0; sp_PolyArray *b = sp_PolyArray_new(); if (start >= a->len || len <= 0) return b; if (start + len > a->len) len = a->len - start; for (mrb_int i = 0; i < len; i++) sp_PolyArray_push(b, a->data[start + i]); return b; }
+static sp_PolyArray *sp_PolyArray_slice_bang(sp_PolyArray *a, mrb_int from, mrb_int n) {
+  if (from < 0) from += a->len;
+  if (from < 0) from = 0;
+  if (from > a->len) from = a->len;
+  if (n < 0) n = 0;
+  if (from + n > a->len) n = a->len - from;
+  sp_PolyArray *r = sp_PolyArray_new();
+  for (mrb_int i = 0; i < n; i++) sp_PolyArray_push(r, a->data[from + i]);
+  for (mrb_int i = from; i + n < a->len; i++) a->data[i] = a->data[i + n];
+  a->len -= n;
+  return r;
+}
 static sp_PolyArray *sp_PolyArray_dup(sp_PolyArray *a) { sp_PolyArray *b = sp_PolyArray_new(); for (mrb_int i = 0; i < a->len; i++) sp_PolyArray_push(b, a->data[i]); return b; }
 static void sp_PolyArray_shuffle_bang(sp_PolyArray *a) { for (mrb_int i = a->len - 1; i > 0; i--) { mrb_int j = (mrb_int)(rand() % (i + 1)); sp_RbVal t = a->data[i]; a->data[i] = a->data[j]; a->data[j] = t; } }
 static void sp_PolyArray_rotate_bang(sp_PolyArray*a,mrb_int n){if(a->len<=0)return;n=((n%a->len)+a->len)%a->len;if(n==0)return;sp_RbVal*tmp=(sp_RbVal*)malloc(sizeof(sp_RbVal)*a->len);for(mrb_int i=0;i<a->len;i++)tmp[i]=a->data[(i+n)%a->len];for(mrb_int i=0;i<a->len;i++)a->data[i]=tmp[i];free(tmp);}
@@ -782,6 +794,64 @@ static mrb_bool sp_file_exist(const char *path) { FILE *f = fopen(path, "r"); if
 static void sp_file_delete(const char *path) { remove(path); }
 static const char *sp_backtick(const char *cmd) { FILE *p = popen(cmd, "r"); if (!p) return sp_str_empty; char *buf = sp_str_alloc_raw(4096); size_t n = fread(buf, 1, 4095, p); buf[n] = 0; pclose(p); return buf; }
 static const char *sp_file_basename(const char *path) { const char *s = strrchr(path, '/'); if (s) return s + 1; return path; }
+
+/* `arr.slice!(from, n)` — returns a fresh array of `n` elements
+   starting at `from` and removes them from `a`. IntArray uses its
+   `start` field for an O(1) head peel (from == 0); the others
+   shift the tail down to fill the hole. */
+static sp_IntArray *sp_IntArray_slice_bang(sp_IntArray *a, mrb_int from, mrb_int n) {
+  if (from < 0) from += a->len;
+  if (from < 0) from = 0;
+  if (from > a->len) from = a->len;
+  if (n < 0) n = 0;
+  if (from + n > a->len) n = a->len - from;
+  sp_IntArray *r = sp_IntArray_new();
+  for (mrb_int i = 0; i < n; i++) sp_IntArray_push(r, a->data[a->start + from + i]);
+  if (from == 0) {
+    a->start += n;
+    a->len -= n;
+  } else {
+    for (mrb_int i = from; i + n < a->len; i++) a->data[a->start + i] = a->data[a->start + i + n];
+    a->len -= n;
+  }
+  return r;
+}
+static sp_FloatArray *sp_FloatArray_slice_bang(sp_FloatArray *a, mrb_int from, mrb_int n) {
+  if (from < 0) from += a->len;
+  if (from < 0) from = 0;
+  if (from > a->len) from = a->len;
+  if (n < 0) n = 0;
+  if (from + n > a->len) n = a->len - from;
+  sp_FloatArray *r = sp_FloatArray_new();
+  for (mrb_int i = 0; i < n; i++) sp_FloatArray_push(r, a->data[from + i]);
+  for (mrb_int i = from; i + n < a->len; i++) a->data[i] = a->data[i + n];
+  a->len -= n;
+  return r;
+}
+static sp_StrArray *sp_StrArray_slice_bang(sp_StrArray *a, mrb_int from, mrb_int n) {
+  if (from < 0) from += a->len;
+  if (from < 0) from = 0;
+  if (from > a->len) from = a->len;
+  if (n < 0) n = 0;
+  if (from + n > a->len) n = a->len - from;
+  sp_StrArray *r = sp_StrArray_new();
+  for (mrb_int i = 0; i < n; i++) sp_StrArray_push(r, a->data[from + i]);
+  for (mrb_int i = from; i + n < a->len; i++) a->data[i] = a->data[i + n];
+  a->len -= n;
+  return r;
+}
+static sp_PtrArray *sp_PtrArray_slice_bang(sp_PtrArray *a, mrb_int from, mrb_int n) {
+  if (from < 0) from += a->len;
+  if (from < 0) from = 0;
+  if (from > a->len) from = a->len;
+  if (n < 0) n = 0;
+  if (from + n > a->len) n = a->len - from;
+  sp_PtrArray *r = sp_PtrArray_new_scan(a->scan_elem);
+  for (mrb_int i = 0; i < n; i++) sp_PtrArray_push(r, a->data[from + i]);
+  for (mrb_int i = from; i + n < a->len; i++) a->data[i] = a->data[i + n];
+  a->len -= n;
+  return r;
+}
 
 typedef struct sp_Proc { void *fn; void *cap; void (*cap_scan)(void *); } sp_Proc;
 static void sp_Proc_scan(void *p) { sp_Proc *pr = (sp_Proc *)p; if (pr->cap && pr->cap_scan) pr->cap_scan(pr->cap); }

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2353,6 +2353,14 @@ class Compiler
       end
       return "int_array"
     end
+    if mname == "slice!"
+      # Mirrors Array#slice (with !) — returns an array of the same
+      # element type as the receiver.
+      if recv >= 0
+        return infer_type(recv)
+      end
+      return "int_array"
+    end
     if mname == "to_sym" || mname == "intern"
       return "symbol"
     end
@@ -17233,6 +17241,41 @@ class Compiler
     # the receiver pointer used as if it were an `sp_IntArray *`.
     if is_array_type(recv_type) == 0
       return ""
+    end
+    # arr.slice!(from, n) — returns a fresh array of `n` elements
+    # starting at `from` and removes them from the receiver. Each
+    # array type lowers to its own runtime helper that mutates the
+    # backing buffer in place. sym_array shares the IntArray helper
+    # since symbols are stored as interned int IDs.
+    if mname == "slice!"
+      args_id = @nd_arguments[nid]
+      if args_id >= 0
+        aargs = get_args(args_id)
+        if aargs.length >= 2
+          from_e = compile_expr(aargs[0])
+          n_e = compile_expr(aargs[1])
+          if recv_type == "int_array" || recv_type == "sym_array"
+            @needs_int_array = 1
+            return "sp_IntArray_slice_bang(" + rc + ", " + from_e + ", " + n_e + ")"
+          end
+          if recv_type == "float_array"
+            @needs_float_array = 1
+            return "sp_FloatArray_slice_bang(" + rc + ", " + from_e + ", " + n_e + ")"
+          end
+          if recv_type == "str_array"
+            @needs_str_array = 1
+            return "sp_StrArray_slice_bang(" + rc + ", " + from_e + ", " + n_e + ")"
+          end
+          if is_ptr_array_type(recv_type) == 1
+            @needs_ptr_array = 1
+            return "sp_PtrArray_slice_bang(" + rc + ", " + from_e + ", " + n_e + ")"
+          end
+          if recv_type == "poly_array"
+            @needs_poly_array = 1
+            return "sp_PolyArray_slice_bang(" + rc + ", " + from_e + ", " + n_e + ")"
+          end
+        end
+      end
     end
     # Array#inspect and Array#to_s (CRuby aliases them for arrays, so
     # the two share one definition via compile_inspect_for). Guard on

--- a/test/array_slice_bang.rb
+++ b/test/array_slice_bang.rb
@@ -1,0 +1,81 @@
+# Array#slice!(from, n) on every typed array. Returns a fresh
+# array of n elements starting at `from`, and mutates the receiver
+# to remove them. IntArray uses its `start` field for an O(1) head
+# peel; the others shift the tail down to fill the hole.
+
+# --- IntArray: head peel (from == 0) ---
+arr = [10, 20, 30, 40, 50]
+head = arr.slice!(0, 2)
+puts head.length        # 2
+puts head[0]            # 10
+puts head[1]            # 20
+puts arr.length         # 3
+puts arr[0]             # 30
+
+# --- IntArray: middle slice (from > 0, tail shift) ---
+arr2 = [1, 2, 3, 4, 5, 6, 7]
+mid = arr2.slice!(2, 3)
+puts mid[0]             # 3
+puts mid[2]             # 5
+puts arr2.length        # 4
+puts arr2[2]            # 6 (tail shifted down)
+puts arr2[3]            # 7
+
+# --- IntArray: n > available, clamped ---
+arr3 = [100, 200, 300]
+big = arr3.slice!(1, 999)
+puts big.length         # 2
+puts arr3.length        # 1
+
+# --- FloatArray ---
+fa = [1.5, 2.5, 3.5, 4.5, 5.5]
+fh = fa.slice!(0, 2)
+puts fh.length          # 2
+puts fh[0]              # 1.5
+puts fa.length          # 3
+puts fa[0]              # 3.5
+
+# --- StrArray ---
+sa = ["a", "b", "c", "d", "e"]
+sh = sa.slice!(1, 2)
+puts sh.length          # 2
+puts sh[0]              # b
+puts sh[1]              # c
+puts sa.length          # 3
+puts sa[0]              # a
+puts sa[1]              # d (tail shifted down)
+puts sa[2]              # e
+
+# --- SymArray (shares the IntArray helper internally) ---
+syms = [:foo, :bar, :baz, :qux]
+sym_h = syms.slice!(0, 2)
+puts sym_h.length       # 2
+puts sym_h[0]           # foo
+puts syms.length        # 2
+puts syms[0]            # baz
+puts syms[1]            # qux
+
+# --- PtrArray (array of obj_X instances) ---
+class Box
+  attr_reader :v
+  def initialize(v); @v = v; end
+end
+
+pa = [Box.new(10), Box.new(20), Box.new(30), Box.new(40)]
+ph = pa.slice!(1, 2)
+puts ph.length          # 2
+puts ph[0].v            # 20
+puts ph[1].v            # 30
+puts pa.length          # 2
+puts pa[0].v            # 10
+puts pa[1].v            # 40 (tail shifted down)
+
+# --- PolyArray (heterogeneous literal) ---
+poly = [1, "two", :three, 4.5, "five"]
+poly_h = poly.slice!(1, 3)
+puts poly_h.length      # 3
+puts poly_h[0]          # two
+puts poly_h[2]          # 4.5
+puts poly.length        # 2
+puts poly[0]            # 1
+puts poly[1]            # five


### PR DESCRIPTION
## Reproduction

```ruby
arr = [10, 20, 30, 40, 50]
head = arr.slice!(0, 2)
puts head.length    # expected: 2
puts arr.length     # expected: 3
puts arr[0]         # expected: 30

# Same shape on every typed array — FloatArray, StrArray,
# SymArray, PtrArray, PolyArray.
sa = ["a", "b", "c", "d"]
mid = sa.slice!(1, 2)
puts mid[0]         # expected: b
puts sa.length      # expected: 2
puts sa[1]          # expected: d (tail shifted down)
```

## Expected

```
2
3
30
b
2
d
```

## Actual

```
warning: cannot resolve call to 'slice!' on int_array (emitting 0)
warning: cannot resolve call to 'slice!' on str_array (emitting 0)
0
5
10
0
4
b
```

`infer_method_name_type` had no `slice!` branch — the result type
fell through to `int`. `compile_array_dispatch` had no codegen
branch either, so a typed `arr.slice!(from, n)` returned `0` and
no mutation happened, regardless of element type.

## Fix

Two pieces:

- **Type rule**: mirror of `slice` (without `!`) — same element
  type as the receiver.
- **Codegen**: dispatch each array type to its own runtime
  helper:

  | recv type   | helper                     |
  |-------------|----------------------------|
  | IntArray    | `sp_IntArray_slice_bang`   |
  | SymArray    | `sp_IntArray_slice_bang`   |
  | FloatArray  | `sp_FloatArray_slice_bang` |
  | StrArray    | `sp_StrArray_slice_bang`   |
  | PtrArray    | `sp_PtrArray_slice_bang`   |
  | PolyArray   | `sp_PolyArray_slice_bang`  |

Each helper returns a fresh array of `n` elements starting at
`from` and removes them from the receiver. IntArray uses its
`start` field for an O(1) head peel; the others shift the tail
down to fill the hole (no `start` field to advance).
SymArray shares the IntArray helper since symbols are stored as
interned int IDs. PtrArray preserves `scan_elem` so the new
array's GC scan stays consistent with the receiver's.

Originally driven by optcarrot's `ROM.parse_header` peeling the
16-byte iNES header off an IntArray; covering the other element
types in the same PR avoids leaving lopsided support behind.

Test: `test/array_slice_bang.rb` covers all six element types,
plus the from==0 head peel, mid-slice tail shift, and clamping
when `n` exceeds the available count.