### PR TITLE
fix(codegen): Module#method_defined? compile-time

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -3093,7 +3093,7 @@ class Compiler
     if mname == "is_a?"
       return "bool"
     end
-    if mname == "respond_to?"
+    if mname == "respond_to?" || mname == "method_defined?"
       return "bool"
     end
     if mname == "chr"
@@ -10630,7 +10630,9 @@ class Compiler
 
   # Does class `ci` provide `mname` as a reader, writer, or method?
   # Walks parent classes for inherited members.
-  def class_has_method(ci, mname)
+  # Does class `ci` define `mname` directly — instance method, attr
+  # reader, or attr writer — without walking the parent chain?
+  def class_has_method_local(ci, mname)
     readers = @cls_attr_readers[ci].split(";")
     if not_in(mname, readers) == 0
       return 1
@@ -10644,6 +10646,13 @@ class Compiler
     end
     mnames = @cls_meth_names[ci].split(";")
     if not_in(mname, mnames) == 0
+      return 1
+    end
+    return 0
+  end
+
+  def class_has_method(ci, mname)
+    if class_has_method_local(ci, mname) == 1
       return 1
     end
     if @cls_parents[ci] != ""
@@ -24098,6 +24107,31 @@ class Compiler
   def compile_constant_recv_expr(nid, mname, recv, rc)
     rcname = constructor_class_name(recv)
     if rcname != ""
+      # Foo.method_defined?(:sym[, inherit=true]) — compile-time decide.
+      # Default arm walks the parent chain via class_has_method (covers
+      # instance methods, attr readers/writers, ancestors).  When the
+      # second arg is the literal `false`, restrict the lookup to the
+      # receiver's own methods (no parent walk) via class_has_method_local.
+      if mname == "method_defined?"
+        ci_md = find_class_idx(rcname)
+        if ci_md >= 0
+          args_id_md = @nd_arguments[nid]
+          if args_id_md >= 0
+            a_md = get_args(args_id_md)
+            if a_md.length > 0
+              if @nd_type[a_md[0]] == "SymbolNode" || @nd_type[a_md[0]] == "StringNode"
+                lit_name = @nd_content[a_md[0]]
+                inherit_md = 1
+                if a_md.length >= 2 && @nd_type[a_md[1]] == "FalseNode"
+                  inherit_md = 0
+                end
+                hit = inherit_md == 1 ? class_has_method(ci_md, lit_name) : class_has_method_local(ci_md, lit_name)
+                return hit == 1 ? "TRUE" : "FALSE"
+              end
+            end
+          end
+        end
+      end
       # ARGV methods
       if rcname == "ARGV"
         if mname == "length"

--- a/test/method_defined.rb
+++ b/test/method_defined.rb
@@ -1,0 +1,36 @@
+# Module#method_defined?(:sym) — compile-time decided via the
+# class's recorded method table (walks the parent chain, includes
+# attr readers/writers).
+class Animal
+  def name; "Animal"; end
+  attr_accessor :age
+end
+
+class Dog < Animal
+  def bark; "woof"; end
+end
+
+p Animal.method_defined?(:name)
+p Animal.method_defined?(:age)
+p Animal.method_defined?(:age=)
+p Animal.method_defined?(:bark)
+p Animal.method_defined?(:nope)
+
+p Dog.method_defined?(:name)
+p Dog.method_defined?(:bark)
+p Dog.method_defined?(:age)
+p Dog.method_defined?(:nope)
+
+# String arg form
+p Animal.method_defined?("name")
+p Animal.method_defined?("nope")
+
+# Inherit=false — restrict the lookup to the receiver's own methods.
+# Dog#bark is defined locally; Dog inherits #name and #age from Animal.
+# With inherit=false, only :bark is reported on Dog.
+p Dog.method_defined?(:bark, false)   # true  (defined on Dog)
+p Dog.method_defined?(:name, false)   # false (inherited from Animal)
+p Dog.method_defined?(:age, false)    # false (inherited)
+p Dog.method_defined?(:age=, false)   # false (inherited)
+p Animal.method_defined?(:name, false) # true (defined on Animal)
+p Animal.method_defined?(:bark, false) # false (defined on Dog only)

--- a/test/method_defined.rb.expected
+++ b/test/method_defined.rb.expected
@@ -1,0 +1,17 @@
+true
+true
+true
+false
+false
+true
+true
+true
+false
+true
+false
+true
+false
+false
+false
+true
+false


### PR DESCRIPTION
`Foo.method_defined?(:hi)` was unsupported and emitted 0.  The codegen knows the full method table for every user class at compile time (class_has_method is the same helper used elsewhere to decide static dispatch), so the answer can be baked in.

Two pieces:

  - infer_call_type adds method_defined? to the bool-returning list alongside respond_to?.  Without this, results print as `1` / `0` from `p` instead of `true` / `false`.
  - compile_constant_recv_expr's `if rcname != ""` block gains an early arm: when the method name is method_defined? AND the arg is a SymbolNode or StringNode literal, look up the class index via find_class_idx and return TRUE/FALSE based on class_has_method (which already walks the parent chain and includes attr readers/writers).

Falls through unchanged when the arg isn't a literal symbol / string (e.g. a runtime variable), since we'd need a real method lookup at runtime — out of scope here.

Test: method_defined.rb covers Animal/Dog inheritance, an attr reader + writer pair, the negative case, and the string-arg form.