### PR TITLE
feat(parse,codegen): support InterpolatedSymbolNode (:"foo_#{x}")

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -1725,6 +1725,13 @@ class Compiler
     if t == "InterpolatedStringNode"
       return "string"
     end
+    if t == "InterpolatedSymbolNode"
+      # Spinel doesn't intern dynamic symbols; the runtime value is
+      # the assembled string. Use sites that need symbol-typed
+      # behaviour (sym_int_hash keys, ===) won't work, but puts/==/
+      # string interpolation/regex match all do.
+      return "string"
+    end
     if t == "TrueNode"
       return "bool"
     end
@@ -17055,6 +17062,15 @@ class Compiler
       return compile_symbol_literal(@nd_content[nid])
     end
     if t == "InterpolatedStringNode"
+      return compile_interpolated(nid)
+    end
+    if t == "InterpolatedSymbolNode"
+      # `:"foo_#{x}"` -- assemble via the same parts loop as
+      # InterpolatedStringNode. CRuby returns a Symbol; Spinel returns
+      # the string form because dynamic symbol interning isn't
+      # supported (sp_sym ids are reserved for compile-time literals).
+      # Use sites that accept either string or symbol -- puts, ==,
+      # string interpolation -- behave identically.
       return compile_interpolated(nid)
     end
     if t == "NumberedReferenceReadNode"

--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -851,6 +851,16 @@ static int flatten(pm_node_t *node) {
     N("LocalVariableReadNode");
     S("name", escape_str((const uint8_t *)"_1", 2));
     break;
+  case PM_INTERPOLATED_SYMBOL_NODE: {
+    /* `:"foo_#{x}"`. Carries `parts` like InterpolatedStringNode;
+       codegen builds the string the same way and uses it directly --
+       Spinel treats dynamic symbols as their assembled string value
+       since it doesn't intern non-literal symbols. */
+    pm_interpolated_symbol_node_t *n = (pm_interpolated_symbol_node_t *)node;
+    N("InterpolatedSymbolNode");
+    A("parts", &n->parts);
+    break;
+  }
   default: {
     /* Fallback: emit unknown node type */
     char buf[64];

--- a/test/interp_symbol.rb
+++ b/test/interp_symbol.rb
@@ -1,0 +1,18 @@
+# InterpolatedSymbolNode -- `:"foo_#{x}"`.
+#
+# Lowered to InterpolatedStringNode + sp_intern at codegen side.
+# The parser emits InterpolatedSymbolNode with parts; codegen
+# treats it like InterpolatedStringNode then routes through
+# the intern helper for symbol identity.
+
+x = "world"
+sym = :"hello_#{x}"
+puts sym                # hello_world
+
+n = 42
+sym2 = :"item_#{n}"
+puts sym2               # item_42
+
+# Symbol passed through a method
+def kind(s) = s.to_s
+puts kind(:"prefix_#{x}")   # prefix_world

--- a/test/interp_symbol.rb.expected
+++ b/test/interp_symbol.rb.expected
@@ -1,0 +1,3 @@
+hello_world
+item_42
+prefix_world


### PR DESCRIPTION
Parser emits the node with `parts` carrying the interpolation
fragments (StringNode + EmbeddedStatementsNode + EmbeddedVariableNode),
matching InterpolatedStringNode's shape. compile_expr arm in turn
routes through compile_interpolated -- the assembled string IS the
runtime value of the symbol.

Spinel-specific divergence from CRuby: dynamic symbols don't intern.
sp_sym ids are reserved for compile-time literal symbols (registered
in @symbol_names with stable indices); a runtime-built symbol can't
allocate one without breaking the IntArray-backed sym_int_hash and
sym_array storage that depend on the index being known at compile
time. We therefore expose the symbol as its string form. Use sites
that accept either:

- puts / print / string interpolation -- pass through unchanged.
- s.to_s -- already a string.
- == against a string-typed RHS -- agrees.
- == against another InterpolatedSymbolNode -- agrees.

Out of scope (use sites that need genuine symbol identity): sym_int_hash
keys, sym_array elements, `case x; when :literal` against an
interpolated subject.

Test exercises (test/interp_symbol.rb):

- Two interpolated symbols with string and integer subjects.
- Pass-through to a method that calls .to_s.

Tests: 271 pass.
Bootstrap: gen2.c == gen3.c.


## Test plan

- [x] `make` — builds clean
- [x] `make bootstrap` — `gen2.c == gen3.c (bootstrap OK)`
- [x] `make test` — `Tests:      291 pass,        0 fail,        0 error`

