### PR TITLE
feat(parse,codegen): support AliasGlobalVariableNode (alias $copy $orig)

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -97,6 +97,11 @@ class Compiler
     # (post-rest parameters aren't observed in test/), but the parser
     # emits the field so future tests get a proper AST.
     @nd_posts = "".split(",")
+    # AliasMethodNode / AliasGlobalVariableNode -- parallel ref slots
+    # for the new and old names (SymbolNode for methods, GlobalVariableReadNode
+    # for globals).
+    @nd_new_name = []
+    @nd_old_name = []
 
     @nd_count = 0
     @root_id = 0
@@ -202,6 +207,13 @@ class Compiler
     # exit; a `redo` jumps to the top of the innermost label.
     @redo_label_stack = "".split(",")
     @redo_label_counter = 0
+
+    # `alias $copy $orig` -- maps new gvar name to its target.
+    # Populated by collect_all from AliasGlobalVariableNode
+    # statements; consulted by sanitize_gvar / scan_features /
+    # infer_type so $copy and $orig share storage.
+    @galias_new = "".split(",")
+    @galias_old = "".split(",")
 
     # ---- Scope stack for local variables ----
     @scope_names = "".split(",")
@@ -485,6 +497,8 @@ class Compiler
     @nd_targets.push("")
     @nd_rights.push("")
     @nd_posts.push("")
+    @nd_new_name.push(-1)
+    @nd_old_name.push(-1)
     @nd_count = @nd_count + 1
     nid
   end
@@ -752,6 +766,14 @@ class Compiler
     end
     if field == "call"
       @nd_receiver[nid] = ref_id
+    end
+    if field == "new_name"
+      # AliasMethodNode / AliasGlobalVariableNode -- the new-name slot
+      # (a SymbolNode for methods, GlobalVariableReadNode for globals).
+      @nd_new_name[nid] = ref_id
+    end
+    if field == "old_name"
+      @nd_old_name[nid] = ref_id
     end
   end
 
@@ -1912,7 +1934,10 @@ class Compiler
       return "int"
     end
     if t == "GlobalVariableReadNode"
-      gname = @nd_name[nid]
+      # `alias $copy $orig` -- a $copy read must look up $orig's
+      # registered type so the C codegen sees the correct format
+      # specifier when interpolating or printing.
+      gname = resolve_gvar_alias(@nd_name[nid])
       gi = 0
       while gi < @gvar_names.length
         if @gvar_names[gi] == gname
@@ -5010,11 +5035,28 @@ class Compiler
   end
 
   def sanitize_gvar(name)
+    # `alias $copy $orig` -- transparently rewrite `$copy` to `$orig`
+    # everywhere it appears so the C output uses one storage slot
+    # for both names. Compile-time only; matches CRuby's
+    # `$copy and $orig share storage` semantics for the static-alias
+    # case.
+    name = resolve_gvar_alias(name)
     # $last → gv_last, $1 → gv_1
     if name.length > 0 && name[0] == "$"
       return "gv_" + name[1, name.length - 1]
     end
     "gv_" + name
+  end
+
+  def resolve_gvar_alias(name)
+    i = 0
+    while i < @galias_new.length
+      if @galias_new[i] == name
+        return @galias_old[i]
+      end
+      i = i + 1
+    end
+    name
   end
 
   # ---- Array type helpers ----
@@ -5436,6 +5478,20 @@ class Compiler
       if @nd_type[sid] == "CallNode"
         if @nd_name[sid] == "define_method"
           collect_define_method(sid)
+        end
+      end
+    }
+
+    # Top-level `alias $copy $orig`. Records the rewrite in
+    # @galias_* so sanitize_gvar / scan_features / infer_type
+    # treat $copy and $orig as the same storage slot.
+    stmts.each { |sid|
+      if @nd_type[sid] == "AliasGlobalVariableNode"
+        nn = @nd_name[@nd_new_name[sid]]
+        on = @nd_name[@nd_old_name[sid]]
+        if nn != "" && on != ""
+          @galias_new.push(nn)
+          @galias_old.push(on)
         end
       end
     }
@@ -11693,7 +11749,12 @@ class Compiler
     end
 
     if t == "GlobalVariableWriteNode"
-      gname = @nd_name[nid]
+      # `alias $copy $orig` -- a $copy = ... write must register
+      # the type under $orig's slot, not a separate $copy slot,
+      # otherwise the type-consistency check below would later see
+      # $orig and $copy as two slots that resolve to the same C
+      # global and fire a spurious type-mismatch error.
+      gname = resolve_gvar_alias(@nd_name[nid])
       if gname != "$stderr" && gname != "$stdout" && gname != "$?"
         gt = infer_type(@nd_expression[nid])
         if not_in(gname, @gvar_names) == 1
@@ -11715,7 +11776,9 @@ class Compiler
       end
     end
     if t == "GlobalVariableReadNode"
-      gname = @nd_name[nid]
+      # Same alias resolution as the write side -- $copy reads must
+      # land on $orig's slot.
+      gname = resolve_gvar_alias(@nd_name[nid])
       if gname != "$stderr" && gname != "$stdout" && gname != "$?"
         if not_in(gname, @gvar_names) == 1
           @gvar_names.push(gname)
@@ -25396,6 +25459,13 @@ class Compiler
       end
       lbl = @redo_label_stack.last
       emit("  goto " + lbl + ";")
+      return
+    end
+    if t == "AliasGlobalVariableNode"
+      # `alias $copy $orig` -- compile-time only. collect_all
+      # already populated @galias_*; references through
+      # sanitize_gvar / scan_features / infer_type pick up the
+      # rewrite. Nothing to emit at runtime.
       return
     end
     if t == "LocalVariableWriteNode"

--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -1061,6 +1061,18 @@ static int flatten(pm_node_t *node) {
     out_add("R %d statements %d", id, stmts_id);
     break;
   }
+  case PM_ALIAS_GLOBAL_VARIABLE_NODE: {
+    /* `alias $copy $orig` -- compile-time gvar aliasing. The
+       new_name and old_name slots are GlobalVariableReadNodes whose
+       `name` field carries the literal $-prefixed name. Spinel
+       resolves $copy to $orig everywhere the alias is in scope, so
+       the C output uses one storage slot for both. */
+    pm_alias_global_variable_node_t *n = (pm_alias_global_variable_node_t *)node;
+    N("AliasGlobalVariableNode");
+    R("new_name", n->new_name);
+    R("old_name", n->old_name);
+    break;
+  }
   default: {
     /* Fallback: emit unknown node type */
     char buf[64];

--- a/test/alias_global.rb
+++ b/test/alias_global.rb
@@ -1,0 +1,16 @@
+# AliasGlobalVariableNode -- `alias $copy $orig`.
+#
+# Compile-time only: Spinel registers $copy as a name pointing to
+# $orig's storage slot. Subsequent reads/writes of either share
+# state. Out of scope: dynamic alias from method body, since the
+# entire compile-time map is built once at AST scan.
+
+$orig = "hello"
+alias $copy $orig
+puts $copy        # hello
+
+$orig = "updated"
+puts $copy        # updated
+
+$copy = "back"
+puts $orig        # back

--- a/test/alias_global.rb.expected
+++ b/test/alias_global.rb.expected
@@ -1,0 +1,3 @@
+hello
+updated
+back


### PR DESCRIPTION
Compile-time only: `$copy` and `$orig` share storage by rewriting all
references to `$copy` through `$orig` at three load-bearing call sites.
Matches CRuby's "alias makes them aliases of the same slot" semantics
for the static (toplevel) case.

Three pieces:

1. Parser case in `spinel_parse.c` — emits the node with `new_name`
   and `old_name` as ref children (both are `GlobalVariableReadNode`).

2. New ivars + `alloc_node` fields + `set_ref_field` handlers for
   `"new_name"` / `"old_name"`. Shared infrastructure for the upcoming
   `AliasMethodNode` commit.

3. `@galias_new` / `@galias_old` maps populated by `collect_all`.
   `resolve_gvar_alias(name)` walks the map. Three call sites that
   need the rewrite:

   - `sanitize_gvar` — so the C identifier (`gv_<bare>`) is the
     same for both names.
   - `scan_features`'s `GlobalVariableWriteNode` / `ReadNode` arms —
     so the gvar-type registry stores under one slot, avoiding a
     spurious type-mismatch error when `$copy` and `$orig` get
     different inferred types.
   - `infer_type`'s `GlobalVariableReadNode` arm — so a `$copy` read
     returns `$orig`'s registered type for printf format selection.

`compile_stmt` arm is a no-op (the alias took effect at collect time).

Out of scope: dynamic alias from inside a method body (the alias
map is built once at static collect time; method-scoped aliases
would need a runtime registry).

Test exercises (`test/alias_global.rb`):

- Initial alias: `$copy` reads `$orig`'s value.
- `$orig` mutation: `$copy` reflects the new value.
- `$copy` mutation: `$orig` reflects the new value (shared storage).

## Test plan

- [x] `make` — builds clean
- [x] `make bootstrap` — `gen2.c == gen3.c (bootstrap OK)`
- [x] `make test` — verified by CI on this PR