### PR TITLE
feat(parse): support EmbeddedVariableNode ("foo #@bar")

### DIFF
--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -1033,6 +1033,27 @@ static int flatten(pm_node_t *node) {
     A("rights", &n->rights);
     break;
   }
+  case PM_EMBEDDED_VARIABLE_NODE: {
+    /* `"foo #@bar"` shorthand for `"foo #{@bar}"`. The cleanest
+       implementation is parser-side lowering: synthesize an
+       EmbeddedStatementsNode wrapping a StatementsNode whose single
+       body element is the variable read. The existing interpolation
+       path then handles it without any codegen change.
+
+       Same lowering trick as PM_IT_LOCAL_VARIABLE_READ_NODE -- emit
+       a different node type at the same `id` slot so parent walks
+       (parts list of the surrounding InterpolatedString) keep the
+       slot unchanged. The wrapped StatementsNode gets a fresh id
+       allocated via node_counter++. */
+    pm_embedded_variable_node_t *n = (pm_embedded_variable_node_t *)node;
+    N("EmbeddedStatementsNode");
+    int var_id = flatten(n->variable);
+    int stmts_id = node_counter++;
+    out_add("N %d StatementsNode", stmts_id);
+    out_add("A %d body %d", stmts_id, var_id);
+    out_add("R %d statements %d", id, stmts_id);
+    break;
+  }
   default: {
     /* Fallback: emit unknown node type */
     char buf[64];

--- a/test/embedded_var.rb
+++ b/test/embedded_var.rb
@@ -1,0 +1,17 @@
+# EmbeddedVariableNode -- `"#$gv"`, `"#@iv"`, `"#@@cv"`.
+#
+# Shorthand interpolation form that skips the braces around a
+# bare variable reference. Lowered at parser side to an
+# EmbeddedStatementsNode wrapping the matching variable read,
+# so the codegen reuses the existing interpolation path.
+
+$global = "global!"
+puts "got: #$global"          # got: global!
+
+class C
+  def initialize
+    @ivar = "ivar!"
+  end
+  def show = puts("got: #@ivar")
+end
+C.new.show                    # got: ivar!

--- a/test/embedded_var.rb.expected
+++ b/test/embedded_var.rb.expected
@@ -1,0 +1,2 @@
+got: global!
+got: ivar!


### PR DESCRIPTION
Reopen of #280 (auto-closed when master was force-pushed onto the head branch). Rebased onto current master.

---

Parser-side lowering with no codegen change. `EmbeddedVariableNode` covers
the three sigils for shorthand variable interpolation: `"foo #$gv"`,
`"foo #@iv"`, `"foo #@@cv"`. The cleanest implementation is to lower at
parse time to the equivalent `EmbeddedStatementsNode` shape — a
`StatementsNode` with a single body element that's the variable read — so
the existing `compile_interpolated` path handles it without modification.

Same lowering trick as `PM_IT_LOCAL_VARIABLE_READ_NODE` (and
`PM_SHAREABLE_CONSTANT_NODE` / `PM_IMPLICIT_NODE` earlier): emit a
different node type at the *same* `id` slot so the parent's `parts` list
keeps the same reference. The wrapped `StatementsNode` gets a fresh id
via `node_counter++`, and we emit the array-record manually since
`out_add` takes printf-style varargs.

Test exercises (`test/embedded_var.rb`):

- `"got: #\$global"` — top-level `GlobalVariableReadNode` embedded.
- `"got: #@ivar"` — `InstanceVariableReadNode` embedded inside a method.

## Test plan

- [x] `make` — builds clean
- [x] `make test` — `Tests: 333 pass, 0 fail, 0 error`