### PR TITLE
fix(codegen): pad missing positional args in poly-dispatch arms

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -21680,7 +21680,27 @@ class Compiler
       cname = @cls_names[i]
       midx = cls_find_method_direct(i, mname)
       if midx >= 0
-        call_expr = "sp_" + cname + "_" + sanitize_name(mname) + "((sp_" + cname + " *)" + recv_tmp + ".v.p" + arg_strs + ")"
+        # Pad with default-typed zeros when target method has more
+        # params than the call site supplied — same shape that C
+        # demands at every fixed-arity call. Per-arm padding lets us
+        # poly-dispatch `recv.m()` even when one of the candidate
+        # classes has a method that takes positional defaults.
+        arm_arg_strs = arg_strs
+        all_ptypes = @cls_meth_ptypes[i].split("|")
+        if midx < all_ptypes.length
+          arm_ptypes = all_ptypes[midx].split(",")
+          pk = arg_compiled.length
+          while pk < arm_ptypes.length
+            pad = "0"
+            pt_base = base_type(arm_ptypes[pk])
+            if pt_base == "poly"
+              pad = "sp_box_nil()"
+            end
+            arm_arg_strs = arm_arg_strs + ", " + pad
+            pk = pk + 1
+          end
+        end
+        call_expr = "sp_" + cname + "_" + sanitize_name(mname) + "((sp_" + cname + " *)" + recv_tmp + ".v.p" + arm_arg_strs + ")"
         rhs = call_expr
         if is_poly_ret == 1
           this_rt = cls_method_return(i, mname)

--- a/test/poly_dispatch_arity_padding.rb
+++ b/test/poly_dispatch_arity_padding.rb
@@ -1,0 +1,36 @@
+# Poly dispatch over user classes whose `m` definitions have
+# different arities — Switch#toggle takes 0 args; Knob#toggle takes
+# one positional default. Without per-arm padding, the C compiler
+# rejects the dispatch table with "too few arguments to function
+# 'sp_Knob_toggle'" (the dispatch arms have one fixed call shape
+# but the candidate methods have different arities).
+
+class Switch
+  def initialize
+    @v = 1
+  end
+  def toggle
+    @v = 0
+  end
+  attr_reader :v
+end
+
+class Knob
+  def toggle(soft = true)
+    0
+  end
+end
+
+class Box
+  def initialize
+    @items = [Switch.new, Switch.new]   # poly-typed; .toggle dispatch
+                                        # over every class with `toggle`
+  end
+  attr_reader :items
+end
+
+b = Box.new
+b.items[0].toggle
+b.items[1].toggle
+puts b.items[0].v   # 0
+puts b.items[1].v   # 0


### PR DESCRIPTION
## Reproduction

```ruby
class Switch
  def initialize
    @v = 1
  end
  def toggle
    @v = 0
  end
  attr_reader :v
end

class Knob
  def toggle(soft = true)
    0
  end
end

class Box
  def initialize
    @items = [Switch.new, Switch.new]
  end
  attr_reader :items
end

b = Box.new
b.items[0].toggle
b.items[1].toggle
puts b.items[0].v   # 0
puts b.items[1].v   # 0
```

## Expected behavior

```
0
0
```

## Actual behavior

```
$ ./spinel test.rb -o test
/tmp/spinel_out.XXXXXX.c: In function 'sp_Box_toggle_first':
/tmp/spinel_out.XXXXXX.c:NN:34: error: too few arguments to function 'sp_Knob_toggle'; expected 2, have 1
   NN |       if (_t3.cls_id == 1) _t4 = sp_Knob_toggle((sp_Knob *)_t3.v.p);
spinel: C compilation failed
```

## Analysis & fix

When `recv.m(...)` is compiled with a poly receiver, codegen
emits one C-call arm per user class that defines `m`:

```c
if (recv.tag == SP_TAG_OBJ) {
  if (recv.cls_id == 0) _t = sp_Switch_toggle((sp_Switch *)recv.v.p);
  if (recv.cls_id == 1) _t = sp_Knob_toggle  ((sp_Knob   *)recv.v.p); // <- expects 2 args
  ...
}
```

Each arm has to match its target's *fixed* C arity. When the
candidate methods disagree on arity (e.g. `Switch#toggle` takes 0
args, `Knob#toggle(soft = true)` takes 1 with default), the C
compiler rejects the dispatch table with `too few arguments to
function 'sp_<Class>_<m>'` — even though the runtime cls_id
check would skip the wrong arm.

Fix: in `compile_poly_method_call`, when emitting the arm for
class `i`, look up the target method's parameter types via
`@cls_meth_ptypes[i]`. If the target has more params than the
call site supplied, pad each missing trailing slot with a
default-typed zero — `0` for non-poly param types, `sp_box_nil()`
for `poly`. This lets every arm compile regardless of which
other class's method dictates the column shape; the actual
runtime call still goes to the correct arm via cls_id, and that
arm sees the call site's real args (with the rest as filler the
target's own defaults would have placed).

## Test plan

- [x] `test/poly_dispatch_arity_padding.rb` — `Box#@items` typed
      as poly; `b.items[i].toggle` dispatches over Switch and
      Knob; without the fix, C rejects the dispatch table.
- [x] `make -j4 bootstrap` green.
- [x] `make test` 0 fail / 0 error.