### PR TITLE
fix(codegen): cls_ivar_type defers to parent's recorded type

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -1639,21 +1639,38 @@ class Compiler
   def cls_ivar_type(ci, iname)
     names = @cls_ivar_names[ci].split(";")
     types = @cls_ivar_types[ci].split(";")
+    own_t = ""
     j = 0
     while j < names.length
       if names[j] == iname
         if j < types.length
-          return types[j]
+          own_t = types[j]
+        else
+          own_t = "int"
         end
-        return "int"
+        break
       end
       j = j + 1
     end
+    parent_t = ""
     if @cls_parents[ci] != ""
       pi = find_class_idx(@cls_parents[ci])
-      if pi >= 0
-        return cls_ivar_type(pi, iname)
+      if pi >= 0 && ivar_in_chain(pi, iname) == 1
+        parent_t = cls_ivar_type(pi, iname)
       end
+    end
+    # The struct embeds parent ivars at the parent's recorded type
+    # (`emit_class_fields` skips own copies that are also in the
+    # parent chain). When the parent has the same ivar, the parent's
+    # type is what the C struct field actually has — so any access
+    # through `self->iv_X` must agree with that, regardless of what
+    # this child's own table happened to record. Defer to the parent
+    # type when both classes know the ivar.
+    if parent_t != ""
+      return parent_t
+    end
+    if own_t != ""
+      return own_t
     end
     "int"
   end

--- a/test/cls_ivar_type_parent_defer.rb
+++ b/test/cls_ivar_type_parent_defer.rb
@@ -1,0 +1,32 @@
+# When the same ivar is registered on both a child class and a
+# parent, the C struct embeds the parent's field at the parent's
+# recorded type (`emit_class_fields` skips own copies that are also
+# in the parent chain). `cls_ivar_type` used to return the child's
+# own-table entry — letting downstream emit sites disagree with
+# the actual struct field type.
+
+class Parent
+  def initialize
+    @x = 0
+    @x = "s"      # heterogeneous int+string → @x widens to poly
+  end
+end
+
+class Child < Parent
+  def initialize
+    super
+    @x = 7        # write through the inherited (poly) slot
+  end
+  def read_x
+    @x
+  end
+end
+
+c = Child.new
+# Reading back via a Child-defined method that emits `self->iv_x`.
+# Without the fix, cls_ivar_type(Child, "@x") returned the int from
+# Child's own table; the struct field is sp_RbVal (Parent's poly);
+# the read miscompiled / yielded a garbage int. With the fix the
+# emit goes through the poly read path and unboxes correctly.
+v = c.read_x
+puts v        # 7


### PR DESCRIPTION
## Reproduction

```ruby
class Parent
  def initialize
    @x = 0
    @x = "s"      # heterogeneous int+string → @x widens to poly
  end
end

class Child < Parent
  def initialize
    super
    @x = 7        # write through the inherited (poly) slot
  end
  def read_x
    @x
  end
end

c = Child.new
puts c.read_x
```

## Expected behavior

```
7
```

## Actual behavior

The C struct for Child embeds Parent's `iv_x` at Parent's
recorded type:

```c
struct sp_Parent_s { sp_RbVal iv_x; };
struct sp_Child_s  { sp_RbVal iv_x; };  // copied from Parent
```

But the codegen for Child#read_x looks up `cls_ivar_type(Child,
"@x")` which returns Child's own-table entry — `int`, set when
Child#initialize wrote `@x = 7`. The read site emits a raw
`return self->iv_x;` (typed `mrb_int` per the lookup) against a
field that's actually `sp_RbVal`:

```
error: incompatible types when returning type 'sp_RbVal' but 'mrb_int' was expected
```

(or, depending on the path, miscompiles silently to a garbage int
read of the struct's first 8 bytes.)

## Analysis & fix

`emit_class_fields` skips own copies of ivars that already live
in the parent chain — the struct embeds the parent's field at
the parent's recorded type. `cls_ivar_type` did not match that:
it returned the child's own-table entry as soon as it found one,
ignoring the parent's record.

When the same ivar is in both the child and an ancestor, defer
to the ancestor's recorded type. Pure ancestor-only lookups
(child has no entry) still walk up via the recursive call, same
as before. Pure child-only lookups (no parent has it) keep the
own-table answer.

This aligns the type returned by `cls_ivar_type` with the type
the C field actually has — every emit site (IVW / IVR /
op-assign / attr_writer / etc.) produces shape-matching C.

## Test plan

- [x] `test/cls_ivar_type_parent_defer.rb` — Parent widens `@x`
      to poly via heterogeneous writes; Child writes `7` through
      the inherited slot and reads back via a Child-defined
      method.
- [x] `make -j4 bootstrap` green.
- [x] `make test` 0 fail / 0 error.