### PR TITLE
feat(codegen): module_function + bare-class lookup in module method body

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -7357,6 +7357,7 @@ class Compiler
       end
     }
 
+    in_module_function = 0
     body_stmts.each { |sid|
       if @nd_type[sid] == "ConstantWriteNode"
         collect_scoped_constant(mname, sid)
@@ -7365,28 +7366,41 @@ class Compiler
       if @nd_type[sid] == "MultiWriteNode"
         collect_scoped_multi_const(mname, sid)
       end
+      # `module_function` (no args) flips subsequent `def name`
+      # into class-method dispatch, parallel to `def self.name`.
+      # Spinel only needs the class-method shape; the full Ruby
+      # semantics also installs the methods as private instance
+      # methods (for include-mixin), unmodeled here.
+      if @nd_type[sid] == "CallNode" && @nd_receiver[sid] < 0 && @nd_name[sid] == "module_function"
+        args_id_mf = @nd_arguments[sid]
+        if args_id_mf < 0 || get_args(args_id_mf).length == 0
+          in_module_function = 1
+        end
+      end
       # Collect module class methods (def self.xxx) as top-level functions
       if @nd_type[sid] == "DefNode"
-        if @nd_receiver[sid] >= 0
-          if @nd_type[@nd_receiver[sid]] == "SelfNode"
-            dmname = @nd_name[sid]
-            # Create as top-level method with module prefix for dispatch
-            @meth_names.push(mname + "_cls_" + dmname)
-            @meth_param_names.push(collect_params_str(sid))
-            @meth_param_types.push(collect_ptypes_str(sid, -1))
-            @meth_param_empty.push("")
-            @meth_return_types.push("int")
-            @meth_body_ids.push(@nd_body[sid])
-            @meth_has_yield.push(0)
-            # Issue #239: capture default-arg expressions so call
-            # sites that omit trailing args get them filled in by
-            # compile_call_args_with_defaults. Pre-fix this slot
-            # was hardcoded to "0", which `compile_expr` lowered to
-            # the literal `0` regardless of the actual default
-            # (string literals etc.).
-            @meth_has_defaults.push(collect_defaults_str(sid))
-            @meth_rest_index.push(collect_rest_index(sid))
-          end
+        is_self_def = 0
+        if @nd_receiver[sid] >= 0 && @nd_type[@nd_receiver[sid]] == "SelfNode"
+          is_self_def = 1
+        end
+        if is_self_def == 1 || (in_module_function == 1 && @nd_receiver[sid] < 0)
+          dmname = @nd_name[sid]
+          # Create as top-level method with module prefix for dispatch
+          @meth_names.push(mname + "_cls_" + dmname)
+          @meth_param_names.push(collect_params_str(sid))
+          @meth_param_types.push(collect_ptypes_str(sid, -1))
+          @meth_param_empty.push("")
+          @meth_return_types.push("int")
+          @meth_body_ids.push(@nd_body[sid])
+          @meth_has_yield.push(0)
+          # Issue #239: capture default-arg expressions so call
+          # sites that omit trailing args get them filled in by
+          # compile_call_args_with_defaults. Pre-fix this slot
+          # was hardcoded to "0", which `compile_expr` lowered to
+          # the literal `0` regardless of the actual default
+          # (string literals etc.).
+          @meth_has_defaults.push(collect_defaults_str(sid))
+          @meth_rest_index.push(collect_rest_index(sid))
         end
       end
       # Collect module-level ivar writes as global statics
@@ -10542,6 +10556,12 @@ class Compiler
       push_scope
       # Open class self type
       mfn = @meth_names[i]
+      # Pin @current_method_name so current_lexical_scope_name can
+      # peel `<Mod>_cls_<m>` and resolve bare class refs in the body
+      # (e.g. `Video.new` inside `Top::Drv.load` resolves Video to
+      # Top_Video instead of bare Video).
+      saved_meth_ar = @current_method_name
+      @current_method_name = mfn
       if mfn.start_with?("__oc_Integer_")
         declare_var("__self_type", "int")
       end
@@ -10601,6 +10621,7 @@ class Compiler
       end
       rt = infer_body_return(@meth_body_ids[i])
       @meth_return_types[i] = rt
+      @current_method_name = saved_meth_ar
       pop_scope
       i = i + 1
     end

--- a/test/module_function_namespace.rb
+++ b/test/module_function_namespace.rb
@@ -1,0 +1,58 @@
+# `module_function` in a module body installs the subsequent
+# `def name` as both an instance method (for include-mixin)
+# and a class method (`Mod.name`). Spinel only models the
+# class-method form here.
+#
+# The namespace-resolution bug surfaces independently of
+# `module_function`: any method body inside a module needs
+# `current_lexical_scope_name` set so that bare class refs
+# (`Box.new`) walk up via `resolve_const_read_name` to find
+# the qualified `Outer_Box`.
+#
+# Both fixes ride together: register `def name` after
+# `module_function` as `Mod_cls_name`, and pin
+# `@current_method_name` while iterating top-level methods so
+# the body's class-ref lookups peel `<Mod>_cls_<m>` correctly.
+
+module Outer
+  module Helper
+    module_function
+    def small;  [1, 2, 3]; end
+    def medium; [4, 5, 6, 7]; end
+  end
+
+  class Conf
+    def initialize(flag)
+      @flag = flag
+      @arr = []
+      @arr << 0    # force heap layout (sp_Outer_Conf *)
+    end
+    attr_reader :flag
+  end
+
+  class Box
+    def initialize(conf)
+      @c = conf
+      @arr = []
+      @arr << 0
+    end
+    attr_reader :c
+  end
+
+  module Builder
+    # `def self.X` form — the bare `Box.new` inside walks the
+    # lexical scope to resolve `Outer_Box`.
+    def self.make(conf)
+      Box.new(conf)
+    end
+  end
+end
+
+# module_function dispatch.
+puts Outer::Helper.small.length    # 3
+puts Outer::Helper.medium.length   # 4
+
+# Module class method body that references a sibling class
+# bare-named — used to fail with "unknown type name 'sp_Box'".
+b = Outer::Builder.make(Outer::Conf.new(true))
+puts b.c.flag                       # true


### PR DESCRIPTION
### Reproduction

```ruby
module Outer
  module Helper
    module_function
    def small;  [1, 2, 3]; end
    def medium; [4, 5, 6, 7]; end
  end

  class Conf
    def initialize(flag); @flag = flag; @arr = []; @arr << 0; end
    attr_reader :flag
  end

  class Box
    def initialize(conf); @c = conf; @arr = []; @arr << 0; end
    attr_reader :c
  end

  module Builder
    def self.make(conf)
      Box.new(conf)
    end
  end
end

puts Outer::Helper.small.length
puts Outer::Helper.medium.length
b = Outer::Builder.make(Outer::Conf.new(true))
puts b.c.flag
```

### Expected behavior

```
3
4
true
```

### Actual behavior

```
$ ./spinel test.rb -o test
warning: cannot resolve call to 'small' on int (emitting 0)
warning: cannot resolve call to 'length' on int (emitting 0)
$ ./test
0
0
unknown type name 'sp_Box'   # C compile failure for Builder.make
```

Two bugs surface in the same example:

1. **`module_function` is unimplemented.** `collect_module_with_prefix`
   only registered `def self.X` as a class method — bare
   `def X` after `module_function` was ignored, so
   `Helper.small` fell through to the int default.

2. **Bare class refs in a module method body don't resolve.**
   `Builder.make`'s body says `Box.new(conf)`. `resolve_const_read_name`
   walks `current_lexical_scope_name` to find the qualified
   `Outer_Box`, but the top-level inference pass in
   `infer_all_returns` didn't pin `@current_method_name`, so
   the scope was empty and `Box` resolved to bare `Box`,
   producing `sp_Box *lv_b` against an unknown type.

### Analysis & fix

1. In `collect_module_with_prefix`, track an `in_module_function`
   flag flipped on by `module_function` (no args) calls in the
   module body. Subsequent `DefNode`s with no explicit recv
   register as `<Mod>_cls_<name>` alongside the existing
   `def self.X` path.

2. In the top-level method loop of `infer_all_returns`, pin
   `@current_method_name = mfn` (the full `<Mod>_cls_<m>`
   name). `current_lexical_scope_name` peels the `_cls_` suffix
   to recover the module prefix, so `Box` walks up the scope
   chain to `Outer_Box`.

The full Ruby `module_function` semantics also installs the
methods as private instance methods (for include-mixin shape).
Spinel doesn't model that yet — the class-method-only shape is
sufficient for typical `Mod.foo` consumer dispatch.

### Test plan

- [x] `test/module_function_namespace.rb` — covers both fixes:
      `module_function` dispatch on `Helper.small` /
      `Helper.medium`, and `Builder.make(conf)` body resolves
      `Box.new(conf)` to `Outer_Box.new(conf)` with the right
      ptr type.
- [x] `make -j4 bootstrap` green.
- [x] `make test` 0 fail / 0 error.