### PR TITLE
fix(codegen): RescueModifierNode infer_type unifies branch types

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2221,6 +2221,21 @@ class Compiler
     if t == "RangeNode"
       return "range"
     end
+    if t == "RescueModifierNode"
+      # `expr rescue fallback` — unify the types of the two branches.
+      # The fallback always runs on error, so prefer its type when the
+      # main branch is a noreturn-shaped expression like a bare `raise`
+      # (whose compile_expr returns the int literal `0`).
+      t1 = infer_type(@nd_expression[nid])
+      t2 = infer_type(@nd_else_clause[nid])
+      if t1 == t2
+        return t1
+      end
+      if t2 != "void" && t2 != "nil"
+        return t2
+      end
+      return t1
+    end
     if t == "LocalVariableReadNode"
       vt = find_var_type(@nd_name[nid])
       if vt != ""
@@ -20212,7 +20227,7 @@ class Compiler
     if t == "RescueModifierNode"
       @needs_setjmp = 1
       tmp = new_temp
-      rt = infer_type(@nd_else_clause[nid])
+      rt = infer_type(nid)
       emit("  " + c_type(rt) + " " + tmp + " = " + c_default_val(rt) + ";")
       emit("  sp_exc_top++;")
       emit("  if (setjmp(sp_exc_stack[sp_exc_top-1]) == 0) {")

--- a/test/rescue_modifier_assign.rb
+++ b/test/rescue_modifier_assign.rb
@@ -1,0 +1,24 @@
+# `expr rescue fallback` as an rvalue — verifies that
+# RescueModifierNode is wired into infer_type so the receiving
+# variable gets the unified type rather than the default int.
+#
+# Note: Ruby's `=` has higher precedence than the rescue modifier,
+# so `a = "x" rescue "y"` parses as `(a = "x") rescue "y"` — the
+# RescueModifierNode wraps the assignment, not the rvalue. To
+# actually exercise the RescueModifierNode-as-rvalue path through
+# infer_type, the rescue must be parenthesized as a sub-expression.
+
+# Same-type branches: string=string. Trivial baseline.
+a = ("ok" rescue "fallback")
+puts a
+
+# Mismatched branches: main is `raise` (returns int 0 from
+# compile_expr but never actually returns), fallback is string.
+# The fallback wins type inference; result type is string.
+b = (raise "boom" rescue "default")
+puts b
+
+# Same-type int. Endless method shape stays unchanged.
+def parse_int(s) = Integer(s) rescue 0
+puts parse_int("42")
+puts parse_int("abc")

--- a/test/rescue_modifier_assign.rb.expected
+++ b/test/rescue_modifier_assign.rb.expected
@@ -1,0 +1,4 @@
+ok
+default
+42
+0


### PR DESCRIPTION
Previously `result = expr rescue fallback` left `result` typed as the codegen's default (int) because RescueModifierNode had no arm in infer_type. When the fallback was a different type than the default, assignments produced C type mismatches.

Adds an arm that unifies the type of the main expression and the rescue branch — preferring the rescue branch's type when the main branch is a noreturn-shaped expression like a bare \`raise\`. The codegen at compile_expr's RescueModifierNode arm now reads the unified type via infer_type(nid) directly rather than only the fallback's type, so both rvalue and lvalue contexts agree.

New test: test/rescue_modifier_assign.rb covers the same-type baseline, mismatched-types raise+string, and the existing endless method shape that the type-inference change must not regress.

Tests: 347 pass, 0 fail, 0 error. Bootstrap: gen2.c == gen3.c.