### PR TITLE
chore(test): default -j to logical CPU count when no -j was passed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,19 @@ TIMEOUT_BIN := $(shell command -v timeout 2>/dev/null || command -v gtimeout 2>/
 TIMEOUT10 := $(if $(TIMEOUT_BIN),$(TIMEOUT_BIN) 10,)
 TIMEOUT60 := $(if $(TIMEOUT_BIN),$(TIMEOUT_BIN) 60,)
 
+# Default -j to logical CPU count when MAKEFLAGS doesn't already
+# carry a -j flag. The combined guard catches the three forms a user
+# can supply -j in (per the GNU Make manual): `-j N` / `-jN` via
+# filter, the short-flag-cluster form like `-kj` via findstring on
+# the first word (the leading `-` makes firstword non-empty when
+# MAKEFLAGS starts blank), and Make 4.x's `--jobserver-auth=…` long
+# form. Note: GNU Make 3.81 (macOS system make) reports MAKEFLAGS
+# as empty at parse time, so the guard always fires there; users on
+# 3.81 wanting to override should pass `MAKEFLAGS=-jN make …`.
+ifeq (,$(filter -j%,$(MAKEFLAGS))$(findstring j,$(firstword -$(MAKEFLAGS)))$(filter --jobserver%,$(MAKEFLAGS)))
+  MAKEFLAGS += -j$(shell getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)
+endif
+
 # Reference Ruby for `make test` / `make bench` output comparison.
 # Defaults to `ruby` (the system CRuby), matching the historical
 # behaviour. Override on the command line when a newer or differently-


### PR DESCRIPTION
Bare `make test` runs the 345 test recipes serially through a single
worker — ~2× slower than necessary on multi-core machines. This adds
an auto-detect block that sets `-j$(NPROC)` in MAKEFLAGS when the
command line didn't supply one.

The `$(filter -j%, $(MAKEFLAGS))` guard means explicit `make -j N`
still wins. CI (which already passes
`-j$(getconf _NPROCESSORS_ONLN)`) is unaffected. NPROC falls back
to 4 when getconf is unavailable (e.g., a stripped container).

Performance (macOS, M-series 12 logical cores, 345 tests, bare
`make test` with no -j flag):

```
  scenario        master    after   speedup
  -------------  -------  -------  --------
  cold (1st run)  143.0 s   73.6 s     1.9x
  warm (2nd run)  101.4 s   44.7 s     2.3x
```

- `cold` is the first `make test` immediately after `make clean && make all && make bootstrap`.
- `warm` is the next `make test` invoked right after, where OS-level filesystem caches
and ccache (when present) are hot from the cold run. 
- master's `make test` always wipes `.ok` files first via `clean-test-results`,
so neither run benefits from per-test result caching — the warm
speedup is purely OS / ccache state.

Speedup is bounded by REF_RUBY invocations and per-test diff/cmp
which serialize more than the parse/codegen/cc/run pipeline; on
machines where the compile step dominates (no ccache, more cores)
the speedup grows accordingly.