### PR TITLE
feat(codegen,runtime): add String#chop

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -501,6 +501,7 @@ static const char*sp_gets(void){char buf[4096];if(!fgets(buf,sizeof(buf),stdin))
 static sp_StrArray*sp_readlines(void){sp_StrArray*a=sp_StrArray_new();char buf[4096];while(fgets(buf,sizeof(buf),stdin)){size_t l=strlen(buf);char*r=sp_str_alloc_raw(l+1);memcpy(r,buf,l+1);sp_StrArray_push(a,r);}return a;}
 static const char*sp_str_strip(const char*s){while(*s&&isspace((unsigned char)*s))s++;size_t l=strlen(s);while(l>0&&isspace((unsigned char)s[l-1]))l--;char*r=sp_str_alloc_raw(l+1);memcpy(r,s,l);r[l]=0;return r;}
 static const char*sp_str_chomp(const char*s){size_t l=strlen(s);while(l>0&&(s[l-1]=='\n'||s[l-1]=='\r'))l--;char*r=sp_str_alloc_raw(l+1);memcpy(r,s,l);r[l]=0;return r;}
+static const char*sp_str_chop(const char*s){size_t l=strlen(s);if(l>0){if(l>=2&&s[l-2]=='\r'&&s[l-1]=='\n')l-=2;else l--;}char*r=sp_str_alloc_raw(l+1);memcpy(r,s,l);r[l]=0;return r;}
 static mrb_bool sp_str_include(const char*s,const char*sub){return strstr(s,sub)!=NULL;}
 static mrb_bool sp_str_start_with(const char*s,const char*p){return strncmp(s,p,strlen(p))==0;}
 static mrb_bool sp_str_end_with(const char*s,const char*suf){size_t ls=strlen(s),lsuf=strlen(suf);if(lsuf>ls)return FALSE;return strcmp(s+ls-lsuf,suf)==0;}

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2650,7 +2650,7 @@ class Compiler
     if mname == "strip"
       return "string"
     end
-    if mname == "chomp"
+    if mname == "chomp" || mname == "chop"
       return "string"
     end
     if mname == "include?"
@@ -11119,7 +11119,7 @@ class Compiler
       mname = @nd_name[nid]
       # String methods that always need string helpers
       if mname == "to_s" || mname == "upcase" || mname == "downcase" ||
-         mname == "strip" || mname == "chomp" || mname == "slice" ||
+         mname == "strip" || mname == "chomp" || mname == "chop" || mname == "slice" ||
          mname == "include?" || mname == "start_with?" || mname == "end_with?" ||
          mname == "gsub" || mname == "index" || mname == "sub" || mname == "tr" ||
          mname == "ljust" || mname == "rjust" || mname == "capitalize" ||
@@ -20044,6 +20044,9 @@ class Compiler
     end
     if mname == "chomp"
       return "sp_str_chomp(" + rc + ")"
+    end
+    if mname == "chop"
+      return "sp_str_chop(" + rc + ")"
     end
     if mname == "include?"
       return "sp_str_include(" + rc + ", " + compile_arg0(nid) + ")"

--- a/test/string_chop.rb
+++ b/test/string_chop.rb
@@ -1,0 +1,17 @@
+# basic
+puts "hello".chop
+
+# crlf removed together
+puts "hello\r\n".chop
+
+# newline only
+puts "hello\n".chop
+
+# empty string
+puts "".chop
+
+# single char
+puts "x".chop
+
+# already no trailing newline
+puts "abc".chop

--- a/test/string_chop.rb.expected
+++ b/test/string_chop.rb.expected
@@ -1,0 +1,6 @@
+hell
+hello
+hello
+
+
+ab


### PR DESCRIPTION
This adds `String#chop` — removes the last character from a string, or both `\r\n` if the string ends with that sequence. Returns an empty string for empty input.

Uses a new `sp_str_chop()` runtime function next to the existing `sp_str_chomp()`, following the same pattern.

Tests covering basic, crlf, newline, empty, and single-char cases are in `test/string_chop.rb`.