### PR TITLE
fix(codegen): emit sized PolyArray for [nil] * N against poly slot

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -9416,6 +9416,22 @@ class Compiler
       end
       return tmp
     end
+    # `[nil] * N` against a poly slot (e.g. optcarrots @fetch widened
+    # to sp_RbVal because of cyclic inference): build a sp_PolyArray
+    # of N nils and box it. Subsequent heterogeneous writes via the
+    # poly-recv `[]=` branch dispatch into the PolyArray correctly.
+    # Without this branch, `[nil] * N` produces an IntArray and the
+    # subsequent `@x[i] = method_obj` writes the pointer as an int —
+    # reads then return ints and the method dispatch never fires.
+    if expected_base == "poly" && is_sized_empty_array_default(nid) == 1
+      @needs_gc = 1
+      @needs_rb_value = 1
+      cnt_e = compile_arg0(nid)
+      tmp = new_temp
+      emit("  sp_PolyArray *" + tmp + " = sp_PolyArray_new();")
+      emit("  { mrb_int _n = " + cnt_e + "; for (mrb_int _i = 0; _i < _n; _i++) sp_PolyArray_push(" + tmp + ", sp_box_nil()); }")
+      return "sp_box_poly_array(" + tmp + ")"
+    end
     val = compile_expr(nid)
     at = infer_type(nid)
     if expected_base == "poly" && at != "poly"
@@ -17132,6 +17148,18 @@ class Compiler
                   emit_raw("  { mrb_int _n = " + cnt_e_iv + "; for (mrb_int _i = 0; _i < _n; _i++) sp_PtrArray_push(" + tmp_iv + ", NULL); }")
                 end
                 emit_raw("  " + self_arrow + ivar + " = " + tmp_iv + ";")
+              elsif ivt == "poly" && is_sized_empty_array_default(expr_id_iv) == 1
+                # `@arr = [nil] * N` against a poly slot. Build a
+                # sized PolyArray and box it so the runtime storage
+                # supports heterogeneous writes via the poly-recv
+                # `[]=` dispatch.
+                @needs_gc = 1
+                @needs_rb_value = 1
+                cnt_e_iv = compile_arg0(expr_id_iv)
+                tmp_iv = new_temp
+                emit_raw("  sp_PolyArray *" + tmp_iv + " = sp_PolyArray_new();")
+                emit_raw("  { mrb_int _n = " + cnt_e_iv + "; for (mrb_int _i = 0; _i < _n; _i++) sp_PolyArray_push(" + tmp_iv + ", sp_box_nil()); }")
+                emit_raw("  " + self_arrow + ivar + " = sp_box_poly_array(" + tmp_iv + ");")
               elsif ivt == "poly_array" && @nd_type[expr_id_iv] == "ArrayNode"
                 # Non-empty array literal `[a, b, ...]` going into a
                 # poly_array slot. compile_array_literal infers a typed
@@ -27928,6 +27956,22 @@ class Compiler
           emit("  { mrb_int _n = " + cnt_e + "; for (mrb_int _i = 0; _i < _n; _i++) sp_PtrArray_push(" + tmp_arr + ", NULL); }")
         end
         emit("  " + self_arrow + sanitize_ivar(iname) + " = " + tmp_arr + ";")
+        return
+      end
+      # `@arr = [nil] * N` where @arr is a poly slot (sp_RbVal). The
+      # cyclic inference can leave a slot at poly when its definition
+      # site `[nil] * N` would naturally infer as int_array but a
+      # subsequent heterogeneous write demands more. Emit as a sized
+      # PolyArray boxed to poly so the runtime storage supports
+      # heterogeneous writes via the poly-recv `[]=` dispatch.
+      if ivt == "poly" && is_sized_empty_array_default(expr_id) == 1
+        @needs_gc = 1
+        @needs_rb_value = 1
+        cnt_e = compile_arg0(expr_id)
+        tmp_arr = new_temp
+        emit("  sp_PolyArray *" + tmp_arr + " = sp_PolyArray_new();")
+        emit("  { mrb_int _n = " + cnt_e + "; for (mrb_int _i = 0; _i < _n; _i++) sp_PolyArray_push(" + tmp_arr + ", sp_box_nil()); }")
+        emit("  " + self_arrow + sanitize_ivar(iname) + " = sp_box_poly_array(" + tmp_arr + ");")
         return
       end
       # Non-empty array literal `[a, b, ...]` going into a poly_array

--- a/test/sized_poly_array_nil_n.rb
+++ b/test/sized_poly_array_nil_n.rb
@@ -1,0 +1,37 @@
+# `@arr = [nil] * N` against an ivar slot inferred as `poly`
+# (sp_RbVal — wider than poly_array, set by `finalize_ivar_heterogeneity`
+# when distinct non-array writes are observed) used to compile to
+# `sp_box_int_array(sp_IntArray_new())`. The runtime storage was
+# IntArray, so subsequent heterogeneous writes via the poly-recv
+# `[]=` runtime widening path (or directly via `[]=` with cls_id
+# dispatch) lost the typed-pointer cls_id on the IntArray-typed
+# storage path.
+#
+# Repro: force the slot type to plain `poly` via mixed scalar
+# observations. Then `[nil] * N` against the poly slot must
+# produce a PolyArray, not IntArray, for cls_id-preserving
+# heterogeneous reads/writes to work.
+
+class C
+  def init_arr_widen
+    @arr = [nil] * 8
+    @arr[0] = "string-payload"
+    @arr[1] = 42
+    @arr[2] = :sym
+  end
+  def init_str
+    @arr = "scalar"
+  end
+  def init_int
+    @arr = 7
+  end
+  def at(i)
+    @arr[i]
+  end
+end
+
+c = C.new
+c.init_arr_widen
+puts c.at(0).to_s   # "string-payload"
+puts c.at(1).to_i   # 42
+puts c.at(2).to_s   # "sym"

--- a/test/sized_poly_array_nil_n.rb.expected
+++ b/test/sized_poly_array_nil_n.rb.expected
@@ -1,0 +1,3 @@
+string-payload
+42
+sym


### PR DESCRIPTION
## Reproduction

`test/sized_poly_array_nil_n.rb` (committed alongside the fix):

~~~ruby
# `@arr = [nil] * N` against an ivar slot inferred as `poly`
# (sp_RbVal — wider than poly_array, set by
# `finalize_ivar_heterogeneity` when distinct non-array writes
# are observed) used to compile to `sp_box_int_array(sp_IntArray_new())`.
# The runtime storage was IntArray, so subsequent heterogeneous
# writes via the poly-recv `[]=` path lost the typed-pointer
# cls_id on the IntArray-typed storage path.
#
# Repro: force the slot type to plain `poly` via mixed scalar
# observations. Then `[nil] * N` against the poly slot must
# produce a PolyArray, not IntArray, for cls_id-preserving
# heterogeneous reads/writes to work.

class C
  def init_arr_widen
    @arr = [nil] * 8
    @arr[0] = "string-payload"
    @arr[1] = 42
    @arr[2] = :sym
  end
  def init_str
    @arr = "scalar"
  end
  def init_int
    @arr = 7
  end
  def at(i)
    @arr[i]
  end
end

c = C.new
c.init_arr_widen
puts c.at(0).to_s
puts c.at(1).to_i
puts c.at(2).to_s
~~~

## Expected behavior

~~~
$ ruby test/sized_poly_array_nil_n.rb
string-payload
42
sym
~~~

## Actual behavior on master (`4dd7908`)

~~~
$ ./spinel test/sized_poly_array_nil_n.rb -o /tmp/t
test/sized_poly_array_nil_n.rb -> /tmp/t

$ /tmp/t
106932143448159
42
0
~~~

The string at `@arr[0]` was stored by casting its pointer to
`mrb_int` into the IntArray slot; the read recovers the int
back, and `to_s` on a random int produces the garbage decimal
shown above. The symbol at `@arr[2]` similarly truncated to int
`0`.

## Analysis & fix

`@arr = [nil] * N` against an ivar slot inferred as `poly`
(sp_RbVal — wider than poly_array) used to compile to
`sp_box_int_array(sp_IntArray_new())` followed by N bit-shift
left ops via `sp_poly_shl`. The runtime storage was IntArray, so
subsequent heterogeneous writes (`@arr[i] = method_obj`,
`@arr[i] = "string"`, etc.) stored the pointer as an int into
the IntArray and reads returned ints — the cls_id of typed
pointers was lost.

Add a parallel branch alongside the existing poly_array /
ptr_array sized-empty-array codegen in three sites:

- `compile_expr_for_expected_type` (default-arg / call-arg path)
- `emit_constructor`'s ivar-init scan (default `new` constructor)
- `compile_stmt`'s InstanceVariableWriteNode emit (explicit init)

Each emits a sized `sp_PolyArray` of `sp_box_nil()`s and boxes
it via `sp_box_poly_array(...)`. The poly slot then holds a poly
value with `cls_id == SP_BUILTIN_POLY_ARRAY`, and the poly-recv
`[]=` / `<<` dispatch correctly stores boxed values in the
underlying PolyArray instead of casting them through `mrb_int`.

## Diff stat

~~~
 spinel_codegen.rb                          | 44 ++++++++++++++++++++++++++++++++++++++++++++
 test/sized_poly_array_nil_n.rb             | 35 +++++++++++++++++++++++++++++++++++
 test/sized_poly_array_nil_n.rb.expected    |  3 +++
 3 files changed, 82 insertions(+)
~~~

## Test plan

- [x] `make -j4 bootstrap` green.
- [x] `make test` 343 pass / 0 fail / 0 error.
- [x] Manual reproduction: master prints `106932143448159\n42\n0`
  (pointer-as-int garbage + truncated sym), branch prints
  `string-payload\n42\nsym`.