### PR TITLE
fix(codegen): attr-writer boxes rhs when slot is poly

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -22283,7 +22283,31 @@ class Compiler
             j = 0
             while j < writers.length
               if writers[j] == bname
-                return "(" + rc + arrow + sanitize_ivar(bname) + " = " + compile_arg0(nid) + ")"
+                # Box the rhs when the slot is poly so the assignment
+                # type-matches at C level. Without this, an obj-typed
+                # rhs flowing into a poly slot emits
+                # `slot = ptr_value` with a struct LHS — rejected by
+                # C compile. Use a comma expression so the value of
+                # the chain is the *original* rhs (typed), preserving
+                # Ruby's `obj.attr = v` semantics for downstream
+                # consumers like `local = obj.attr = v` or
+                # `puts(obj.attr = v)` where `v`'s static type drives
+                # the formatter / cast.
+                slot_t = cls_ivar_type(ci, "@" + bname)
+                args_id_w = @nd_arguments[nid]
+                arg0_w = compile_arg0(nid)
+                if slot_t == "poly"
+                  arg_t = "int"
+                  if args_id_w >= 0
+                    arg_ids_w = get_args(args_id_w)
+                    if arg_ids_w.length > 0
+                      arg_t = infer_type(arg_ids_w[0])
+                    end
+                  end
+                  boxed = box_value_to_poly(arg_t, arg0_w)
+                  return "(" + rc + arrow + sanitize_ivar(bname) + " = " + boxed + ", " + arg0_w + ")"
+                end
+                return "(" + rc + arrow + sanitize_ivar(bname) + " = " + arg0_w + ")"
               end
               j = j + 1
             end
@@ -26784,7 +26808,22 @@ class Compiler
               if is_value_type_obj(rt) == 1
                 arrow2 = "."
               end
-              emit("  " + rc + arrow2 + sanitize_ivar(bname) + " = " + compile_arg0(nid) + ";")
+              # Box rhs when the slot is poly, same as the
+              # expression-form attr_writer above.
+              slot_t = cls_ivar_type(r_ci, "@" + bname)
+              arg0_w = compile_arg0(nid)
+              if slot_t == "poly"
+                args_id_w = @nd_arguments[nid]
+                arg_t = "int"
+                if args_id_w >= 0
+                  arg_ids_w = get_args(args_id_w)
+                  if arg_ids_w.length > 0
+                    arg_t = infer_type(arg_ids_w[0])
+                  end
+                end
+                arg0_w = box_value_to_poly(arg_t, arg0_w)
+              end
+              emit("  " + rc + arrow2 + sanitize_ivar(bname) + " = " + arg0_w + ";")
               return 1
             end
           end

--- a/test/attr_writer_poly_box.rb
+++ b/test/attr_writer_poly_box.rb
@@ -1,0 +1,24 @@
+# `obj.attr = v` codegen emitted `slot = arg0` regardless of slot
+# type. When the slot is poly (sp_RbVal — widened by heterogeneous
+# writes) and the rhs is typed (int / string / obj_X / ...), C
+# rejects the assignment as a struct-from-scalar/pointer mismatch.
+
+class Bag
+  attr_accessor :item
+  def initialize
+    @item = "tag"     # string first…
+    @item = 5         # …then int — slot widens to poly
+  end
+end
+
+class Caller
+  def stuff(bag)
+    bag.item = 99     # statement-form attr-writer on poly slot
+    bag.item
+  end
+end
+
+b = Bag.new
+puts Caller.new.stuff(b)   # 99
+puts (b.item = 7)          # 7  (expression-form; `=` returns rhs)
+puts b.item                # 7


### PR DESCRIPTION
## Reproduction

```ruby
class Bag
  attr_accessor :item
  def initialize
    @item = "tag"
    @item = 5         # heterogeneous writes — slot widens to poly
  end
end

class Caller
  def stuff(bag)
    bag.item = 99
    bag.item
  end
end

b = Bag.new
puts Caller.new.stuff(b)   # 99
puts (b.item = 7)          # 7
puts b.item                # 7
```

## Expected behavior

```
99
7
7
```

## Actual behavior

```
$ ./spinel test.rb -o test
/tmp/spinel_out.XXXXXX.c: In function 'sp_Caller_stuff':
/tmp/spinel_out.XXXXXX.c:NN:NN: error: incompatible types when assigning to type 'sp_RbVal' from type 'mrb_int' {aka 'long int'}
   NN |   lv_bag->iv_item = 99;
spinel: C compilation failed
```

`@item` was widened to poly (`sp_RbVal`) by the writer-scan. The
attr-writer codegen emitted a raw `slot = 99` — assigning an int
to a struct field, rejected by the C compiler.

## Analysis & fix

The attr-writer call has two emit paths:

- Statement form (`compile_call_stmt`):
  `emit("  slot = compile_arg0(nid);")`
- Expression form (`compile_object_method_expr`):
  `return "(slot = compile_arg0(nid))"`

Neither inspected the slot's recorded type. When the slot is
poly, the rhs needs to flow through `box_value_to_poly` first.

Both paths now look up the slot's type via `cls_ivar_type` and,
when poly, box the rhs:

- Statement: `slot = box_value_to_poly(arg_t, arg0);`
- Expression: `(slot = box_value_to_poly(arg_t, arg0), arg0)` —
  comma expression so the chain's value remains the *original*
  rhs (typed). This preserves Ruby's `obj.attr = v` semantics for
  downstream consumers like `local = obj.attr = v` or
  `puts(obj.attr = v)` where `v`'s static type drives the
  formatter / cast.

Non-poly slots keep the existing direct assignment and existing
return-rhs shape from `pr/attr-writer-returns-rhs` (#244).

## Test plan

- [x] `test/attr_writer_poly_box.rb` — Bag#@item poly slot, set
      via `bag.item = N` (statement form) and `(b.item = 7)`
      (expression form).
- [x] `make -j4 bootstrap` green.
- [x] `make test` 0 fail / 0 error.