### PR TITLE
feat(codegen): add Integer#nobits?

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2339,6 +2339,9 @@ class Compiler
     if mname == "odd?"
       return "bool"
     end
+    if mname == "nobits?"
+      return "bool"
+    end
     if mname == "zero?"
       return "bool"
     end
@@ -18424,6 +18427,9 @@ class Compiler
     end
     if mname == "odd?"
       return "((" + rc + ") % 2 != 0)"
+    end
+    if mname == "nobits?"
+      return "(((" + rc + ") & (" + compile_arg0(nid) + ")) == 0)"
     end
     if mname == "zero?"
       return "((" + rc + ") == 0)"

--- a/test/integer_nobits.rb
+++ b/test/integer_nobits.rb
@@ -1,0 +1,23 @@
+# no overlap
+puts 256.nobits?(1)
+puts 256.nobits?(255)
+puts 8.nobits?(4)
+
+# overlap exists
+puts 255.nobits?(1)
+puts 6.nobits?(2)
+
+# zero mask
+puts 0.nobits?(0)
+puts 42.nobits?(0)
+
+# single bit
+puts 4.nobits?(2)
+puts 4.nobits?(4)
+
+# negative
+puts((-1).nobits?(1))
+puts((-4).nobits?(2))
+
+# large value
+puts 0xFF00.nobits?(0x00FF)

--- a/test/integer_nobits.rb.expected
+++ b/test/integer_nobits.rb.expected
@@ -1,0 +1,12 @@
+true
+true
+true
+false
+false
+true
+true
+true
+false
+false
+true
+true


### PR DESCRIPTION
This adds `Integer#nobits?` — returns true when no bits in the mask are set in the receiver.

The codegen emits a simple bitwise AND zero-check: `(self & mask) == 0`. No runtime function needed.

Tests covering edge cases (zero mask, overlap, no overlap, negative receiver, large values) are in `test/integer_nobits.rb`.