### PR TITLE
fix(codegen,runtime): exception hierarchy matching for rescue

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -1016,7 +1016,23 @@ static const char *sp_exc_cls[SP_EXC_STACK_MAX];
 static volatile const char *sp_last_exc_cls = "";
 static void sp_raise_cls(const char *cls, const char *msg) { if (sp_exc_top > 0) { sp_exc_msg[sp_exc_top-1] = msg; sp_exc_cls[sp_exc_top-1] = cls; sp_last_exc_cls = cls; longjmp(sp_exc_stack[sp_exc_top-1], 1); } fprintf(stderr, "unhandled exception: %s\n", msg); exit(1); }
 static void sp_raise(const char *msg) { sp_raise_cls("RuntimeError", msg); }
-static mrb_bool sp_exc_is_a(const char *cls, const char *target) { return strcmp(cls, target) == 0; }
+/* Forward declared; defined in generated code so that user-defined
+   exception classes can extend the built-in ancestry chain (e.g.
+   `class MyErr < StandardError`). The codegen emits the body
+   unconditionally, so an empty source still links. */
+static const char *sp_exc_parent(const char *cls);
+static mrb_bool sp_exc_is_a(const char *cls, const char *target) {
+  while (cls != NULL) {
+    /* Pointer equality short-circuit: exception class names are
+       string literals in the generated code, so the C compiler
+       typically deduplicates them within a TU and the pointers
+       match for the common case (direct rescue of the raised
+       class). Skips the strcmp on the hot path. */
+    if (cls == target || strcmp(cls, target) == 0) return TRUE;
+    cls = sp_exc_parent(cls);
+  }
+  return FALSE;
+}
 
 #define SP_CATCH_STACK_MAX 64
 static jmp_buf sp_catch_stack[SP_CATCH_STACK_MAX];

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -14458,6 +14458,7 @@ class Compiler
     end
     emit_class_structs
     emit_raw("/*TUPLE_INSERT_POINT*/")
+    emit_exc_parent_function
     emit_gc_scan_functions
     scan_toplevel_ivars(@root_id)
     emit_toplevel_ivar_decls
@@ -16337,6 +16338,61 @@ class Compiler
 
   def emit_tuple_structs
     # Tuple structs are now inserted at end of generate_code
+  end
+
+  # Emits the sp_exc_parent function that walks the exception
+  # hierarchy. The runtime header forward-declares this and uses it
+  # inside sp_exc_is_a, so it must always be defined regardless of
+  # whether the user wrote any rescue/raise — otherwise even unused
+  # rescue codepaths trip the linker. Built-in chain follows CRuby's
+  # standard hierarchy. User-defined classes that inherit from a known
+  # exception class extend the chain via cls_parents.
+  def emit_exc_parent_function
+    emit_raw("static const char *sp_exc_parent(const char *cls) {")
+    # User-defined exception classes: emit each one whose superclass
+    # chain (transitively) reaches a known exception class. We iterate
+    # @cls_names and emit if @cls_parents[i] is non-empty. The runtime
+    # walker handles the transitive closure by following the chain.
+    i = 0
+    while i < @cls_names.length
+      pn = ""
+      if i < @cls_parents.length
+        pn = @cls_parents[i]
+      end
+      if pn != "" && pn != "Object"
+        emit_raw("  if (strcmp(cls, \"" + @cls_names[i] + "\") == 0) return \"" + pn + "\";")
+      end
+      i = i + 1
+    end
+    # Built-in CRuby exception hierarchy (subset that spinel recognizes
+    # in is_known_constant_name). Exception is the root.
+    emit_raw("  if (strcmp(cls, \"Exception\") == 0) return NULL;")
+    emit_raw("  if (strcmp(cls, \"StandardError\") == 0) return \"Exception\";")
+    emit_raw("  if (strcmp(cls, \"ScriptError\") == 0) return \"Exception\";")
+    emit_raw("  if (strcmp(cls, \"SystemExit\") == 0) return \"Exception\";")
+    emit_raw("  if (strcmp(cls, \"SignalException\") == 0) return \"Exception\";")
+    emit_raw("  if (strcmp(cls, \"NoMemoryError\") == 0) return \"Exception\";")
+    emit_raw("  if (strcmp(cls, \"SystemCallError\") == 0) return \"StandardError\";")
+    emit_raw("  if (strcmp(cls, \"RuntimeError\") == 0) return \"StandardError\";")
+    emit_raw("  if (strcmp(cls, \"ArgumentError\") == 0) return \"StandardError\";")
+    emit_raw("  if (strcmp(cls, \"TypeError\") == 0) return \"StandardError\";")
+    emit_raw("  if (strcmp(cls, \"NameError\") == 0) return \"StandardError\";")
+    emit_raw("  if (strcmp(cls, \"NoMethodError\") == 0) return \"NameError\";")
+    emit_raw("  if (strcmp(cls, \"IndexError\") == 0) return \"StandardError\";")
+    emit_raw("  if (strcmp(cls, \"KeyError\") == 0) return \"StandardError\";")
+    emit_raw("  if (strcmp(cls, \"ZeroDivisionError\") == 0) return \"StandardError\";")
+    emit_raw("  if (strcmp(cls, \"RangeError\") == 0) return \"StandardError\";")
+    emit_raw("  if (strcmp(cls, \"FloatDomainError\") == 0) return \"RangeError\";")
+    emit_raw("  if (strcmp(cls, \"IOError\") == 0) return \"StandardError\";")
+    emit_raw("  if (strcmp(cls, \"NotImplementedError\") == 0) return \"ScriptError\";")
+    emit_raw("  if (strcmp(cls, \"StopIteration\") == 0) return \"IndexError\";")
+    emit_raw("  if (strcmp(cls, \"RegexpError\") == 0) return \"StandardError\";")
+    emit_raw("  if (strcmp(cls, \"FrozenError\") == 0) return \"RuntimeError\";")
+    emit_raw("  if (strcmp(cls, \"LocalJumpError\") == 0) return \"StandardError\";")
+    emit_raw("  if (strcmp(cls, \"FiberError\") == 0) return \"StandardError\";")
+    emit_raw("  if (strcmp(cls, \"EncodingError\") == 0) return \"StandardError\";")
+    emit_raw("  return NULL;")
+    emit_raw("}")
   end
 
   def emit_class_structs

--- a/test/exception_hierarchy.rb
+++ b/test/exception_hierarchy.rb
@@ -1,0 +1,66 @@
+# Exception class hierarchy matching: rescue should catch the
+# raised class AND any of its ancestor classes (CRuby semantics).
+# Spinel's runtime walks @cls_parents transitively via the codegen-
+# emitted sp_exc_parent function.
+#
+# This test only exercises the hierarchy lookup itself. Exception
+# objects (.message / .class) and propagation-on-no-match are
+# intentionally NOT tested here — those are separate fixes that
+# layer onto this one.
+
+# Built-in chain: ArgumentError < StandardError < Exception
+begin
+  raise ArgumentError, "arg-1"
+rescue StandardError => e
+  puts "StandardError caught: #{e}"
+end
+
+begin
+  raise ArgumentError, "arg-2"
+rescue Exception => e
+  puts "Exception caught: #{e}"
+end
+
+# Built-in chain: ZeroDivisionError < StandardError
+begin
+  raise ZeroDivisionError, "zd"
+rescue StandardError => e
+  puts "ZD as Std: #{e}"
+end
+
+# User-defined chain: MyError < StandardError, SubError < MyError.
+class MyError < StandardError
+end
+class SubError < MyError
+end
+
+begin
+  raise MyError, "user-1"
+rescue StandardError => e
+  puts "MyError as StandardError: #{e}"
+end
+
+# Transitive: SubError -> MyError -> StandardError -> Exception.
+begin
+  raise SubError, "user-2"
+rescue Exception => e
+  puts "SubError as Exception: #{e}"
+end
+
+# Direct match still works (no regression in the strcmp-equality path).
+begin
+  raise SubError, "user-3"
+rescue SubError => e
+  puts "SubError direct: #{e}"
+end
+
+# Multiple rescue clauses: parent class catches the descendant.
+begin
+  raise SubError, "user-4"
+rescue TypeError => e
+  puts "wrong: #{e}"
+rescue MyError => e
+  puts "MyError catches Sub: #{e}"
+end
+
+puts "done"

--- a/test/exception_hierarchy.rb.expected
+++ b/test/exception_hierarchy.rb.expected
@@ -1,0 +1,8 @@
+StandardError caught: arg-1
+Exception caught: arg-2
+ZD as Std: zd
+MyError as StandardError: user-1
+SubError as Exception: user-2
+SubError direct: user-3
+MyError catches Sub: user-4
+done


### PR DESCRIPTION
Replaces the strcmp-only sp_exc_is_a runtime check with an ancestor-walking variant: a `rescue StandardError` clause now catches `ArgumentError`, `RuntimeError`, user-defined subclasses, and any other descendant class — matching CRuby's `is_a?` rules for the rescue type filter.

The walker calls a new sp_exc_parent function whose body the codegen always emits (regardless of @needs_setjmp) so that the forward declaration in sp_runtime.h resolves to a definition during link. Built-in chain follows CRuby's standard hierarchy: StandardError, ScriptError, RuntimeError, ArgumentError, TypeError, NameError, NoMethodError, IndexError, KeyError, ZeroDivisionError, RangeError, FloatDomainError, IOError, NotImplementedError, StopIteration, RegexpError, FrozenError, LocalJumpError, FiberError, EncodingError, SystemCallError, plus Exception as the root.

User-defined classes extend the chain via @cls_parents (the existing class-graph spinel already tracks for
class X < Parent), so `class MyError < StandardError` Just Works.

New test: test/exception_hierarchy.rb covers built-in chain matches (ArgumentError caught as StandardError + Exception), user-defined chain matches (MyError, SubError -> ... -> Exception), direct strcmp match (no regression), and parent-as-multi-rescue.

Tests: 347 pass, 0 fail, 0 error. Bootstrap: gen2.c == gen3.c.