### PR TITLE
fix(codegen): poly_array `<<` / `push` handlers in both expr and stmt context

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -21595,6 +21595,12 @@ class Compiler
         rc = compile_expr_gc_rooted(recv)
         return "(sp_PtrArray_push(" + rc + ", " + compile_arg0(nid) + "), " + rc + ")"
       end
+      if lt == "poly_array"
+        @needs_rb_value = 1
+        @needs_gc = 1
+        rc = compile_expr_gc_rooted(recv)
+        return "(sp_PolyArray_push(" + rc + ", " + box_expr_to_poly(get_args(@nd_arguments[nid])[0]) + "), " + rc + ")"
+      end
       if lt == "poly"
         @needs_rb_value = 1
         return "sp_poly_shl(" + compile_expr(recv) + ", " + box_expr_to_poly(get_args(@nd_arguments[nid])[0]) + ")"
@@ -28682,6 +28688,22 @@ class Compiler
           rc = compile_expr_gc_rooted(recv)
           emit("  sp_PtrArray_push(" + rc + ", " + compile_arg0(nid) + ");")
           return 1
+        end
+        if rt == "poly_array"
+          rc = compile_expr_gc_rooted(recv)
+          args_id3 = @nd_arguments[nid]
+          if args_id3 >= 0
+            aa = get_args(args_id3)
+            if aa.length > 0
+              vt = infer_type(aa[0])
+              vexpr = compile_expr(aa[0])
+              if vt != "poly"
+                vexpr = box_value_to_poly(vt, vexpr)
+              end
+              emit("  sp_PolyArray_push(" + rc + ", " + vexpr + ");")
+              return 1
+            end
+          end
         end
       end
     end

--- a/test/poly_array_push_handlers.rb
+++ b/test/poly_array_push_handlers.rb
@@ -1,0 +1,19 @@
+# `compile_call_expr` and `compile_mutating_call_stmt` had no `<<`
+# / `push` arms for poly_array recv. The expr-context fall-through
+# produced raw C `<<` on `sp_PolyArray *` (gcc error: "invalid
+# operands to binary <<"); the stmt-context fall-through silently
+# dropped the push from generated C entirely.
+#
+# Repro: a heterogeneous literal lowers to poly_array; then both
+# `arr << v` (expr / stmt-without-receiver-rewrite) and
+# `arr.push(v)` exercise the dispatch.
+
+arr = [1, "two", :three]
+arr << 42
+arr.push("four")
+puts arr.length
+puts arr[0]
+puts arr[1]
+puts arr[2]
+puts arr[3]
+puts arr[4]

--- a/test/poly_array_push_handlers.rb.expected
+++ b/test/poly_array_push_handlers.rb.expected
@@ -1,0 +1,6 @@
+5
+1
+two
+three
+42
+four


### PR DESCRIPTION
## Reproduction

`test/poly_array_push_handlers.rb` (committed alongside the fix):

~~~ruby
arr = [1, "two", :three]
arr << 42
arr.push("four")
puts arr.length
puts arr[0]
puts arr[1]
puts arr[2]
puts arr[3]
puts arr[4]
~~~

## Expected behavior

~~~
$ ruby test/poly_array_push_handlers.rb
5
1
two
three
42
four
~~~

## Actual behavior on master (`5a9d7c9`)

~~~
$ ./spinel test/poly_array_push_handlers.rb -o /tmp/t
/tmp/spinel_out.XXX.c: In function ‘main’:
/tmp/spinel_out.XXX.c:57:13: error: invalid operands to binary << (have ‘sp_PolyArray *’ and ‘int’)
   57 |     (lv_arr << 42);
      |             ^~
spinel: C compilation failed
~~~

The expression `arr << 42` falls through to the raw C `<<`
operator. `arr.push("four")` (stmt context) silently disappears
from the generated C — no push happens.

## Analysis & fix

`compile_call_expr` (expression context) and
`compile_mutating_call_stmt` (statement context) had `<<` / `push`
arms for int_array, float_array, str_array, sym_array, ptr_array,
but no arm for poly_array. So `arr << val` on a poly_array recv
fell through:

- **expr context**: emitted `(arr << val)` with raw C `<<`.
- **stmt context**: no fall-through path → silently dropped.

Add poly_array branches in both contexts. The argument is boxed
via `box_value_to_poly` when its static type is non-poly so the
PolyArray's elements stay typed as `sp_RbVal`:

- expr context: `(sp_PolyArray_push(rc, box(val)), rc)`
- stmt context: `sp_PolyArray_push(rc, box(val));`

After the fix, the same source compiles cleanly and prints the
expected output.

## Diff stat

~~~
 spinel_codegen.rb                          | 22 ++++++++++++++++++++++
 test/poly_array_push_handlers.rb           | 12 ++++++++++++
 test/poly_array_push_handlers.rb.expected  |  6 ++++++
 3 files changed, 40 insertions(+)
~~~

## Test plan

- [x] `make -j4 bootstrap` green.
- [x] `make test` 322 pass / 0 fail / 0 error (was 321, +1 for the
  new regression test).
- [x] Manual reproduction: master fails C compile, branch prints
  the 6 expected lines.