### PR TITLE
fix(codegen): skip body emission when if/unless predicate folds to static FALSE/TRUE

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -30568,6 +30568,28 @@ class Compiler
 
   def compile_if_stmt(nid)
     cond = compile_cond_expr(@nd_predicate[nid])
+    # Static-false fold: a predicate whose static type is `nil`
+    # (e.g. an attr_reader for an ivar only ever assigned `nil`)
+    # collapses to `if (FALSE) { … }`. The body is unreachable, but
+    # its statements still pass through the C compiler — and they
+    # often type-error against ivars/methods whose shapes only make
+    # sense when the predicate is true. Drop the body entirely; emit
+    # the else branch (if any) at the surrounding scope.
+    if cond == "FALSE"
+      sub_sf = @nd_subsequent[nid]
+      if sub_sf >= 0
+        if @nd_type[sub_sf] == "ElseNode"
+          compile_stmts_body(@nd_body[sub_sf])
+        else
+          compile_if_stmt(sub_sf)
+        end
+      end
+      return
+    end
+    if cond == "TRUE"
+      compile_stmts_body(@nd_body[nid])
+      return
+    end
     emit("  if (" + cond + ") {")
     @indent = @indent + 1
     compile_stmts_body(@nd_body[nid])
@@ -30602,6 +30624,20 @@ class Compiler
 
   def compile_unless_stmt(nid)
     cond = compile_cond_expr(@nd_predicate[nid])
+    # Symmetric to compile_if_stmt's static-fold: an `unless` whose
+    # predicate is statically TRUE drops its body, FALSE drops the
+    # else branch.
+    if cond == "TRUE"
+      ec_sf = @nd_else_clause[nid]
+      if ec_sf >= 0
+        compile_stmts_body(@nd_body[ec_sf])
+      end
+      return
+    end
+    if cond == "FALSE"
+      compile_stmts_body(@nd_body[nid])
+      return
+    end
     emit("  if (!(" + cond + ")) {")
     @indent = @indent + 1
     compile_stmts_body(@nd_body[nid])

--- a/test/if_static_false_skips_dead_branch_compile.rb
+++ b/test/if_static_false_skips_dead_branch_compile.rb
@@ -1,0 +1,50 @@
+# `compile_cond_expr` already returns the literal "FALSE" for a
+# predicate whose static type is `nil` (e.g. an attr-style read
+# of an ivar only ever assigned `nil`). The if/unless emit then
+# wraps the dead body in `if (FALSE) { … }`, but the body's C
+# statements still pass through gcc — and they often type-error
+# against ivars/methods whose shapes only make sense when the
+# predicate is true. Skipping body emission lets the rest of
+# the program compile.
+
+class Profiler
+  def initialize
+    # `@mode` is statically nil — only ever assigned this literal.
+    # The read in the predicate below folds to `if (FALSE)`.
+    @mode = nil
+  end
+
+  def run
+    # Dead branch when @mode is nil. Pre-fix, spinel emits the
+    # body anyway: `sp_str_sub("...", "MODE", iv_mode)` with
+    # iv_mode typed as `mrb_int` (its only init being `= nil`)
+    # — the 3rd arg fails -Wint-conversion.
+    if @mode
+      out = "label_MODE".sub("MODE", @mode)
+      puts out
+    end
+    puts "ran"
+  end
+end
+
+# `if @nil_ivar; ... else; ... end` with a trailing stmt forces
+# the if into statement position (compile_if_stmt). The else arm
+# is the live one when the predicate is statically nil.
+class Either
+  def initialize
+    @verbose = nil
+  end
+
+  def run
+    if @verbose
+      out = "label_MODE".sub("MODE", @verbose)
+      puts out
+    else
+      puts "quiet"
+    end
+    puts "done"
+  end
+end
+
+Profiler.new.run
+Either.new.run

--- a/test/if_static_false_skips_dead_branch_compile.rb.expected
+++ b/test/if_static_false_skips_dead_branch_compile.rb.expected
@@ -1,0 +1,3 @@
+ran
+quiet
+done


### PR DESCRIPTION
## Reproduction

`test/if_static_false_skips_dead_branch_compile.rb` (committed alongside the fix):

~~~ruby
class Profiler
  def initialize
    @mode = nil
  end

  def run
    if @mode
      out = "label_MODE".sub("MODE", @mode)
      puts out
    end
    puts "ran"
  end
end

class Either
  def initialize
    @verbose = nil
  end

  def run
    if @verbose
      out = "label_MODE".sub("MODE", @verbose)
      puts out
    else
      puts "quiet"
    end
    puts "done"
  end
end

Profiler.new.run
Either.new.run
~~~

## Expected behavior

~~~
$ ruby test/if_static_false_skips_dead_branch_compile.rb
ran
quiet
done
~~~

## Actual behavior on master (`0d10645`)

`compile_cond_expr` already returns the literal `"FALSE"` for a
predicate whose static type is `nil` (an attr-style read of an
ivar only ever assigned `nil`). The if/unless emit then wraps
the dead body in `if (FALSE) { … }`, but the body's C statements
still pass through gcc:

~~~
$ ./spinel test/if_static_false_skips_dead_branch_compile.rb -o /tmp/r
/tmp/spinel_out.7woEHY.c: In function ‘sp_Profiler_run’:
/tmp/spinel_out.7woEHY.c:55:83: error: passing argument 3 of ‘sp_str_sub’ makes pointer from integer without a cast [-Wint-conversion]
   55 |       lv_out = sp_str_sub((&("\xff" "label_MODE")[1]), (&("\xff" "MODE")[1]), self->iv_mode);
      |                                                                               ~~~~^~~~~~~~~
      |                                                                                   |
      |                                                                                   mrb_int {aka long int}
…
/tmp/spinel_out.7woEHY.c: In function ‘sp_Either_run’:
/tmp/spinel_out.7woEHY.c:82:83: error: passing argument 3 of ‘sp_str_sub’ makes pointer from integer without a cast [-Wint-conversion]
   82 |       lv_out = sp_str_sub((&("\xff" "label_MODE")[1]), (&("\xff" "MODE")[1]), self->iv_verbose);
      |                                                                               ~~~~^~~~~~~~~~~~
      |                                                                                   |
      |                                                                                   mrb_int {aka long int}
spinel: C compilation failed
~~~

`iv_mode` / `iv_verbose` got typed `mrb_int` from the only init
they ever saw (`= nil`). The `sub("MODE", @mode)` call inside
the dead `if @mode` branch passes that int as the third arg
expected to be `const char *`. The branch is unreachable but
its statements still pass through the C compiler.

## Analysis & fix

`compile_cond_expr(@mode_read)` → `infer_type` → `"nil"` →
returns the literal `"FALSE"` string. `compile_if_stmt` /
`compile_unless_stmt` already see this constant return value;
the existing emit wrapped it in `if (FALSE) { … }` and emitted
the body anyway.

Fold the dead branch out at the codegen level:

* `compile_if_stmt`: when `cond == "FALSE"`, skip the body and
  emit only the else branch (recurse for elsif). When
  `cond == "TRUE"`, emit only the body.

* `compile_unless_stmt`: symmetric — `unless TRUE` drops the
  body, `unless FALSE` drops the else.

Behavior is preserved (the dead body was already unreachable at
runtime); the only change is that type errors hidden inside the
dead branch no longer reach gcc.

The expression-position counterparts (`compile_if_expr`,
`compile_if_return`, `compile_unless_expr`) are deliberately
out of scope for this PR — the test uses statement-position
shapes only (the `if/unless` is followed by another stmt) so
the existing dispatch routes through `compile_if_stmt` /
`compile_unless_stmt`. Folding the expr forms can follow as a
separate change once a corresponding test shape exists.

## Diff stat

~~~
 spinel_codegen.rb                                  | 36 ++++++++++++++++
 test/if_static_false_skips_dead_branch_compile.rb  | 50 ++++++++++++++++++++++
 ...tic_false_skips_dead_branch_compile.rb.expected |  3 ++
 3 files changed, 89 insertions(+)
~~~

## Test plan

- [x] `make -j4 bootstrap` green; gen2 == gen3 fixpoint OK.
- [x] `make test` 291 pass / 0 fail / 0 error
      (290 baseline + 1 new test).
- [x] Manual reproduction: master fails with the
      `-Wint-conversion` cluster above; this branch produces the
      expected output.