### PR TITLE
feat(codegen): poly_array#map { |x| ... }

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -27315,6 +27315,73 @@ class Compiler
       pop_scope
       return tmp_arr
     end
+    # poly_array recv #map: iterate sp_PolyArray_get (sp_RbVal
+    # elements) and build a fresh container based on the block's
+    # return type. Without this branch the call falls through to
+    # `"0"`, the result is assigned as `lv_out = 0`, and any
+    # `.length` / `[i]` on the typed accumulator dereferences NULL.
+    if rt == "poly_array"
+      @needs_gc = 1
+      block_ret_p = "int"
+      blk_p = @nd_block[nid]
+      if blk_p >= 0
+        body_p = @nd_body[blk_p]
+        if body_p >= 0
+          stmts_p = get_stmts(body_p)
+          if stmts_p.length > 0
+            block_ret_p = infer_type(stmts_p.last)
+          end
+        end
+      end
+      push_scope
+      if block_ret_p == "string"
+        @needs_str_array = 1
+        emit("  sp_StrArray *" + tmp_arr + " = sp_StrArray_new();")
+      elsif block_ret_p == "float"
+        @needs_float_array = 1
+        emit("  sp_FloatArray *" + tmp_arr + " = sp_FloatArray_new();")
+      elsif block_ret_p == "int" || block_ret_p == "bool"
+        @needs_int_array = 1
+        emit("  sp_IntArray *" + tmp_arr + " = sp_IntArray_new();")
+      else
+        # Heterogeneous / pointer-typed block return: keep the
+        # poly shape so any element type round-trips through
+        # sp_RbVal.
+        emit("  sp_PolyArray *" + tmp_arr + " = sp_PolyArray_new();")
+      end
+      emit("  SP_GC_ROOT(" + tmp_arr + ");")
+      emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_PolyArray_length(" + rc + "); " + tmp_i + "++) {")
+      declare_var(bp1, "poly")
+      emit("    lv_" + bp1 + " = sp_PolyArray_get(" + rc + ", " + tmp_i + ");")
+      @indent = @indent + 1
+      if blk_p >= 0
+        body_p2 = @nd_body[blk_p]
+        if body_p2 >= 0
+          stmts_p2 = get_stmts(body_p2)
+          k_p = 0
+          while k_p < stmts_p2.length - 1
+            compile_stmt(stmts_p2[k_p])
+            k_p = k_p + 1
+          end
+          if stmts_p2.length > 0
+            lastv_p = compile_expr(stmts_p2.last)
+            if block_ret_p == "string"
+              emit("  sp_StrArray_push(" + tmp_arr + ", " + lastv_p + ");")
+            elsif block_ret_p == "float"
+              emit("  sp_FloatArray_push(" + tmp_arr + ", " + lastv_p + ");")
+            elsif block_ret_p == "int" || block_ret_p == "bool"
+              emit("  sp_IntArray_push(" + tmp_arr + ", " + lastv_p + ");")
+            else
+              emit("  sp_PolyArray_push(" + tmp_arr + ", " + box_value_to_poly(block_ret_p, lastv_p) + ");")
+            end
+          end
+        end
+      end
+      @indent = @indent - 1
+      emit("  }")
+      pop_scope
+      return tmp_arr
+    end
     "0"
   end
 

--- a/test/poly_array_map.rb
+++ b/test/poly_array_map.rb
@@ -1,0 +1,30 @@
+# `compile_map_expr` had no `poly_array` recv branch — a
+# heterogeneous-element array (`[1, "two", :three]`) called
+# `.map { ... }` and the dispatch fell through to the `"0"`
+# placeholder. The result was typed as `sp_IntArray *` (per the
+# inferred map result), `lv_out = 0` was emitted, and any
+# `.length` / `[i]` on the accumulator dereferenced NULL,
+# crashing at runtime.
+
+# (1) poly_array → IntArray (int-return block).
+arr = [1, "two", :three, 4.5]
+out = arr.map { |x| x.to_s.length }
+puts out.length      # 4
+puts out[0]          # 1
+puts out[1]          # 3
+puts out[2]          # 5
+puts out[3]          # 3
+
+# (2) poly_array → StrArray (string-return block).
+strs = arr.map { |x| x.to_s }
+puts strs.length     # 4
+puts strs[0]         # 1
+puts strs[1]         # two
+puts strs[2]         # three
+puts strs[3]         # 4.5
+
+# (3) poly_array → IntArray (different int expression).
+sizes = arr.map { |x| x.to_s.length * 2 }
+puts sizes.length    # 4
+puts sizes[0]        # 2
+puts sizes[3]        # 6


### PR DESCRIPTION
## Reproduction

```ruby
arr = [1, "two", :three, 4.5]
out = arr.map { |x| x.to_s.length }
puts out.length    # expected: 4
puts out[0]        # expected: 1
puts out[3]        # expected: 3
```

## Expected

```
4
1
3
```

## Actual

```
[runtime SIGSEGV]
```

The C output looks like:

```c
sp_PolyArray *lv_arr = ...;
sp_IntArray *lv_out = NULL;
SP_GC_ROOT(lv_out);
...
lv_out = 0;                                 // ← map returned "0"
printf("%lld\n", sp_IntArray_length(lv_out));   // NULL deref → SIGSEGV
```

`compile_map_expr` had no `poly_array` recv branch — the dispatch
fell through to the trailing `"0"` placeholder. The map's result
type was inferred as `int_array` (per `infer_method_name_type`),
spinel emitted `lv_out = 0`, and any `.length` / `[i]` on the
typed accumulator dereferenced NULL.

## Fix

Add a `poly_array` branch to `compile_map_expr` that walks
`sp_PolyArray_get` (returning `sp_RbVal`), declares the block
param as `poly`, and pushes each block result into a fresh
accumulator chosen by the block's return type:

| block return | accumulator |
|---|---|
| `string`   | `StrArray`   |
| `float`    | `FloatArray` |
| `int` / `bool` | `IntArray` |
| anything else | `PolyArray` (preserves the poly shape) |

The accumulator is rooted with `SP_GC_ROOT` to match the other
map branches.

## Test

`test/poly_array_map.rb` covers a heterogeneous
`[Int, String, Symbol, Float]` recv with three block shapes:

- int-return: `arr.map { |x| x.to_s.length }`
- string-return: `arr.map { |x| x.to_s }`
- compound int-return: `arr.map { |x| x.to_s.length * 2 }`

Spinel output matches Ruby in all three cases.