### PR TITLE
fix(codegen): String#lines preserves trailing newlines per CRuby

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -509,6 +509,12 @@ static mrb_bool sp_str_include(const char*s,const char*sub){return strstr(s,sub)
 static mrb_bool sp_str_start_with(const char*s,const char*p){return strncmp(s,p,strlen(p))==0;}
 static mrb_bool sp_str_end_with(const char*s,const char*suf){size_t ls=strlen(s),lsuf=strlen(suf);if(lsuf>ls)return FALSE;return strcmp(s+ls-lsuf,suf)==0;}
 static sp_StrArray*sp_str_split(const char*s,const char*sep){sp_StrArray*a=sp_StrArray_new();if(*s==0)return a;size_t sl=strlen(sep);if(sl==0){const char*p=s;while(*p){int cn=sp_utf8_advance(p);char*c=sp_str_alloc_raw(cn+1);memcpy(c,p,cn);c[cn]=0;sp_StrArray_push(a,c);p+=cn;}return a;}const char*p=s;while(1){const char*f=strstr(p,sep);if(!f){char*r=sp_str_alloc_raw(strlen(p)+1);strcpy(r,p);sp_StrArray_push(a,r);break;}size_t n=f-p;char*r=sp_str_alloc_raw(n+1);memcpy(r,p,n);r[n]=0;sp_StrArray_push(a,r);p=f+sl;}return a;}
+/* String#lines: split on \n but PRESERVE the trailing newline on each
+   line (CRuby semantics). The last line keeps its terminator if present;
+   if absent, it just stops there. Empty string returns an empty array.
+   `end` is computed once at entry so a string with no newlines avoids
+   a redundant strlen call on the trailing piece. */
+static sp_StrArray*sp_str_lines(const char*s){sp_StrArray*a=sp_StrArray_new();if(*s==0)return a;const char*end=s+strlen(s);const char*p=s;while(p<end){const char*nl=strchr(p,'\n');size_t n=nl?(size_t)(nl-p+1):(size_t)(end-p);char*r=sp_str_alloc_raw(n+1);memcpy(r,p,n);r[n]=0;sp_StrArray_push(a,r);if(!nl)break;p=nl+1;}return a;}
 static const char*sp_str_gsub(const char*s,const char*pat,const char*rep){size_t pl=strlen(pat),rl=strlen(rep),sl=strlen(s);if(pl==0)return s;size_t cap=sl*2+1;char*out=(char*)malloc(cap);size_t ol=0;const char*p=s;while(*p){const char*f=strstr(p,pat);if(!f){size_t n=strlen(p);if(ol+n>=cap){cap=(ol+n)*2+1;out=(char*)realloc(out,cap);}memcpy(out+ol,p,n);ol+=n;break;}size_t n=f-p;if(ol+n+rl>=cap){cap=(ol+n+rl)*2+1;out=(char*)realloc(out,cap);}memcpy(out+ol,p,n);ol+=n;memcpy(out+ol,rep,rl);ol+=rl;p=f+pl;}out[ol]=0;return out;}
 /* Returns a *character* offset (codepoint index), not a byte offset. */
 static mrb_int sp_str_index(const char*s,const char*sub){const char*f=strstr(s,sub);if(!f)return -1;mrb_int n=0;const char*p=s;while(p<f){p+=sp_utf8_advance(p);n++;}return n;}

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -22134,7 +22134,7 @@ class Compiler
     end
     if mname == "lines"
       @needs_str_array = 1
-      return "sp_str_split(" + rc + ", \"\\n\")"
+      return "sp_str_lines(" + rc + ")"
     end
     if mname == "scan"
       if @nd_block[nid] < 0

--- a/test/string_lines.rb
+++ b/test/string_lines.rb
@@ -1,0 +1,9 @@
+# Tests String#lines preserves trailing newline on each piece (CRuby semantics).
+p "hello\nworld\n".lines
+p "hello\nworld".lines
+p "single line".lines
+p "".lines
+p "\n\n\n".lines
+puts "hello\nworld\n".lines.length
+puts "hello\nworld\n".lines[0]
+puts "hello\nworld\n".lines[1]

--- a/test/string_lines.rb.expected
+++ b/test/string_lines.rb.expected
@@ -1,0 +1,8 @@
+["hello\n", "world\n"]
+["hello\n", "world"]
+["single line"]
+[]
+["\n", "\n", "\n"]
+2
+hello
+world


### PR DESCRIPTION
`"hello\nworld\n".lines` should return `["hello\n", "world\n"]` — each element keeps its terminator (CRuby semantics). Spinel was lowering to `sp_str_split(s, "\n")`, which strips the separator. That dropped the trailing newline on every element AND treated a trailing newline as a synthetic empty-string element (split's "every separator yields a piece" semantics).

Adds a new sp_str_lines runtime helper that walks the string, finds each '\n' boundary, and copies inclusive of the newline into a fresh char array. Last segment keeps its terminator if present; otherwise just stops there. Empty input → empty array.

compile_string_method_expr's `lines` arm switches the call site from sp_str_split to sp_str_lines.

Test: string_lines.rb covers multi-line + trailing nl, multi-line no trailing nl, single line, empty, and consecutive newlines.