### PR TITLE
fix(codegen): name-based `sample` shortcut defers when recv isn't an array

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2953,6 +2953,13 @@ class Compiler
         if rt == "float_array"
           return "float"
         end
+        if rt == "int_array"
+          return "int"
+        end
+        # Not an array — recv has a user-defined `sample`. Defer to
+        # the user-class dispatch path instead of returning the
+        # Array#sample default of int.
+        return ""
       end
       return "int"
     end

--- a/test/sample_user_method.rb
+++ b/test/sample_user_method.rb
@@ -1,0 +1,20 @@
+# `infer_method_name_type` had a name-based shortcut for `sample`
+# that returned the Array#sample default of int regardless of recv.
+# A user-defined `sample` on an obj receiver inferred as int even
+# though the method returns a non-int — and downstream consumers
+# (puts, comparisons, etc.) used the wrong shape.
+
+class Box
+  def initialize(label)
+    @label = label
+  end
+
+  attr_reader :label
+
+  def sample
+    @label
+  end
+end
+
+b = Box.new("ok")
+puts b.sample    # ok


### PR DESCRIPTION
## Reproduction

```ruby
class Box
  def initialize(label)
    @label = label
  end

  attr_reader :label

  def sample
    @label
  end
end

b = Box.new("ok")
puts b.sample
```

## Expected behavior

```
ok
```

## Actual behavior

```
$ ./spinel test.rb -o test
$ ./test
105077359878145
```

The C output:

```c
static inline mrb_int sp_Box_sample(sp_Box *self) { ... }
...
printf("%lld\n", (long long)(mrb_int)(sp_Box_sample(_t1)));
```

`Box#sample` returns a `const char *`, but the inferred return
type of `b.sample` was `int`. The `puts` codegen picked the int
formatter, casting the string pointer to `long long` and
printing its address.

## Analysis & fix

`infer_method_name_type` had a name-based shortcut for `sample`
that returned the Array#sample default of `int` for any non-
string/sym/float-array receiver:

```ruby
if mname == "sample"
  if recv >= 0
    rt = infer_type(recv)
    if rt == "str_array"; return "string"; end
    if rt == "sym_array"; return "symbol"; end
    if rt == "float_array"; return "float"; end
  end
  return "int"   # <- swallows obj recv with user-defined sample
end
```

That short-circuited *before* `infer_recv_method_type` could see
a user-defined `sample` on an obj or poly receiver, so calls like
`box.sample` (where the recv class has its own `sample` returning
a non-int type) were inferred as int regardless of the actual
return type — and downstream sites that depended on the inferred
type (puts formatter, binop dispatch, ivar slot type, etc.) used
the wrong shape.

Match `int_array` explicitly for completeness, then return `""`
(defer) for any other recv type so the user-class lookup path
runs:

```ruby
if mname == "sample"
  if recv >= 0
    rt = infer_type(recv)
    if rt == "str_array"; return "string"; end
    ...
    if rt == "int_array"; return "int"; end
    return ""   # not an array — defer to user-class dispatch
  end
  return "int"
end
```

The existing `infer_recv_method_type` then walks the recv's class
table and returns the user method's actual return type.

## Test plan

- [x] `test/sample_user_method.rb` — `Box#sample` returns
      `@label` (a string). Without the fix, `puts box.sample`
      prints the pointer-as-int instead of the string.
- [x] `make -j4 bootstrap` green.
- [x] `make test` 0 fail / 0 error.