### PR TITLE
fix(codegen): SP_GC_ROOT Range#map / N.times.map accumulators

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -26983,6 +26983,11 @@ class Compiler
         @needs_int_array = 1
         emit("  sp_IntArray *" + tmp_arrn + " = sp_IntArray_new();")
       end
+      # Root the accumulator so a GC pass triggered by an
+      # allocation inside the block (e.g. string interpolation)
+      # doesn't free the half-built array. Same reasoning as the
+      # int_array / str_array branches further down.
+      emit("  SP_GC_ROOT(" + tmp_arrn + ");")
       emit("  for (mrb_int " + tmp_in + " = 0; " + tmp_in + " < " + ncount + "; " + tmp_in + "++) {")
       if bpn != ""
         emit("    lv_" + bpn + " = " + tmp_in + ";")
@@ -27064,6 +27069,11 @@ class Compiler
       else
         emit("  sp_IntArray *" + tmp_arr + " = sp_IntArray_new();")
       end
+      # Root the accumulator so a GC pass triggered by an
+      # allocation inside the block (e.g. string interpolation)
+      # doesn't free the half-built array. Same reasoning as the
+      # int_array / str_array branches further down.
+      emit("  SP_GC_ROOT(" + tmp_arr + ");")
       # Walk through ParenthesesNode wrappers to find a literal
       # RangeNode (so we can read its exclude_end flag and its raw
       # endpoint expressions). If the receiver is a variable holding

--- a/test/gc_root_range_and_times_map.rb
+++ b/test/gc_root_range_and_times_map.rb
@@ -1,0 +1,40 @@
+# `Range#map` and `N.times.map` build a fresh accumulator
+# (IntArray / StrArray / FloatArray) and push each block result.
+# When the block allocates inside (e.g. string interpolation), a
+# GC pass triggered mid-loop frees the unrooted accumulator and
+# the next push corrupts malloc bookkeeping — typically surfaces
+# as a SIGSEGV in `_int_malloc` on the next allocation.
+#
+# `int_array` / `str_array` recv branches already root the
+# accumulator (PR #198). This covers the missing branches:
+# `Range#map` and `N.times.map`.
+
+# (1) Range#map with string-allocating block.
+r1 = (0..3000).map { |i| "padded-string-#{i}-with-some-extra-text" }
+puts r1.length          # 3001
+puts r1[0][0, 6]        # padded
+puts r1[3000][-3, 3]    # ext
+
+# (2) Range#map with int block (heap pressure from inner allocations).
+r2 = (0...3000).map do |i|
+  _scratch = "scratch-#{i}-discarded-inner-allocation-padding"
+  i * 2
+end
+puts r2.length          # 3000
+puts r2[0]              # 0
+puts r2[2999]           # 5998
+
+# (3) N.times.map.
+r3 = 3000.times.map { |i| "kept-#{i}-with-extra-padding-text" }
+puts r3.length          # 3000
+puts r3[0]              # kept-0-with-extra-padding-text
+puts r3[2999][-3, 3]    # ext
+
+# (4) N.times.map with int block + scratch allocations.
+r4 = 3000.times.map do |i|
+  _scratch = "scratch-#{i}-discarded-inner-allocation-padding"
+  i + 1
+end
+puts r4.length          # 3000
+puts r4[0]              # 1
+puts r4[2999]           # 3000


### PR DESCRIPTION
## What

`compile_map_expr`'s `Range#map` and `N.times.map` branches build
a fresh accumulator (`sp_*Array_new`) and push each block result
in a `for` loop. The accumulator was not registered as a GC root,
so an allocation inside the block (e.g. string interpolation)
could trigger a GC pass mid-loop that frees the unrooted buffer;
the next push then writes into freed memory and corrupts malloc
bookkeeping, surfacing as a SIGSEGV in `_int_malloc` on the next
allocation.

The same fix landed for the `int_array` / `sym_array` / `str_array`
recv branches in #198. The two `Range`-shaped branches were missed.

## Fix

Emit `SP_GC_ROOT(<accumulator>)` immediately after the
`sp_*Array_new` call in each branch:

```c
sp_StrArray *_t1 = sp_StrArray_new();
SP_GC_ROOT(_t1);                     // ← added
for (mrb_int _t2 = 0; _t2 < n; _t2++) {
    ...
    sp_StrArray_push(_t1, val);
}
```

`SP_GC_ROOT` uses a `cleanup`-attribute sentinel so the root is
auto-popped at scope end — no manual `SP_GC_RESTORE` needed,
matches the variable's actual lifetime.

## Test

`test/gc_root_range_and_times_map.rb` exercises both branches
with 3000-iteration loops where each block iteration allocates a
discarded scratch string alongside the kept result, comfortably
crossing spinel's 256KB GC threshold:

- `(0..3000).map { |i| "padded-string-#{i}-with-some-extra-text" }`
- `(0...3000).map { |i| _scratch = "scratch-..."; i * 2 }`
- `3000.times.map { |i| "kept-#{i}-with-extra-padding-text" }`
- `3000.times.map { |i| _scratch = "scratch-..."; i + 1 }`

The test verifies the accumulator's contents are correct after
the loop. It does **not** deterministically reproduce the SIGSEGV
without the fix — whether the freed buffer's memory has been
reclaimed by the next push depends on `malloc` bookkeeping, and
the dangling pointer often "works" in isolation. The fix is still
the right behavior; the test guards against regressions in the
accumulator's GC-rooting and exercises the heavy-allocation shape
that originally triggered the SIGSEGV in optcarrot.