### PR TITLE
fix(codegen): truncate extra args in poly-dispatch arms

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -22500,25 +22500,30 @@ class Compiler
       cname = @cls_names[i]
       midx = cls_find_method_direct(i, mname)
       if midx >= 0
-        # Pad with default-typed zeros when target method has more
-        # params than the call site supplied — same shape that C
-        # demands at every fixed-arity call. Per-arm padding lets us
-        # poly-dispatch `recv.m()` even when one of the candidate
-        # classes has a method that takes positional defaults.
-        arm_arg_strs = arg_strs
+        # Match each arm to the target method's *fixed* C arity:
+        # pad missing trailing slots with default-typed zeros, and
+        # truncate extras (when the call site supplies more args than
+        # this candidate accepts — happens when several classes share
+        # the method name but disagree on parameter count).
+        arm_arg_strs = ""
         all_ptypes = @cls_meth_ptypes[i].split("|")
+        arm_ptypes = "".split(",")
         if midx < all_ptypes.length
           arm_ptypes = all_ptypes[midx].split(",")
-          pk = arg_compiled.length
-          while pk < arm_ptypes.length
+        end
+        pk = 0
+        while pk < arm_ptypes.length
+          if pk < arg_compiled.length
+            arm_arg_strs = arm_arg_strs + ", " + arg_compiled[pk]
+          else
             pad = "0"
             pt_base = base_type(arm_ptypes[pk])
             if pt_base == "poly"
               pad = "sp_box_nil()"
             end
             arm_arg_strs = arm_arg_strs + ", " + pad
-            pk = pk + 1
           end
+          pk = pk + 1
         end
         call_expr = "sp_" + cname + "_" + sanitize_name(mname) + "((sp_" + cname + " *)" + recv_tmp + ".v.p" + arm_arg_strs + ")"
         rhs = call_expr

--- a/test/poly_dispatch_arity_truncate.rb
+++ b/test/poly_dispatch_arity_truncate.rb
@@ -1,0 +1,45 @@
+# Poly-dispatch arms must match each candidate method's *fixed* C
+# arity. The padding side (target takes more params than the call
+# supplied — defaults fill the extras) was already in place. The
+# truncate side is the complement: when a candidate class's method
+# accepts *fewer* params than the call supplied, that arm has to
+# drop the surplus to compile, even though the runtime cls_id check
+# would skip it for a non-matching receiver.
+
+class Heater
+  def initialize
+    @v = 0
+  end
+  def write(addr, data)
+    @v = addr + data
+  end
+  attr_reader :v
+end
+
+class Buzzer
+  def initialize
+    @v = 0
+  end
+  def write(addr)        # one fewer arg than Heater#write
+    @v = addr
+  end
+  attr_reader :v
+end
+
+class Box
+  def initialize
+    @poly = nil
+    @poly = "x"
+    @poly = Heater.new   # widen to poly via heterogeneous writes
+  end
+
+  attr_reader :poly
+
+  def call_write(addr, data)
+    @poly.write(addr, data)   # poly recv → arms over Heater + Buzzer
+  end
+end
+
+b = Box.new
+b.call_write(7, 5)
+puts b.poly.v   # 12  (Heater: addr + data)


### PR DESCRIPTION
Follow-up to `pr/poly-dispatch-arity-padding` (#243): the padding
side handled "target method takes more params than the call site
supplied — fill with defaults". This handles the complement: when
the target accepts *fewer* params, drop the surplus.

## Reproduction

```ruby
class Heater
  def initialize; @v = 0; end
  attr_reader :v
  def write(addr, data); @v = addr + data; end
end

class Buzzer
  def initialize; @v = 0; end
  attr_reader :v
  def write(addr); @v = addr; end       # one fewer arg
end

class Box
  def initialize
    @poly = nil
    @poly = "x"
    @poly = Heater.new                  # widen @poly to poly
  end
  attr_reader :poly

  def call_write(addr, data)
    @poly.write(addr, data)             # poly dispatch over Heater + Buzzer
  end
end

b = Box.new
b.call_write(7, 5)
puts b.poly.v
```

## Expected behavior

```
12
```

## Actual behavior

```
$ ./spinel test.rb -o test
/tmp/spinel_out.XXXXXX.c: In function 'sp_Box_call_write':
/tmp/spinel_out.XXXXXX.c:NN:NN: error: too many arguments to function 'sp_Buzzer_write'; expected 2, have 3
   NN |       if (_t1.cls_id == 1) _t2 = sp_Buzzer_write((sp_Buzzer *)_t1.v.p, lv_addr, lv_data);
spinel: C compilation failed
```

## Analysis & fix

The poly-dispatch table emits one C call per user class that
defines the method:

```c
if (recv.cls_id == 0) sp_Heater_write((sp_Heater *)recv.v.p, lv_addr, lv_data);
if (recv.cls_id == 1) sp_Buzzer_write((sp_Buzzer *)recv.v.p, lv_addr, lv_data);
```

The padding pass added defaults when a candidate's method took
*more* params than the call supplied (#243). It did not handle the
reverse: when the candidate takes *fewer* params, the call shape
exceeds that candidate's fixed C arity and the compile fails — even
though the runtime cls_id check would skip the over-shaped arm for
any actual receiver.

Rebuild `arm_arg_strs` from `arg_compiled` per arm, indexing each
target slot up to `arm_ptypes.length`:

- `pk < arg_compiled.length`: take the call site's arg.
- otherwise: pad with default-typed zero (`0` or `sp_box_nil()`).
- `pk >= arm_ptypes.length`: stop — extras are dropped.

Each arm now compiles with exactly the shape its target signature
demands; the runtime cls_id selection is unchanged.

## Test plan

- [x] `test/poly_dispatch_arity_truncate.rb` — heterogeneous union
      with `Heater#write(addr, data)` and `Buzzer#write(addr)`,
      called with two args via a poly receiver.
- [x] `make -j4 bootstrap` green.
- [x] `make test` 0 fail / 0 error.