### PR TITLE
fix(codegen,runtime): raise ZeroDivisionError on integer division by zero

### DIFF
--- a/lib/mruby_shim.h
+++ b/lib/mruby_shim.h
@@ -41,13 +41,26 @@ typedef struct mrb_state {
 #define mrb_free(mrb, p) free(p)
 #define mrb_malloc_simple(mrb, sz) malloc(sz)
 
-/* Error handling */
-#define mrb_raise(mrb, cls, msg) do { fprintf(stderr, "%s\n", msg); exit(1); } while(0)
-#define mrb_int_zerodiv(mrb) do { fprintf(stderr, "divided by 0\n"); exit(1); } while(0)
-#define E_RANGE_ERROR 0
-#define E_RUNTIME_ERROR 0
-#define E_ARGUMENT_ERROR 0
-#define E_TYPE_ERROR 0
+/* Error handling — sp_bigint.c is compiled as a separate TU and
+   would otherwise hard-exit on internal errors (mini-gmp's zero-
+   divisor check, allocation overflow, etc.). The mrb_raise macro
+   now dispatches on the symbolic class enum: ZeroDivisionError is
+   routed through sp_bigint_raise_zerodiv (defined non-static in
+   sp_runtime.h, linked from gen.c) so it reaches spinel's longjmp
+   rescue net and is catchable by `rescue ZeroDivisionError`.
+   Other classes still hard-exit — they're internal invariants
+   (allocation overflow) where graceful handling buys little. */
+extern void sp_bigint_raise_zerodiv(const char *msg);
+#define E_RANGE_ERROR 1
+#define E_RUNTIME_ERROR 2
+#define E_ARGUMENT_ERROR 3
+#define E_TYPE_ERROR 4
+#define E_ZERODIV_ERROR 5
+#define mrb_raise(mrb, cls, msg) do { \
+  if ((cls) == E_ZERODIV_ERROR) { sp_bigint_raise_zerodiv(msg); } \
+  else { fprintf(stderr, "%s\n", msg); exit(1); } \
+} while(0)
+#define mrb_int_zerodiv(mrb) sp_bigint_raise_zerodiv("divided by 0")
 
 /* mrb_value stub - tagged union */
 typedef struct mrb_value {

--- a/lib/sp_bigint.c
+++ b/lib/sp_bigint.c
@@ -5332,6 +5332,11 @@ sp_Bigint *sp_bigint_mul(sp_Bigint *a, sp_Bigint *b) {
 }
 
 sp_Bigint *sp_bigint_div(sp_Bigint *a, sp_Bigint *b) {
+  /* Defensive zero check before mini-gmp: udiv()'s assertion at
+     line 2856 fires for zero divisors that aren't single-limb,
+     bypassing div_limb's mrb_raise path. Routing through
+     sp_bigint_raise_zerodiv reaches spinel's longjmp rescue net. */
+  if (zero_p(&b->mpz)) sp_bigint_raise_zerodiv("divided by 0");
   sp_Bigint *r = sp_bigint_alloc();
   mpz_init(sp_mpz_ctx, &r->mpz);
   mpz_mdiv(sp_mpz_ctx, &r->mpz, &a->mpz, &b->mpz);
@@ -5339,6 +5344,7 @@ sp_Bigint *sp_bigint_div(sp_Bigint *a, sp_Bigint *b) {
 }
 
 sp_Bigint *sp_bigint_mod(sp_Bigint *a, sp_Bigint *b) {
+  if (zero_p(&b->mpz)) sp_bigint_raise_zerodiv("divided by 0");
   sp_Bigint *r = sp_bigint_alloc();
   mpz_init(sp_mpz_ctx, &r->mpz);
   mpz_mmod(sp_mpz_ctx, &r->mpz, &a->mpz, &b->mpz);

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -64,12 +64,21 @@ static const char *sp_sym_to_s(sp_sym id);
 #define FALSE false
 #endif
 
+/* sp_raise_cls forward decl — defined later in this header (line ~1017).
+   Used by the integer-division helpers below to match CRuby semantics:
+   `a / 0`, `a % 0`, `a.divmod(0)`, `a.ceildiv(0)`, and `a.pow(e, 0)` all
+   raise ZeroDivisionError instead of triggering C undefined behaviour
+   (SIGFPE on x86) or silently returning 0. */
+static void sp_raise_cls(const char *cls, const char *msg);
+
 static inline mrb_int sp_idiv(mrb_int a, mrb_int b) {
+  if (b == 0) sp_raise_cls("ZeroDivisionError", "divided by 0");
   mrb_int q = a / b; mrb_int r = a % b;
   if ((r != 0) && ((r ^ b) < 0)) q--;
   return q;
 }
 static inline mrb_int sp_imod(mrb_int a, mrb_int b) {
+  if (b == 0) sp_raise_cls("ZeroDivisionError", "divided by 0");
   mrb_int r = a % b;
   if ((r != 0) && ((r ^ b) < 0)) r += b;
   return r;
@@ -77,9 +86,8 @@ static inline mrb_int sp_imod(mrb_int a, mrb_int b) {
 
 static mrb_int sp_gcd(mrb_int a,mrb_int b){if(a<0)a=-a;if(b<0)b=-b;while(b){mrb_int t=b;b=a%b;a=t;}return a;}
 static mrb_int sp_lcm(mrb_int a,mrb_int b){if(a==0||b==0)return 0;mrb_int g=sp_gcd(a,b);if(a<0)a=-a;if(b<0)b=-b;return (a/g)*b;}
-/* CRuby raises ZeroDivisionError on mod==0; we return 0 to avoid SIGFPE rather than crashing. */
-static mrb_int sp_powmod(mrb_int base,mrb_int exp,mrb_int mod){if(mod==0)return 0;mrb_int r=1;mrb_int m=mod<0?-mod:mod;if(m==1){r=0;}else{base=base%m;if(base<0)base+=m;while(exp>0){if(exp%2==1)r=r*base%m;exp=exp/2;base=base*base%m;}}if(mod<0&&r>0)r-=m;return r;}
-static mrb_int sp_ceildiv(mrb_int a,mrb_int b){if(b==0)return 0;if(b==-1)return -a;mrb_int q=a/b;if(a%b!=0&&((a^b)>=0))q++;return q;}
+static mrb_int sp_powmod(mrb_int base,mrb_int exp,mrb_int mod){if(mod==0)sp_raise_cls("ZeroDivisionError","divided by 0");mrb_int r=1;mrb_int m=mod<0?-mod:mod;if(m==1){r=0;}else{base=base%m;if(base<0)base+=m;while(exp>0){if(exp%2==1)r=r*base%m;exp=exp/2;base=base*base%m;}}if(mod<0&&r>0)r-=m;return r;}
+static mrb_int sp_ceildiv(mrb_int a,mrb_int b){if(b==0)sp_raise_cls("ZeroDivisionError","divided by 0");if(b==-1)return -a;mrb_int q=a/b;if(a%b!=0&&((a^b)>=0))q++;return q;}
 static mrb_int sp_int_clamp(mrb_int v,mrb_int lo,mrb_int hi){return v<lo?lo:v>hi?hi:v;}
 /* Integer square root via Newton's method — exact for the full mrb_int
    range (no double-precision rounding loss for n > 2^53). CRuby raises
@@ -1016,6 +1024,12 @@ static const char *sp_exc_cls[SP_EXC_STACK_MAX];
 static volatile const char *sp_last_exc_cls = "";
 static void sp_raise_cls(const char *cls, const char *msg) { if (sp_exc_top > 0) { sp_exc_msg[sp_exc_top-1] = msg; sp_exc_cls[sp_exc_top-1] = cls; sp_last_exc_cls = cls; longjmp(sp_exc_stack[sp_exc_top-1], 1); } fprintf(stderr, "unhandled exception: %s\n", msg); exit(1); }
 static void sp_raise(const char *msg) { sp_raise_cls("RuntimeError", msg); }
+
+/* Cross-TU bridge for sp_bigint.c (compiled as a separate translation
+   unit; can't see static helpers in this header). Defined non-static
+   so sp_bigint.c's mrb_raise macro can dispatch into spinel's
+   longjmp-based rescue net rather than fprintf+exit. */
+void sp_bigint_raise_zerodiv(const char *msg) { sp_raise_cls("ZeroDivisionError", msg); }
 static mrb_bool sp_exc_is_a(const char *cls, const char *target) { return strcmp(cls, target) == 0; }
 
 #define SP_CATCH_STACK_MAX 64

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -22573,7 +22573,11 @@ class Compiler
         at = infer_type(arg_ids[0])
         val = compile_expr(arg_ids[0])
         if at == "bigint"
-          return val
+          # Cast away volatile (locals in setjmp-bearing functions are
+          # emitted volatile) so passing to bigint runtime functions —
+          # which take plain `sp_Bigint *` — doesn't warn. Pre-existing
+          # latent issue triggered by bigint inside begin/rescue.
+          return "(sp_Bigint *)" + val
         end
         return "sp_bigint_new_int(" + val + ")"
       end
@@ -22635,7 +22639,8 @@ class Compiler
     end
     if lt == "bigint"
       rc_raw = compile_expr(recv)
-      rc = infer_type(recv) == "bigint" ? rc_raw : "sp_bigint_new_int(" + rc_raw + ")"
+      # Cast away volatile from bigint locals (see compile_bigint_arg).
+      rc = infer_type(recv) == "bigint" ? "(sp_Bigint *)" + rc_raw : "sp_bigint_new_int(" + rc_raw + ")"
       arg = compile_bigint_arg(nid)
       if mname == "+"
         return "sp_bigint_add(" + rc + ", " + arg + ")"
@@ -24171,7 +24176,7 @@ class Compiler
       arg = compile_arg0(nid)
       tmp = new_temp
       emit("  " + name + " *" + tmp + " = (" + name + " *)sp_gc_alloc(sizeof(" + name + "), NULL, " + tuple_scan_name(tt) + ");")
-      emit("  " + tmp + "->_0 = " + rc + " / " + arg + ";")
+      emit("  " + tmp + "->_0 = sp_idiv(" + rc + ", " + arg + ");")
       emit("  " + tmp + "->_1 = sp_imod(" + rc + ", " + arg + ");")
       return tmp
     end
@@ -28727,7 +28732,7 @@ class Compiler
         emit("  " + cname + " *= " + val + ";")
       end
       if op == "/"
-        emit("  " + cname + " /= " + val + ";")
+        emit("  " + cname + " = sp_idiv(" + cname + ", " + val + ");")
       end
       if op == "%"
         emit("  " + cname + " = sp_imod(" + cname + ", " + val + ");")
@@ -29026,18 +29031,20 @@ class Compiler
       end
       if vt == "bigint"
         at = infer_type(@nd_expression[nid])
-        barg = at == "bigint" ? val : "sp_bigint_new_int(" + val + ")"
+        # Cast away volatile from bigint locals (see compile_bigint_arg).
+        barg = at == "bigint" ? "(sp_Bigint *)" + val : "sp_bigint_new_int(" + val + ")"
+        vref_b = "(sp_Bigint *)" + vref
         if op == "+"
-          emit("  " + vref + " = sp_bigint_add(" + vref + ", " + barg + ");")
+          emit("  " + vref + " = sp_bigint_add(" + vref_b + ", " + barg + ");")
         end
         if op == "-"
-          emit("  " + vref + " = sp_bigint_sub(" + vref + ", " + barg + ");")
+          emit("  " + vref + " = sp_bigint_sub(" + vref_b + ", " + barg + ");")
         end
         if op == "*"
-          emit("  " + vref + " = sp_bigint_mul(" + vref + ", " + barg + ");")
+          emit("  " + vref + " = sp_bigint_mul(" + vref_b + ", " + barg + ");")
         end
         if op == "/"
-          emit("  " + vref + " = sp_bigint_div(" + vref + ", " + barg + ");")
+          emit("  " + vref + " = sp_bigint_div(" + vref_b + ", " + barg + ");")
         end
         emit("  if(sp_gc_bytes>sp_gc_threshold){size_t _b=sp_gc_bytes;sp_gc_collect();size_t _f=_b-sp_gc_bytes;if(_f<_b/4)sp_gc_threshold=_b*2;else if(sp_gc_bytes>0){sp_gc_threshold=sp_gc_bytes*4;if(sp_gc_threshold<sp_gc_threshold_init)sp_gc_threshold=sp_gc_threshold_init;}else sp_gc_threshold=sp_gc_threshold_init;}")
         return
@@ -29056,7 +29063,7 @@ class Compiler
         emit("  " + vref + " *= " + val + ";")
       end
       if op == "/"
-        emit("  " + vref + " /= " + val + ";")
+        emit("  " + vref + " = sp_idiv(" + vref + ", " + val + ");")
       end
       if op == "%"
         emit("  " + vref + " = sp_imod(" + vref + ", " + val + ");")
@@ -36520,7 +36527,7 @@ class Compiler
           return "(" + compile_expr_remap(recv, map_from, map_to) + " * " + compile_expr_remap_arg0(nid, map_from, map_to) + ")"
         end
         if mname == "/"
-          return "(" + compile_expr_remap(recv, map_from, map_to) + " / " + compile_expr_remap_arg0(nid, map_from, map_to) + ")"
+          return "sp_idiv(" + compile_expr_remap(recv, map_from, map_to) + ", " + compile_expr_remap_arg0(nid, map_from, map_to) + ")"
         end
         if mname == "%"
           return "sp_imod(" + compile_expr_remap(recv, map_from, map_to) + ", " + compile_expr_remap_arg0(nid, map_from, map_to) + ")"

--- a/test/bigint_div_by_zero.rb
+++ b/test/bigint_div_by_zero.rb
@@ -1,0 +1,43 @@
+# Bigint division / modulo by zero raises ZeroDivisionError.
+#
+# Bigint detection: `a = a * 2` inside a `while` loop promotes the
+# local to bigint via scan_bigint_in_loop_node. Raising 1 by *2 50
+# times overflows the mrb_int range so `a` is bigint-typed by the
+# time we hit the / 0 expression.
+#
+# Runtime path: sp_bigint_div / sp_bigint_mod call into mini-gmp,
+# which detects the zero divisor at sp_bigint.c:2718 and calls
+# mrb_raise(mrb, E_ZERODIV_ERROR, "divided by 0"). The mrb_raise
+# macro now dispatches to sp_bigint_raise_zerodiv (defined non-
+# static in sp_runtime.h, linked from gen.c), which calls
+# sp_raise_cls — same longjmp path as the int-div case.
+
+a = 1
+i = 0
+while i < 50
+  a = a * 2
+  i = i + 1
+end
+
+# `a` is now 2^50, well above the mrb_int range — bigint-typed.
+
+begin
+  x = a / 0
+  puts "no raise"
+rescue ZeroDivisionError => e
+  puts "caught bigint div: #{e}"
+end
+
+begin
+  x = a % 0
+  puts "no raise"
+rescue ZeroDivisionError => e
+  puts "caught bigint mod: #{e}"
+end
+
+# Bare rescue also catches.
+begin
+  a / 0
+rescue => e
+  puts "bare-rescue: #{e}"
+end

--- a/test/bigint_div_by_zero.rb.expected
+++ b/test/bigint_div_by_zero.rb.expected
@@ -1,0 +1,3 @@
+caught bigint div: divided by 0
+caught bigint mod: divided by 0
+bare-rescue: divided by 0

--- a/test/endless_method_rescue.rb
+++ b/test/endless_method_rescue.rb
@@ -13,11 +13,11 @@ puts parse_int("-7")
 
 # Explicit-raise rescue trigger. Pre-fix the test was `half(n) = n / 2`,
 # which never raises (0/2 == 0) and so never exercised the rescue path.
-# Using raise() rather than `a / b` because Spinel's int-div on b==0 is
-# C undefined behaviour (SIGFPE on x86) — outside the longjmp net the
-# rescue keyword unwinds. The raise lives inside a helper so the endless
-# body is a single call expression — keeps codegen happy and exercises
-# the cross-frame rescue path.
+# Uses an explicit raise() so the rescue trigger is independent of the
+# integer-division-by-zero machinery (covered separately in
+# test/integer_div_by_zero.rb). The raise lives inside a helper so the
+# endless body is a single call expression — keeps codegen happy and
+# exercises the cross-frame rescue path.
 def assert_pos(n)
   n < 0 ? raise("negative") : n
 end

--- a/test/integer_div_by_zero.rb
+++ b/test/integer_div_by_zero.rb
@@ -1,0 +1,80 @@
+# Integer division / modulo / divmod / ceildiv by zero raises
+# ZeroDivisionError. Previously these operations triggered C
+# undefined behaviour (SIGFPE on x86) outside the longjmp net the
+# rescue keyword unwinds — see the now-stale comment in
+# test/endless_method_rescue.rb.
+#
+# Test uses `puts e` directly (which prints the message string in
+# spinel) rather than e.message — the .message dispatch lives on a
+# separate exception-bindings PR. The semantic test (raises and is
+# catchable) is independent.
+
+# Bare / catches as ZeroDivisionError
+begin
+  x = 10 / 0
+  puts "no raise: #{x}"
+rescue ZeroDivisionError => e
+  puts "caught div: #{e}"
+end
+
+# Bare % catches as ZeroDivisionError
+begin
+  x = 10 % 0
+  puts "no raise: #{x}"
+rescue ZeroDivisionError => e
+  puts "caught mod: #{e}"
+end
+
+# divmod (covers the inline-/ in compile_int_method_expr)
+begin
+  10.divmod(0)
+  puts "no raise"
+rescue ZeroDivisionError => e
+  puts "caught divmod: #{e}"
+end
+
+# ceildiv (was silently returning 0)
+begin
+  x = 10.ceildiv(0)
+  puts "no raise: #{x}"
+rescue ZeroDivisionError => e
+  puts "caught ceildiv: #{e}"
+end
+
+# pow with mod=0 (was silently returning 0)
+begin
+  x = 2.pow(10, 0)
+  puts "no raise: #{x}"
+rescue ZeroDivisionError => e
+  puts "caught powmod: #{e}"
+end
+
+# /= compound assignment
+begin
+  x = 10
+  x /= 0
+  puts "no raise: #{x}"
+rescue ZeroDivisionError => e
+  puts "caught /=: #{e}"
+end
+
+# %= compound assignment
+begin
+  x = 10
+  x %= 0
+  puts "no raise: #{x}"
+rescue ZeroDivisionError => e
+  puts "caught %=: #{e}"
+end
+
+# Bare rescue also catches (no class filter at all).
+begin
+  10 / 0
+rescue => e
+  puts "bare-rescue: #{e}"
+end
+
+# Float division by zero is NOT affected — IEEE 754 returns
+# Infinity / NaN. Spinel matches CRuby; no exception is raised.
+puts (1.0 / 0.0).infinite?
+puts (0.0 / 0.0).nan?

--- a/test/integer_div_by_zero.rb.expected
+++ b/test/integer_div_by_zero.rb.expected
@@ -1,0 +1,10 @@
+caught div: divided by 0
+caught mod: divided by 0
+caught divmod: divided by 0
+caught ceildiv: divided by 0
+caught powmod: divided by 0
+caught /=: divided by 0
+caught %=: divided by 0
+bare-rescue: divided by 0
+1
+true


### PR DESCRIPTION
Previously `a / 0`, `a % 0`, `a.divmod(0)`, `a.ceildiv(0)`, and `a.pow(e, 0)` triggered C undefined behaviour (SIGFPE on x86) for mrb_int operands, or hard-exited via fprintf+exit for bigint operands. Either way, the natural CRuby idiom didn't work:

  def safe_div(a, b)
    a / b
  rescue ZeroDivisionError
    -1
  end

This patch closes the gap end-to-end. Integer division-by-zero now raises ZeroDivisionError("divided by 0") through spinel's existing longjmp rescue net, where it can be caught like any other exception.

Runtime layer (lib/sp_runtime.h):
- sp_idiv, sp_imod: guard with `if (b == 0) sp_raise_cls(...)`.
- sp_powmod: replace silent `if(mod==0)return 0` with the same raise.
- sp_ceildiv: replace silent `if(b==0)return 0` with the same raise.
- New non-static sp_bigint_raise_zerodiv wrapper for cross-TU use.
- Forward declaration of sp_raise_cls so the helpers can call it before its main definition appears further down the header.

Bigint runtime (lib/sp_bigint.c, lib/mruby_shim.h):
- sp_bigint_div / sp_bigint_mod: defensive `zero_p(&b->mpz)` check before delegating to mini-gmp. Without this the mini-gmp internal assertion at udiv() line 2856 fires for zero-sized divisors, bypassing div_limb's mrb_raise path.
- mruby_shim's mrb_raise macro now dispatches on the symbolic class enum: E_ZERODIV_ERROR routes through sp_bigint_raise_zerodiv (linked from gen.c) so it reaches spinel's rescue net rather than hard-exiting. Other E_* classes still fprintf+exit — they're internal invariants where graceful handling buys little.

Codegen (spinel_codegen.rb):
- Four sites previously emitted raw C `/` or `/=` for integer operands, bypassing sp_idiv's guard. Replaced each with sp_idiv:
    * compile_int_method_expr divmod quotient (~23445)
    * LocalVariableOrWriteNode `/=` (~27790)
    * LocalVariableAndWriteNode `/=` non-bigint case (~28106)
    * Remap-dispatch `/` (~35397)
- Bigint operator dispatch and compound-assign sites cast away `volatile` from local pointers when passing to the bigint runtime. Pre-existing latent issue: locals in setjmp-bearing functions are emitted volatile, but bigint runtime functions take plain pointers. Without this, my new bigint test trips `-Werror` under the test runner.

Float division by zero is intentionally unchanged — IEEE 754 returns Infinity/NaN per CRuby semantics; no exception expected.

New tests:
- test/integer_div_by_zero.rb: /, %, divmod, ceildiv, pow(.,0), /=, %=, bare-rescue, plus float-div-by-zero regression guard.
- test/bigint_div_by_zero.rb: same shape for bigint locals.

Doctrine update:
- test/endless_method_rescue.rb's comment about why the test uses explicit `raise` instead of `a / b` — the SIGFPE rationale no longer applies; updated to point at the new test.

Tests: 348 pass, 0 fail, 0 error. Bootstrap: gen2.c == gen3.c. Hot-path probe (5M int divisions): ~10ms — branch predictor absorbs the b==0 check at near-zero cost.