### PR TITLE
feat(codegen): widen heterogeneous int/nil + obj scalar slots to poly

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -6430,7 +6430,26 @@ class Compiler
       if names[k] == iname
         if k < types.length
           old = types[k]
-          if old == "int" || old == "nil"
+          # Heterogeneous int/nil + obj → poly when the prior write
+          # was a *definite* int/nil literal. The previous "int wins"
+          # / "nil wins" overwrite silently cast the int payload to a
+          # struct pointer, miscompiling `@x = 10; @x = Box.new` and
+          # any subsequent obj method dispatch. Widen to poly so the
+          # slot can carry either case at runtime; the dispatch path
+          # then decides per cls_id at the call site.
+          #
+          # The definiteness gate avoids false widening when "int"
+          # was just `infer_ivar_init_type`'s placeholder fallback for
+          # a CallNode rhs that's later refined to an obj type by
+          # the writer-scan / inference passes (e.g.
+          # `@m = method(:foo)` initially scans as int and a
+          # refinement promotes it to `obj_Method` — no heterogeneity
+          # to widen for).
+          if (old == "int" || old == "nil") && is_obj_type(new_type) == 1 && cls_ivar_definite_flag(ci, iname) == 1
+            types[k] = "poly"
+            @needs_rb_value = 1
+            @cls_ivar_types[ci] = types.join(";")
+          elsif old == "int" || old == "nil"
             types[k] = new_type
             @cls_ivar_types[ci] = types.join(";")
           elsif old != new_type && old != "poly"

--- a/test/widen_int_obj_to_poly.rb
+++ b/test/widen_int_obj_to_poly.rb
@@ -1,0 +1,29 @@
+# When an ivar's first observed write is a definite int / nil
+# literal and a later write assigns an obj-typed value, the slot
+# was overwritten with the obj type — silently casting the prior
+# int payload to a struct pointer. Subsequent dispatch through
+# the slot then read garbage or computed pointer arithmetic.
+#
+# Widening to poly so the slot carries either case at runtime
+# preserves the program's actual semantics: the dispatch path
+# decides per cls_id at the call site.
+
+class Box
+  def initialize(n)
+    @n = n
+    @arr = []
+    @arr << n
+  end
+  attr_reader :n
+end
+
+class Holder
+  def initialize
+    @poly = 10              # definite int first
+    @poly = Box.new(5)      # …then obj — slot widens to poly
+  end
+  attr_reader :poly
+end
+
+# poly recv → Box#n via cls_id == Box dispatch
+puts Holder.new.poly.n      # 5


### PR DESCRIPTION
### Reproduction

```ruby
class Box
  def initialize(n); @n = n; @arr = []; @arr << n; end
  attr_reader :n
end

class Holder
  def initialize
    @poly = 10              # definite int first
    @poly = Box.new(5)      # …then obj
  end
  attr_reader :poly
end

puts Holder.new.poly.n
```

### Expected behavior

```
5
```

### Actual behavior

```
$ ./spinel test.rb -o test
$ ./test
105077359878144         # the Box pointer interpreted as int
```

(Or similar pointer-shaped garbage, depending on what was
assigned. With `-Wint-conversion` upgraded to error the C
compile fails; under the default `-Wno-all` it silently
miscompiles.)

`@poly`'s recorded type was overwritten by the second write —
spinel chose `obj_Box` over the prior `int`. The C struct's
`iv_poly` then declared `sp_Box *`. The first write `@poly = 10`
silently cast `10` to a bogus pointer; the second wrote a real
pointer; the read via attr_reader returned the pointer, and
`puts ... .n` either segfaulted or read past the Box struct.

The shape

```ruby
@x = some_int
@x = some_obj
```

is exactly Ruby's "this slot can hold either kind" pattern, and
should compile to a slot that carries either case at runtime —
with the dispatch path deciding per cls_id at every use site.

### Analysis & fix

`update_ivar_type` had

```ruby
if old == "int" || old == "nil"
  types[k] = new_type    # silently overwrite
elsif old != new_type && old != "poly"
  ...elsif widening...
end
```

The "overwrite" branch unconditionally adopted the new type when
the old one was `int` or `nil` — historically used to refine a
placeholder int into a more specific type. But it also clobbered
genuine heterogeneity.

Add a guard that widens to poly when the prior write was a
*definite literal* int/nil and the new write is obj-typed:

```ruby
if (old == "int" || old == "nil") && is_obj_type(new_type) == 1 \
    && cls_ivar_definite_flag(ci, iname) == 1
  types[k] = "poly"
elsif old == "int" || old == "nil"
  types[k] = new_type
elsif old != new_type && old != "poly"
  ...
end
```

The `cls_ivar_definite_flag == 1` gate avoids false widening
when "int" was just `infer_ivar_init_type`'s placeholder
fallback for a CallNode rhs that's later refined by writer-scan
/ inference passes (e.g. `@m = method(:foo)` initially scans as
int and a later pass promotes it to `obj_Method` — no
heterogeneity to widen for).

The poly-aware emit paths (IVW / IVR / op-assign / binop / `&&` /
attr-writer / etc.) take it from there and dispatch per cls_id
at the call site.

### Test plan

- [x] `test/widen_int_obj_to_poly.rb` — Holder@poly written once
      as an int literal then as an obj; reading via
      `holder.poly.n` dispatches correctly to Box#n.
- [x] `make -j4 bootstrap` green.
- [x] `make test` 0 fail / 0 error.