### PR TITLE
fix(codegen): op-assign on obj slot dispatches user-defined operator

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -17509,7 +17509,15 @@ class Compiler
       # outer write zeroes the ivar.
       op = @nd_binop[nid]
       val = compile_expr(@nd_expression[nid])
-      return "(" + fiber_var_ref(@nd_name[nid]) + " " + op + "= " + val + ")"
+      vref = fiber_var_ref(@nd_name[nid])
+      vt = find_var_type(@nd_name[nid])
+      # Obj-typed local: dispatch via user-defined operator instead
+      # of emitting raw C `OP=` (pointer arithmetic on an obj slot).
+      disp = obj_op_dispatch_expr(vt, vref, op, val)
+      if disp != ""
+        return "(" + vref + " = " + disp + ")"
+      end
+      return "(" + vref + " " + op + "= " + val + ")"
     end
     if t == "LocalVariableOrWriteNode"
       # `local ||= expr` in expression context. Lower as
@@ -24542,6 +24550,32 @@ class Compiler
     ""
   end
 
+  # `recv OP rhs` lowering for an obj-typed receiver. When the
+  # receiver's class (or an ancestor) defines `op` as a user method,
+  # returns the C expression `sp_<owner>_<op>(<recv_c>, <rhs_c>)`.
+  # Returns "" when no dispatch applies (caller falls back to its
+  # inline path, or to `warn_unresolved_call`).
+  def obj_op_dispatch_expr(recv_t, recv_c, op, rhs_c)
+    if is_obj_type(recv_t) == 0
+      return ""
+    end
+    cname = recv_t[4, recv_t.length - 4]
+    ci = find_class_idx(cname)
+    if ci < 0
+      return ""
+    end
+    owner = find_method_owner(ci, op)
+    if owner == ""
+      warn_unresolved_call(op, "obj_" + cname)
+      return ""
+    end
+    cast = ""
+    if owner != cname
+      cast = "(sp_" + owner + " *)"
+    end
+    "sp_" + owner + "_" + sanitize_name(op) + "(" + cast + recv_c + ", " + rhs_c + ")"
+  end
+
   def compile_if_expr(nid)
     cond = compile_cond_expr(@nd_predicate[nid])
     then_val = "0"
@@ -25049,6 +25083,14 @@ class Compiler
       val = compile_expr(@nd_expression[nid])
       vref = fiber_var_ref(@nd_name[nid])
       vt = find_var_type(@nd_name[nid])
+      # Same desugaring as the ivar form: `local OP= rhs` is
+      # `local = local OP rhs`. Dispatch through the user-defined
+      # operator when the local is obj-typed.
+      disp = obj_op_dispatch_expr(vt, vref, op, val)
+      if disp != ""
+        emit("  " + vref + " = " + disp + ";")
+        return
+      end
       if vt == "bigint"
         at = infer_type(@nd_expression[nid])
         barg = at == "bigint" ? val : "sp_bigint_new_int(" + val + ")"
@@ -25252,6 +25294,19 @@ class Compiler
       op = @nd_binop[nid]
       val = compile_expr(@nd_expression[nid])
       lhs = ivar_lhs(@nd_name[nid])
+      ivar_t = ""
+      if @current_class_idx >= 0
+        ivar_t = cls_ivar_type(@current_class_idx, @nd_name[nid])
+      end
+      # `@x OP= v` desugars to `@x = @x OP v`. When @x is obj-typed
+      # and the class defines OP, dispatch to the user method
+      # instead of emitting a raw C `+=` (which on a pointer is
+      # silently miscompiled as pointer arithmetic).
+      disp = obj_op_dispatch_expr(ivar_t, lhs, op, val)
+      if disp != ""
+        emit("  " + lhs + " = " + disp + ";")
+        return
+      end
       if op == "+"
         emit("  " + lhs + " += " + val + ";")
       end

--- a/test/op_assign_user_operator.rb
+++ b/test/op_assign_user_operator.rb
@@ -1,0 +1,36 @@
+# `slot OP= rhs` desugars to `slot = slot OP rhs`. When the slot
+# is obj-typed and the class defines OP as a user method, codegen
+# must dispatch through that method. The previous version emitted
+# raw C `slot OP= rhs` for every slot type — on an obj pointer
+# that compiled to pointer arithmetic, silently miscompiling the
+# Ruby semantics.
+
+class Box
+  def initialize(n)
+    @n = n
+    @arr = []
+    @arr << n   # force heap layout (sp_Box *), not value-type
+  end
+  attr_reader :n
+
+  def +(other); Box.new(@n + other); end
+  def -(other); Box.new(@n - other); end
+end
+
+# Instance-variable op-assign in stmt position.
+class IvarStmt
+  def initialize
+    @b = Box.new(10)
+    @b += 5
+  end
+  attr_reader :b
+end
+puts IvarStmt.new.b.n          # 15
+
+# Local-variable op-assign in stmt position.
+def local_stmt
+  b = Box.new(20)
+  b -= 3
+  b.n
+end
+puts local_stmt                # 17


### PR DESCRIPTION
### Reproduction

```ruby
class Box
  def initialize(n)
    @n = n
    @arr = []
    @arr << n   # force heap layout (sp_Box *), not value-type
  end
  attr_reader :n
  def +(other); Box.new(@n + other); end
  def -(other); Box.new(@n - other); end
end

class Holder
  def initialize
    @b = Box.new(10)
    @b += 5
  end
  attr_reader :b
end
puts Holder.new.b.n   # expect 15

def local_minus
  b = Box.new(20)
  b -= 3
  b.n
end
puts local_minus      # expect 17
```

### Expected behavior

```
15
17
```

### Actual behavior

```
$ ./spinel test.rb -o test
$ ./test
1
65
```

The previous codegen lowered `slot OP= rhs` to a raw C `slot OP=
rhs` for every slot kind. On an obj-typed slot the C compiler
interpreted that as pointer arithmetic — `@b += 5` becomes
`self->iv_b += 5`, advancing the pointer by `5 * sizeof(sp_Box)`
bytes, then `.n` reads off the end of the (different) struct
that landed at that address. The two outputs above are the
arbitrary words that happened to live at those offsets.

Ruby semantics: `slot OP= rhs` desugars to `slot = slot OP rhs`,
so an obj-typed slot must dispatch through `Box#+` and
`Box#-`.

### Analysis & fix

Add `obj_op_dispatch_expr`: when the receiver type is `obj_<X>`
and `X` (or an ancestor) defines `OP` as a user method, return
`sp_<owner>_<op>(<recv>, <rhs>)` so the assignment goes through
the user method. When the class doesn't define the operator,
emit the standard `cannot resolve call to '<op>' on obj_<X>`
warning that already covers every other unresolved obj method
site, mirroring its fallback contract — the user gets a
build-time diagnostic instead of silent garbage.

Wired into the `InstanceVariableOperatorWriteNode` and
`LocalVariableOperatorWriteNode` paths (both statement and
expression forms). Existing int / numeric / string / bigint /
hash op-assign behavior is unchanged (the helper bails early
for non-obj slot types).

### Test plan

- [x] `test/op_assign_user_operator.rb` — `@b += 5` (ivar form)
      and `b -= 3` (local form) on a Box with user-defined `+`
      and `-`. Without the fix `b.n` returns pointer-arithmetic
      garbage (1 / 65 in our run); with the fix it returns the
      Ruby values 15 / 17.
- [x] `make -j4 bootstrap` green.
- [x] `make test` 0 fail / 0 error.