### PR TITLE
fix(codegen): AndNode wraps poly operand with sp_poly_truthy

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -16524,7 +16524,13 @@ class Compiler
       return compile_unless_expr(nid)
     end
     if t == "AndNode"
-      return "(" + compile_expr(@nd_left[nid]) + " && " + compile_expr(@nd_right[nid]) + ")"
+      lt = infer_type(@nd_left[nid])
+      rt = infer_type(@nd_right[nid])
+      le = compile_expr(@nd_left[nid])
+      re = compile_expr(@nd_right[nid])
+      le_t = lt == "poly" ? "sp_poly_truthy(" + le + ")" : le
+      re_t = rt == "poly" ? "sp_poly_truthy(" + re + ")" : re
+      return "(" + le_t + " && " + re_t + ")"
     end
     if t == "OrNode"
       left_nid = @nd_left[nid]

--- a/test/and_node_poly_operand.rb
+++ b/test/and_node_poly_operand.rb
@@ -1,0 +1,24 @@
+# `a && b` codegen used to lower to raw C `a && b` regardless of
+# operand type. When either operand is `sp_RbVal` (poly), C rejects
+# `&&` between a struct and an int. Wrap poly operands with
+# `sp_poly_truthy`.
+
+class Holder
+  def initialize
+    @poly = "x"   # string first…
+    @poly = 42    # …then int — slot widens to poly
+    @counter = 0
+  end
+
+  attr_reader :poly, :counter
+
+  def chain
+    if @poly && @counter == 0
+      @counter = 1
+    end
+    @counter
+  end
+end
+
+h = Holder.new
+puts h.chain    # 1


### PR DESCRIPTION
## Reproduction

```ruby
class Holder
  def initialize
    @poly = "x"
    @poly = 42         # heterogeneous writes — slot widens to poly
    @counter = 0
  end

  def chain
    if @poly && @counter == 0
      @counter = 1
    end
    @counter
  end
end

puts Holder.new.chain
```

## Expected behavior

```
1
```

## Actual behavior

```
$ ./spinel test.rb -o test
/tmp/spinel_out.XXXXXX.c: In function 'sp_Holder_chain':
/tmp/spinel_out.XXXXXX.c:NN:NN: error: invalid operands to binary &&
   NN |     if ((self->iv_poly && (self->iv_counter == 0))) {
      |                        ^~
spinel: C compilation failed
```

`@poly` is widened to `sp_RbVal` by the writer-scan. The `&&`
codegen emits the operand verbatim; C rejects `&&` between a
struct and an int.

## Analysis & fix

`compile_expr` for `AndNode` emitted

```c
(<left> && <right>)
```

unconditionally. When either operand has type `poly` the C
compiler rejects the operator (struct vs int). The matching
`OrNode` handler already wraps poly operands with
`sp_poly_truthy`; do the same on `AndNode`:

```c
(sp_poly_truthy(left) && sp_poly_truthy(right))
```

Non-poly operands keep the direct `&&`.

## Test plan

- [x] `test/and_node_poly_operand.rb` — `@poly && @counter == 0`
      where `@poly` is widened to poly. Without the fix the C
      compile rejects the `&&`.
- [x] `make -j4 bootstrap` green.
- [x] `make test` 0 fail / 0 error.