### PR TITLE
feat(parse,codegen): support PostExecutionNode (END { ... })

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -228,6 +228,12 @@ class Compiler
     # the top of main() during emit_main.
     @pre_execution_blocks = []
 
+    # `END { ... }` bodies, in source-encounter order. Each emits a
+    # static C function; main() startup registers them via atexit()
+    # which naturally invokes handlers LIFO -- matches CRuby's
+    # reverse-of-source-order END execution.
+    @post_execution_blocks = []
+
     # ---- Scope stack for local variables ----
     @scope_names = "".split(",")
     @scope_types = "".split(",")
@@ -5671,6 +5677,12 @@ class Compiler
         bid = @nd_body[sid]
         if bid >= 0
           @pre_execution_blocks.push(bid)
+        end
+      end
+      if @nd_type[sid] == "PostExecutionNode"
+        bid = @nd_body[sid]
+        if bid >= 0
+          @post_execution_blocks.push(bid)
         end
       end
     }
@@ -13710,6 +13722,11 @@ class Compiler
     emit_class_methods
     emit_ieval_funcs
     emit_toplevel_methods
+    # `END { ... }` -- emit one zero-arg static C function per
+    # PostExecutionNode body. main() startup will atexit()-register
+    # them in source order; atexit invokes handlers LIFO, matching
+    # CRuby's reverse-order END execution.
+    emit_post_execution_funcs
     # Emit lambda functions before main (they are generated during compilation)
     # We emit them in emit_main after forward declarations
     emit_main
@@ -16764,6 +16781,29 @@ class Compiler
     end
   end
 
+  # `END { ... }` -- one zero-arg static C function per registered
+  # PostExecutionNode body. main() registers them via atexit() at
+  # startup. atexit invokes handlers LIFO, matching CRuby's
+  # reverse-of-source-order END execution.
+  def emit_post_execution_funcs
+    pe = 0
+    while pe < @post_execution_blocks.length
+      bnid = @post_execution_blocks[pe]
+      emit_raw("static void sp_end_block_" + pe.to_s + "(void) {")
+      @indent = 1
+      @in_main = 1
+      push_scope
+      if bnid >= 0
+        compile_stmt(bnid)
+      end
+      pop_scope
+      @in_main = 0
+      emit_raw("}")
+      emit_raw("")
+      pe = pe + 1
+    end
+  end
+
   def emit_toplevel_method(mi)
     mfullname = @meth_names[mi]
     @current_method_name = mfullname
@@ -18435,6 +18475,17 @@ class Compiler
         compile_stmt(bnid)
       end
       pi = pi + 1
+    end
+
+    # `END { ... }` register-atexit: each PostExecutionNode body
+    # was emitted as a static `sp_end_block_<n>` function during
+    # emit_post_execution_funcs. We register them in source order;
+    # atexit invokes handlers LIFO, matching CRuby's reverse-order
+    # END semantics.
+    pe = 0
+    while pe < @post_execution_blocks.length
+      emit("  atexit(sp_end_block_" + pe.to_s + ");")
+      pe = pe + 1
     end
 
     # Compile main statements
@@ -26308,6 +26359,13 @@ class Compiler
       # @pre_execution_blocks; emit_main hoists it to the top of
       # main(). The toplevel statement itself is a no-op at its
       # source location.
+      return
+    end
+    if t == "PostExecutionNode"
+      # `END { ... }`. collect_all pushed the body onto
+      # @post_execution_blocks; emit_post_execution_funcs emits the
+      # static sp_end_block_<n> function and emit_main inserts an
+      # atexit() call at startup.
       return
     end
     if t == "LocalVariableWriteNode"

--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -1103,6 +1103,16 @@ static int flatten(pm_node_t *node) {
     R("old_name", n->old_name);
     break;
   }
+  case PM_POST_EXECUTION_NODE: {
+    /* `END { ... }`. CRuby runs END blocks in REVERSE registration
+       order at program exit. Spinel emits each as a static C
+       function and registers them via atexit() at main() startup --
+       atexit naturally invokes handlers LIFO, matching CRuby. */
+    pm_post_execution_node_t *n = (pm_post_execution_node_t *)node;
+    N("PostExecutionNode");
+    R("statements", n->statements);
+    break;
+  }
   case PM_PRE_EXECUTION_NODE: {
     /* `BEGIN { ... }`. CRuby runs all BEGIN blocks in source order
        BEFORE any other top-level statements. Spinel collects the

--- a/test/post_execution.rb
+++ b/test/post_execution.rb
@@ -1,0 +1,17 @@
+# PostExecutionNode -- `END { ... }`.
+#
+# CRuby runs END blocks at program exit in REVERSE order of
+# registration. Spinel emits each END body as a static C function
+# and registers it via atexit() during main() startup.
+
+puts "middle"
+
+END {
+  puts "last-1"
+}
+
+END {
+  puts "last-2"  # registered second; runs first per atexit semantics
+}
+
+puts "before-end"

--- a/test/post_execution.rb.expected
+++ b/test/post_execution.rb.expected
@@ -1,0 +1,4 @@
+middle
+before-end
+last-2
+last-1


### PR DESCRIPTION
> [!NOTE]
> Stacked on #308 (PreExecutionNode), which is itself stacked on #307
> (UndefNode). Until those land, this PR includes those commits; once
> they merge, only the PostExecutionNode commit remains.

CRuby runs `END` blocks at program exit in REVERSE registration order
(LIFO). Spinel emits each block as a static C function and registers
them via `atexit()` at `main()` startup -- `atexit` naturally invokes
handlers LIFO, so the order matches without any extra bookkeeping.

Three pieces:

1. Parser case in `spinel_parse.c` -- emits the node with the
   `statements` ref slot.

2. `collect_all` Pass 2.1 walks the toplevel for PostExecutionNode
   and queues each body onto `@post_execution_blocks` (in
   source-encounter order).

3. `emit_post_execution_funcs` (called from `compile()` right before
   `emit_main`) emits one zero-arg static C function per block:

       static void sp_end_block_<n>(void) { /* body */ }

   `emit_main` then inserts `atexit(sp_end_block_<n>);` calls in
   source order, after the BEGIN-block hoist and before the
   regular statement loop.

The `compile_stmt` arm for PostExecutionNode at its source location
is a no-op.

Out of scope:
- `END` blocks that capture closure state from the surrounding
  scope (the static C function has no enclosing locals to read).

Test exercises (`test/post_execution.rb`):

- Two `END` blocks with `puts "last-1"` and `puts "last-2"` --
  verifies LIFO order ("last-2" prints before "last-1") and that
  `END` runs after the regular statement-flow output.

## Test plan

- [x] `make` — builds clean
- [x] `make bootstrap` — `gen2.c == gen3.c (bootstrap OK)`
- [x] `make test` — all tests pass