### PR TITLE
fix(codegen): poly_array slot consumes ArrayNode literal via PolyArray

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -15057,6 +15057,27 @@ class Compiler
                 emit_raw("  sp_PtrArray *" + tmp_iv + " = sp_PtrArray_new();")
                 emit_raw("  { mrb_int _n = " + cnt_e_iv + "; for (mrb_int _i = 0; _i < _n; _i++) sp_PtrArray_push(" + tmp_iv + ", NULL); }")
                 emit_raw("  " + self_arrow + ivar + " = " + tmp_iv + ";")
+              elsif ivt == "poly_array" && @nd_type[expr_id_iv] == "ArrayNode"
+                # Non-empty array literal `[a, b, ...]` going into a
+                # poly_array slot. compile_array_literal infers a typed
+                # storage (ptr_array of one class for homogeneous obj
+                # literals, etc.) — emit a fresh PolyArray with each
+                # element boxed instead.
+                @needs_gc = 1
+                @needs_rb_value = 1
+                tmp_iv = new_temp
+                emit_raw("  sp_PolyArray *" + tmp_iv + " = sp_PolyArray_new();")
+                elems_iv = parse_id_list(@nd_elements[expr_id_iv])
+                ek = 0
+                while ek < elems_iv.length
+                  eid = elems_iv[ek]
+                  et = infer_type(eid)
+                  ev = compile_expr(eid)
+                  ebox = et == "poly" ? ev : box_value_to_poly(et, ev)
+                  emit_raw("  sp_PolyArray_push(" + tmp_iv + ", " + ebox + ");")
+                  ek = ek + 1
+                end
+                emit_raw("  " + self_arrow + ivar + " = " + tmp_iv + ";")
               else
                 # Issue #130: same poly-slot boxing as the general
                 # InstanceVariableWriteNode emit path (compile_expr branch).
@@ -24728,6 +24749,30 @@ class Compiler
         tmp_arr = new_temp
         emit("  sp_PtrArray *" + tmp_arr + " = sp_PtrArray_new();")
         emit("  { mrb_int _n = " + cnt_e + "; for (mrb_int _i = 0; _i < _n; _i++) sp_PtrArray_push(" + tmp_arr + ", NULL); }")
+        emit("  " + self_arrow + sanitize_ivar(iname) + " = " + tmp_arr + ";")
+        return
+      end
+      # Non-empty array literal `[a, b, ...]` going into a poly_array
+      # slot. compile_array_literal infers a typed array (ptr_array of
+      # one class for homogeneous obj literals, etc.) and emits the
+      # corresponding storage — but the slot was widened to poly_array,
+      # so a typed-array-pointer assignment would fail the C compile.
+      # Emit a fresh PolyArray with each element boxed to sp_RbVal.
+      if ivt == "poly_array" && @nd_type[expr_id] == "ArrayNode"
+        @needs_gc = 1
+        @needs_rb_value = 1
+        tmp_arr = new_temp
+        emit("  sp_PolyArray *" + tmp_arr + " = sp_PolyArray_new();")
+        elems_pa = parse_id_list(@nd_elements[expr_id])
+        ek = 0
+        while ek < elems_pa.length
+          eid = elems_pa[ek]
+          et = infer_type(eid)
+          ev = compile_expr(eid)
+          ebox = et == "poly" ? ev : box_value_to_poly(et, ev)
+          emit("  sp_PolyArray_push(" + tmp_arr + ", " + ebox + ");")
+          ek = ek + 1
+        end
         emit("  " + self_arrow + sanitize_ivar(iname) + " = " + tmp_arr + ";")
         return
       end

--- a/test/poly_array_slot_literal.rb
+++ b/test/poly_array_slot_literal.rb
@@ -1,0 +1,41 @@
+# `@arr = [a, b]` going into a poly_array slot used to compile the
+# rhs via `compile_array_literal`, which infers a typed storage
+# (ptr_array of one class for homogeneous obj literals, etc.) and
+# emits the matching `sp_PtrArray *`. The slot is `sp_PolyArray *`
+# (widened by writer-scan via heterogeneous `@arr[i] = v` writes
+# elsewhere in the class), so the resulting C contains a pointer-
+# type mismatch:
+#
+#   sp_PtrArray *_t1 = sp_PtrArray_new();
+#   sp_PtrArray_push(_t1, sp_Pad_new());
+#   self->iv_pads = _t1;          /* iv_pads is sp_PolyArray * */
+#
+# The default `-Wno-all` build accepts the cast silently and
+# coerces, but strict flags reject it as
+# `assignment to 'sp_PolyArray *' from incompatible pointer type
+# 'sp_PtrArray *'`. Even under `-Wno-all` the runtime is wrong:
+# `PolyArray_set` writes 16-byte sp_RbVal entries into 8-byte
+# PtrArray slots and silently corrupts adjacent memory.
+
+class Pad
+  def initialize(n)
+    @n = n
+    @arr = []
+    @arr << n
+  end
+  attr_reader :n
+end
+
+class Holder
+  def initialize
+    @pads = [Pad.new(10), Pad.new(20)]
+    @pads[0] = "x"   # heterogeneous []= → @pads widens to poly_array
+  end
+  attr_reader :pads
+
+  def count
+    @pads.length
+  end
+end
+
+puts Holder.new.count    # 2


### PR DESCRIPTION
### Reproduction

```ruby
class Pad
  def initialize(n); @n = n; @arr = []; @arr << n; end
  attr_reader :n
end

class Holder
  def initialize
    @pads = [Pad.new(10), Pad.new(20)]
    @pads[0] = "x"   # heterogeneous []= → @pads widens to poly_array
  end
  attr_reader :pads

  def count
    @pads.length
  end
end

puts Holder.new.count
```

### Expected behavior

```
2
```

### Actual behavior

The default `-Wno-all` build silently coerces a pointer-type
mismatch and runs:

```
$ ./spinel test.rb -o test
$ ./test
2          # by coincidence — see below
```

…but the generated C contains an assignment the C compiler
rejects with stricter flags:

```
error: assignment to 'sp_PolyArray *' from incompatible pointer
       type 'sp_PtrArray *' [-Wincompatible-pointer-types]
       self->iv_pads = _t1;
                     ^
```

The "by coincidence" runtime is also broken: subsequent
`sp_PolyArray_set` calls write 16-byte `sp_RbVal` entries into
the 8-byte `sp_PtrArray` slots that the constructor allocated,
silently corrupting adjacent memory. With slightly different
layouts (one more element, a different element class) the
runtime crashes or returns garbage.

### Analysis & fix

The IVW codegen for `@arr = [a, b, ...]`:

- `compile_array_literal` infers the array's storage from the
  element types: homogeneous obj-class elements yield
  `<obj>_ptr_array`, mixed-class yields `poly_array`, etc. It
  doesn't see the slot's recorded type.
- The IVW emit then assigns the result to `slot = val`. When
  the slot was widened to `poly_array` by writer-scan (because
  `@arr[i] = "x"` is observed elsewhere in the class), the rhs
  is still the ptr_array storage `compile_array_literal` chose.

When the slot is `poly_array` and the rhs is an `ArrayNode`,
emit a fresh PolyArray with each element boxed via
`box_value_to_poly`:

```c
sp_PolyArray *_tmp = sp_PolyArray_new();
sp_PolyArray_push(_tmp, box_value_to_poly(<elem>));
...
self->iv_arr = _tmp;
```

Same shape `compile_expr_for_expected_type` already emits for a
poly_array-typed param destination, just driven by the slot type
rather than the inferred element type. Fix lands in both the
`compile_stmt` and `emit_constructor` IVW paths (the constructor
uses `emit_raw` and the same poly-aware fallback).

### Test plan

- [x] `test/poly_array_slot_literal.rb` — homogeneous Pad
      literal into a slot widened to poly_array via heterogeneous
      `@pads[0] = "x"`.
- [x] `make -j4 bootstrap` green.
- [x] `make test` 0 fail / 0 error.