### PR TITLE
fix: replace silent UnknownNode_* fallback with hard compile error

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -648,6 +648,11 @@ class Compiler
     if field == "unescaped"
       @nd_unescaped[nid] = val
     end
+    if field == "kind"
+      # UnsupportedNode carries the Prism node-type name here so
+      # codegen can surface a precise compile error.
+      @nd_content[nid] = val
+    end
   end
 
   def set_int_field(nid, field, val)
@@ -664,6 +669,11 @@ class Compiler
       @nd_value[nid] = val
     end
     if field == "start_line"
+      @nd_value[nid] = val
+    end
+    if field == "source_line"
+      # UnsupportedNode carries the source line so codegen can cite
+      # location in the compile error.
       @nd_value[nid] = val
     end
   end
@@ -17728,6 +17738,13 @@ class Compiler
       return "0"
     end
     t = @nd_type[nid]
+    if t == "UnsupportedNode"
+      # The parser emitted this sentinel because it hit a Prism node
+      # type it doesn't know how to serialize. Refusing to compile is
+      # far better than the historical silent "0".
+      $stderr.puts "Spinel: cannot compile " + @nd_content[nid] + " at line " + @nd_value[nid].to_s + " (unsupported Ruby syntax)"
+      exit(1)
+    end
     if t == "IntegerNode"
       return @nd_value[nid].to_s
     end
@@ -25295,6 +25312,11 @@ class Compiler
       return
     end
     t = @nd_type[nid]
+    if t == "UnsupportedNode"
+      # Same loud-error path as compile_expr's UnsupportedNode arm.
+      $stderr.puts "Spinel: cannot compile " + @nd_content[nid] + " at line " + @nd_value[nid].to_s + " (unsupported Ruby syntax)"
+      exit(1)
+    end
     if t == "MultiWriteNode"
       compile_multi_write(nid)
       return

--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -77,6 +77,23 @@ static char *escape_pm_string(const pm_string_t *s) {
   return escape_str(pm_string_source(s), pm_string_length(s));
 }
 
+/* Convert "PM_FOO_BAR_NODE" -> "FooBarNode" into `out`, truncated to
+   out_size-1 chars + NUL. Prism's node-type strings are pure ASCII
+   upper + underscore so we add 32 to lowercase non-leading letters. */
+static size_t prism_kind_to_pascal(const char *raw, char *out, size_t out_size) {
+  if (out_size == 0) return 0;
+  if (strncmp(raw, "PM_", 3) == 0) raw += 3;
+  size_t j = 0;
+  int upper = 1;
+  for (; *raw && j < out_size - 1; raw++) {
+    if (*raw == '_') { upper = 1; continue; }
+    out[j++] = upper ? *raw : (char)(*raw + 32);
+    upper = 0;
+  }
+  out[j] = '\0';
+  return j;
+}
+
 /* ---- Forward ---- */
 static int flatten(pm_node_t *node);
 
@@ -1034,10 +1051,20 @@ static int flatten(pm_node_t *node) {
     break;
   }
   default: {
-    /* Fallback: emit unknown node type */
-    char buf[64];
-    snprintf(buf, sizeof(buf), "UnknownNode_%d", (int)t);
-    out_add("N %d %s", id, buf);
+    /* Previously emitted UnknownNode_<n> which silently degraded to
+       "0" in codegen. Now emit a hard-error sentinel carrying the
+       Prism node kind name (in human-friendly Ruby vocabulary) + the
+       source line so codegen refuses to compile and tells the user
+       exactly what's wrong. */
+    char pretty[128];
+    size_t plen = prism_kind_to_pascal(pm_node_type_to_str(t), pretty, sizeof(pretty));
+    int32_t line = pm_newline_list_line(&g_parser->newline_list, node->location.start, g_parser->start_line);
+
+    N("UnsupportedNode");
+    char *kind_e = escape_str((const uint8_t *)pretty, plen);
+    emit_str(id, "kind", kind_e);
+    free(kind_e);
+    emit_int(id, "source_line", (long long)line);
     break;
   }
   }


### PR DESCRIPTION
Previously, any Prism node not handled by spinel_parse.c's flatten() switch was emitted as `UnknownNode_<numeric_type>`, which compile_expr silently turned into `"0"`. Programs using unsupported syntax compiled and ran but produced wrong output -- the worst possible failure mode.

Concrete example (`$counter &&= 5` -- GlobalVariableAndWriteNode is not on master's parser switch):

    BEFORE              AFTER
    ------              -----
    CRuby:    5         spinel exits 1 with:
    spinel:   1         "Spinel: cannot compile GlobalVariableAndWriteNode
              ^^^         at line 2 (unsupported Ruby syntax)"
              wrong,
              no error

This change emits an `UnsupportedNode` sentinel in the text AST, carrying the Prism node-type name and the source line. compile_stmt and compile_expr both refuse to compile that sentinel and exit(1) with a precise message.

The error message uses the Ruby-vocabulary node name (`GlobalVariableAndWriteNode`, `FlipFlopNode`, etc.) rather than the C macro form (`PM_GLOBAL_VARIABLE_AND_WRITE_NODE`). The parser does the prefix-strip + PascalCase conversion inline so the message reads as Ruby docs the user can google.

Self-host audit shows spinel_codegen.rb itself uses only nodes the parser handles, so the bootstrap is unaffected.