### PR TITLE
perf(test): incremental test caching via make-native stamps + auto-detect ccache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,21 @@
 #   make clean        Remove built binaries
 
 CC       ?= cc
+# Auto-wrap CC with sccache or ccache when present. Skip when CC is
+# already wrapped — the substring guard catches both "ccache" and
+# "sccache" since "ccache" is a substring of "sccache", so CI's
+# `CC=sccache <cc>` env stays untouched. NO_CCACHE=1 opts out.
+# `override` is required so that `make CC=gcc` (command-line CC) is
+# also wrapped — without it, command-line CC takes precedence over
+# Makefile assignments and the wrap is silently ignored.
+ifeq (,$(findstring ccache,$(CC)))
+ifeq (,$(NO_CCACHE))
+  CCACHE_BIN := $(shell command -v sccache 2>/dev/null || command -v ccache 2>/dev/null)
+  ifneq (,$(CCACHE_BIN))
+    override CC := $(CCACHE_BIN) $(CC)
+  endif
+endif
+endif
 # `-Wno-alloc-size-larger-than` silences a gcc 13+ paranoia warning that
 # fires on the inlined `h->cap *= 2` in sp_*Hash_grow when the inliner
 # can't bound h->cap. The pattern is bounded in practice (cap doubles
@@ -91,7 +106,10 @@ PRISM_SRC    = $(wildcard $(PRISM_DIR)/src/*.c) $(wildcard $(PRISM_DIR)/src/util
 PRISM_OBJ    = $(patsubst $(PRISM_DIR)/src/%.c,build/prism/%.o,$(PRISM_SRC))
 PRISM_LIB    = build/libprism.a
 
-.PHONY: all parse bootstrap codegen test test-run clean-test-results regen-expected bench clean install uninstall deps
+CODEGEN_STAMP := build/stamps/spinel_codegen.rb.stamp
+PARSE_STAMP   := build/stamps/spinel_parse.c.stamp
+
+.PHONY: all parse bootstrap codegen test retest clean-test-results regen-expected bench clean install uninstall deps
 
 all: parse regexp spinel_codegen$(EXE)
 
@@ -136,12 +154,27 @@ build/prism/%.o: $(PRISM_DIR)/src/%.c
 	@mkdir -p $(dir $@)
 	$(CC) -c -O2 -I$(PRISM_INC) -I$(PRISM_DIR)/src $< -o $@
 
+# ---- Content stamps ----
+# Content stamps: rules depend on `build/stamps/foo.stamp` instead of
+# `foo` directly, so `touch foo` (or `git checkout` of an identical
+# version) doesn't invalidate downstream targets. cmp-or-replace
+# advances the stamp's mtime only on real content change.
+build/stamps:
+	@mkdir -p $@
+
+build/stamps/%.stamp: % | build/stamps
+	@cmp -s $< $@ 2>/dev/null || cp $< $@
+
+# Without .PRECIOUS make would delete these as pattern-rule
+# intermediates, recreating them with fresh mtimes next run.
+.PRECIOUS: build/stamps/%.stamp
+
 # ---- C Parser ----
 
 parse: spinel_parse$(EXE)
 
-spinel_parse$(EXE): spinel_parse.c $(PRISM_LIB)
-	$(CC) $(CFLAGS) -I$(PRISM_INC) $< $(PRISM_LIB) -lm -o $@
+spinel_parse$(EXE): $(PARSE_STAMP) $(PRISM_LIB)
+	$(CC) $(CFLAGS) -I$(PRISM_INC) spinel_parse.c $(PRISM_LIB) -lm -o $@
 
 # ---- Runtime library (regexp + bigint) ----
 
@@ -171,7 +204,7 @@ regexp: $(SP_RT_LIB)
 
 codegen: spinel_codegen$(EXE)
 
-spinel_codegen$(EXE): spinel_codegen.rb spinel_parse$(EXE)
+spinel_codegen$(EXE): $(CODEGEN_STAMP) spinel_parse$(EXE)
 	./spinel_parse$(EXE) spinel_codegen.rb build/codegen.ast
 	ruby spinel_codegen.rb build/codegen.ast build/gen1.c
 	$(CC) $(BOOTSTRAP_CFLAGS) -Ilib build/gen1.c $(LDFLAGS) -lm -o spinel_codegen$(EXE)
@@ -196,10 +229,9 @@ bootstrap: spinel_codegen$(EXE)
 TESTS := $(wildcard test/*.rb)
 TEST_TARGETS := $(patsubst test/%.rb,build/test-results/%.ok,$(TESTS))
 
-test: clean-test-results
-	@$(MAKE) --no-print-directory test-run
-
-test-run: $(TEST_TARGETS)
+# `make test` is incremental via mtime tracking on .ok files;
+# `make retest` wipes them for a forced rerun.
+test: $(TEST_TARGETS)
 	@if [ -z "$(TIMEOUT_BIN)" ]; then echo "Note: no 'timeout' command found; running without time limits."; fi
 	@if [ -t 1 ]; then printf '\n'; fi
 	@pass=$$(grep -l '^PASS' build/test-results/*.ok 2>/dev/null | wc -l); \
@@ -218,7 +250,13 @@ test-run: $(TEST_TARGETS)
 	echo "Tests: $$pass pass, $$fail fail, $$err error"; \
 	if [ $$fail -ne 0 ] || [ $$err -ne 0 ]; then exit 1; fi
 
-build/test-results/%.ok: test/%.rb spinel_parse$(EXE) $(SP_RT_LIB) spinel_codegen$(EXE)
+retest: clean-test-results
+	@$(MAKE) --no-print-directory test
+
+# The .ok target is the test's stamp; mtime tracking gives per-test
+# caching for free. Order-only spinel_parse$(EXE) / spinel_codegen$(EXE)
+# stop a bootstrap relink from invalidating every test.
+build/test-results/%.ok: test/%.rb $(SP_RT_LIB) $(CODEGEN_STAMP) $(PARSE_STAMP) | spinel_parse$(EXE) spinel_codegen$(EXE)
 	@mkdir -p build/test-results
 	@tmpdir=$$(mktemp -d /tmp/spinel-test.XXXXXX); \
 	ast=$$tmpdir/test.ast; \


### PR DESCRIPTION
Replace `make test`'s "always wipe + always re-run" loop with native mtime-based incremental caching, and auto-wrap CC with a compiler cache when one is available.

Two complementary changes, both Makefile-only:

1. CC auto-wrap. If `sccache` (matches CI's `CC=sccache <cc>` env setup) or `ccache` is on PATH and CC is not already wrapped, prepend it. The substring guard catches both "ccache" and "sccache" — "ccache" is a substring of "sccache", so CI's pre-wrapped CC stays untouched. `NO_CCACHE=1` opts out.

2. Make-native test cache. `.ok` files become per-test stamp files; make's mtime tracking decides whether to re-run. Three dep-graph changes turn this into a content-aware cache:

   - cmp-or-replace stamps for spinel_codegen.rb and spinel_parse.c (`build/stamps/%.stamp: % | build/stamps`). The stamp's mtime only advances when content actually changes, so `git checkout` between branches with identical sources or an editor save with no edit doesn't invalidate downstream targets.
   - The two upstream rules (spinel_parse$(EXE) and spinel_codegen$(EXE)) depend on the stamps instead of the raw sources, so a content-free touch doesn't trigger a 2:30 bootstrap relink either.
   - The per-test `.ok` recipe depends on the stamps; the binary targets are order-only so a relink alone doesn't invalidate every test.

   `.PRECIOUS: build/stamps/%.stamp` keeps make from auto-deleting
   the stamps as pattern-rule intermediates between invocations
   (without it, the next run re-creates them with a fresh mtime
   and invalidates everything).

`make test` is now incremental. `make retest` (= `clean-test-results && test`) preserves the old "wipe everything and start fresh" behaviour for the rare cases that need it.

Performance (macOS Sequoia, Apple M-series, ccache via brew, 345 tests, `make -j8`, on-disk caches warmed by a prior run):

```
  scenario                              master       PR    speedup
  -----------------------------------  --------  -------  --------
  cold test (after clean)                76.3s    72.8s         1x
  warm rerun, no changes                 42.0s     1.7s        25x
  touch spinel_codegen.rb (no edit)     196.6s     1.7s       115x
  edit one test source                   73.6s     2.1s        35x
  make retest (force rerun)              N/A      42.6s         —
```

### Reviewer verification 

Save the script below as `/tmp/verify-test-cache.sh`, then run it in the spinel repo root on master and on this branch, comparing the per-scenario rows:

```sh
  #!/bin/sh
  set -eu
  if [ ! -f Makefile ] || [ ! -f spinel_codegen.rb ]; then
    echo "error: run from the spinel repo root" >&2
    exit 1
  fi
  run() {
    label=$1; shift
    real=$(/usr/bin/time -p "$@" 2>&1 1>/dev/null | awk '/^real/{print $2}')
    printf '  %-36s %7s s\n' "$label" "$real"
  }
  echo '== setup (one-time, not measured) =='
  make clean     >/dev/null 2>&1
  make all       >/dev/null 2>&1
  make bootstrap >/dev/null 2>&1
  echo '  done.'
  echo
  echo '== scenarios =='
  run 'cold test (after clean)'           make test -j8
  run 'warm rerun (no changes)'           make test -j8
  touch spinel_codegen.rb
  run 'touch spinel_codegen.rb (no edit)' make test -j8
  touch spinel_parse.c
  run 'touch spinel_parse.c (no edit)'    make test -j8
  touch test/array_concat.rb
  run 'edit one test source'              make test -j8
  if make -n retest >/dev/null 2>&1; then
    run 'make retest (force rerun)'       make retest -j8
  fi
```

CI (`CC=sccache gcc` already in workflow env) is unchanged: the substring guard skips the auto-wrap, and the stamps + `.ok` files don't exist in fresh CI checkouts so the first run populates them.