### PR TITLE
fix(codegen+runtime): array-keyed Hash via IntArray content hash/eql

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -5482,6 +5482,8 @@ class Compiler
       return "sp_SymPolyHash *"
     end
     if t == "poly_poly_hash"
+      @needs_poly_poly_hash = 1
+      @needs_rb_value = 1
       return "sp_PolyPolyHash *"
     end
     if t == "sym_array"
@@ -19670,6 +19672,9 @@ class Compiler
                       elsif promoted == "sym_poly_hash"
                         @needs_sym_poly_hash = 1
                         @needs_rb_value = 1
+                      elsif promoted == "poly_poly_hash"
+                        @needs_poly_poly_hash = 1
+                        @needs_rb_value = 1
                       end
                     end
                   end
@@ -20147,22 +20152,49 @@ class Compiler
   end
 
   # ---- Main emission ----
+  # Emit the cls_id-aware obj hash/eql dispatch shims that
+  # sp_PolyPolyHash uses for OBJ-tag keys. The default runtime
+  # behavior is pointer identity; this dispatch overrides it for
+  # classes whose `eql?` semantics are content-based:
+  #
+  # - sp_Method (when the class is in scope): equal iff bound
+  #   receiver + fn_ptr match — covers `obj.method(:foo)` dedup.
+  # - sp_IntArray (SP_BUILTIN_INT_ARRAY = -1): element-wise content
+  #   compare — covers `entries[[a, b]] ||= ...` array-keyed Hash
+  #   patterns.
   def emit_method_eql_dispatch
     return unless @needs_poly_poly_hash == 1
-    return if find_class_idx("Method") < 0
-    method_cid = find_class_idx("Method").to_s
+    has_method = find_class_idx("Method") >= 0
+    method_cid = has_method ? find_class_idx("Method").to_s : ""
     emit_raw("static mrb_int sp_method_obj_hash_dispatch(int cls_id, void *p) {")
-    emit_raw("  if (cls_id == " + method_cid + ") {")
-    emit_raw("    sp_Method *m = (sp_Method *)p;")
-    emit_raw("    return ((mrb_int)(uintptr_t)m->iv_self_obj * 31) ^ (mrb_int)m->iv_fn_ptr;")
+    if has_method
+      emit_raw("  if (cls_id == " + method_cid + ") {")
+      emit_raw("    sp_Method *m = (sp_Method *)p;")
+      emit_raw("    return ((mrb_int)(uintptr_t)m->iv_self_obj * 31) ^ (mrb_int)m->iv_fn_ptr;")
+      emit_raw("  }")
+    end
+    emit_raw("  if (cls_id == SP_BUILTIN_INT_ARRAY) {")
+    emit_raw("    sp_IntArray *a = (sp_IntArray *)p;")
+    emit_raw("    mrb_int h = 5381;")
+    emit_raw("    for (mrb_int i = 0; i < a->len; i++) h = ((h << 5) + h) ^ sp_IntArray_get(a, i);")
+    emit_raw("    return h;")
     emit_raw("  }")
     emit_raw("  return (mrb_int)((uintptr_t)p);")
     emit_raw("}")
     emit_raw("static mrb_bool sp_method_obj_eql_dispatch(int cls_id, void *a, void *b) {")
-    emit_raw("  if (cls_id == " + method_cid + ") {")
-    emit_raw("    sp_Method *ma = (sp_Method *)a;")
-    emit_raw("    sp_Method *mb = (sp_Method *)b;")
-    emit_raw("    return ma->iv_self_obj == mb->iv_self_obj && ma->iv_fn_ptr == mb->iv_fn_ptr;")
+    if has_method
+      emit_raw("  if (cls_id == " + method_cid + ") {")
+      emit_raw("    sp_Method *ma = (sp_Method *)a;")
+      emit_raw("    sp_Method *mb = (sp_Method *)b;")
+      emit_raw("    return ma->iv_self_obj == mb->iv_self_obj && ma->iv_fn_ptr == mb->iv_fn_ptr;")
+      emit_raw("  }")
+    end
+    emit_raw("  if (cls_id == SP_BUILTIN_INT_ARRAY) {")
+    emit_raw("    sp_IntArray *aa = (sp_IntArray *)a;")
+    emit_raw("    sp_IntArray *bb = (sp_IntArray *)b;")
+    emit_raw("    if (aa->len != bb->len) return FALSE;")
+    emit_raw("    for (mrb_int i = 0; i < aa->len; i++) if (sp_IntArray_get(aa, i) != sp_IntArray_get(bb, i)) return FALSE;")
+    emit_raw("    return TRUE;")
     emit_raw("  }")
     emit_raw("  return FALSE;")
     emit_raw("}")
@@ -20183,10 +20215,12 @@ class Compiler
     end
     # poly_poly_hash uses sp_obj_hash_hook / sp_obj_eql_hook for cls_id-
     # aware OBJ-tag dispatch. The hooks default to identity; install
-    # the codegen-emitted Method-aware shim so equivalent
+    # the codegen-emitted dispatch shim so equivalent
     # `obj.method(:foo)` instances (fresh allocations, but same iv_self_obj
-    # + iv_fn_ptr) dedup as eql? in @cache[m] ||= m style use.
-    if @needs_poly_poly_hash == 1 && find_class_idx("Method") >= 0
+    # + iv_fn_ptr) dedup as eql? in @cache[m] ||= m style use, and
+    # IntArray keys (e.g. `entries[[a, b]] ||= ...`) compare by
+    # element-wise content rather than pointer identity.
+    if @needs_poly_poly_hash == 1
       emit_raw("  sp_obj_hash_hook = sp_method_obj_hash_dispatch;")
       emit_raw("  sp_obj_eql_hook = sp_method_obj_eql_dispatch;")
     end

--- a/test/array_keyed_hash_int_array_eql.rb
+++ b/test/array_keyed_hash_int_array_eql.rb
@@ -1,0 +1,29 @@
+# Array-keyed Hash. `entries[[a, b]] ||= ...` was broken because
+# spinel's PolyPolyHash defaulted to pointer-identity comparison
+# for SP_TAG_OBJ keys — every fresh `[a, b]` literal allocated a
+# new IntArray, so identical-content keys never matched and the
+# `||=` never deduped. The cache grew unboundedly and reads with
+# a fresh `[a, b]` returned nil.
+#
+# Fix: extend the codegen-emitted sp_obj_hash_hook /
+# sp_obj_eql_hook to handle SP_BUILTIN_INT_ARRAY with element-wise
+# content hash + comparison. Two IntArray instances with the same
+# elements now hash and eql? identically — array-keyed Hash
+# behaves like CRuby's `Hash` with the [a,b]-style key idiom.
+
+entries = {}
+entries[[1, 2]] = "a"
+entries[[3, 4]] = "b"
+entries[[1, 2]] ||= "z"   # already set, no overwrite
+puts entries[[1, 2]]      # "a"
+puts entries[[3, 4]]      # "b"
+puts entries.length       # 2
+
+# Heterogeneous keys still work — int / IntArray / string mixed.
+mixed = {}
+mixed[42] = "int-key"
+mixed[[5, 6, 7]] = "arr-key"
+mixed[[5, 6, 7]] ||= "no-overwrite"
+puts mixed[42]            # int-key
+puts mixed[[5, 6, 7]]     # arr-key
+puts mixed.length         # 2

--- a/test/array_keyed_hash_int_array_eql.rb.expected
+++ b/test/array_keyed_hash_int_array_eql.rb.expected
@@ -1,0 +1,6 @@
+a
+b
+2
+int-key
+arr-key
+2


### PR DESCRIPTION
## Reproduction

`test/array_keyed_hash_int_array_eql.rb`:

~~~ruby
entries = {}
entries[[1, 2]] = "a"
entries[[3, 4]] = "b"
entries[[1, 2]] ||= "z"   # already set, no overwrite
puts entries[[1, 2]]      # "a"
puts entries[[3, 4]]      # "b"
puts entries.length       # 2

# Heterogeneous keys still work — int / IntArray / string mixed.
mixed = {}
mixed[42] = "int-key"
mixed[[5, 6, 7]] = "arr-key"
mixed[[5, 6, 7]] ||= "no-overwrite"
puts mixed[42]            # int-key
puts mixed[[5, 6, 7]]     # arr-key
puts mixed.length         # 2
~~~

## Expected behavior

~~~
a
b
2
int-key
arr-key
2
~~~

## Actual behavior on master (`994d4d6`)

The `||=` adds a new entry every time and `entries[[1, 2]]` lookup
on a fresh array literal returns nil. Output collapses to:

~~~
3
~~~

(Two `puts` lines emit empty lines because the lookup misses, the
`length` is `3` because every `[1, 2]` literal allocated a new
IntArray and the hash never deduped.)

## Analysis & fix

PolyPolyHash (PR #356) routed OBJ-tag keys through
`sp_obj_hash_hook` / `sp_obj_eql_hook`. The hooks default to
pointer identity, with codegen patching them in for Method (the
`@peeks[m] ||= m` dedup pattern). For IntArray keys
(`entries[[a, b]] ||= ...`) every fresh `[a, b]` literal allocates
a new IntArray, so identical-content keys never matched and the
`||=` never deduped.

Extend `sp_method_obj_hash_dispatch` /
`sp_method_obj_eql_dispatch` to also handle
`SP_BUILTIN_INT_ARRAY`:

- hash: DJB2 fold over the IntArray's elements.
- eql?: pairwise content compare.

Two IntArrays with the same elements now hash and `eql?`
identically, and array-keyed Hash behaves like CRuby.

Companion bookkeeping fixes:

- Drop the `find_class_idx("Method") >= 0` gate on the dispatch
  install — IntArray dispatch is needed regardless of whether the
  Method class is in scope.
- Set `@needs_poly_poly_hash` in `c_type` and at the
  scan_locals empty-hash promotion site so the dispatch shim
  emits whenever the program uses a poly_poly_hash.

## Diff stat

~~~
 spinel_codegen.rb                               | 58 ++++++++++++++++++++-----
 test/array_keyed_hash_int_array_eql.rb          | 29 +++++++++++++
 test/array_keyed_hash_int_array_eql.rb.expected |  6 +++
 3 files changed, 81 insertions(+), 12 deletions(-)
~~~

## Test plan

- [x] `make -j4 bootstrap` — gen2.c == gen3.c.
- [x] `make test` — 284 pass, 0 fail, 0 error (was 283 + 1 fail
      with the new test on master).
- [x] `ruby test/array_keyed_hash_int_array_eql.rb` matches
      spinel-built binary output.