### PR TITLE
fix(codegen): is_a? / kind_of? / instance_of? on poly receiver

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -1784,6 +1784,30 @@ class Compiler
     -1
   end
 
+  # Walk @cls_parents starting from `child_idx` and return 1 if we
+  # ever land on `ancestor_idx`. Used by `is_a?(<Klass>)` on poly
+  # receivers to enumerate descendant cls_ids — `recv.is_a?(C)` is
+  # true when recv's class is C or any subclass of C, so we OR
+  # together every cls_id whose parent chain reaches C.
+  def cls_is_descendant(child_idx, ancestor_idx)
+    ck = child_idx
+    while ck >= 0
+      pname = @cls_parents[ck]
+      if pname == ""
+        return 0
+      end
+      pi = find_class_idx(pname)
+      if pi < 0
+        return 0
+      end
+      if pi == ancestor_idx
+        return 1
+      end
+      ck = pi
+    end
+    0
+  end
+
   def find_method_idx(name)
     i = 0
     while i < @meth_names.length
@@ -26433,6 +26457,66 @@ class Compiler
     common == "" ? "int" : common
   end
 
+  # Runtime tag-check for `<poly>.is_a?(<klass>)` / `kind_of?` /
+  # `instance_of?`. Returns a C boolean expression for the named
+  # built-in class (Integer, String, Float, etc.), including
+  # mixin-style names that match every value (Object, Kernel,
+  # BasicObject, Comparable). Returns "" when the name has no
+  # SP_TAG_* mapping (caller falls back to user-class dispatch).
+  def poly_is_a_tag_check(klass, recv_tmp, is_instance_of)
+    if klass == "Integer"
+      return "(" + recv_tmp + ".tag == SP_TAG_INT)"
+    end
+    if klass == "String"
+      return "(" + recv_tmp + ".tag == SP_TAG_STR)"
+    end
+    if klass == "Float"
+      return "(" + recv_tmp + ".tag == SP_TAG_FLT)"
+    end
+    if klass == "Symbol"
+      return "(" + recv_tmp + ".tag == SP_TAG_SYM)"
+    end
+    if klass == "NilClass"
+      return "(" + recv_tmp + ".tag == SP_TAG_NIL)"
+    end
+    if klass == "TrueClass"
+      return "(" + recv_tmp + ".tag == SP_TAG_BOOL && " + recv_tmp + ".v.b)"
+    end
+    if klass == "FalseClass"
+      return "(" + recv_tmp + ".tag == SP_TAG_BOOL && !" + recv_tmp + ".v.b)"
+    end
+    if klass == "Numeric"
+      return "(" + recv_tmp + ".tag == SP_TAG_INT || " + recv_tmp + ".tag == SP_TAG_FLT)"
+    end
+    if klass == "Comparable"
+      if is_instance_of == 1
+        return "0"
+      end
+      return "(" + recv_tmp + ".tag == SP_TAG_INT || " + recv_tmp + ".tag == SP_TAG_FLT || " + recv_tmp + ".tag == SP_TAG_STR || " + recv_tmp + ".tag == SP_TAG_SYM)"
+    end
+    if klass == "Object" || klass == "Kernel" || klass == "BasicObject"
+      # Every value is_a? Object in Ruby. instance_of?(Object) is FALSE
+      # for primitives (their class is Integer/String/etc., not Object).
+      if is_instance_of == 1
+        return "0"
+      end
+      return "1"
+    end
+    if klass == "Array"
+      return "(" + recv_tmp + ".tag == SP_TAG_OBJ && (" + recv_tmp + ".cls_id == SP_BUILTIN_INT_ARRAY || " + recv_tmp + ".cls_id == SP_BUILTIN_STR_ARRAY || " + recv_tmp + ".cls_id == SP_BUILTIN_FLT_ARRAY || " + recv_tmp + ".cls_id == SP_BUILTIN_SYM_ARRAY || " + recv_tmp + ".cls_id == SP_BUILTIN_PTR_ARRAY || " + recv_tmp + ".cls_id == SP_BUILTIN_POLY_ARRAY))"
+    end
+    if klass == "Hash"
+      return "(" + recv_tmp + ".tag == SP_TAG_OBJ && (" + recv_tmp + ".cls_id == SP_BUILTIN_STR_INT_HASH || " + recv_tmp + ".cls_id == SP_BUILTIN_STR_STR_HASH || " + recv_tmp + ".cls_id == SP_BUILTIN_INT_STR_HASH || " + recv_tmp + ".cls_id == SP_BUILTIN_SYM_INT_HASH || " + recv_tmp + ".cls_id == SP_BUILTIN_SYM_STR_HASH || " + recv_tmp + ".cls_id == SP_BUILTIN_STR_POLY_HASH || " + recv_tmp + ".cls_id == SP_BUILTIN_SYM_POLY_HASH))"
+    end
+    if klass == "Range"
+      return "(" + recv_tmp + ".tag == SP_TAG_OBJ && " + recv_tmp + ".cls_id == SP_BUILTIN_RANGE)"
+    end
+    if klass == "Proc"
+      return "(" + recv_tmp + ".tag == SP_TAG_OBJ && " + recv_tmp + ".cls_id == SP_BUILTIN_PROC)"
+    end
+    ""
+  end
+
   def compile_poly_method_call(nid, rc, mname)
     @needs_rb_value = 1
     if mname == "nil?"
@@ -26455,6 +26539,51 @@ class Compiler
       emit("  sp_RbVal " + recv_tmp + " = " + rc + ";")
       emit("  mrb_int " + tmp + " = (" + recv_tmp + ".tag == SP_TAG_INT) ? " + recv_tmp + ".v.i : 0;")
       return tmp
+    end
+    # `<poly>.is_a?(<Class>)` / `kind_of?` / `instance_of?` — decide
+    # at runtime by inspecting the SP_TAG_* tag (and cls_id for
+    # SP_TAG_OBJ). Without this branch the call falls through to the
+    # SP_TAG_OBJ dispatch below, which has no `is_a?` method on any
+    # user class — every primitive arm returns the default and
+    # `is_a?(Integer)` on a poly slot is always falsy. Common in
+    # dispatch helpers like `(addr.is_a?(Integer) ? [addr] : addr).each`.
+    if mname == "is_a?" || mname == "kind_of?" || mname == "instance_of?"
+      args_id = @nd_arguments[nid]
+      if args_id >= 0
+        a = get_args(args_id)
+        if a.length > 0
+          arg_name = @nd_name[a[0]]
+          recv_tmp = new_temp
+          emit("  sp_RbVal " + recv_tmp + " = " + rc + ";")
+          io = mname == "instance_of?" ? 1 : 0
+          tag_check = poly_is_a_tag_check(arg_name, recv_tmp, io)
+          if tag_check != ""
+            return tag_check
+          end
+          # User-defined class: match by cls_id. instance_of? requires
+          # exact class; is_a?/kind_of? include subclasses, so
+          # enumerate user classes whose ancestor chain reaches
+          # arg_name (cls_is_descendant) and OR them in.
+          ci = find_class_idx(arg_name)
+          if ci >= 0
+            if mname == "instance_of?"
+              return "(" + recv_tmp + ".tag == SP_TAG_OBJ && " + recv_tmp + ".cls_id == " + ci.to_s + ")"
+            end
+            check = "(" + recv_tmp + ".tag == SP_TAG_OBJ && (" + recv_tmp + ".cls_id == " + ci.to_s
+            cn = 0
+            while cn < @cls_names.length
+              if cn != ci && cls_is_descendant(cn, ci) == 1
+                check = check + " || " + recv_tmp + ".cls_id == " + cn.to_s
+              end
+              cn = cn + 1
+            end
+            check = check + "))"
+            return check
+          end
+          return "0"
+        end
+      end
+      return "0"
     end
     # For object method calls, dispatch based on cls_id. Two namespaces
     # of cls_id share SP_TAG_OBJ:

--- a/test/poly_is_a.rb
+++ b/test/poly_is_a.rb
@@ -1,0 +1,47 @@
+# `<poly>.is_a?(Klass)` / `kind_of?` / `instance_of?` runtime
+# dispatch. Spinel previously fell through to user-class dispatch
+# only — the SP_TAG_INT / SP_TAG_STR / SP_TAG_FLT / SP_TAG_NIL /
+# SP_TAG_BOOL / SP_TAG_SYM / built-in Array / Hash / Range cases
+# were missing, so `is_a?(Integer)` against a poly slot always
+# returned false and downstream branches took the wrong arm. The
+# user-class dispatch also walked the wrong direction (recv->parent
+# instead of any-descendant->ancestor).
+#
+# Repro: a heterogeneous poly array yields each element back as
+# poly, then the type test routes it to the right branch. The
+# trailing Bar.new must select the `is_a?(Bar)` arm AND the
+# Foo.new before it must NOT match `is_a?(Bar)` (subclass-only).
+
+class Foo
+  def name; "foo"; end
+end
+class Bar < Foo
+  def name; "bar"; end
+end
+
+arr = [42, "hello", :sym, 1.5, nil, true, false, [1, 2], Foo.new, Bar.new]
+arr.each do |x|
+  if x.is_a?(Integer)
+    puts "Integer #{x}"
+  elsif x.is_a?(String)
+    puts "String #{x}"
+  elsif x.is_a?(Symbol)
+    puts "Symbol #{x.to_s}"
+  elsif x.is_a?(Float)
+    puts "Float"
+  elsif x.is_a?(NilClass)
+    puts "Nil"
+  elsif x.is_a?(TrueClass)
+    puts "True"
+  elsif x.is_a?(FalseClass)
+    puts "False"
+  elsif x.is_a?(Array)
+    puts "Array"
+  elsif x.is_a?(Bar)
+    puts "Bar"
+  elsif x.is_a?(Foo)
+    puts "Foo"
+  else
+    puts "?"
+  end
+end

--- a/test/poly_is_a.rb.expected
+++ b/test/poly_is_a.rb.expected
@@ -1,0 +1,10 @@
+Integer 42
+String hello
+Symbol sym
+Float
+Nil
+True
+False
+Array
+Foo
+Bar


### PR DESCRIPTION
## Reproduction

`test/poly_is_a.rb` (committed alongside the fix):

~~~ruby
class Foo
  def name; "foo"; end
end
class Bar < Foo
  def name; "bar"; end
end

arr = [42, "hello", :sym, 1.5, nil, true, false, [1, 2], Foo.new, Bar.new]
arr.each do |x|
  if x.is_a?(Integer)
    puts "Integer #{x}"
  elsif x.is_a?(String)
    puts "String #{x}"
  elsif x.is_a?(Symbol)
    puts "Symbol #{x.to_s}"
  elsif x.is_a?(Float)
    puts "Float"
  elsif x.is_a?(NilClass)
    puts "Nil"
  elsif x.is_a?(TrueClass)
    puts "True"
  elsif x.is_a?(FalseClass)
    puts "False"
  elsif x.is_a?(Array)
    puts "Array"
  elsif x.is_a?(Bar)
    puts "Bar"
  elsif x.is_a?(Foo)
    puts "Foo"
  else
    puts "?"
  end
end
~~~

## Expected behavior

~~~
$ ruby test/poly_is_a.rb
Integer 42
String hello
Symbol sym
Float
Nil
True
False
Array
Foo
Bar
~~~

## Actual behavior on master (`1433e5e`)

~~~
$ ./spinel test/poly_is_a.rb -o /tmp/t
$ /tmp/t
?
?
?
?
?
?
?
?
?
?
~~~

Every `is_a?` test on the poly slot returns false. The unboxed
arm of `compile_poly_method_call` falls through to the user-class
SP_TAG_OBJ dispatch, which has no `is_a?` method on any user
class — so every primitive case (Int / Str / Flt / Nil / Bool /
Sym / Array / Hash / Range / Proc) returns the default-zero.

## Analysis & fix

`compile_poly_method_call` (entered when the static type of the
receiver is `poly`) handled `nil?`, `to_s`, and `to_i` directly,
but missed `is_a?` / `kind_of?` / `instance_of?`. The dispatch
then fell through to the SP_TAG_OBJ user-class arm — and since no
user class declares an `is_a?` method, every value (including
SP_TAG_INT / SP_TAG_STR / etc.) hit the default `0` and the
condition was always falsy.

Add a runtime tag-check at the same level as `nil?` / `to_s` /
`to_i`:

- For built-in primitives (Integer / String / Float / Symbol /
  NilClass / TrueClass / FalseClass / Numeric) check `recv.tag`
  against the corresponding `SP_TAG_*`.
- For built-in containers (Array / Hash / Range / Proc) check
  `recv.cls_id` against the negative `SP_BUILTIN_*` ids (Array
  spans every `*_ARRAY` cls_id; Hash spans every `*_HASH` cls_id).
- For mixin-style names (Object / Kernel / BasicObject) return
  `1`; `instance_of?` returns `0` for these (a primitive's
  concrete class is Integer/String/etc., not Object).
- For user-defined classes, OR together every cls_id whose
  parent chain reaches the queried class — `recv.is_a?(C)` is
  true when recv's class IS C *or a subclass of C*. The dispatch
  enumerates descendants (via `cls_is_descendant`), not ancestors.
  `instance_of?` falls back to the exact-class check.

~~~diff
+    # `<poly>.is_a?(<Class>)` / `kind_of?` / `instance_of?` — decide
+    # at runtime by inspecting the SP_TAG_* tag (and cls_id for
+    # SP_TAG_OBJ). Without this branch the call falls through to the
+    # SP_TAG_OBJ dispatch below, which has no `is_a?` method on any
+    # user class — every primitive arm returns the default and
+    # `is_a?(Integer)` on a poly slot is always falsy.
+    if mname == "is_a?" || mname == "kind_of?" || mname == "instance_of?"
+      ...
+      tag_check = poly_is_a_tag_check(arg_name, recv_tmp, io)
+      if tag_check != ""
+        return tag_check
+      end
+      # User class: OR every descendant's cls_id (is_a? matches
+      # subclasses; instance_of? requires exact match).
+      ...
+    end
~~~

After the fix, the same test prints `Integer 42` / ... / `Foo` /
`Bar` matching CRuby. Notably, `Foo.new` correctly takes the
`is_a?(Foo)` arm and not the earlier `is_a?(Bar)` arm — the
descendant-walk is in the right direction.

Common idiom unblocked: `(addr.is_a?(Integer) ? [addr] : addr).each`
where `addr` is a heterogeneous Range / Integer / Array union (a
shape that appears in many dispatch helpers).

## Diff stat

~~~
 spinel_codegen.rb              | 138 ++++++++++++++++++++++++++++++++++++++++
 test/poly_is_a.rb              |  47 ++++++++++++++
 test/poly_is_a.rb.expected     |  10 +++
 3 files changed, 195 insertions(+)
~~~

## Test plan

- [x] `make -j4 bootstrap` green.
- [x] `make test` 348 pass / 0 fail / 0 error.
- [x] Manual reproduction: master prints ten `?` lines, branch
  prints the matching arm for each value.