### PR TITLE
feat(codegen): ptr_array#map { |x| ... }

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -27421,6 +27421,73 @@ class Compiler
       pop_scope
       return tmp_arr
     end
+    # ptr_array recv #map: iterate sp_PtrArray_get and build a fresh
+    # accumulator. Like poly_array (handled above), master fell
+    # through to "0" for ptr_array recv, so any `.map { ... }` on a
+    # typed `obj_X[]` ivar/local got NULL-derefed downstream.
+    if is_ptr_array_type(rt) == 1
+      @needs_gc = 1
+      @needs_ptr_array = 1
+      elem_t = ptr_array_elem_type(rt)
+      block_ret_p = "int"
+      blk_p = @nd_block[nid]
+      if blk_p >= 0
+        body_p = @nd_body[blk_p]
+        if body_p >= 0
+          stmts_p = get_stmts(body_p)
+          if stmts_p.length > 0
+            block_ret_p = infer_type(stmts_p.last)
+          end
+        end
+      end
+      push_scope
+      if block_ret_p == "string"
+        @needs_str_array = 1
+        emit("  sp_StrArray *" + tmp_arr + " = sp_StrArray_new();")
+      elsif block_ret_p == "float"
+        @needs_float_array = 1
+        emit("  sp_FloatArray *" + tmp_arr + " = sp_FloatArray_new();")
+      elsif block_ret_p == "int" || block_ret_p == "bool"
+        @needs_int_array = 1
+        emit("  sp_IntArray *" + tmp_arr + " = sp_IntArray_new();")
+      else
+        # obj/ptr/poly block return: keep a PtrArray of the result.
+        emit("  sp_PtrArray *" + tmp_arr + " = sp_PtrArray_new();")
+      end
+      emit("  SP_GC_ROOT(" + tmp_arr + ");")
+      emit("  for (mrb_int " + tmp_i + " = 0; " + tmp_i + " < sp_PtrArray_length(" + rc + "); " + tmp_i + "++) {")
+      declare_var(bp1, elem_t)
+      cast_t = c_type(elem_t)
+      emit("    lv_" + bp1 + " = (" + cast_t + ")sp_PtrArray_get(" + rc + ", " + tmp_i + ");")
+      @indent = @indent + 1
+      if blk_p >= 0
+        body_p2 = @nd_body[blk_p]
+        if body_p2 >= 0
+          stmts_p2 = get_stmts(body_p2)
+          k_p = 0
+          while k_p < stmts_p2.length - 1
+            compile_stmt(stmts_p2[k_p])
+            k_p = k_p + 1
+          end
+          if stmts_p2.length > 0
+            lastv_p = compile_expr(stmts_p2.last)
+            if block_ret_p == "string"
+              emit("  sp_StrArray_push(" + tmp_arr + ", " + lastv_p + ");")
+            elsif block_ret_p == "float"
+              emit("  sp_FloatArray_push(" + tmp_arr + ", " + lastv_p + ");")
+            elsif block_ret_p == "int" || block_ret_p == "bool"
+              emit("  sp_IntArray_push(" + tmp_arr + ", " + lastv_p + ");")
+            else
+              emit("  sp_PtrArray_push(" + tmp_arr + ", (void *)(" + lastv_p + "));")
+            end
+          end
+        end
+      end
+      @indent = @indent - 1
+      emit("  }")
+      pop_scope
+      return tmp_arr
+    end
     "0"
   end
 

--- a/test/ptr_array_map.rb
+++ b/test/ptr_array_map.rb
@@ -1,0 +1,39 @@
+# `compile_map_expr` had no `ptr_array` recv branch — `.map { ... }`
+# on a typed `obj_X[]` ivar/local fell through to the trailing
+# `"0"` placeholder. The map's result type was inferred as e.g.
+# `int_array`, spinel emitted `lv_out = 0`, and any `.length` /
+# `[i]` on the typed accumulator dereferenced NULL — runtime
+# SIGSEGV.
+#
+# Mirrors `test/poly_array_map.rb` for the homogeneous obj_X case.
+
+class Box
+  attr_reader :v
+  def initialize(v); @v = v; end
+end
+
+class Bag
+  def initialize
+    @items = [Box.new(1), Box.new(2), Box.new(3)]
+  end
+  def doubled
+    @items.map { |b| b.v * 2 }
+  end
+  def names
+    @items.map { |b| "v=#{b.v}" }
+  end
+end
+
+bag = Bag.new
+
+# ptr_array → IntArray (int-return block).
+ints = bag.doubled
+puts ints.length     # 3
+puts ints[0]         # 2
+puts ints[2]         # 6
+
+# ptr_array → StrArray (string-return block).
+names = bag.names
+puts names.length    # 3
+puts names[0]        # v=1
+puts names[2]        # v=3


### PR DESCRIPTION
## Reproduction

```ruby
class Box
  attr_reader :v
  def initialize(v); @v = v; end
end

class Bag
  def initialize
    @items = [Box.new(1), Box.new(2), Box.new(3)]
  end
  def doubled
    @items.map { |b| b.v * 2 }
  end
end

bag = Bag.new
out = bag.doubled
puts out.length    # expected: 3
puts out[0]        # expected: 2
puts out[2]        # expected: 6
```

## Expected

```
3
2
6
```

## Actual

```
[runtime SIGSEGV]
```

The C output looks like:

```c
sp_PtrArray *_t1 = self->iv_items;
sp_IntArray *lv_out = NULL;
SP_GC_ROOT(lv_out);
...
lv_out = 0;                                 // ← map returned "0"
printf("%lld\n", sp_IntArray_length(lv_out));  // NULL deref → SIGSEGV
```

`compile_map_expr` had no `ptr_array` recv branch — `.map { ... }`
on a typed `obj_X[]` ivar/local fell through to the trailing
`"0"` placeholder. The map's result type was inferred as e.g.
`int_array`, spinel emitted `lv_out = 0`, and any `.length` /
`[i]` on the typed accumulator dereferenced NULL.

Same shape as the poly_array bug fixed by #210; this is the
sibling case for homogeneous `obj_X` arrays.

## Fix

Add a `ptr_array` branch to `compile_map_expr` that walks
`sp_PtrArray_get` and casts each element to the recv's element
type. The accumulator follows the block's return type:

| block return | accumulator |
|---|---|
| `string` | `StrArray` |
| `float` | `FloatArray` |
| `int` / `bool` | `IntArray` |
| anything else | `PtrArray` (preserves obj/ptr/poly) |

The accumulator is rooted with `SP_GC_ROOT` to match the other
map branches.

## Test

`test/ptr_array_map.rb` mirrors `test/poly_array_map.rb` for the
homogeneous obj_X case — a `Box` ivar array with int-return
(`b.v * 2`) and string-return (`"v=#{b.v}"`) block shapes.

Spinel output matches Ruby in all three cases.