### PR TITLE
feat(codegen): nested array literals (3D+) via PolyArray-of-PolyArray

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -694,6 +694,7 @@ typedef uint64_t sp_RbValue;
 #define SP_BUILTIN_PROC         (-9)                              /* sp_Proc *, distinct from any tag-based id */
 #define SP_BUILTIN_RANGE        (-10)                             /* sp_Range *, heap copy of stack-typed sp_Range when crossing into poly */
 #define SP_BUILTIN_TIME         (-11)                             /* sp_Time *, heap copy of stack-typed sp_Time when crossing into poly */
+#define SP_BUILTIN_POLY_ARRAY   (-12)                             /* sp_PolyArray *, array of sp_RbVal */
 typedef struct { int tag; int cls_id; union { mrb_int i; const char *s; mrb_float f; mrb_bool b; void *p; } v; } sp_RbVal;
 static sp_RbVal sp_box_int(mrb_int v) { sp_RbVal r; r.tag = SP_TAG_INT; r.cls_id = 0; r.v.i = v; return r; }
 static sp_RbVal sp_box_str(const char *v) { sp_RbVal r; r.tag = SP_TAG_STR; r.cls_id = 0; r.v.s = v; return r; }
@@ -751,6 +752,7 @@ static const char *sp_Time_inspect(sp_Time *t) {
   }
   return buf;
 }
+static sp_RbVal sp_box_poly_array(void *p)  { return sp_box_obj(p, SP_BUILTIN_POLY_ARRAY); }
 static void sp_poly_puts(sp_RbVal v) {
   switch (v.tag) {
     case SP_TAG_INT: printf("%lld\n", (long long)v.v.i); break;

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2116,6 +2116,18 @@ class Compiler
         end
         return "poly_array"
       end
+      # Nested-deeper case: elements are themselves a typed
+      # ptr_array (`int_array_ptr_array`, etc.) or already
+      # poly_array. Spinel doesn't have a typed
+      # `<X>_ptr_array_ptr_array` slot, so box each level via
+      # poly_array — sp_box_*_array on each push, and the
+      # poly-builtin dispatch on `[]` recurses into the next
+      # level.
+      if is_ptr_array_type(et) == 1 || et == "poly_array"
+        @needs_gc = 1
+        @needs_rb_value = 1
+        return "poly_array"
+      end
       # Check if elements have mixed types
       k = 1
       while k < elems.length
@@ -15401,9 +15413,17 @@ class Compiler
                 while ek < elems_iv.length
                   eid = elems_iv[ek]
                   et = infer_type(eid)
-                  ev = compile_expr(eid)
-                  ebox = et == "poly" ? ev : box_value_to_poly(et, ev)
-                  emit_raw("  sp_PolyArray_push(" + tmp_iv + ", " + ebox + ");")
+                  # 3D+ shape: nested ArrayNode with ptr_array elem
+                  # type → recompile as poly_array so cls_id chain
+                  # stays tagged through every level.
+                  if @nd_type[eid] == "ArrayNode" && (is_ptr_array_type(et) == 1 || et == "poly_array")
+                    inner_iv = compile_array_literal_as_poly(eid)
+                    emit_raw("  sp_PolyArray_push(" + tmp_iv + ", sp_box_poly_array(" + inner_iv + "));")
+                  else
+                    ev = compile_expr(eid)
+                    ebox = et == "poly" ? ev : box_value_to_poly(et, ev)
+                    emit_raw("  sp_PolyArray_push(" + tmp_iv + ", " + ebox + ");")
+                  end
                   ek = ek + 1
                 end
                 emit_raw("  " + self_arrow + ivar + " = " + tmp_iv + ";")
@@ -24632,6 +24652,34 @@ class Compiler
     "(!" + cond + " ? " + then_val + " : 0)"
   end
 
+  # Compile an `ArrayNode` literal as `sp_PolyArray *`, regardless
+  # of the inferred elem type. Used by the nested-array path in
+  # the poly_array branch so 3D-and-deeper arrays preserve cls_id
+  # tags through every level (e.g. an inner `[1,2,3]` ends up
+  # boxed via `sp_box_int_array` so the dispatch can still
+  # `sp_IntArray_get` on it).
+  def compile_array_literal_as_poly(nid)
+    @needs_gc = 1
+    @needs_rb_value = 1
+    elems = parse_id_list(@nd_elements[nid])
+    tmp = new_temp
+    emit("  sp_PolyArray *" + tmp + " = sp_PolyArray_new();")
+    k = 0
+    while k < elems.length
+      eid = elems[k]
+      et = infer_type(eid)
+      if @nd_type[eid] == "ArrayNode" && (is_ptr_array_type(et) == 1 || et == "poly_array")
+        inner = compile_array_literal_as_poly(eid)
+        emit("  sp_PolyArray_push(" + tmp + ", sp_box_poly_array(" + inner + "));")
+      else
+        val = compile_expr(eid)
+        emit("  sp_PolyArray_push(" + tmp + ", " + box_value_to_poly(et, val) + ");")
+      end
+      k = k + 1
+    end
+    tmp
+  end
+
   def compile_array_literal(nid)
     @needs_gc = 1
     elems = parse_id_list(@nd_elements[nid])
@@ -24670,8 +24718,21 @@ class Compiler
       k = 0
       while k < elems.length
         et = infer_type(elems[k])
-        val = compile_expr(elems[k])
-        emit("  sp_PolyArray_push(" + tmp + ", " + box_value_to_poly(et, val) + ");")
+        # 3D+ shape: when the element is itself a typed
+        # `<X>_ptr_array` that came from a nested ArrayNode, the
+        # default `compile_array_literal` for that element would
+        # emit a typed sp_PtrArray and `sp_box_ptr_array` would
+        # erase the elem type (cls_id PTR_ARRAY). Recompile the
+        # nested literal as poly_array so the next-level dispatch
+        # sees `cls_id == POLY_ARRAY` and recurses with each
+        # innermost typed array still tagged correctly.
+        if @nd_type[elems[k]] == "ArrayNode" && (is_ptr_array_type(et) == 1 || et == "poly_array")
+          val = compile_array_literal_as_poly(elems[k])
+          emit("  sp_PolyArray_push(" + tmp + ", sp_box_poly_array(" + val + "));")
+        else
+          val = compile_expr(elems[k])
+          emit("  sp_PolyArray_push(" + tmp + ", " + box_value_to_poly(et, val) + ");")
+        end
         k = k + 1
       end
       return tmp
@@ -25265,9 +25326,17 @@ class Compiler
         while ek < elems_pa.length
           eid = elems_pa[ek]
           et = infer_type(eid)
-          ev = compile_expr(eid)
-          ebox = et == "poly" ? ev : box_value_to_poly(et, ev)
-          emit("  sp_PolyArray_push(" + tmp_arr + ", " + ebox + ");")
+          # 3D+ shape: nested ArrayNode with ptr_array element
+          # type — recompile as poly_array so cls_id chain stays
+          # tagged through every level.
+          if @nd_type[eid] == "ArrayNode" && (is_ptr_array_type(et) == 1 || et == "poly_array")
+            inner = compile_array_literal_as_poly(eid)
+            emit("  sp_PolyArray_push(" + tmp_arr + ", sp_box_poly_array(" + inner + "));")
+          else
+            ev = compile_expr(eid)
+            ebox = et == "poly" ? ev : box_value_to_poly(et, ev)
+            emit("  sp_PolyArray_push(" + tmp_arr + ", " + ebox + ");")
+          end
           ek = ek + 1
         end
         emit("  " + self_arrow + sanitize_ivar(iname) + " = " + tmp_arr + ";")

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -23164,6 +23164,12 @@ class Compiler
       pc = "sp_PtrArray_get((sp_PtrArray *)" + recv_tmp + ".v.p, " + a0 + ")"
       prhs = is_poly_ret == 1 ? "sp_box_obj(" + pc + ", 0)" : pc
       emit("    if (" + recv_tmp + ".cls_id == SP_BUILTIN_PTR_ARRAY) " + result_tmp + " = " + prhs + ";")
+      # PolyArray dispatch — sp_PolyArray_get returns sp_RbVal directly.
+      # When the result temp is poly, just assign; otherwise unbox via .v.i
+      # (the typed temp's static type drives caller-side conversion).
+      polyc = "sp_PolyArray_get((sp_PolyArray *)" + recv_tmp + ".v.p, " + a0 + ")"
+      polyrhs = is_poly_ret == 1 ? polyc : "(" + polyc + ").v.i"
+      emit("    if (" + recv_tmp + ".cls_id == SP_BUILTIN_POLY_ARRAY) " + result_tmp + " = " + polyrhs + ";")
     end
     # `length` / `size` — every built-in array exposes its own
     # `_length` helper (sym_array shares IntArray's). PtrArray is
@@ -23185,6 +23191,9 @@ class Compiler
       pc = "sp_PtrArray_length((sp_PtrArray *)" + recv_tmp + ".v.p)"
       prhs = is_poly_ret == 1 ? "sp_box_int(" + pc + ")" : pc
       emit("    if (" + recv_tmp + ".cls_id == SP_BUILTIN_PTR_ARRAY) " + result_tmp + " = " + prhs + ";")
+      polyc = "sp_PolyArray_length((sp_PolyArray *)" + recv_tmp + ".v.p)"
+      polyrhs = is_poly_ret == 1 ? "sp_box_int(" + polyc + ")" : polyc
+      emit("    if (" + recv_tmp + ".cls_id == SP_BUILTIN_POLY_ARRAY) " + result_tmp + " = " + polyrhs + ";")
     end
   end
 
@@ -23356,6 +23365,9 @@ class Compiler
       if is_ptr_array_type(at) == 1
         return "sp_box_nullable_obj(" + val + ", SP_BUILTIN_PTR_ARRAY)"
       end
+      if at == "poly_array"
+        return "sp_box_nullable_obj(" + val + ", SP_BUILTIN_POLY_ARRAY)"
+      end
       if at == "proc" || at == "lambda"
         return "sp_box_nullable_obj(" + val + ", SP_BUILTIN_PROC)"
       end
@@ -23407,6 +23419,9 @@ class Compiler
     end
     if is_ptr_array_type(at) == 1
       return "sp_box_ptr_array(" + val + ")"
+    end
+    if at == "poly_array"
+      return "sp_box_poly_array(" + val + ")"
     end
     if at == "proc" || at == "lambda"
       return "sp_box_proc(" + val + ")"

--- a/test/array_3d_nested.rb
+++ b/test/array_3d_nested.rb
@@ -1,0 +1,48 @@
+# Deep-nested array literals (3D and beyond). Spinel doesn't
+# have a typed `<X>_ptr_array_ptr_array` slot — the second-level
+# `[[1,2,3],[4,5,6]]` infers as `int_array_ptr_array` and the
+# outer `[[[...]],[[...]]]` would naively box each element via
+# `sp_box_ptr_array`, which erases the elem-type info and
+# leaves the dispatch returning an unknown obj at the next `[]`
+# read.
+#
+# Fix: when an array literal element is itself a typed
+# ptr_array (or already poly_array) and the outer is
+# poly_array, recompile the inner literal as poly_array so
+# every level boxes via `sp_box_poly_array` / `sp_box_int_array`
+# / etc. — the cls_id chain stays tagged and the poly-builtin
+# dispatch recurses correctly through `arr[i][j][k]...`.
+#
+# The recursion in `compile_array_literal_as_poly` makes the
+# fix dimension-agnostic — 3D, 4D, 5D, ... all work.
+#
+# Without the fix `read` returned 0 for every index (sp_box_nil
+# fallback). With the fix it returns the right ints.
+
+class H3
+  def initialize
+    @t = [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]
+  end
+  def read(i, j, k); @t[i][j][k]; end
+end
+
+h3 = H3.new
+puts h3.read(0, 0, 0)   # 1
+puts h3.read(0, 1, 1)   # 5
+puts h3.read(1, 0, 2)   # 9
+puts h3.read(1, 1, 2)   # 12
+
+# 4D — recursion handles arbitrary depth.
+class H4
+  def initialize
+    @t = [[[[1, 2], [3, 4]], [[5, 6], [7, 8]]],
+          [[[9, 10], [11, 12]], [[13, 14], [15, 16]]]]
+  end
+  def read(i, j, k, l); @t[i][j][k][l]; end
+end
+
+h4 = H4.new
+puts h4.read(0, 0, 0, 0)   # 1
+puts h4.read(0, 1, 0, 1)   # 6
+puts h4.read(1, 0, 1, 0)   # 11
+puts h4.read(1, 1, 1, 1)   # 16


### PR DESCRIPTION
Two commits, ordered:

1. `feat(codegen): SP_BUILTIN_POLY_ARRAY for poly-boxed sp_PolyArray`
   — reserves the cls_id, adds `sp_box_poly_array` runtime helper,
   wires the dispatch arm in `emit_poly_builtin_dispatch`.

2. `feat(codegen): nested array literals (3D+) via PolyArray-of-PolyArray`
   — the recursive 3D+ fix (dimension-agnostic).

### Reproduction

```ruby
class H3
  def initialize
    @t = [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]
  end
  def read(i, j, k); @t[i][j][k]; end
end

class H4
  def initialize
    @t = [[[[1, 2], [3, 4]], [[5, 6], [7, 8]]],
          [[[9, 10], [11, 12]], [[13, 14], [15, 16]]]]
  end
  def read(i, j, k, l); @t[i][j][k][l]; end
end

puts H3.new.read(0, 1, 1)   # 5
puts H4.new.read(1, 1, 1, 1) # 16
```

### Expected behavior

```
5
16
```

### Actual behavior

```
$ ./spinel test.rb -o test
$ ./test
0
0
```

### Analysis & fix

Spinel doesn't have a typed `<X>_ptr_array_ptr_array` slot.
The second-level `[[1,2,3],[4,5,6]]` infers as
`int_array_ptr_array`, but the outer level used to box each
element via `sp_box_ptr_array(_t2)` — which erases the
elem-type info (the resulting `sp_RbVal` has `cls_id =
SP_BUILTIN_PTR_ARRAY` but the elements inside the PtrArray
are stored as raw `void *`).

When the next `[]` read fires:
- `arr[i]` returns `sp_RbVal { cls_id = PTR_ARRAY, v.p = sp_PtrArray }`.
- `arr[i][j]` dispatches to the PTR_ARRAY arm, returns
  `sp_box_obj(sp_PtrArray_get(...), 0)` — a poly value with
  `cls_id = 0` (unknown obj).
- `arr[i][j][k]` dispatches but no arm matches `cls_id == 0`,
  so it falls through to `sp_box_nil()`.

Fix: `infer_array_elem_type` returns `poly_array` when the
elements are themselves a typed `<X>_ptr_array` (or
`poly_array`). Then `compile_array_literal_as_poly` (a new
recursive helper) boxes every level via `sp_box_poly_array` /
`sp_box_int_array` / etc., so the cls_id chain stays tagged
through every level. The recursion makes the fix
**dimension-agnostic** — 3D, 4D, 5D, ... all work via
the same code path. Three call sites use it: the poly_array
branch of `compile_array_literal`, the constructor IVW path
in `emit_constructor`, and the general IVW path in
`compile_stmt`.

### Test plan

- [x] `test/array_3d_nested.rb` — covers 3D and 4D shapes;
      verifies `read(...)` returns the right ints rather than
      0 at every depth.
- [x] `make -j4 bootstrap` green.
- [x] `make test` 0 fail / 0 error.