### PR TITLE
fix(codegen): multi-write from array-returning RHS to ivar/const targets

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -22348,8 +22348,17 @@ class Compiler
       k = 0
       while k < targets.length
         tid = targets[k]
+        rhs = "sp_IntArray_get(" + tmp + ", " + k.to_s + ")"
         if @nd_type[tid] == "LocalVariableTargetNode"
-          emit("  " + fiber_var_ref(@nd_name[tid]) + " = sp_IntArray_get(" + tmp + ", " + k.to_s + ");")
+          emit("  " + fiber_var_ref(@nd_name[tid]) + " = " + rhs + ";")
+        end
+        if @nd_type[tid] == "InstanceVariableTargetNode"
+          emit("  " + self_arrow + sanitize_ivar(@nd_name[tid]) + " = " + rhs + ";")
+        end
+        if @nd_type[tid] == "ConstantTargetNode"
+          if find_const_idx(@nd_name[tid]) >= 0
+            emit("  cst_" + @nd_name[tid] + " = " + rhs + ";")
+          end
         end
         k = k + 1
       end

--- a/test/multi_write_ivar_const_from_array_rhs.rb
+++ b/test/multi_write_ivar_const_from_array_rhs.rb
@@ -1,0 +1,53 @@
+# `compile_multi_write`'s int_array-returning RHS branch (RHS is a
+# non-literal expression that evaluates to an array, e.g.
+# `.map { ... }`, a method call) only emitted assignments for
+# `LocalVariableTargetNode` targets — `InstanceVariableTargetNode`
+# and `ConstantTargetNode` targets were silently dropped. The C
+# code compiled fine, but the ivars / constants stayed at their
+# default values.
+#
+# Repro: `@a, @b = [10, 20].map { |x| x + 1 }` where the targets
+# are ivars. Master emitted neither write, so c.a / c.b returned 0.
+#
+# (Constant-target coverage requires the multi-write-to-constants
+# parser support, which lives in a sibling PR; the InstanceVariable
+# fix here is independent and lands first.)
+
+# (1) ivar targets, RHS is .map
+class C1
+  def initialize
+    @a, @b = [10, 20].map { |x| x + 1 }
+  end
+  attr_reader :a, :b
+end
+c = C1.new
+puts c.a              # 11
+puts c.b              # 21
+
+# (2) mixed: local + ivar from one int_array RHS.
+class C2
+  def initialize
+    local, @i = [1, 2].map { |x| x * 10 }
+    @captured_local = local
+  end
+  attr_reader :i, :captured_local
+end
+c2 = C2.new
+puts c2.captured_local  # 10
+puts c2.i               # 20
+
+# (3) ivar targets where the RHS is a top-level method returning
+# a fresh array. The intervening method-boundary forces the
+# `sp_IntArray *` rhs path (RHS is not a literal ArrayNode).
+def make_pair
+  [7, 8]
+end
+class C3
+  attr_reader :x, :y
+  def initialize
+    @x, @y = make_pair
+  end
+end
+c3 = C3.new
+puts c3.x   # 7
+puts c3.y   # 8


### PR DESCRIPTION
## Reproduction

```ruby
class C
  def initialize
    @a, @b = [10, 20].map { |x| x + 1 }
  end
  attr_reader :a, :b
end
c = C.new
puts c.a    # expected: 11
puts c.b    # expected: 21
```

## Expected

```
11
21
```

## Actual

```
0
0
```

The C code compiles fine (no error), but `@a` and `@b` are never
written.

## Analysis

`compile_multi_write` has three RHS-shape branches:

1. RHS is a literal `ArrayNode` (`@a, @b = 1, 2`) — splits at emit time per element.
2. RHS is a tuple-returning call — destructures via field access.
3. **RHS is a non-literal int_array expression** (`.map { ... }`, a method call) — evaluates once into a temp, then `sp_IntArray_get(tmp, k)` per target.

The third branch only emitted assignments for
`LocalVariableTargetNode` targets:

```ruby
if @nd_type[tid] == "LocalVariableTargetNode"
  emit("  " + fiber_var_ref(@nd_name[tid]) + " = sp_IntArray_get(...);")
end
```

`InstanceVariableTargetNode` and `ConstantTargetNode` targets fell
through silently. The C code compiled cleanly (the `tmp` and the
`SP_GC_ROOT` were emitted), but the destructured slots stayed at
their default values.

## Fix

Handle ivar and const targets in the same branch:

```ruby
rhs = "sp_IntArray_get(" + tmp + ", " + k.to_s + ")"
if @nd_type[tid] == "LocalVariableTargetNode"
  emit("  " + fiber_var_ref(@nd_name[tid]) + " = " + rhs + ";")
end
if @nd_type[tid] == "InstanceVariableTargetNode"
  emit("  " + self_arrow + sanitize_ivar(@nd_name[tid]) + " = " + rhs + ";")
end
if @nd_type[tid] == "ConstantTargetNode"
  if find_const_idx(@nd_name[tid]) >= 0
    emit("  cst_" + @nd_name[tid] + " = " + rhs + ";")
  end
end
```

The constant target write is gated on `find_const_idx >= 0` so we
don't emit assignments to unregistered symbols. (Full
constant-target coverage requires the multi-write-to-constants
parser support, which lives in a sibling PR; this PR is the
broader target-dispatch fix that benefits any int_array RHS.)

## Test

`test/multi_write_ivar_const_from_array_rhs.rb` covers:

1. `@a, @b = [10, 20].map { |x| x + 1 }` (ivar from .map)
2. `local, @i = [1, 2].map { |x| x * 10 }` (mixed local + ivar)
3. `@x, @y = make_pair` (ivar from top-level method call)

Spinel output matches Ruby in all three cases.