### PR TITLE
feat(codegen): Array#[]=(start, length, src) slice assignment

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -28189,6 +28189,20 @@ class Compiler
     if args_id >= 0
       arg_ids = get_args(args_id)
     end
+    # Slice assignment `arr[i, n] = src`: replace n elements
+    # starting at index i with the elements of src. Same-length
+    # only (n == src.length); resize semantics not yet supported.
+    # Only fires when both sides are the same C kind — falls
+    # through otherwise to avoid silent miscompiles on mistyped
+    # inputs (e.g. an `int_array`-typed src that's actually an
+    # array-of-IntArrays would copy the wrong shape).
+    if arg_ids.length == 3 && (rt == "int_array" || rt == "float_array" || rt == "str_array" || rt == "sym_array" || is_ptr_array_type(rt) == 1 || rt == "poly_array")
+      src_t_check = infer_type(arg_ids[2])
+      if array_c_prefix(rt) == array_c_prefix(src_t_check) && (src_t_check == "int_array" || src_t_check == "float_array" || src_t_check == "str_array" || src_t_check == "sym_array" || is_ptr_array_type(src_t_check) == 1 || src_t_check == "poly_array")
+        compile_slice_assign(nid, recv, rt, rc, arg_ids)
+        return
+      end
+    end
     idx = "0"
     val = "0"
     if arg_ids.length >= 1
@@ -28263,6 +28277,44 @@ class Compiler
       emit("  sp_StrStrHash_set(" + rc + ", " + idx + ", " + val + ");")
       return
     end
+  end
+
+  # Compile `arr[start, len] = src` slice assignment. Replaces
+  # `len` elements of `arr` starting at `start` with the elements
+  # of `src`. Same-length only — `src.length` must equal `len` at
+  # runtime; resize semantics not implemented. Each index `i in
+  # 0...len` is emitted as `arr[start + i] = src[i]`.
+  def compile_slice_assign(nid, recv, rt, rc, arg_ids)
+    start_id = arg_ids[0]
+    len_id = arg_ids[1]
+    src_id = arg_ids[2]
+    src_t = infer_type(src_id)
+    start_e = compile_expr(start_id)
+    len_e = compile_expr(len_id)
+    src_e = compile_expr_gc_rooted(src_id)
+    pfx = array_c_prefix(rt)
+    src_pfx = array_c_prefix(src_t)
+    if pfx == "" || src_pfx == ""
+      return
+    end
+    rc_t = new_temp
+    src_t_v = new_temp
+    start_t = new_temp
+    ii = new_temp
+    emit("  {")
+    emit("    sp_" + pfx + " *" + rc_t + " = " + rc + ";")
+    emit("    sp_" + src_pfx + " *" + src_t_v + " = " + src_e + ";")
+    emit("    mrb_int " + start_t + " = " + start_e + ";")
+    emit("    mrb_int _n = " + len_e + ";")
+    # Inner loop: copy n elements from src to dest. Casting between
+    # array kinds isn't supported here (e.g. int_array ← float_array
+    # would silently truncate); both must be the same C kind.
+    if pfx == src_pfx
+      emit("    for (mrb_int " + ii + " = 0; " + ii + " < _n; " + ii + "++) {")
+      emit("      sp_" + pfx + "_set(" + rc_t + ", " + start_t + " + " + ii + ", sp_" + src_pfx + "_get(" + src_t_v + ", " + ii + "));")
+      emit("    }")
+    end
+    emit("  }")
   end
 
   # Compile `recv[idx] OP= value` (IndexOperatorWriteNode).

--- a/test/array_slice_assign.rb
+++ b/test/array_slice_assign.rb
@@ -1,0 +1,22 @@
+# `arr[i, n] = src` (Array#[]= with three args) replaces n
+# elements of `arr` starting at index i with the elements of
+# `src`. Same-length only — n must equal `src.length`; resize
+# semantics not supported.
+#
+# Without this, the codegen path for `[]=` only looked at args
+# 0 and 1, so `a[2, 8] = [10, 20, ...]` lowered to `a[2] = 8`,
+# silently treating the length argument as the value.
+
+a = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+a[2, 8] = [10, 20, 30, 40, 50, 60, 70, 80]
+p a
+
+# Float array
+f = [0.0, 0.0, 0.0, 0.0]
+f[1, 2] = [3.5, 4.5]
+p f
+
+# String array
+s = ["", "", "", ""]
+s[0, 3] = ["a", "b", "c"]
+p s


### PR DESCRIPTION
### Reproduction

```ruby
a = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
a[2, 8] = [10, 20, 30, 40, 50, 60, 70, 80]
p a
```

### Expected behavior

```
[0, 0, 10, 20, 30, 40, 50, 60, 70, 80]
```

### Actual behavior

```
[0, 0, 8, 0, 0, 0, 0, 0, 0, 0]
```

The length argument `8` was treated as the value, the source
array discarded. The codegen path for `[]=` only consumed args
0 and 1 as `idx` and `val`, ignoring the third argument.

### Analysis & fix

Add `compile_slice_assign`: when a `[]=` call has three
positional args and the receiver is a typed array kind
(`int_array` / `float_array` / `str_array` / `sym_array` /
`ptr_array` / `poly_array`), emit a per-element copy loop:

```c
{
  sp_<X>Array *_dst = arr;
  sp_<Y>Array *_src = src;
  mrb_int _start = start_e;
  mrb_int _n = len_e;
  for (mrb_int _i = 0; _i < _n; _i++) {
    sp_<X>Array_set(_dst, _start + _i, sp_<Y>Array_get(_src, _i));
  }
}
```

Same-length only — `src.length` must equal `len` at runtime;
resize semantics (when `src.length != len`, the receiver
shrinks/grows) are not implemented. Cross-kind assignment
(e.g. `int_array ← float_array`) is intentionally a no-op
rather than emitting a silent truncation; both sides must be
the same C kind.

### Test plan

- [x] `test/array_slice_assign.rb` — three-arg `[]=` against
      int_array, float_array, and str_array with same-length
      sources. All match Ruby's output.
- [x] `make -j4 bootstrap` green.
- [x] `make test` 0 fail / 0 error.