### PR TITLE
feat(parse,codegen): support PreExecutionNode (BEGIN { ... })

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -224,6 +224,10 @@ class Compiler
     @undef_class_idx = []
     @undef_method = "".split(",")
 
+    # `BEGIN { ... }` bodies, in source-encounter order. Hoisted to
+    # the top of main() during emit_main.
+    @pre_execution_blocks = []
+
     # ---- Scope stack for local variables ----
     @scope_names = "".split(",")
     @scope_types = "".split(",")
@@ -5647,9 +5651,11 @@ class Compiler
       end
     }
 
-    # Top-level `alias $copy $orig`. Records the rewrite in
-    # @galias_* so sanitize_gvar / scan_features / infer_type
-    # treat $copy and $orig as the same storage slot.
+    # Top-level `alias $copy $orig` and BEGIN. Aliases are
+    # recorded into @galias_* (consulted by sanitize_gvar /
+    # scan_features / infer_type so $copy and $orig share
+    # storage). BEGIN bodies are queued for emit_main to hoist
+    # to the top of main() in source-encounter order.
     stmts.each { |sid|
       if @nd_type[sid] == "AliasGlobalVariableNode"
         nn = @nd_name[@nd_new_name[sid]]
@@ -5657,6 +5663,14 @@ class Compiler
         if nn != "" && on != ""
           @galias_new.push(nn)
           @galias_old.push(on)
+        end
+      end
+      if @nd_type[sid] == "PreExecutionNode"
+        # Parser maps the "statements" field onto @nd_body via
+        # set_ref_field at line 706.
+        bid = @nd_body[sid]
+        if bid >= 0
+          @pre_execution_blocks.push(bid)
         end
       end
     }
@@ -18411,6 +18425,18 @@ class Compiler
     # Pre-scan: map lambda variable names to their return types
     scan_lambda_ret_types(stmts)
 
+    # `BEGIN { ... }` hoist: each PreExecutionNode body runs at the
+    # very top of main, in source-encounter order, BEFORE any other
+    # top-level statements. Bodies were collected by collect_all.
+    pi = 0
+    while pi < @pre_execution_blocks.length
+      bnid = @pre_execution_blocks[pi]
+      if bnid >= 0
+        compile_stmt(bnid)
+      end
+      pi = pi + 1
+    end
+
     # Compile main statements
     stmts.each { |sid|
       if @nd_type[sid] != "DefNode"
@@ -26275,6 +26301,13 @@ class Compiler
     if t == "UndefNode"
       # `undef foo` -- compile-time only. The class-collect pass
       # already recorded the removal in @undef_*; nothing to emit.
+      return
+    end
+    if t == "PreExecutionNode"
+      # `BEGIN { ... }`. collect_all already pushed the body onto
+      # @pre_execution_blocks; emit_main hoists it to the top of
+      # main(). The toplevel statement itself is a no-op at its
+      # source location.
       return
     end
     if t == "LocalVariableWriteNode"

--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -1103,6 +1103,16 @@ static int flatten(pm_node_t *node) {
     R("old_name", n->old_name);
     break;
   }
+  case PM_PRE_EXECUTION_NODE: {
+    /* `BEGIN { ... }`. CRuby runs all BEGIN blocks in source order
+       BEFORE any other top-level statements. Spinel collects the
+       bodies during a pre-pass and emits them at the very top of
+       main() in source-encounter order. */
+    pm_pre_execution_node_t *n = (pm_pre_execution_node_t *)node;
+    N("PreExecutionNode");
+    R("statements", n->statements);
+    break;
+  }
   case PM_UNDEF_NODE: {
     /* `undef foo, bar` inside a class body. CRuby raises NoMethodError
        at runtime when an undef'd method is called; Spinel's AOT model

--- a/test/pre_execution.rb
+++ b/test/pre_execution.rb
@@ -1,0 +1,18 @@
+# PreExecutionNode -- `BEGIN { ... }`.
+#
+# CRuby runs all BEGIN blocks in source order, BEFORE any other
+# top-level statements, regardless of where they appear in the file.
+# Spinel hoists each BEGIN body to the top of main() in source-encounter
+# order during a pre-pass.
+
+puts "middle"
+
+BEGIN {
+  puts "first"
+}
+
+BEGIN {
+  puts "first-2"
+}
+
+puts "last"

--- a/test/pre_execution.rb.expected
+++ b/test/pre_execution.rb.expected
@@ -1,0 +1,4 @@
+first
+first-2
+middle
+last


### PR DESCRIPTION
> [!NOTE]
> Stacked on #307 (UndefNode). Until that lands, this PR includes the
> UndefNode commit; once #307 merges, only the PreExecutionNode commit
> remains.

CRuby runs all `BEGIN` blocks in source order BEFORE any other
top-level statements, regardless of where in the file they appear.
The classic Perl-inheritance quirk -- `BEGIN` at the bottom still
fires first.

Spinel implements this by:

1. Parser case in `spinel_parse.c` -- emits the node with the
   `statements` ref slot.

2. `collect_all` Pass 2.1 walks the toplevel for PreExecutionNode and
   queues each body onto `@pre_execution_blocks` (in source-encounter
   order).

3. `emit_main` runs through `@pre_execution_blocks` BEFORE the regular
   toplevel-statement loop, calling `compile_stmt` on each body.
   The PreExecutionNode at its source location is a no-op
   (`compile_stmt` arm).

This puts every `BEGIN` body at the top of `main()` in source order
even if its source location is at file end -- matching CRuby.

Out of scope:
- `BEGIN` inside a method body (CRuby doesn't allow this either; we
  rely on Prism rejecting it at parse time).
- `BEGIN` inside a class body that affects class init ordering --
  Spinel doesn't run class bodies at startup, so the question
  doesn't arise.

Test exercises (`test/pre_execution.rb`):

- Two `BEGIN` blocks both before any toplevel `puts` -- verify they
  run before "middle" and "last", in source-encounter order.

## Test plan

- [x] `make` — builds clean
- [x] `make bootstrap` — `gen2.c == gen3.c (bootstrap OK)`
- [x] `make test` — all tests pass