### PR TITLE
fix(codegen): Range#=== as cover (case-when membership)

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -3060,6 +3060,9 @@ class Compiler
     if mname == "cover?"
       return "bool"
     end
+    if mname == "==="
+      return "bool"
+    end
     if mname == "match?"
       return "bool"
     end
@@ -22438,7 +22441,9 @@ class Compiler
     # so they share the same emission. Exclude_end isn't tracked in the
     # runtime sp_Range struct; non-literal receivers fall back to the
     # inclusive form (matches length/size).
-    if mname == "include?" || mname == "cover?"
+    if mname == "include?" || mname == "cover?" || mname == "==="
+      # Range#=== is the case-when membership operator and behaves like
+      # cover? for numeric ranges (Ruby docs: "tests for membership").
       tmp = new_temp
       emit("  sp_Range " + tmp + " = " + rc + ";")
       arg = compile_arg0(nid)

--- a/test/range.rb
+++ b/test/range.rb
@@ -106,6 +106,13 @@ puts classify(10)
 puts classify(99)
 puts classify(100)
 
+# === Range#=== (case-when membership) ===
+puts (1..10) === 5      # true
+puts (1..10) === 1      # true
+puts (1..10) === 10     # true
+puts (1..10) === 0      # false
+puts (1..10) === 11     # false
+
 # === step without block param ===
 # `Integer#step` with a do-block that omits its parameter used a
 # synthesized `_i` index that wasn't declared. Two paramless `step`

--- a/test/range.rb.expected
+++ b/test/range.rb.expected
@@ -53,4 +53,9 @@ small
 medium
 medium
 large
+true
+true
+true
+false
+false
 560


### PR DESCRIPTION
`(1..10) === 5` (Range#===) is the implicit operator behind `case x when 1..10`, which Ruby documents as testing for "membership" and implementing as cover? for numeric ranges.

Spinel routed `===` through the generic operator dispatch and emitted `range_struct == arg`, which is meaningless. Adds two arms to the existing range method handler:

  - `mname == "==="` joins the include?/cover? branch in compile_range_method_expr → reuses the same first<=x<=last emission.
  - infer_call_type adds `===` to the bool list so result use sites type-check.

Test coverage extends the existing test/range.rb with a Range#=== section (5 cases: low/mid/high inside, plus boundary fails on each side).