### PR TITLE
feat(codegen): add Integer#anybits?

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2339,6 +2339,9 @@ class Compiler
     if mname == "odd?"
       return "bool"
     end
+    if mname == "anybits?"
+      return "bool"
+    end
     if mname == "zero?"
       return "bool"
     end
@@ -18424,6 +18427,9 @@ class Compiler
     end
     if mname == "odd?"
       return "((" + rc + ") % 2 != 0)"
+    end
+    if mname == "anybits?"
+      return "(((" + rc + ") & (" + compile_arg0(nid) + ")) != 0)"
     end
     if mname == "zero?"
       return "((" + rc + ") == 0)"

--- a/test/integer_anybits.rb
+++ b/test/integer_anybits.rb
@@ -1,0 +1,23 @@
+# basic
+puts 255.anybits?(128)
+puts 255.anybits?(1)
+
+# no overlap
+puts 0.anybits?(1)
+puts 16.anybits?(8)
+puts 4.anybits?(2)
+
+# zero mask
+puts 0.anybits?(0)
+puts 42.anybits?(0)
+
+# single bit match
+puts 6.anybits?(4)
+puts 6.anybits?(2)
+
+# negative
+puts((-1).anybits?(1))
+puts((-4).anybits?(4))
+
+# large value
+puts 0xFF00.anybits?(0x0100)

--- a/test/integer_anybits.rb.expected
+++ b/test/integer_anybits.rb.expected
@@ -1,0 +1,12 @@
+true
+true
+false
+false
+false
+false
+false
+true
+true
+true
+true
+true


### PR DESCRIPTION
This adds `Integer#anybits?` — returns true when any bit in the mask is set in the receiver.

The codegen emits a simple bitwise AND check: `(self & mask) != 0`. No runtime function needed.

Tests covering edge cases (zero mask, no overlap, single bit, negative receiver, large values) are in `test/integer_anybits.rb`.