### PR TITLE
fix(codegen): poly_array slot consumes sized-empty default via PolyArray

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -15046,16 +15046,23 @@ class Compiler
               if iv_ctor != ""
                 @needs_gc = 1
                 emit_raw("  " + self_arrow + ivar + " = " + iv_ctor + ";")
-              elsif is_ptr_array_type(ivt) == 1 && is_sized_empty_array_default(expr_id_iv) == 1
+              elsif (ivt == "poly_array" || is_ptr_array_type(ivt) == 1) && is_sized_empty_array_default(expr_id_iv) == 1
                 # `@arr = [nil] * N` with @arr already widened to
-                # ptr_array via writer-scan. The default `*` codegen
-                # produces an sp_IntArray that mismatches the slot
-                # type; emit a sized PtrArray of NULLs inline.
+                # poly_array (or ptr_array) via writer-scan. The
+                # default `*` codegen produces an sp_IntArray that
+                # mismatches the slot type; emit a sized PolyArray
+                # of sp_box_nil() (or PtrArray of NULLs) inline.
                 @needs_gc = 1
                 cnt_e_iv = compile_arg0(expr_id_iv)
                 tmp_iv = new_temp
-                emit_raw("  sp_PtrArray *" + tmp_iv + " = sp_PtrArray_new();")
-                emit_raw("  { mrb_int _n = " + cnt_e_iv + "; for (mrb_int _i = 0; _i < _n; _i++) sp_PtrArray_push(" + tmp_iv + ", NULL); }")
+                if ivt == "poly_array"
+                  @needs_rb_value = 1
+                  emit_raw("  sp_PolyArray *" + tmp_iv + " = sp_PolyArray_new();")
+                  emit_raw("  { mrb_int _n = " + cnt_e_iv + "; for (mrb_int _i = 0; _i < _n; _i++) sp_PolyArray_push(" + tmp_iv + ", sp_box_nil()); }")
+                else
+                  emit_raw("  sp_PtrArray *" + tmp_iv + " = sp_PtrArray_new();")
+                  emit_raw("  { mrb_int _n = " + cnt_e_iv + "; for (mrb_int _i = 0; _i < _n; _i++) sp_PtrArray_push(" + tmp_iv + ", NULL); }")
+                end
                 emit_raw("  " + self_arrow + ivar + " = " + tmp_iv + ";")
               else
                 # Issue #130: same poly-slot boxing as the general
@@ -24717,17 +24724,24 @@ class Compiler
           return
         end
       end
-      # `@arr = [nil] * N` where @arr is a ptr_array slot. The
-      # default `*` codegen produces an sp_IntArray, which mismatches
-      # the slot type and corrupts later sp_PtrArray_set calls. Emit
-      # a sized PtrArray pre-filled with NULLs inline so the slot
+      # `@arr = [nil] * N` where @arr is a poly_array (or ptr_array)
+      # slot. The default `*` codegen produces an sp_IntArray, which
+      # mismatches the slot type and corrupts later
+      # `sp_PolyArray_set(@arr, ...)` calls. Emit a sized PolyArray
+      # of sp_box_nil() (or PtrArray of NULLs) inline so the slot
       # holds the matching storage.
-      if is_ptr_array_type(ivt) == 1 && is_sized_empty_array_default(expr_id) == 1
+      if (ivt == "poly_array" || is_ptr_array_type(ivt) == 1) && is_sized_empty_array_default(expr_id) == 1
         @needs_gc = 1
         cnt_e = compile_arg0(expr_id)
         tmp_arr = new_temp
-        emit("  sp_PtrArray *" + tmp_arr + " = sp_PtrArray_new();")
-        emit("  { mrb_int _n = " + cnt_e + "; for (mrb_int _i = 0; _i < _n; _i++) sp_PtrArray_push(" + tmp_arr + ", NULL); }")
+        if ivt == "poly_array"
+          @needs_rb_value = 1
+          emit("  sp_PolyArray *" + tmp_arr + " = sp_PolyArray_new();")
+          emit("  { mrb_int _n = " + cnt_e + "; for (mrb_int _i = 0; _i < _n; _i++) sp_PolyArray_push(" + tmp_arr + ", sp_box_nil()); }")
+        else
+          emit("  sp_PtrArray *" + tmp_arr + " = sp_PtrArray_new();")
+          emit("  { mrb_int _n = " + cnt_e + "; for (mrb_int _i = 0; _i < _n; _i++) sp_PtrArray_push(" + tmp_arr + ", NULL); }")
+        end
         emit("  " + self_arrow + sanitize_ivar(iname) + " = " + tmp_arr + ";")
         return
       end

--- a/test/poly_array_slot_sized_default.rb
+++ b/test/poly_array_slot_sized_default.rb
@@ -1,0 +1,33 @@
+# `@arr = [nil] * N` going into a poly_array slot used to lower
+# the rhs via the default `*` codegen, which produces an sp_IntArray.
+# The slot is `sp_PolyArray *` (widened by writer-scan via
+# heterogeneous `@arr[i] = v` writes elsewhere in the class), so
+# the resulting C contains a pointer-type mismatch:
+#
+#   sp_IntArray *_t1 = sp_IntArray_new();
+#   ...
+#   self->iv_arr = _t1;          /* iv_arr is sp_PolyArray * */
+#
+# The default `-Wno-all` build silently coerces and the runtime
+# runs with garbage: subsequent `sp_PolyArray_set(@arr, ...)`
+# calls write 16-byte sp_RbVal entries into 8-byte IntArray slots,
+# corrupting adjacent memory and skewing `@arr.length`.
+#
+# An equivalent guard exists for ptr_array slots; this PR extends
+# it to poly_array slots (constructor + general InstanceVariable-
+# WriteNode paths) so the lowered storage matches the slot.
+
+class Holder
+  def initialize
+    @arr = [nil] * 3
+    @arr[0] = 42      # int
+    @arr[1] = "two"   # str — heterogeneous → @arr widens to poly_array
+  end
+  attr_reader :arr
+
+  def count
+    @arr.length
+  end
+end
+
+puts Holder.new.count   # 3


### PR DESCRIPTION
### Reproduction

```ruby
class Holder
  def initialize
    @arr = [nil] * 3
    @arr[0] = 42      # int
    @arr[1] = "two"   # str — heterogeneous → @arr widens to poly_array
  end
  attr_reader :arr

  def count
    @arr.length
  end
end

puts Holder.new.count
```

### Expected behavior

```
3
```

### Actual behavior

```
$ ./spinel test.rb -o test
$ ./test
0
```

The default `-Wno-all` build silently coerces a pointer-type
mismatch. The generated C declares `iv_arr` as `sp_PolyArray *`
but the constructor builds an `sp_IntArray` and assigns it:

```c
struct sp_Holder_s {
  sp_PolyArray * iv_arr;
};
...
sp_IntArray *_t4 = sp_IntArray_new();
sp_IntArray_push(_t4, 0);
sp_IntArray *_t2 = _t4;
mrb_int _t3 = 3;
sp_IntArray *_t1 = sp_IntArray_new();
{ ... fill _t1 with N copies of _t2 ... }
self->iv_arr = _t1;        /* sp_PolyArray * = sp_IntArray * */
```

Stricter flags would reject as `assignment to 'sp_PolyArray *'
from incompatible pointer type 'sp_IntArray *'`. With the
default build the runtime is broken: subsequent
`sp_PolyArray_set(@arr, ...)` calls write 16-byte `sp_RbVal`
entries into 8-byte `sp_IntArray` slots, silently corrupting
adjacent memory. `@arr.length` reads the wrong slot and returns
0.

### Analysis & fix

The IVW codegen for `@arr = [nil] * N`:

- `compile_array_literal` lowers `[nil] * N` through the default
  `*` codegen, producing an `sp_IntArray` (because `nil` types
  as int). It doesn't see the slot's recorded type.
- The IVW emit then assigns the result to `slot = val`. When
  the slot was widened to `poly_array` by writer-scan, the rhs
  is still the IntArray storage that `*` chose.

The existing IVW handling for `[nil] * N` already routes
ptr_array slots through a sized-empty PtrArray constructor.
Apply the same pattern to poly_array slots:

```c
sp_PolyArray *_tmp = sp_PolyArray_new();
{ mrb_int _n = N; for (mrb_int _i = 0; _i < _n; _i++)
    sp_PolyArray_push(_tmp, sp_box_nil()); }
self->iv_arr = _tmp;
```

Same shape `compile_expr_for_expected_type` already emits when
the expected type is `poly_array`, just driven by the slot type
rather than the param type. Fix lands in both the `compile_stmt`
and `emit_constructor` IVW paths (the constructor uses
`emit_raw` and the same poly-aware fallback).

### Test plan

- [x] `test/poly_array_slot_sized_default.rb` — `[nil] * 3`
      literal into a slot widened to poly_array via heterogeneous
      `@arr[0] = int` + `@arr[1] = str` writes. Without the fix
      `@arr.length` returns 0.
- [x] `make -j4 bootstrap` green.
- [x] `make test` 0 fail / 0 error.