### PR TITLE
build: split test/bench compile+link to enable compiler caching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,8 @@ build/test-results/%.ok: test/%.rb spinel_parse$(EXE) $(SP_RT_LIB) spinel_codege
 	rm -f "$@.diff"; \
 	./spinel_parse$(EXE) "$<" "$$ast" 2>/dev/null && \
 	./spinel_codegen$(EXE) "$$ast" "$$cfile" 2>/dev/null && \
-	$(CC) $(CFLAGS) -Werror $(SEC_FLAGS) -Ilib "$$cfile" $(SP_RT_LIB) $(LDFLAGS) -lm $(GC_FLAGS) -o "$$bin" 2>/dev/null; \
+	$(CC) $(CFLAGS) -Werror $(SEC_FLAGS) -Ilib -c "$$cfile" -o "$$cfile.o" 2>/dev/null && \
+	$(CC) $(CFLAGS) "$$cfile.o" $(SP_RT_LIB) $(LDFLAGS) -lm $(GC_FLAGS) -o "$$bin" 2>/dev/null; \
 	if [ $$? -eq 0 ]; then \
 	  if [ -f "$<.expected" ]; then \
 	    LC_ALL=C sed 's/\r$$//' "$<.expected" >"$$exp.n"; \
@@ -291,7 +292,8 @@ bench: spinel_parse$(EXE) $(SP_RT_LIB) spinel_codegen$(EXE)
 	  if [ "$$tty" = 1 ]; then printf '\r\033[K  [%d/%d] %s' "$$i" "$$total" "$$bn"; fi; \
 	  $(TIMEOUT10) ./spinel_parse$(EXE) "$$f" /tmp/_sp_b.ast 2>/dev/null && \
 	  $(TIMEOUT10) ./spinel_codegen$(EXE) /tmp/_sp_b.ast /tmp/_sp_b.c 2>/dev/null && \
-	  $(CC) $(CFLAGS) -Werror $(SEC_FLAGS) -Ilib /tmp/_sp_b.c $(SP_RT_LIB) $(LDFLAGS) -lm $(GC_FLAGS) -o /tmp/_sp_b_bin$(EXE) 2>/dev/null; \
+	  $(CC) $(CFLAGS) -Werror $(SEC_FLAGS) -Ilib -c /tmp/_sp_b.c -o /tmp/_sp_b.c.o 2>/dev/null && \
+	  $(CC) $(CFLAGS) /tmp/_sp_b.c.o $(SP_RT_LIB) $(LDFLAGS) -lm $(GC_FLAGS) -o /tmp/_sp_b_bin$(EXE) 2>/dev/null; \
 	  if [ $$? -eq 0 ]; then \
 	    $(TIMEOUT60) $(REF_RUBY) "$$f" >/tmp/_sp_b_exp 2>/dev/null; \
 	    ruby_rc=$$?; \
@@ -321,7 +323,7 @@ bench: spinel_parse$(EXE) $(SP_RT_LIB) spinel_codegen$(EXE)
 	  fi; \
 	done; \
 	if [ "$$tty" = 1 ]; then printf '\r\033[K'; fi; \
-	rm -f /tmp/_sp_b.ast /tmp/_sp_b.c /tmp/_sp_b_bin$(EXE) /tmp/_sp_b_exp /tmp/_sp_b_act /tmp/_sp_b_exp.n /tmp/_sp_b_act.n; \
+	rm -f /tmp/_sp_b.ast /tmp/_sp_b.c /tmp/_sp_b.c.o /tmp/_sp_b_bin$(EXE) /tmp/_sp_b_exp /tmp/_sp_b_act /tmp/_sp_b_exp.n /tmp/_sp_b_act.n; \
 	echo "Benchmarks: $$pass pass, $$fail fail, $$err error, $$skip skip"; \
 	if [ $$fail -ne 0 ] || [ $$err -ne 0 ]; then exit 1; fi
 


### PR DESCRIPTION
## Summary
- Split the test rule (`Makefile:232`) into a separate compile step (`-c source.c -o source.o`) and link step (`source.o $(SP_RT_LIB) ... -o test_bin`).
- Same split applied to the bench rule (`Makefile:294`) for consistency, plus added `/tmp/_sp_b.c.o` to the bench cleanup list.
- No behavior change for users running `make test` or `make bench`; only the shape of the cc invocations changes.

## Why
Compiler caches like sccache and ccache only cache **pure compile invocations** — `cc -c source.c -o out.o`. Combined compile+link calls (no `-c`, output is an executable, links static libs and `-lm`) are classified as non-cacheable.

On the recent sccache CI experiments, this showed up clearly: of 307 sccache invocations on `ubuntu-gcc`, only **25 were cached** (the prism + regexp + bigint build-phase compiles). The 278 per-test calls were all classified as `non-compilation calls` and skipped.

Splitting unlocks per-test caching. The warm-cache test phase should drop from ~3min to ~1min for PRs that don't touch tests.

## Test plan
- [x] `make -j$(sysctl -n hw.ncpu) LTO=0 all` — clean build succeeds.
- [x] `make -j$(sysctl -n hw.ncpu) test OPT=-O0` — **282/282 pass** in 1m02s locally (macOS, clang).
- [x] CI confirms all 4 matrix jobs still green.

## Trade-offs
- One extra `exec()` per test (the link step) adds maybe 1ms × 282 = ~280ms of overhead on a clean run. Negligible vs. the ~120s saved on warm cache.
- The intermediate `.o` lives in the same `\$\$tmpdir` as the other test artifacts, so cleanup at line 258 already handles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)