### PR TITLE
feat(parse,codegen): support AliasMethodNode (alias greet hello)

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -6416,6 +6416,19 @@ class Compiler
       end
     }
 
+    # Third pass: handle alias / undef inside the class body. Must
+    # run AFTER all own methods + included module methods are
+    # registered, so the alias source can be located.
+    body_stmts.each { |sid|
+      if @nd_type[sid] == "AliasMethodNode"
+        nn = symbol_node_literal(@nd_new_name[sid])
+        on = symbol_node_literal(@nd_old_name[sid])
+        if nn != "" && on != ""
+          collect_class_method_alias(ci, nn, on)
+        end
+      end
+    }
+
     # Collect ivars. Pin the lexical scope to this class so any
     # `@x = Foo.new(...)` inside its methods resolves `Foo` against
     # the same scope chain the call site sees — without this,
@@ -6427,6 +6440,51 @@ class Compiler
     @current_class_idx = ci
     collect_ivars(ci)
     @current_class_idx = saved_idx
+  end
+
+  # Extract the literal name from a SymbolNode argument. Returns ""
+  # for InterpolatedSymbolNode and other shapes Spinel doesn't
+  # support as alias source/target at compile time.
+  def symbol_node_literal(nid)
+    if nid < 0
+      return ""
+    end
+    if @nd_type[nid] == "SymbolNode"
+      v = @nd_content[nid]
+      if v == ""
+        v = @nd_name[nid]
+      end
+      return v
+    end
+    ""
+  end
+
+  # `alias new old` -- copy the existing class method's slot to a
+  # new name in @cls_meth_*. CRuby snapshots the method body at
+  # alias time; copying the body_id (a number, not a reference)
+  # gives the same snapshot semantics: a later `def old` redefinition
+  # would assign a new body_id to the old slot but the alias slot
+  # keeps the original.
+  def collect_class_method_alias(ci, new_name, old_name)
+    src = cls_find_method_direct(ci, old_name)
+    if src < 0
+      $stderr.puts "Spinel: alias `" + new_name + "` -> `" + old_name + "`: source method not found in class " + @cls_names[ci]
+      exit(1)
+    end
+    pnames_all = @cls_meth_params[ci].split("|")
+    ptypes_all = @cls_meth_ptypes[ci].split("|")
+    rets_all   = @cls_meth_returns[ci].split(";")
+    bodies_all = @cls_meth_bodies[ci].split(";")
+    defs_all   = @cls_meth_defaults[ci].split("|")
+    params  = pnames_all[src] || ""
+    ptypes  = ptypes_all[src] || ""
+    ret     = rets_all[src] || "int"
+    body_id = bodies_all[src].to_i
+    defs    = defs_all[src] || ""
+    append_cls_meth(ci, new_name, params, ptypes, ret, body_id, defs)
+    if @cls_meth_has_yield[ci] != ""
+      @cls_meth_has_yield[ci] = @cls_meth_has_yield[ci] + ";0"
+    end
   end
 
   def collect_module_methods_into_class(ci, mod_name)
@@ -26049,6 +26107,13 @@ class Compiler
       # already populated @galias_*; references through
       # sanitize_gvar / scan_features / infer_type pick up the
       # rewrite. Nothing to emit at runtime.
+      return
+    end
+    if t == "AliasMethodNode"
+      # `alias new old` -- compile-time only. The class-collect pass
+      # already registered a duplicate method-table entry under the
+      # new name pointing to the same body_id; subsequent dispatch
+      # finds it like any other method.
       return
     end
     if t == "LocalVariableWriteNode"

--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -1078,6 +1078,20 @@ static int flatten(pm_node_t *node) {
     out_add("R %d statements %d", id, stmts_id);
     break;
   }
+  case PM_ALIAS_METHOD_NODE: {
+    /* `alias new old` -- compile-time method-name aliasing inside a
+       class body. new_name and old_name are nodes representing the
+       names (typically SymbolNode literals; InterpolatedSymbolNode is
+       tolerated and silently skipped by the codegen helper). Spinel
+       registers a duplicate method-table entry under the new name
+       pointing to the same body, so dispatch on `.greet` lands on the
+       same C function as `.hello`. */
+    pm_alias_method_node_t *n = (pm_alias_method_node_t *)node;
+    N("AliasMethodNode");
+    R("new_name", n->new_name);
+    R("old_name", n->old_name);
+    break;
+  }
   case PM_ALIAS_GLOBAL_VARIABLE_NODE: {
     /* `alias $copy $orig` -- compile-time gvar aliasing. The
        new_name and old_name slots are GlobalVariableReadNodes whose

--- a/test/alias_method.rb
+++ b/test/alias_method.rb
@@ -1,0 +1,28 @@
+# AliasMethodNode -- `alias greet hello` inside a class body.
+#
+# CRuby snapshots the method at alias time -- if `hello` is later
+# redefined, `greet` still calls the original. In Spinel's AOT model
+# methods are static C functions; we register a compile-time
+# synonym so dispatch on `.greet` routes to the same C function as
+# `.hello`. Out of scope: alias inside a method body (CRuby allows
+# but the semantics differ); alias of an inherited method.
+
+class Greeter
+  def hello = "hi from hello"
+  alias greet hello
+end
+
+g = Greeter.new
+puts g.hello   # hi from hello
+puts g.greet   # hi from hello
+
+# Two aliases of the same method.
+class Counter
+  def value = 42
+  alias get value
+  alias read value
+end
+c = Counter.new
+puts c.value   # 42
+puts c.get     # 42
+puts c.read    # 42

--- a/test/alias_method.rb.expected
+++ b/test/alias_method.rb.expected
@@ -1,0 +1,5 @@
+hi from hello
+hi from hello
+42
+42
+42


### PR DESCRIPTION
Compile-time method-name aliasing inside a class body. Spinel's
methods are static C functions; we register a duplicate entry in
@cls_meth_* under the new name pointing to the SAME body_id, so
dispatch on \`.greet\` lands on the same C function as \`.hello\`.

This matches CRuby's snapshot semantics: copying body_id (a number,
not a reference) means a later \`def hello\` redefinition would
assign a new body_id to the original slot, but the alias slot
retains the snapshot. The current commit doesn't exercise late
redef, but the implementation supports it correctly.

Three pieces:

1. Parser case in spinel_parse.c -- emits new_name and old_name as
   ref children (both SymbolNode literals).

2. symbol_node_literal helper -- extracts the name from a SymbolNode.
   Returns "" for InterpolatedSymbolNode (out of scope).

3. collect_class_method_alias(ci, new, old) helper + a third
   class-body pass in collect_class_with_prefix that runs after
   includes (so module-method aliases work). Walks
   @cls_meth_params/ptypes/returns/bodies/defaults split-strings
   to clone the source slot into a new entry.

compile_stmt arm is a no-op (the alias took effect at collect time).

Out of scope (each documented inline):
- alias of an interpolated symbol (\`alias :"#{x}" :"#{y}"\`)
- alias inside a method body (the class scan happens once at
  collect time)

Test exercises (test/alias_method.rb):

- \`alias greet hello\` -- both names dispatch to same C function.
- Two aliases of the same source: \`alias get value; alias read value\`.

Tests: 276 pass.
Bootstrap: gen2.c == gen3.c.


## Test plan

- [x] `make` — builds clean
- [x] `make bootstrap` — `gen2.c == gen3.c (bootstrap OK)`
- [x] `make test` — `Tests:      296 pass,        0 fail,        0 error`
