### PR TITLE
fix(codegen): scan multi-write ivar targets for type widening

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -8144,6 +8144,30 @@ class Compiler
         end
       end
     end
+    # Multi-write to ivars: `@a, @b = pulse_0, pulse_1`. Mirrors the
+    # single-write branch above so each ivar's type is widened from
+    # the corresponding RHS slot. Without this the multi-write left
+    # the ivars at their initial "int" guess and the struct came out
+    # with mrb_int fields that the assigning method then tried to
+    # overwrite with pointer values.
+    if @nd_type[nid] == "MultiWriteNode"
+      if @current_class_idx >= 0
+        targets_mw = parse_id_list(@nd_targets[nid])
+        val_mw = @nd_expression[nid]
+        ti_mw = 0
+        while ti_mw < targets_mw.length
+          tid_mw = targets_mw[ti_mw]
+          if @nd_type[tid_mw] == "InstanceVariableTargetNode"
+            iname_mw = @nd_name[tid_mw]
+            at_mw = scan_ivars_multi_target_type(val_mw, ti_mw)
+            if at_mw != "int" && at_mw != "nil"
+              update_ivar_type(@current_class_idx, iname_mw, at_mw)
+            end
+          end
+          ti_mw = ti_mw + 1
+        end
+      end
+    end
     if @nd_type[nid] == "CallNode"
       mname = @nd_name[nid]
       recv = @nd_receiver[nid]

--- a/test/multi_write_ivar_widening.rb
+++ b/test/multi_write_ivar_widening.rb
@@ -1,0 +1,10 @@
+class Pair
+  def initialize(a, b)
+    @x, @y = [a, b]
+  end
+  attr_reader :x, :y
+end
+
+p = Pair.new("hello", "world")
+puts p.x
+puts p.y


### PR DESCRIPTION
## Reproduction

```ruby
class Pair
  def initialize(a, b)
    @x, @y = [a, b]
  end
  attr_reader :x, :y
end

p = Pair.new("hello", "world")
puts p.x
puts p.y
```

## Expected

```
hello
world
```

## Actual

```
t.c:32:13: error: assignment to ‘mrb_int’ {aka ‘long int’} from ‘const char *’ makes integer from pointer without a cast [-Wint-conversion]
   32 |   self.iv_y = _t2;
      |             ^
t.c: In function ‘sp_Pair_initialize’:
t.c:39:14: error: assignment to ‘mrb_int’ {aka ‘long int’} from ‘const char *’ makes integer from pointer without a cast [-Wint-conversion]
   39 |   self->iv_x = _t3;
      |              ^
t.c:40:14: error: assignment to ‘mrb_int’ {aka ‘long int’} from ‘const char *’ makes integer from pointer without a cast [-Wint-conversion]
   40 |   self->iv_y = _t4;
      |              ^
```

## Analysis

`scan_writer_calls` widens ivar types via a direct
`InstanceVariableWriteNode` match but had no `MultiWriteNode`
branch. A class whose ivars are only ever written through
destructuring is left at its initial `int` guess: `iv_x` and
`iv_y` are `mrb_int` in the emitted struct, and the constructor
fails to compile when the RHS is anything else.

## Fix

Add a `MultiWriteNode` branch to `scan_writer_calls` that walks
the targets list, picks out each `InstanceVariableTargetNode`,
asks `scan_ivars_multi_target_type` for the matching RHS slot
type, and routes through the existing `update_ivar_type`. Same
shape as the single-write branch.

The widened type also reaches the parent class's struct slot
because `update_ivar_type` already recurses up
`@cls_parents`, so `class Pair < Base` shapes work without
any extra machinery.

## Test

`test/multi_write_ivar_widening.rb` covers the destructure-only
case above. Spinel output matches Ruby.

Real-world trigger: optcarrot's `APU::Mixer` constructor
(`@pulse_0, @pulse_1, @triangle, @noise, @dmc = pulse_0, ...`).