### PR TITLE
feat(parse,codegen,runtime): support InterpolatedRegularExpressionNode (/foo_#{x}/)

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -281,6 +281,13 @@ class Compiler
     @needs_rand = 0
     @regexp_patterns = "".split(",")
     @regexp_flags = "".split(",")
+    # Dynamic-regex (InterpolatedRegularExpressionNode) call-site cache.
+    # Each AST node gets a unique idx so the emitter can produce one
+    # `sp_re_dyn_<idx>` helper per source location with its own
+    # function-scope cache (string key + compiled pattern). Collected
+    # in scan_features so indexes are stable across compile_expr visits.
+    @dyn_regex_node_ids = []
+    @dyn_regex_flags = "".split(",")
     # `var = /lit/` resolution. Parallel arrays: `@local_regex_names`
     # holds the local-variable name and `@local_regex_idx` holds the
     # corresponding `@regexp_patterns` index, or -1 when the same name
@@ -1548,6 +1555,66 @@ class Compiler
         end
         i = i + 1
       end
+    end
+    -1
+  end
+
+  # Returns a C expression evaluating to a `mrb_regexp_pattern *`, or "" if
+  # the node isn't a regex source. Static literals resolve to their
+  # pre-compiled `sp_re_pat_<i>` global; InterpolatedRegularExpressionNode
+  # gets a runtime `sp_re_runtime_compile(...)` call. Centralizes the
+  # dispatch so each =~/match?/match/gsub/sub/scan/split call site doesn't
+  # have to repeat the InterpolatedRegex check.
+  def regex_pat_c_expr(nid)
+    ridx = find_regexp_index(nid)
+    if ridx >= 0
+      return "sp_re_pat_" + ridx.to_s
+    end
+    if @nd_type[nid] == "InterpolatedRegularExpressionNode"
+      @needs_regexp = 1
+      return compile_expr(nid)
+    end
+    ""
+  end
+
+  # Maps Prism's regex flag bits to the engine's `RE_FLAG_*` values and
+  # returns a C bitwise-OR string ("0", "1", "1|6", etc.). Single source
+  # of truth used by both the static-regex collector arm in scan_features
+  # and the per-call-site helper emitted by emit_dyn_regex_helpers.
+  # Prism: IGNORE_CASE=4, EXTENDED=8, MULTI_LINE=16.
+  # Engine: IGNORECASE=1, MULTILINE=2, DOTALL=4, EXTENDED=8.
+  # Ruby's /m (dot-matches-newline) maps to MULTILINE|DOTALL = 6.
+  def regex_engine_flags(nid)
+    if @nd_flags[nid] == 0
+      return "0"
+    end
+    f = @nd_flags[nid]
+    parts = "".split(",")
+    if f & 4 != 0
+      parts.push("1")
+    end
+    if f & 16 != 0
+      parts.push("6")
+    end
+    if f & 8 != 0
+      parts.push("8")
+    end
+    if parts.length == 0
+      return "0"
+    end
+    parts.join("|")
+  end
+
+  # Index of an InterpolatedRegularExpressionNode in @dyn_regex_node_ids,
+  # or -1 if scan_features hasn't registered it (defensive — should not
+  # happen for any reachable node).
+  def find_dyn_regex_index(nid)
+    i = 0
+    while i < @dyn_regex_node_ids.length
+      if @dyn_regex_node_ids[i] == nid
+        return i
+      end
+      i = i + 1
     end
     -1
   end
@@ -12088,31 +12155,35 @@ class Compiler
         @needs_setjmp = 1
       end
     end
+    if t == "InterpolatedRegularExpressionNode" || t == "InterpolatedMatchLastLineNode"
+      # Pre-flag so emit_regexp_runtime fires (defines sp_re_init) even
+      # when the program uses ONLY interpolated regexes -- without this,
+      # the linker fails on the unreferenced sp_re_init main() call.
+      @needs_regexp = 1
+    end
+    if t == "InterpolatedRegularExpressionNode"
+      # Register this AST site so emit_dyn_regex_helpers produces a
+      # dedicated `sp_re_dyn_<idx>` cache for it. Idempotent: a node
+      # visited twice (e.g. through type-inference + emit passes) keeps
+      # its first-assigned index.
+      already_dyn = 0
+      di = 0
+      while di < @dyn_regex_node_ids.length
+        if @dyn_regex_node_ids[di] == nid
+          already_dyn = 1
+        end
+        di = di + 1
+      end
+      if already_dyn == 0
+        @dyn_regex_node_ids.push(nid)
+        @dyn_regex_flags.push(regex_engine_flags(nid))
+      end
+    end
     if t == "RegularExpressionNode"
       @needs_regexp = 1
       # Collect pattern and flags
       pat = @nd_unescaped[nid]
-      flags = "0"
-      if @nd_flags[nid] != 0
-        f = @nd_flags[nid]
-        parts = "".split(",")
-        # Prism flag bits → engine `RE_FLAG_*` values (see re_internal.h).
-        # Prism: IGNORE_CASE=4, EXTENDED=8, MULTI_LINE=16.
-        # Engine: IGNORECASE=1, MULTILINE=2, DOTALL=4, EXTENDED=8.
-        # Ruby's /m (dot-matches-newline) maps to MULTILINE|DOTALL = 6.
-        if f & 4 != 0
-          parts.push("1")
-        end
-        if f & 16 != 0
-          parts.push("6")
-        end
-        if f & 8 != 0
-          parts.push("8")
-        end
-        if parts.length > 0
-          flags = parts.join("|")
-        end
-      end
+      flags = regex_engine_flags(nid)
       # Idempotent: identical patterns share the same compiled global,
       # so a second visit (e.g. via the LocalVariableWriteNode pre-scan
       # below) is a no-op.
@@ -13490,6 +13561,7 @@ class Compiler
     # Emit program-specific regexp patterns
     if @needs_regexp == 1
       emit_regexp_runtime
+      emit_dyn_regex_helpers
     end
     emit_class_structs
     emit_raw("/*TUPLE_INSERT_POINT*/")
@@ -14207,6 +14279,34 @@ class Compiler
     end
     emit_raw("}")
     emit_raw("")
+  end
+
+  # Per-call-site cached helper for InterpolatedRegularExpressionNode.
+  # Each AST source location gets a `sp_re_dyn_<idx>(const char *new_pat)`
+  # function with its own function-scope statics for the cached pattern
+  # string and compiled engine pattern. On a cache hit (strcmp match) we
+  # return the existing pattern; on a miss we re_free the old one and
+  # recompile with the call-site's baked flags. This bounds heap to one
+  # `mrb_regexp_pattern` per call site (count fixed at AOT compile time)
+  # and matches Ruby's per-source-location dynamic-regexp cache. The old
+  # `sp_re_runtime_compile` leaked a fresh pattern every evaluation.
+  def emit_dyn_regex_helpers
+    i = 0
+    while i < @dyn_regex_node_ids.length
+      flags = @dyn_regex_flags[i]
+      emit_raw("static mrb_regexp_pattern *sp_re_dyn_" + i.to_s + "(const char *new_pat) {")
+      emit_raw("  static char *cached_str = NULL;")
+      emit_raw("  static mrb_regexp_pattern *cached_pat = NULL;")
+      emit_raw("  if (cached_str != NULL && strcmp(cached_str, new_pat) == 0) return cached_pat;")
+      emit_raw("  re_free(cached_pat);")
+      emit_raw("  free(cached_str);")
+      emit_raw("  cached_str = strdup(new_pat);")
+      emit_raw("  cached_pat = re_compile(new_pat, (int64_t)strlen(new_pat), " + flags + ");")
+      emit_raw("  return cached_pat;")
+      emit_raw("}")
+      emit_raw("")
+      i = i + 1
+    end
   end
 
   # ---- Struct emission ----
@@ -18354,6 +18454,20 @@ class Compiler
       $stderr.puts "Spinel: BackReferenceReadNode `" + n + "` not supported"
       exit(1)
     end
+    if t == "InterpolatedRegularExpressionNode"
+      # `/foo_#{x}/` -- pattern is only known at execution time, so we
+      # can't pre-compile to an sp_re_pat_<i> global. The pattern string
+      # is built via compile_interpolated and passed to a per-call-site
+      # cached helper `sp_re_dyn_<idx>` (emitted by emit_dyn_regex_helpers).
+      # The helper compares the new pattern bytes to its cached key and
+      # only re_free+recompile on miss, so heap is bounded to one engine
+      # pattern per source location regardless of how many times the
+      # site evaluates. Flags are baked into the helper at emission time.
+      @needs_regexp = 1
+      pat_c = compile_interpolated(nid)
+      idx = find_dyn_regex_index(nid)
+      return "sp_re_dyn_" + idx.to_s + "(" + pat_c + ")"
+    end
     if t == "NumberedReferenceReadNode"
       num = @nd_value[nid]
       if num >= 1 && num <= 9
@@ -19656,19 +19770,20 @@ class Compiler
     # regex.match? / regex.match / regex =~ str  — receiver is the regex
     # (typically a constant referring to a /…/ literal). Dispatched here
     # rather than compile_string_method_expr, which wants a string
-    # receiver.
+    # receiver. Receiver can also be InterpolatedRegularExpressionNode
+    # for `/foo_#{x}/.match?(s)` (rare but valid).
     if recv >= 0 && (mname == "match?" || mname == "=~" || mname == "match")
-      ridx = find_regexp_index(recv)
-      if ridx >= 0
+      rpat = regex_pat_c_expr(recv)
+      if rpat != ""
         args_id = @nd_arguments[nid]
         if args_id >= 0
           arg_ids = get_args(args_id)
           if arg_ids.length > 0
             sc = compile_expr(arg_ids[0])
             if mname == "match?"
-              return "sp_re_match_p(sp_re_pat_" + ridx.to_s + ", " + sc + ")"
+              return "sp_re_match_p(" + rpat + ", " + sc + ")"
             end
-            return "sp_re_match(sp_re_pat_" + ridx.to_s + ", " + sc + ")"
+            return "sp_re_match(" + rpat + ", " + sc + ")"
           end
         end
       end
@@ -20879,15 +20994,17 @@ class Compiler
       return "(" + compile_expr(recv) + " >= " + compile_arg0(nid) + ")"
     end
     if mname == "=~"
-      # str =~ /pattern/ → sp_re_match(pat, str)
+      # str =~ /pattern/ → sp_re_match(pat, str). Pattern source can be
+      # a static literal, a regex-typed local/const (find_regexp_index),
+      # or InterpolatedRegularExpressionNode (runtime-compiled).
       rc = compile_expr_gc_rooted(recv)
       re_args_id = @nd_arguments[nid]
       if re_args_id >= 0
         argl = get_args(re_args_id)
         if argl.length > 0
-          ridx = find_regexp_index(argl[0])
-          if ridx >= 0
-            return "sp_re_match(sp_re_pat_" + ridx.to_s + ", " + rc + ")"
+          rpat = regex_pat_c_expr(argl[0])
+          if rpat != ""
+            return "sp_re_match(" + rpat + ", " + rc + ")"
           end
         end
       end
@@ -21460,9 +21577,9 @@ class Compiler
       if args_id >= 0
         a = get_args(args_id)
         if a.length > 0
-          ridx = find_regexp_index(a[0])
-          if ridx >= 0
-            return "sp_re_split(sp_re_pat_" + ridx.to_s + ", " + rc + ")"
+          rpat = regex_pat_c_expr(a[0])
+          if rpat != ""
+            return "sp_re_split(" + rpat + ", " + rc + ")"
           end
           # Peephole: literal "".split(literal) is the empty-StrArray idiom;
           # skip the strlen+sep scan and emit a direct allocator call.
@@ -21484,11 +21601,10 @@ class Compiler
         if args_id >= 0
           argl = get_args(args_id)
           if argl.length > 0
-            ridx = find_regexp_index(argl[0])
-            if ridx >= 0
+            rpat = regex_pat_c_expr(argl[0])
+            if rpat != ""
               @needs_str_array = 1
-              @needs_regexp = 1
-              return "sp_re_scan(sp_re_pat_" + ridx.to_s + ", " + rc + ")"
+              return "sp_re_scan(" + rpat + ", " + rc + ")"
             end
           end
         end
@@ -21499,9 +21615,9 @@ class Compiler
       if re_args_id >= 0
         argl = get_args(re_args_id)
         if argl.length > 0
-          ridx = find_regexp_index(argl[0])
-          if ridx >= 0
-            return "sp_re_match_p(sp_re_pat_" + ridx.to_s + ", " + rc + ")"
+          rpat = regex_pat_c_expr(argl[0])
+          if rpat != ""
+            return "sp_re_match_p(" + rpat + ", " + rc + ")"
           end
         end
       end
@@ -21512,9 +21628,9 @@ class Compiler
       if args_id >= 0
         a = get_args(args_id)
         if a.length >= 2
-          ridx = find_regexp_index(a[0])
-          if ridx >= 0
-            return "sp_re_gsub(sp_re_pat_" + ridx.to_s + ", " + rc + ", " + compile_expr(a[1]) + ")"
+          rpat = regex_pat_c_expr(a[0])
+          if rpat != ""
+            return "sp_re_gsub(" + rpat + ", " + rc + ", " + compile_expr(a[1]) + ")"
           end
           return "sp_str_gsub(" + rc + ", " + compile_expr(a[0]) + ", " + compile_expr(a[1]) + ")"
         end
@@ -21526,9 +21642,9 @@ class Compiler
       if args_id >= 0
         a = get_args(args_id)
         if a.length >= 2
-          ridx = find_regexp_index(a[0])
-          if ridx >= 0
-            return "sp_re_sub(sp_re_pat_" + ridx.to_s + ", " + rc + ", " + compile_expr(a[1]) + ")"
+          rpat = regex_pat_c_expr(a[0])
+          if rpat != ""
+            return "sp_re_sub(" + rpat + ", " + rc + ", " + compile_expr(a[1]) + ")"
           end
           return "sp_str_sub(" + rc + ", " + compile_expr(a[0]) + ", " + compile_expr(a[1]) + ")"
         end

--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -946,6 +946,17 @@ static int flatten(pm_node_t *node) {
     I("flags", n->base.flags);
     break;
   }
+  case PM_INTERPOLATED_REGULAR_EXPRESSION_NODE: {
+    /* `/foo_#{x}/`. Same shape as InterpolatedStringNode -- carries
+       `parts` -- plus a flags integer matching RegularExpressionNode.
+       Codegen builds the pattern string via compile_interpolated and
+       feeds it to sp_re_runtime_compile at execution time. */
+    pm_interpolated_regular_expression_node_t *n = (pm_interpolated_regular_expression_node_t *)node;
+    N("InterpolatedRegularExpressionNode");
+    A("parts", &n->parts);
+    I("flags", n->base.flags);
+    break;
+  }
   case PM_NUMBERED_REFERENCE_READ_NODE: {
     pm_numbered_reference_read_node_t *n = (pm_numbered_reference_read_node_t *)node;
     N("NumberedReferenceReadNode");

--- a/test/regex.rb
+++ b/test/regex.rb
@@ -113,3 +113,40 @@ if re_ml_r =~ "a\rb"
 else
   puts "no4"
 end
+
+# InterpolatedRegularExpressionNode (/foo_#{x}/). Pattern is only known
+# at execution time; each AST site gets a `sp_re_dyn_<idx>(const char *)`
+# helper with a function-scope cache so heap is bounded to one engine
+# pattern per source location. Match-site dispatch goes through the
+# regex_pat_c_expr helper so =~, match?, match, gsub, sub, scan, and
+# split all accept either form.
+
+# match? predicate (boolean -- safe across CRuby/Spinel int/value
+# differences in =~ which returns a position vs a count).
+ir_x = "bar"
+puts "foo_bar".match?(/foo_#{ir_x}/)   #=> true
+puts "foo_baz".match?(/foo_#{ir_x}/)   #=> false
+
+# Captures populate $1
+if "foo_bar_42" =~ /foo_#{ir_x}_(\d+)/
+  puts $1   #=> 42
+end
+
+# gsub with interpolated pattern
+ir_who = "world"
+puts "hello world".gsub(/#{ir_who}/, "Ruby")   #=> hello Ruby
+
+# sub
+puts "abc 123 def".sub(/(\d+)/, "X")           #=> abc X def
+
+# Interpolation that varies per-iteration (proves no stale cache and
+# that runtime compilation actually re-fires per evaluation).
+ir_i = 0
+while ir_i < 3
+  ir_seed = ir_i.to_s
+  puts ("v_" + ir_seed).match?(/v_#{ir_seed}/)
+  ir_i = ir_i + 1
+end
+#=> true
+#=> true
+#=> true

--- a/test/regex.rb.expected
+++ b/test/regex.rb.expected
@@ -33,3 +33,11 @@ ok1
 ok2
 ok3
 ok4
+true
+false
+42
+hello Ruby
+abc X def
+true
+true
+true


### PR DESCRIPTION
Pattern is only known at execution time, so it can't be pre-compiled
to an `sp_re_pat_<i>` global. Each `InterpolatedRegularExpressionNode`
AST site is registered during the existing `scan_features` collector
pass (parallel `@dyn_regex_node_ids` / `@dyn_regex_flags` arrays,
mirroring how static `RegularExpressionNode` patterns are collected),
and gets a dedicated emitted helper `sp_re_dyn_<idx>(const char *)`
with function-scope `static` cache state.

Four pieces:

1. **Parser case in `spinel_parse.c`** — emits the node with `parts`
   (the interpolation pieces) and `flags` (matching the static
   RegularExpressionNode shape).

2. **Collector + emitter in `spinel_codegen.rb`** — `scan_features`
   pushes each interpolated-regex node id onto `@dyn_regex_node_ids`
   (idempotent against double-visits during type inference + emit
   passes). `emit_dyn_regex_helpers` then emits one helper per site:

   ```c
   static mrb_regexp_pattern *sp_re_dyn_<idx>(const char *new_pat) {
     static char *cached_str = NULL;
     static mrb_regexp_pattern *cached_pat = NULL;
     if (cached_str != NULL && strcmp(cached_str, new_pat) == 0) return cached_pat;
     re_free(cached_pat);
     free(cached_str);
     cached_str = strdup(new_pat);
     cached_pat = re_compile(new_pat, (int64_t)strlen(new_pat), <baked_flags>);
     return cached_pat;
   }
   ```

   On a cache hit (`strcmp` match) the existing pattern is returned
   with no allocation. On a miss, the old pattern is `re_free`'d and
   the new key is `strdup`'d. Heap is bounded to one
   `mrb_regexp_pattern *` per source location (count fixed at AOT
   compile time), and stable interpolation gets a fast path matching
   CRuby's per-source-location dynamic-regexp cache semantics.

3. **Dispatch helper `regex_pat_c_expr(nid)` in `spinel_codegen.rb`** —
   returns `sp_re_pat_<i>` for static literals or
   `sp_re_dyn_<idx>(<pat_c>)` for interpolated. Each `=~` / `match?` /
   `match` / `gsub` / `sub` / `scan` / `split` dispatch site goes
   through this helper, so the same call shape handles both forms
   transparently. The receiver-side `regex.match?(s)` path also uses
   it for `/foo_#{x}/.match?(s)`. Flag mapping (Prism IGNORE_CASE/
   EXTENDED/MULTI_LINE → engine RE_FLAG_*) is centralized in a new
   `regex_engine_flags(nid)` helper used by both static and dynamic
   collectors.

4. **No new runtime header code.** The earlier `sp_re_runtime_compile`
   wrapper has been deleted; `re_free` (already in
   `lib/regexp/re_compile.c`) cascades to all internal allocations.
   Pre-flagged `@needs_regexp` from `scan_features` so the regex
   runtime is emitted even when a program uses ONLY interpolated
   regexes.

Test exercises (folded into `test/regex.rb`, keeping all regex
coverage in one file):

- `match?` predicate with interpolated pattern (true and false cases)
- `$1` capture from a `/foo_#{x}_(\d+)/` match
- `gsub` and `sub` with interpolated patterns
- per-iteration interpolation in a `while` loop — verifies the cache
  correctly evicts and recompiles when the pattern changes (a stale
  cache would mismatch `/v_#{ir_seed}/` against `"v_<seed>"`)

Generated-C inspection on `test/regex.rb`: 0 `sp_re_runtime_compile`
references; 5 `sp_re_dyn_<idx>` helper definitions (one per distinct
AST site in the file); 10 cache-hitting call sites.

## Test plan

- [x] `make` — builds clean
- [x] `make bootstrap` — `gen2.c == gen3.c (bootstrap OK)`
- [x] `make test` — `Tests: 311 pass, 0 fail, 0 error`