### PR TITLE
Add keys/values support for sym-keyed hashes

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -852,6 +852,7 @@ static void sp_StrPolyHash_set(sp_StrPolyHash*h,const char*k,sp_RbVal v){if(h->l
 static mrb_bool sp_StrPolyHash_has_key(sp_StrPolyHash*h,const char*k){mrb_int idx=(mrb_int)(sp_str_hash(k)&h->mask);while(h->keys[idx]){if(strcmp(h->keys[idx],k)==0)return TRUE;idx=(idx+1)&h->mask;}return FALSE;}
 static mrb_int sp_StrPolyHash_length(sp_StrPolyHash*h){return h->len;}
 static sp_StrArray*sp_StrPolyHash_keys(sp_StrPolyHash*h){sp_StrArray*a=sp_StrArray_new();for(mrb_int i=0;i<h->len;i++)sp_StrArray_push(a,h->order[i]);return a;}
+static sp_PolyArray*sp_StrPolyHash_values(sp_StrPolyHash*h){sp_PolyArray*a=sp_PolyArray_new();for(mrb_int i=0;i<h->len;i++)sp_PolyArray_push(a,sp_StrPolyHash_get(h,h->order[i]));return a;}
 
 /* SymPolyHash: symbol keys, sp_RbVal values — same shape as SymStrHash but with poly values. */
 typedef struct{sp_sym*keys;sp_RbVal*vals;sp_sym*order;mrb_int len;mrb_int cap;mrb_int mask;}sp_SymPolyHash;
@@ -863,6 +864,8 @@ static sp_RbVal sp_SymPolyHash_get(sp_SymPolyHash*h,sp_sym k){mrb_int idx=(mrb_i
 static void sp_SymPolyHash_set(sp_SymPolyHash*h,sp_sym k,sp_RbVal v){if(h->len*2>=h->cap)sp_SymPolyHash_grow(h);mrb_int idx=(mrb_int)(((mrb_int)k)&h->mask);while(h->keys[idx]>=0){if(h->keys[idx]==k){h->vals[idx]=v;return;}idx=(idx+1)&h->mask;}h->keys[idx]=k;h->vals[idx]=v;h->order[h->len]=k;h->len++;}
 static mrb_bool sp_SymPolyHash_has_key(sp_SymPolyHash*h,sp_sym k){mrb_int idx=(mrb_int)(((mrb_int)k)&h->mask);while(h->keys[idx]>=0){if(h->keys[idx]==k)return TRUE;idx=(idx+1)&h->mask;}return FALSE;}
 static mrb_int sp_SymPolyHash_length(sp_SymPolyHash*h){return h->len;}
+static sp_IntArray*sp_SymPolyHash_keys(sp_SymPolyHash*h){sp_IntArray*a=sp_IntArray_new();for(mrb_int i=0;i<h->len;i++)sp_IntArray_push(a,(mrb_int)h->order[i]);return a;}
+static sp_PolyArray*sp_SymPolyHash_values(sp_SymPolyHash*h){sp_PolyArray*a=sp_PolyArray_new();for(mrb_int i=0;i<h->len;i++)sp_PolyArray_push(a,sp_SymPolyHash_get(h,h->order[i]));return a;}
 
 #include <setjmp.h>
 #define SP_EXC_STACK_MAX 64

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2938,6 +2938,9 @@ class Compiler
         if rt == "int_str_hash"
           return "int_array"
         end
+        if rt == "sym_int_hash" || rt == "sym_str_hash" || rt == "sym_poly_hash"
+          return "sym_array"
+        end
       end
       return "str_array"
     end
@@ -3015,8 +3018,11 @@ class Compiler
     if mname == "values"
       if recv >= 0
         rt = infer_type(recv)
-        if rt == "str_str_hash" || rt == "int_str_hash"
+        if rt == "str_str_hash" || rt == "int_str_hash" || rt == "sym_str_hash"
           return "str_array"
+        end
+        if rt == "sym_poly_hash" || rt == "str_poly_hash"
+          return "poly_array"
         end
       end
       return "int_array"
@@ -12137,6 +12143,8 @@ class Compiler
     emit_raw("static mrb_bool sp_SymIntHash_has_key(sp_SymIntHash*h,sp_sym k){mrb_int idx=(mrb_int)(((mrb_int)k)&h->mask);while(h->keys[idx]>=0){if(h->keys[idx]==k)return TRUE;idx=(idx+1)&h->mask;}return FALSE;}")
     emit_raw("static mrb_int sp_SymIntHash_length(sp_SymIntHash*h){return h->len;}")
     emit_raw("static void sp_SymIntHash_delete(sp_SymIntHash*h,sp_sym k){mrb_int idx=(mrb_int)(((mrb_int)k)&h->mask);while(h->keys[idx]>=0){if(h->keys[idx]==k){h->keys[idx]=-1;h->vals[idx]=0;h->len--;mrb_int j=(idx+1)&h->mask;while(h->keys[j]>=0){mrb_int nj=(mrb_int)(((mrb_int)h->keys[j])&h->mask);if((j>idx&&(nj<=idx||nj>j))||(j<idx&&nj<=idx&&nj>j)){h->keys[idx]=h->keys[j];h->vals[idx]=h->vals[j];h->keys[j]=-1;h->vals[j]=0;idx=j;}j=(j+1)&h->mask;}return;}idx=(idx+1)&h->mask;}}")
+    emit_raw("static sp_IntArray*sp_SymIntHash_keys(sp_SymIntHash*h){sp_IntArray*a=sp_IntArray_new();for(mrb_int i=0;i<h->len;i++)sp_IntArray_push(a,(mrb_int)h->order[i]);return a;}")
+    emit_raw("static sp_IntArray*sp_SymIntHash_values(sp_SymIntHash*h){sp_IntArray*a=sp_IntArray_new();for(mrb_int i=0;i<h->len;i++)sp_IntArray_push(a,sp_SymIntHash_get(h,h->order[i]));return a;}")
     # sym_array.tally — emitted alongside sp_SymIntHash because the
     # helper depends on the typedef. sym_array storage is sp_IntArray
     # (sym ids stored as mrb_int); cast each element to sp_sym for the
@@ -12158,6 +12166,8 @@ class Compiler
     emit_raw("static mrb_bool sp_SymStrHash_has_key(sp_SymStrHash*h,sp_sym k){mrb_int idx=(mrb_int)(((mrb_int)k)&h->mask);while(h->keys[idx]>=0){if(h->keys[idx]==k)return TRUE;idx=(idx+1)&h->mask;}return FALSE;}")
     emit_raw("static mrb_int sp_SymStrHash_length(sp_SymStrHash*h){return h->len;}")
     emit_raw("static void sp_SymStrHash_delete(sp_SymStrHash*h,sp_sym k){mrb_int idx=(mrb_int)(((mrb_int)k)&h->mask);while(h->keys[idx]>=0){if(h->keys[idx]==k){h->keys[idx]=-1;h->vals[idx]=NULL;h->len--;mrb_int j=(idx+1)&h->mask;while(h->keys[j]>=0){mrb_int nj=(mrb_int)(((mrb_int)h->keys[j])&h->mask);if((j>idx&&(nj<=idx||nj>j))||(j<idx&&nj<=idx&&nj>j)){h->keys[idx]=h->keys[j];h->vals[idx]=h->vals[j];h->keys[j]=-1;h->vals[j]=NULL;idx=j;}j=(j+1)&h->mask;}return;}idx=(idx+1)&h->mask;}}")
+    emit_raw("static sp_IntArray*sp_SymStrHash_keys(sp_SymStrHash*h){sp_IntArray*a=sp_IntArray_new();for(mrb_int i=0;i<h->len;i++)sp_IntArray_push(a,(mrb_int)h->order[i]);return a;}")
+    emit_raw("static sp_StrArray*sp_SymStrHash_values(sp_SymStrHash*h){sp_StrArray*a=sp_StrArray_new();for(mrb_int i=0;i<h->len;i++)sp_StrArray_push(a,sp_SymStrHash_get(h,h->order[i]));return a;}")
     emit_raw("")
   end
 
@@ -20875,6 +20885,14 @@ class Compiler
           return "sp_SymIntHash_get((sp_SymIntHash *)(" + rc + "), " + key + ")"
         end
       end
+      if mname == "keys"
+        @needs_int_array = 1
+        return "sp_SymIntHash_keys(" + rc + ")"
+      end
+      if mname == "values"
+        @needs_int_array = 1
+        return "sp_SymIntHash_values(" + rc + ")"
+      end
     end
     if recv_type == "sym_str_hash"
       if mname == "[]"
@@ -20921,6 +20939,14 @@ class Compiler
           return "sp_SymStrHash_get((sp_SymStrHash *)(" + rc + "), " + key + ")"
         end
       end
+      if mname == "keys"
+        @needs_int_array = 1
+        return "sp_SymStrHash_keys(" + rc + ")"
+      end
+      if mname == "values"
+        @needs_str_array = 1
+        return "sp_SymStrHash_values(" + rc + ")"
+      end
     end
     if recv_type == "sym_poly_hash"
       if mname == "[]"
@@ -20937,6 +20963,15 @@ class Compiler
       end
       if mname == "any?" && @nd_block[nid] < 0
         return "(sp_SymPolyHash_length(" + rc + ") > 0)"
+      end
+      if mname == "keys"
+        @needs_int_array = 1
+        return "sp_SymPolyHash_keys(" + rc + ")"
+      end
+      if mname == "values"
+        @needs_poly_array = 1
+        @needs_rb_value = 1
+        return "sp_SymPolyHash_values(" + rc + ")"
       end
     end
     if recv_type == "str_poly_hash"
@@ -20957,6 +20992,11 @@ class Compiler
       end
       if mname == "keys"
         return "sp_StrPolyHash_keys(" + rc + ")"
+      end
+      if mname == "values"
+        @needs_poly_array = 1
+        @needs_rb_value = 1
+        return "sp_StrPolyHash_values(" + rc + ")"
       end
     end
     if recv_type == "str_int_hash"

--- a/test/sym_hash_keys_values.rb
+++ b/test/sym_hash_keys_values.rb
@@ -1,0 +1,36 @@
+# keys / values for sym-keyed hash variants plus str_poly_hash.
+
+# sym_int_hash
+h1 = {a: 1, b: 2, c: 3}
+puts h1.keys.inspect
+puts h1.values.inspect
+puts h1.keys.length
+puts h1.values.length
+
+# sym_str_hash
+h2 = {name: "Alice", role: "admin"}
+puts h2.keys.inspect
+puts h2.values.inspect
+
+# sym_poly_hash (mixed value types)
+h3 = {name: "Alice", age: 30, active: true}
+puts h3.keys.inspect
+puts h3.values.inspect
+
+# str_poly_hash (string keys, mixed values)
+h4 = {"name" => "Alice", "age" => 30, "active" => true}
+puts h4.keys.inspect
+puts h4.values.inspect
+
+h1.keys.each do |k1|
+  puts k1
+end
+h2.values.each do |sv|
+  puts sv
+end
+h3.keys.each do |k3|
+  puts k3
+end
+h3.values.each do |pv|
+  puts pv
+end

--- a/test/sym_hash_keys_values.rb.expected
+++ b/test/sym_hash_keys_values.rb.expected
@@ -1,0 +1,21 @@
+[:a, :b, :c]
+[1, 2, 3]
+3
+3
+[:name, :role]
+["Alice", "admin"]
+[:name, :age, :active]
+["Alice", 30, true]
+["name", "age", "active"]
+["Alice", 30, true]
+a
+b
+c
+Alice
+admin
+name
+age
+active
+Alice
+30
+true


### PR DESCRIPTION
## Summary
- Adds `keys` / `values` codegen for `sym_int_hash`, `sym_str_hash`, `sym_poly_hash`, plus `values` for `str_poly_hash`
- Adds matching runtime helpers in `lib/sp_runtime.h` (`sp_SymIntHash_keys/values`, `sp_SymStrHash_keys/values`, `sp_SymPolyHash_keys/values`, `sp_StrPolyHash_values`)
- Extends `infer_type` so `keys` returns `sym_array` and `values` returns the right element-array type for these receivers

## Test plan
- [ ] `test/sym_hash_keys_values.rb` matches `test/sym_hash_keys_values.rb.expected`

🤖 Generated with [Claude Code](https://claude.com/claude-code)