### PR TITLE
feat(parse): support ImplicitNode top-level via parser-side unwrap

### DIFF
--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -462,14 +462,10 @@ static int flatten(pm_node_t *node) {
     N("AssocNode");
     R("key", n->key);
     /* Hash shorthand `{ x: }` lowers to an AssocNode whose value is a
-       PM_IMPLICIT_NODE wrapping the actual LocalVariableReadNode (or
-       MethodCallNode for an undeclared name). Unwrap one level here so
-       the codegen never sees the implicit wrapper. */
-    pm_node_t *val = n->value;
-    if (val && PM_NODE_TYPE_P(val, PM_IMPLICIT_NODE)) {
-      val = ((pm_implicit_node_t *)val)->value;
-    }
-    R("value", val);
+       PM_IMPLICIT_NODE. The top-level PM_IMPLICIT_NODE case below
+       handles the unwrap by recursing into n->value at the same id
+       slot, so the codegen never sees the implicit wrapper here. */
+    R("value", n->value);
     break;
   }
   case PM_KEYWORD_HASH_NODE: {
@@ -759,6 +755,16 @@ static int flatten(pm_node_t *node) {
        frozen string. All Spinel sources are UTF-8. */
     N("SourceEncodingNode");
     break;
+  }
+  case PM_IMPLICIT_NODE: {
+    /* Wraps an implicit value reference, e.g. the value side of a
+       hash-shorthand `{x:}`. Lowers to its inner value at the same
+       id slot so the codegen never sees the implicit wrapper. Covers
+       PM_IMPLICIT_NODE in any context (AssocNode value, kwarg
+       shorthand inside KeywordHashNode, future Prism evolutions). */
+    pm_implicit_node_t *n = (pm_implicit_node_t *)node;
+    node_counter--;
+    return flatten(n->value);
   }
   case PM_SPLAT_NODE: {
     pm_splat_node_t *n = (pm_splat_node_t *)node;


### PR DESCRIPTION
PM_ASSOC_NODE at line 445 already unwraps PM_IMPLICIT_NODE inline
when it appears as an AssocNode value (the hash-shorthand `{x:}`
form added in PR #143). But PM_IMPLICIT_NODE can appear in other
contexts too -- KeywordHashNode kwarg shorthand, pattern-match
implicit values in future Prism evolutions -- and any of those
paths fell into Phase 0's UnsupportedNode loud-error.

Adds a top-level PM_IMPLICIT_NODE case that lowers to the inner
value at the same id slot via the node_counter rewind trick:

    case PM_IMPLICIT_NODE: {
      pm_implicit_node_t *n = (pm_implicit_node_t *)node;
      node_counter--;
      return flatten(n->value);
    }

Same idiom PM_SHAREABLE_CONSTANT_NODE and
PM_IT_LOCAL_VARIABLE_READ_NODE already use. The codegen never sees
an ImplicitNode -- it sees the unwrapped inner expression directly,
so no codegen arm is needed.

No test fixture: PM_IMPLICIT_NODE only reaches the top-level case
in contexts that rely on later-phase work (kwarg shorthand needs
KeywordHashNode arm work; pattern-match implicit values need
HashPatternNode). The case is defensive -- it future-proofs against
those phases without changing observable behaviour today.

Tests: 256 pass (no new fixture).
Bootstrap: gen2.c == gen3.c.


## Test plan

- [x] `make` — builds clean
- [x] `make bootstrap` — `gen2.c == gen3.c (bootstrap OK)`
- [x] `make test` — `Tests:      276 pass,        0 fail,        0 error`

