### PR TITLE
feat(parse+codegen): CallTargetNode in multi-write targets

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -22380,6 +22380,29 @@ class Compiler
         end
         emit("  " + self_arrow + sanitize_ivar(iname) + " = " + v + ";")
       end
+      return
+    end
+    if @nd_type[tid] == "CallTargetNode"
+      # `obj.attr = val` style — used as one slot in a multi-write
+      # destructure. Lower as either a direct ivar write (when the
+      # receiver class has an attr_writer for the name) or as a call
+      # to `sp_<C>_<attr>_eq`.
+      recv_id = @nd_receiver[tid]
+      mname = @nd_name[tid]
+      if mname.end_with?("=")
+        mname = mname[0, mname.length - 1]
+      end
+      recv_t = infer_type(recv_id)
+      recv_c = compile_expr(recv_id)
+      if recv_t.start_with?("obj_")
+        cls_n = recv_t[4, recv_t.length - 4]
+        ci_w = find_class_idx(cls_n)
+        if cls_has_attr_writer(ci_w, mname) == 1
+          emit("  " + recv_c + "->iv_" + mname + " = " + value_expr + ";")
+        else
+          emit("  sp_" + cls_n + "_" + mname + "_eq(" + recv_c + ", " + value_expr + ");")
+        end
+      end
     end
   end
 
@@ -22587,6 +22610,28 @@ class Compiler
         tid = targets[k]
         if @nd_type[tid] == "LocalVariableTargetNode"
           emit("  " + fiber_var_ref(@nd_name[tid]) + " = sp_IntArray_get(" + tmp + ", " + k.to_s + ");")
+        end
+        if @nd_type[tid] == "CallTargetNode"
+          # `obj.attr = <slot>` in a multi-write context.
+          # Inline as a direct ivar write when the recv class has an
+          # attr_writer; otherwise fall back to the generated setter.
+          recv_id = @nd_receiver[tid]
+          mname = @nd_name[tid]
+          if mname.end_with?("=")
+            mname = mname[0, mname.length - 1]
+          end
+          recv_t = infer_type(recv_id)
+          recv_c = compile_expr(recv_id)
+          slot_expr = "sp_IntArray_get(" + tmp + ", " + k.to_s + ")"
+          if recv_t.start_with?("obj_")
+            cls_n = recv_t[4, recv_t.length - 4]
+            ci_w = find_class_idx(cls_n)
+            if cls_has_attr_writer(ci_w, mname) == 1
+              emit("  " + recv_c + "->iv_" + mname + " = " + slot_expr + ";")
+            else
+              emit("  sp_" + cls_n + "_" + mname + "_eq(" + recv_c + ", " + slot_expr + ");")
+            end
+          end
         end
         k = k + 1
       end

--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -300,6 +300,13 @@ static int flatten(pm_node_t *node) {
     NAME("name", n->name);
     break;
   }
+  case PM_CALL_TARGET_NODE: {
+    pm_call_target_node_t *n = (pm_call_target_node_t *)node;
+    N("CallTargetNode");
+    NAME("name", n->name);
+    R("receiver", n->receiver);
+    break;
+  }
   case PM_INSTANCE_VARIABLE_AND_WRITE_NODE: {
     pm_instance_variable_and_write_node_t *n = (pm_instance_variable_and_write_node_t *)node;
     N("InstanceVariableAndWriteNode");

--- a/test/multi_write_setter.rb
+++ b/test/multi_write_setter.rb
@@ -1,0 +1,28 @@
+# `a, b, c.x = expr` where one target is a setter call (`c.x =`)
+# parses to a CallTargetNode in the targets list. Without parser
+# support for CallTargetNode the setter target was silently dropped.
+
+class Box
+  def initialize; @v = 0; end
+  attr_accessor :v
+end
+
+class Holder
+  def initialize
+    @a = 0
+    @b = 0
+    @c = Box.new
+  end
+  def fill
+    @a, @b, @c.v = [11, 22, 33]
+  end
+  def show
+    puts @a
+    puts @b
+    puts @c.v
+  end
+end
+
+h = Holder.new
+h.fill
+h.show


### PR DESCRIPTION
## Reproduction

```ruby
class Box
  def initialize; @v = 0; end
  attr_accessor :v
end

class Holder
  def initialize
    @a = 0
    @b = 0
    @c = Box.new
  end
  def fill
    @a, @b, @c.v = [11, 22, 33]
  end
  def show
    puts @a
    puts @b
    puts @c.v
  end
end

h = Holder.new
h.fill
h.show
```

## Expected

```
11
22
33
```

## Actual

```
11
22
0
```

The first two writes (`@a`, `@b`) land. The third (`@c.v`) is
silently dropped — the generated C contains no assignment for
that slot.

## Analysis

`obj.attr = ...` appearing as one slot in a multi-write
destructure parses as `PM_CALL_TARGET_NODE` in prism. Spinel's
parser had no case for that node type, so the serialized AST
contained `UnknownNode_<type>` where the target should be. The
codegen target-list iterator therefore saw a hole and skipped the
slot.

## Fix

Two pieces:

1. **Parser**: translate `PM_CALL_TARGET_NODE` to
   `CallTargetNode` with `name` and `receiver` fields. This
   mirrors the `LocalVariableTargetNode` /
   `InstanceVariableTargetNode` cases that were already handled.

2. **Codegen**: handle `CallTargetNode` in both the `ArrayNode`
   RHS branch and the `IntArray`-returning RHS branch of
   `compile_multi_write`. When the receiver class has an
   `attr_writer` for the name, inline a direct `iv_<name>` write;
   otherwise call the explicit `sp_<Cls>_<name>_eq()` setter.

## Test

`test/multi_write_setter.rb` covers `@a, @b, @c.v = [...]` where
`@c` is a class instance with an `attr_accessor`. Spinel output
matches Ruby.

Real-world trigger: optcarrot's `PPU#setup_frame` multi-assigns
`@cpu.next_frame_clock` so the CPU outer loop iterates instead of
exiting on the initial `0 == 0` check.