### PR TITLE
fix(codegen): attr-writer call returns rhs, not 0

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -21482,7 +21482,7 @@ class Compiler
             j = 0
             while j < writers.length
               if writers[j] == bname
-                return "(" + rc + arrow + sanitize_ivar(bname) + " = " + compile_arg0(nid) + ", 0)"
+                return "(" + rc + arrow + sanitize_ivar(bname) + " = " + compile_arg0(nid) + ")"
               end
               j = j + 1
             end

--- a/test/attr_writer_returns_rhs.rb
+++ b/test/attr_writer_returns_rhs.rb
@@ -1,0 +1,23 @@
+# `obj.attr = v` as an expression should evaluate to `v`, the rhs,
+# matching Ruby semantics. Codegen used to emit `(rc->iv = v, 0)` —
+# the trailing `, 0` made the C expression value `0`, so chained
+# writes `local = obj.attr = v` saw 0 instead of v.
+
+class Box
+  attr_accessor :n
+  def initialize
+    @n = 0
+  end
+end
+
+b = Box.new
+local = (b.n = 42)
+puts local      # 42
+puts b.n        # 42
+
+# Chained variant — both lvalues should land on the same rhs value.
+b1 = Box.new
+b2 = Box.new
+b1.n = b2.n = 7
+puts b1.n       # 7
+puts b2.n       # 7


### PR DESCRIPTION
## Reproduction

```ruby
class Box
  attr_accessor :n
  def initialize
    @n = 0
  end
end

b = Box.new
local = (b.n = 42)
puts local      # 42
puts b.n        # 42

b1 = Box.new
b2 = Box.new
b1.n = b2.n = 7
puts b1.n       # 7
puts b2.n       # 7
```

## Expected behavior

```
42
42
7
7
```

## Actual behavior

```
0
42
0
7
```

The first `puts local` prints `0` because the assignment
expression `b.n = 42` evaluates to `0` instead of `42`. The
chained `b1.n = b2.n = 7` lands the right value at `b2.n` (the
inner write) but `0` at `b1.n` (the outer slot reads the chain
expression's value, which was `0`).

## Analysis & fix

`compile_object_method_expr`'s attr-writer branch emits

```c
(rc->iv_<bname> = compile_arg0(nid), 0)
```

The trailing `, 0` is a C comma operator: do the assignment, then
discard its value and yield `0`. So as an expression, `obj.attr
= v` always evaluates to `0` regardless of `v`. Ruby semantics
say it should evaluate to `v`.

Drop the trailing `, 0`:

```c
(rc->iv_<bname> = compile_arg0(nid))
```

The assignment expression itself evaluates to `v` (C semantics
for `=`). The slot-type-vs-rhs-type cast is handled implicitly
the same way it is at the plain ivar/local-write sites.

## Test plan

- [x] `test/attr_writer_returns_rhs.rb` — value of `b.n = 42`
      bound to `local`; chained `b1.n = b2.n = 7` lands `7` at
      both slots.
- [x] `make -j4 bootstrap` green.
- [x] `make test` 0 fail / 0 error.