### PR TITLE
feat(parse,codegen): support SourceFileNode (__FILE__)

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -1665,6 +1665,9 @@ class Compiler
     if t == "StringNode"
       return "string"
     end
+    if t == "SourceFileNode"
+      return "string"
+    end
     if t == "SymbolNode"
       return "symbol"
     end
@@ -15633,6 +15636,12 @@ class Compiler
     end
     if t == "SourceLineNode"
       return @nd_value[nid].to_s
+    end
+    if t == "SourceFileNode"
+      # __FILE__ — parser populated @nd_content with the toplevel
+      # script path. (Inlined-require call sites all see the same
+      # path; documented limitation in test/source_file.rb.)
+      return c_string_literal(@nd_content[nid])
     end
     if t == "ArgumentsNode"
       arg_ids = parse_id_list(@nd_args[nid])

--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -43,6 +43,8 @@ static void out_add(const char *fmt, ...) {
 
 /* ---- Name from constant pool ---- */
 static const pm_parser_t *g_parser;
+static const char *g_source_file = "";
+static char *g_source_file_escaped = NULL;  /* escape_str(g_source_file), set once at init */
 
 static char *cstr(pm_constant_id_t id) {
   if (id == 0) return strdup("");
@@ -695,6 +697,16 @@ static int flatten(pm_node_t *node) {
     I("start_line", (long long)line);
     break;
   }
+  case PM_SOURCE_FILE_NODE: {
+    /* `__FILE__`. Spinel inlines `require`/`require_relative` at parse
+       time so we cannot recover the per-call-site source file; we
+       always return the toplevel script path passed to spinel_parse,
+       documented in test/source_file.rb. The escaped form is cached
+       in g_source_file_escaped at init since it never changes. */
+    N("SourceFileNode");
+    emit_str(id, "content", g_source_file_escaped);
+    break;
+  }
   case PM_SPLAT_NODE: {
     pm_splat_node_t *n = (pm_splat_node_t *)node;
     N("SplatNode");
@@ -1218,6 +1230,8 @@ int main(int argc, char **argv) {
   }
 
   g_parser = &parser;
+  g_source_file = source_file;
+  g_source_file_escaped = escape_str((const uint8_t *)g_source_file, strlen(g_source_file));
 
   /* Flatten AST to text */
   lines = NULL;
@@ -1249,6 +1263,8 @@ int main(int argc, char **argv) {
   pm_node_destroy(&parser, root);
   pm_parser_free(&parser);
   free(source);
+  free(g_source_file_escaped);  /* paired with the escape_str() in init */
+  g_source_file_escaped = NULL;
   sp_includes_free();
   return 0;
 }

--- a/test/source_file.rb
+++ b/test/source_file.rb
@@ -1,0 +1,37 @@
+# SourceFileNode -- the `__FILE__` keyword.
+#
+# Spinel inlines `require`/`require_relative` at parse time, so call
+# sites in different source files are not distinguished. `__FILE__`
+# always returns the toplevel script path passed to spinel_parse,
+# matching CRuby's behavior for top-level uses.
+#
+# This test exercises __FILE__ end-to-end: it must (a) emit the path,
+# (b) flow as `string` through type inference (so dispatch picks the
+# string-method arms), (c) interoperate with literals (concat / compare
+# / interpolate), and (d) round-trip through a typed-String parameter
+# at a method call site.
+
+# Basic emission.
+puts __FILE__
+
+# String#length returns an Integer -> dispatch hit the string arm.
+puts __FILE__.length > 0
+
+# Concat with literal -> __FILE__ is a `string`, not poly/object.
+puts "[" + __FILE__ + "]"
+
+# Interpolation works (path appears verbatim).
+puts "got: #{__FILE__}"
+
+# Two reads compare equal -- same toplevel path resolves identically.
+puts __FILE__ == __FILE__
+
+# String predicates dispatch via the string arm.
+puts __FILE__.end_with?(".rb")
+puts __FILE__.include?("source_file")
+
+# Round-trip through a typed-String parameter at a method call site.
+def show(s)
+  puts "param: " + s
+end
+show(__FILE__)

--- a/test/source_file.rb.expected
+++ b/test/source_file.rb.expected
@@ -1,0 +1,8 @@
+test/source_file.rb
+true
+[test/source_file.rb]
+got: test/source_file.rb
+true
+true
+true
+param: test/source_file.rb


### PR DESCRIPTION
Adds parser case in spinel_parse.c that emits the toplevel script path (passed via argv) as the SourceFileNode's content. Codegen arm in compile_expr returns it as a c_string_literal, plus an infer_type arm so the type system knows __FILE__ produces a string (without it, puts(__FILE__) emitted printf("%lld\n", ...) casting the pointer to long).

Limitation: spinel inlines require/require_relative at parse time, so __FILE__ at every call site sees the toplevel script path. This matches CRuby for top-level uses but diverges inside required files. Documented in the test fixture.

Test: test/source_file.rb.
Bootstrap: gen2.c == gen3.c.