### PR TITLE
fix(codegen): box value when filling poly_array via Array#fill

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -832,6 +832,7 @@ static sp_PolyArray *sp_PolyArray_new(void) { sp_PolyArray *a = (sp_PolyArray *)
 static void sp_PolyArray_push(sp_PolyArray *a, sp_RbVal v) { if (a->len >= a->cap) { sp_gc_hdr *h = (sp_gc_hdr *)((char *)a - sizeof(sp_gc_hdr)); sp_gc_bytes -= sizeof(sp_RbVal) * a->cap; h->size -= sizeof(sp_RbVal) * a->cap; a->cap = a->cap * 2 + 1; a->data = (sp_RbVal *)realloc(a->data, sizeof(sp_RbVal) * a->cap); h->size += sizeof(sp_RbVal) * a->cap; sp_gc_bytes += sizeof(sp_RbVal) * a->cap; } a->data[a->len++] = v; }
 static mrb_int sp_PolyArray_length(sp_PolyArray *a) { return a->len; }
 static sp_RbVal sp_PolyArray_get(sp_PolyArray *a, mrb_int i) { if (i < 0) i += a->len; return a->data[i]; }
+static void sp_PolyArray_set(sp_PolyArray *a, mrb_int i, sp_RbVal v) { if (i < 0) i += a->len; a->data[i] = v; }
 static sp_PolyArray *sp_PolyArray_slice(sp_PolyArray *a, mrb_int start, mrb_int len) { if (start < 0) start += a->len; if (start < 0) start = 0; sp_PolyArray *b = sp_PolyArray_new(); if (start >= a->len || len <= 0) return b; if (start + len > a->len) len = a->len - start; for (mrb_int i = 0; i < len; i++) sp_PolyArray_push(b, a->data[start + i]); return b; }
 static sp_PolyArray *sp_PolyArray_slice_bang(sp_PolyArray *a, mrb_int from, mrb_int n) {
   if (from < 0) from += a->len;

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -20940,7 +20940,17 @@ class Compiler
       end
       itmp = new_temp
       emit("  for (mrb_int " + itmp + " = " + start_expr + "; " + itmp + " < " + end_expr + "; " + itmp + "++)")
-      emit("    sp_" + pfx + "_set(" + rc + ", " + itmp + ", " + val + ");")
+      if recv_type == "poly_array"
+        v_id = -1
+        if args_id_fill >= 0
+          v_id = get_args(args_id_fill)[0]
+        end
+        vt = v_id >= 0 ? infer_type(v_id) : "int"
+        vbox = vt == "poly" ? val : box_value_to_poly(vt, val)
+        emit("    sp_PolyArray_set(" + rc + ", " + itmp + ", " + vbox + ");")
+      else
+        emit("    sp_" + pfx + "_set(" + rc + ", " + itmp + ", " + val + ");")
+      end
       return rc
     end
     if mname == "rotate"

--- a/test/array_fill_poly.rb
+++ b/test/array_fill_poly.rb
@@ -1,0 +1,17 @@
+# `arr.fill(val)` on a poly_array used to lower as
+# `sp_PolyArray_set(arr, i, val)` with the raw scalar `val`. The
+# storage is sp_RbVal — passing an unboxed int / str / float
+# fails to compile (`incompatible type for argument 3 of
+# sp_PolyArray_set`).
+#
+# Fix: wrap the value via `box_value_to_poly` first when the
+# receiver is `poly_array`. Other typed-array fills (int / float
+# / str / sym / ptr) keep their raw scalar path.
+
+def make_arr
+  arr = [1, "two", 3.14]   # heterogeneous → poly_array
+  arr.fill(42)
+  arr
+end
+
+p make_arr   # [42, 42, 42]


### PR DESCRIPTION
### Reproduction

```ruby
def make_arr
  arr = [1, "two", 3.14]   # heterogeneous → poly_array
  arr.fill(42)
  arr
end

p make_arr
```

### Expected behavior

```
[42, 42, 42]
```

### Actual behavior

```
$ ./spinel test.rb -o test
spinel: C compilation failed
```

```
error: incompatible type for argument 3 of 'sp_PolyArray_set'
       sp_PolyArray_set(arr, i, val);
                                ^~~
note: expected 'sp_RbVal' but argument is of type 'mrb_int'
```

The Array#fill codegen lowered `arr.fill(val)` to
`sp_*_set(arr, i, val)` for every typed array kind. For
int / float / str / sym / ptr arrays the C compound assignment
into the matching slot type works, but poly_array's storage is
`sp_RbVal` — passing an unboxed scalar fails to type-check.

### Analysis & fix

When the receiver is `poly_array`, wrap the value via
`box_value_to_poly` before the `sp_PolyArray_set` call:

```c
sp_PolyArray_set(arr, i, sp_box_int(val));   /* int  */
sp_PolyArray_set(arr, i, sp_box_str(val));   /* str  */
sp_PolyArray_set(arr, i, val);               /* poly */
```

Inferred from the value-expression's type via the existing
`box_value_to_poly` table (which already knows how to box every
non-poly type). Other typed-array fills are unchanged.

Also adds `sp_PolyArray_set` to `lib/sp_runtime.h` (parallel to
the existing `sp_PolyArray_get` / `sp_PolyArray_push`
helpers) — it was missing.

### Test plan

- [x] `test/array_fill_poly.rb` — heterogeneous `[1, "two",
      3.14]` literal → `poly_array`, `fill(42)` rewrites every
      slot to `sp_box_int(42)`.
- [x] `make -j4 bootstrap` green.
- [x] `make test` 0 fail / 0 error.