### PR TITLE
fix(codegen): emit SP_GC_SAVE for value-type ctors with GC-managed locals

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -12919,6 +12919,7 @@ class Compiler
     if @cls_is_value_type[ci] == 1
       emit_raw("static sp_" + cname + " sp_" + cname + "_new(" + constructor_params_decl(ci) + ") {")
       emit_raw("  sp_" + cname + " self = {0};")
+      @in_gc_scope = 0
     else
       emit_raw("static inline sp_" + cname + " *sp_" + cname + "_new(" + constructor_params_decl(ci) + ") {")
       emit_raw("  SP_GC_SAVE();")

--- a/test/value_type_ctor_gc_save.rb
+++ b/test/value_type_ctor_gc_save.rb
@@ -1,0 +1,46 @@
+# A value-type constructor body that introduces a GC-managed local
+# (here `arr`, an int_array) needs `SP_GC_SAVE()` paired with the
+# `SP_GC_ROOT(lv_arr)` that `declare_method_locals` emits.
+#
+# `emit_constructor` only emits SP_GC_SAVE for the non-value-type
+# branch. For value types it leaves `@in_gc_scope` whatever the
+# *previous* method left it as. If the previous method was a
+# non-value class's body (which sets `@in_gc_scope = 1`), the
+# inherited scope made `declare_method_locals` skip its SP_GC_SAVE
+# and the value-type ctor emitted an unbalanced SP_GC_ROOT —
+# pushing a stack pointer that becomes dangling on return.
+#
+# Reproducer: Foo (heap class) is compiled before Vec (value type),
+# so without the fix Vec_new's lv_arr root gets pushed without a
+# matching save. The fix resets `@in_gc_scope = 0` at the value-
+# type ctor entry so declare_method_locals emits SP_GC_SAVE.
+
+class Foo
+  def make
+    [1, 2, 3]
+  end
+end
+
+class Vec
+  attr_reader :sum
+  def initialize(x, y)
+    arr = [x, y, x + y]
+    @sum = arr[2]
+  end
+end
+
+f = Foo.new
+puts f.make.length            # 3
+v = Vec.new(3, 4)
+puts v.sum                    # 7
+
+# Many ctor calls so the unbalanced ROOTs would saturate
+# sp_gc_nroots if they weren't matched by SP_GC_RESTORE.
+sum = 0
+i = 0
+while i < 200
+  vv = Vec.new(i, i + 1)
+  sum = sum + vv.sum
+  i = i + 1
+end
+puts sum                       # 200 * (i + (i+1)) summed = sum of (2i+1) for i=0..199 = 200*200 = 40000


### PR DESCRIPTION
## Reproduction

```ruby
class Foo
  def make
    [1, 2, 3]
  end
end

class Vec
  attr_reader :sum
  def initialize(x, y)
    arr = [x, y, x + y]
    @sum = arr[2]
  end
end

puts Foo.new.make.length
puts Vec.new(3, 4).sum
```

## Expected (generated `sp_Vec_new`)

```c
static sp_Vec sp_Vec_new(mrb_int lv_x, mrb_int lv_y) {
  sp_Vec self = {0};
  SP_GC_SAVE();
  sp_IntArray * lv_arr = NULL;
  SP_GC_ROOT(lv_arr);
  ...
}
```

## Actual (generated `sp_Vec_new` on master)

```c
static sp_Vec sp_Vec_new(mrb_int lv_x, mrb_int lv_y) {
  sp_Vec self = {0};
  sp_IntArray * lv_arr = NULL;
  SP_GC_ROOT(lv_arr);
  ...
}
```

`SP_GC_SAVE()` is missing. The `SP_GC_ROOT` push has nothing to
balance against — `sp_gc_nroots` keeps climbing on each
`Vec.new` call. With a tight loop of constructions, the pinned
roots accumulate and eventually crowd the GC root array.

## Analysis

`emit_constructor`'s non-value-type branch emits `SP_GC_SAVE()`
itself and sets `@in_gc_scope = 1` so `declare_method_locals`
knows not to emit a duplicate. The value-type branch doesn't
emit `SP_GC_SAVE()` directly, but also wasn't resetting
`@in_gc_scope` — if the previously-emitted method was a
non-value-type class body (which had set the flag to `1`), the
leftover state made `declare_method_locals` skip its own
`SP_GC_SAVE()` too. Net result: the value-type ctor pushed roots
without any save.

Order-dependent: `Foo` (heap) compiled before `Vec` (value type)
is the minimum reproducer.

## Fix

Reset `@in_gc_scope = 0` at the value-type branch entry of
`emit_constructor`. The `saved_gc_scope` save/restore wrapping
the function already restores the caller's view on exit.

## Test

`test/value_type_ctor_gc_save.rb` exercises the order-dependent
case (`Foo` before `Vec`), then runs 200 `Vec.new` calls in a
loop so the leaked roots accumulate visibly. With the fix, the
generated C contains the missing `SP_GC_SAVE()` and the loop
produces the expected sum.