### PR TITLE
feat(parse): support MissingNode (parse-error placeholder; defensive handler)

### DIFF
--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -794,6 +794,16 @@ static int flatten(pm_node_t *node) {
     node_counter--;
     return flatten(n->value);
   }
+  case PM_MISSING_NODE: {
+    /* Prism emits MissingNode as an error-recovery placeholder. main()
+       bails out before flatten() runs when parser.error_list is
+       non-empty, so reaching this case means Prism produced a
+       MissingNode without flagging an error -- a contract violation we
+       surface clearly rather than silently miscompile. */
+    fprintf(stderr, "spinel_parse: internal error: MissingNode reached flatten() at byte offset %td; parse error not in error_list\n",
+            node->location.start - g_parser->start);
+    exit(1);
+  }
   case PM_SPLAT_NODE: {
     pm_splat_node_t *n = (pm_splat_node_t *)node;
     N("SplatNode");


### PR DESCRIPTION
Adds a parser case for `PM_MISSING_NODE` that exits with a clear internal-error message. Prism emits `MissingNode` as an error-recovery placeholder.

## Why no test fixture

The parser's main loop bails on parse errors before `flatten()` is called (`spinel_parse.c:1201`), so reaching this case indicates Prism produced a `MissingNode` without flagging an error in `error_list` — a contract violation we surface clearly rather than route through the generic `UnsupportedNode` path. The handler is defense-in-depth in case Prism's contract changes.

I tried to construct an exercising fixture from both valid and invalid Ruby; the `error_list` bail-out catches every case I could come up with. Happy to add one if a reviewer can think of input that reaches this arm.

## Why `exit(1)` and not `mrb_raise`

Matches the existing `UnsupportedNode`-style `fprintf(stderr, ...); exit(1)` precedent already in `flatten()`. Loud-failure over silent miscompile.

## Verification

- `make test` — 326 pass, 0 fail.
- `make bootstrap` — `gen2.c == gen3.c`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>