### PR TITLE
feat(codegen): add Integer#allbits?

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2339,6 +2339,9 @@ class Compiler
     if mname == "odd?"
       return "bool"
     end
+    if mname == "allbits?"
+      return "bool"
+    end
     if mname == "zero?"
       return "bool"
     end
@@ -18424,6 +18427,10 @@ class Compiler
     end
     if mname == "odd?"
       return "((" + rc + ") % 2 != 0)"
+    end
+    if mname == "allbits?"
+      mask = compile_arg0(nid)
+      return "(((" + rc + ") & (" + mask + ")) == (" + mask + "))"
     end
     if mname == "zero?"
       return "((" + rc + ") == 0)"

--- a/test/integer_allbits.rb
+++ b/test/integer_allbits.rb
@@ -1,0 +1,24 @@
+# all bits set
+puts 255.allbits?(255)
+
+# subset of bits
+puts 255.allbits?(128)
+
+# zero mask
+puts 0.allbits?(0)
+puts 42.allbits?(0)
+
+# not all bits present
+puts 5.allbits?(6)
+puts 8.allbits?(3)
+
+# single bit
+puts 4.allbits?(4)
+puts 4.allbits?(2)
+
+# large value
+puts 0xFFFF.allbits?(0xFF00)
+
+# negative (all bits set)
+puts((-1).allbits?(255))
+puts 0.allbits?(1)

--- a/test/integer_allbits.rb.expected
+++ b/test/integer_allbits.rb.expected
@@ -1,0 +1,11 @@
+true
+true
+true
+true
+false
+false
+true
+false
+true
+true
+false


### PR DESCRIPTION
This adds `Integer#allbits?` — returns true when all bits in the mask are set in the receiver.

The codegen emits a simple bitwise AND comparison: `(self & mask) == mask`. No runtime function needed.

Tests covering edge cases (zero mask, subset, no match, negative receiver, large values) are in `test/integer_allbits.rb`.