### PR TITLE
fix(codegen): scan_ivars routes writes to parent's slot when inherited

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -6392,6 +6392,19 @@ class Compiler
     0
   end
 
+  def ivar_exists_in_ancestor(ci, iname)
+    if @cls_parents[ci] != ""
+      pi = find_class_idx(@cls_parents[ci])
+      if pi >= 0
+        if ivar_exists(pi, iname) == 1
+          return 1
+        end
+        return ivar_exists_in_ancestor(pi, iname)
+      end
+    end
+    0
+  end
+
   def add_ivar(ci, iname, itype, definite = 0)
     if @cls_ivar_names[ci] != ""
       @cls_ivar_names[ci] = @cls_ivar_names[ci] + ";" + iname
@@ -6477,7 +6490,19 @@ class Compiler
     if @nd_type[nid] == "InstanceVariableWriteNode"
       iname = @nd_name[nid]
       expr_first = @nd_expression[nid]
-      if ivar_exists(ci, iname) == 0
+      if ivar_exists(ci, iname) == 0 && ivar_exists_in_ancestor(ci, iname) == 1
+        # Slot is on a parent class — route the write through
+        # update_ivar_type so the parent's type widens consistently.
+        # Without this, the child re-adds the ivar to its own table
+        # with the new write's type, while the parent widens to poly
+        # via update_ivar_type's recurse, leaving the two tables
+        # disagreeing — and downstream cls_ivar_type lookups on the
+        # child see only its (narrower) entry, missing the widening.
+        vtype = infer_ivar_init_type(expr_first)
+        if vtype != "int" && vtype != "nil"
+          update_ivar_type(ci, iname, vtype)
+        end
+      elsif ivar_exists(ci, iname) == 0
         vtype = infer_ivar_init_type(expr_first)
         add_ivar(ci, iname, vtype, is_definite_ivar_init(expr_first))
       else

--- a/test/scan_ivars_inherited_slot.rb
+++ b/test/scan_ivars_inherited_slot.rb
@@ -1,0 +1,32 @@
+# When a child class first writes to an ivar that already lives on
+# a parent, scan_ivars used to register the ivar on the child too.
+# update_ivar_type then recursed up to the parent and widened
+# (e.g. `int` → `poly` for heterogeneous writes), but the child's
+# own-table entry kept the new write's narrower type. Two tables
+# disagreed about the slot — and downstream type lookups picked
+# the wrong one depending on path, so codegen for the same field
+# disagreed across class methods.
+#
+# Now scan_ivars detects that the slot is already in an ancestor's
+# table and routes the write through update_ivar_type without
+# adding a duplicate entry to the child. The parent's table stays
+# the single source of truth.
+
+class Parent
+  def initialize
+    @v = 0
+    @v = "s"     # parent widens @v to poly
+  end
+end
+
+class Child < Parent
+  def initialize
+    super
+    @v = 42      # child writes through inherited slot
+  end
+  def read
+    @v
+  end
+end
+
+puts Child.new.read     # 42


### PR DESCRIPTION
## Reproduction

```ruby
class Parent
  def initialize
    @v = 0
    @v = "s"     # parent widens @v to poly
  end
end

class Child < Parent
  def initialize
    super
    @v = 42      # child writes through inherited slot
  end
  def read
    @v
  end
end

puts Child.new.read
```

## Expected behavior

```
42
```

## Actual behavior

```
$ ./spinel test.rb -o test
/tmp/spinel_out.XXXXXX.c: In function 'sp_Child_read':
/tmp/spinel_out.XXXXXX.c:NN:NN: error: incompatible types when returning type 'sp_RbVal' but 'mrb_int' was expected
   NN |     return self->iv_v;
spinel: C compilation failed
```

## Analysis & fix

`scan_ivars` saw Child's `@v = 42` write, called
`ivar_exists(Child, "@v")` (returns 0 — the child's own table is
empty), and so `add_ivar(Child, "@v", "int")`.
`update_ivar_type` then recursed up to Parent and widened
Parent's `@v` to poly via the existing
`old != new && old != poly` rule. The child's own-table entry
kept the new write's `int` type.

`emit_class_fields` skips own copies of ivars that also live in
the parent chain — so the C struct emits Parent's `sp_RbVal
iv_v`, not Child's `mrb_int iv_v`. But the codegen for Child#read
looked up `cls_ivar_type(Child, "@v")` which returned the
child's own-table `int` and emitted `return self->iv_v;` typed
`mrb_int`. The C compiler rejects the return.

Add `ivar_exists_in_ancestor` and use it in `scan_ivars` to
detect "slot lives on an ancestor". When that fires, route the
write through `update_ivar_type` (which already recurses up to
the parent) instead of `add_ivar`. The child's table doesn't
grow a duplicate entry; the parent's table is the single source
of truth, matching how the C struct is built.

## Test plan

- [x] `test/scan_ivars_inherited_slot.rb` — Parent widens `@v`
      via heterogeneous writes; Child writes the inherited slot
      and reads it back from a Child-defined method. Without the
      fix, the C compile fails on the return-type mismatch.
- [x] `make -j4 bootstrap` green.
- [x] `make test` 0 fail / 0 error.