### PR TITLE
fix(codegen): infer_call_type for attr-writer returns rhs type

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2244,6 +2244,34 @@ class Compiler
       end
     end
 
+    # `obj.attr = val` (attr-writer call) — Ruby semantics: the
+    # assignment expression evaluates to the rhs value, so the
+    # inferred type is the rhs argument's type. Without this, a
+    # chain like `@a = obj.attr = val` mistypes the outer `@a`
+    # as int because the inner call falls through to the int
+    # default.
+    if mname.length > 1 && mname[mname.length - 1] == "=" &&
+       mname != "==" && mname != "!=" && mname != "<=" && mname != ">="
+      if recv >= 0
+        rt_w = infer_type(recv)
+        if is_obj_type(rt_w) == 1
+          bname_w = mname[0, mname.length - 1]
+          bt_w = base_type(rt_w)
+          cname_w = bt_w[4, bt_w.length - 4]
+          ci_w = find_class_idx(cname_w)
+          if ci_w >= 0 && cls_has_attr_writer(ci_w, bname_w) == 1
+            args_id_w = @nd_arguments[nid]
+            if args_id_w >= 0
+              arg_ids_w = get_args(args_id_w)
+              if arg_ids_w.length > 0
+                return infer_type(arg_ids_w[0])
+              end
+            end
+          end
+        end
+      end
+    end
+
     # User-defined top-level method (bare call): take precedence over
     # name-based builtin inference so `def minmax(a,b); ... end; minmax(1,2)`
     # binds to the user def instead of Array#minmax's tuple return.

--- a/test/chained_attr_setter.rb
+++ b/test/chained_attr_setter.rb
@@ -1,0 +1,55 @@
+# `@a = obj.attr = val` and similar chains used to mistype the
+# outer LHS. `infer_call_type` had no special case for an
+# attr-writer CallNode (`obj.attr = val`), so it fell through to
+# the int default. Codegen was emitting the right C-level
+# assignment expression `(rc->iv_attr = arg)` (which evaluates
+# to the rhs in C), but the surrounding LHS was declared as
+# `mrb_int`, so `outer = (rc->iv_attr = obj_value)` typed the
+# outer slot as int and any later use went through the wrong
+# dispatch.
+#
+# Fix: when `infer_call_type` sees a CallNode whose name ends
+# with `=` (and isn't `==` / `<=` / etc.), and the receiver is
+# obj-typed and has an attr_writer for the slot, return the rhs
+# argument's type. Ruby semantics: an assignment expression
+# evaluates to the rhs.
+
+class Box
+  def initialize(n); @n = n; @arr = []; @arr << n; end
+  attr_reader :n
+end
+
+class Holder
+  attr_writer :box
+end
+
+# Simple chain — the result of `h.box = Box.new(...)` should be
+# a Box, not an int.
+h = Holder.new
+b = (h.box = Box.new(42))
+puts b.n   # 42
+
+# Optcarrot-shape chain: `@a = obj.x = expr`. Both `@a` and
+# `obj.x` get the same Box; reading either back gives the
+# same value.
+class Apu
+  def initialize(n); @n = n; @arr = []; @arr << n; end
+  attr_reader :n
+end
+
+class Cpu
+  attr_writer :apu
+  attr_reader :apu
+end
+
+class Nes
+  def initialize
+    @cpu = Cpu.new
+    @apu = @cpu.apu = Apu.new(99)
+  end
+  attr_reader :apu, :cpu
+end
+
+n = Nes.new
+puts n.apu.n        # 99
+puts n.cpu.apu.n    # 99


### PR DESCRIPTION
### Reproduction

```ruby
class Box
  def initialize(n); @n = n; @arr = []; @arr << n; end
  attr_reader :n
end

class Holder
  attr_writer :box
end

h = Holder.new
b = (h.box = Box.new(42))
puts b.n
```

### Expected behavior

```
42
```

### Actual behavior

```
$ ./spinel test.rb -o test
warning: cannot resolve call to 'n' on int (emitting 0)
$ ./test
0
```

The C output declares `b` as `mrb_int` and emits

```c
mrb_int b = 0;
b = (h->iv_box = sp_Box_new(42));
```

The C-level assignment expression `(h->iv_box = ...)` evaluates
to the rhs (correct), but `b` is typed as `mrb_int`, so the
later `b.n` lookup falls back to "cannot resolve" and returns
0.

### Analysis & fix

The codegen at `compile_call_expr` already returns the C
assignment expression `(rc->iv_attr = arg0_w)` for an obj-typed
receiver with a matching attr_writer. The bug is on the
**inference** side: `infer_call_type` had no special case for
attr-writer CallNodes (`obj.attr = val`), so it fell through to
the int default. The outer `LocalVariableWriteNode` then
declared `b` as `mrb_int`.

Add an inference case before the user-defined-method fallback:
when `mname` ends with `=` (and isn't `==` / `!=` / `<=` /
`>=`), the receiver is obj-typed, and the receiver class has
an `attr_writer` for the slot, return the rhs argument's type.
Mirrors Ruby's assignment-expression semantics — the chain's
value is the rhs.

### Test plan

- [x] `test/chained_attr_setter.rb` — covers the simple
      `(h.box = Box.new(...))` form *and* the optcarrot-shape
      `@a = obj.attr = expr` form (both ivar and attr-reader
      readbacks land on the same Box).
- [x] `make -j4 bootstrap` green.
- [x] `make test` 0 fail / 0 error.