### PR TITLE
chore(test): add optcarrot integration target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ PRISM_LIB    = build/libprism.a
 CODEGEN_STAMP := build/stamps/spinel_codegen.rb.stamp
 PARSE_STAMP   := build/stamps/spinel_parse.c.stamp
 
-.PHONY: all parse bootstrap codegen test retest clean-test-results regen-expected bench clean install uninstall deps
+.PHONY: all parse bootstrap codegen test retest clean-test-results regen-expected bench optcarrot clean install uninstall deps
 
 all: parse regexp spinel_codegen$(EXE)
 
@@ -377,6 +377,34 @@ bench: spinel_parse$(EXE) $(SP_RT_LIB) spinel_codegen$(EXE)
 	rm -f /tmp/_sp_b.ast /tmp/_sp_b.c /tmp/_sp_b.c.o /tmp/_sp_b_bin$(EXE) /tmp/_sp_b_exp /tmp/_sp_b_act /tmp/_sp_b_exp.n /tmp/_sp_b_act.n; \
 	echo "Benchmarks: $$pass pass, $$fail fail, $$err error, $$skip skip"; \
 	if [ $$fail -ne 0 ] || [ $$err -ne 0 ]; then exit 1; fi
+
+# ---- Optcarrot integration test ----
+#
+# End-to-end pipeline: clone optcarrot's `experiment/spinel` branch,
+# pack `lib/optcarrot/*.rb` into a single Ruby file via the upstream
+# `tools/pack-for-spinel.rb`, compile through spinel, run the
+# resulting binary against `examples/Lan_Master.nes`, and verify the
+# output contains `fps: <num>` and `checksum: 59662` (the canonical
+# 180-frame checksum for `--benchmark`).
+
+OPTCARROT_DIR  := build/optcarrot
+OPTCARROT_REPO := https://github.com/mame/optcarrot.git
+OPTCARROT_BRANCH := experiment/spinel
+
+optcarrot: spinel_parse$(EXE) $(SP_RT_LIB) spinel_codegen$(EXE)
+	@if [ ! -d $(OPTCARROT_DIR) ]; then \
+	  git clone --depth=1 --branch=$(OPTCARROT_BRANCH) $(OPTCARROT_REPO) $(OPTCARROT_DIR); \
+	fi
+	@ruby $(OPTCARROT_DIR)/tools/pack-for-spinel.rb > build/optcarrot-single.rb
+	@./spinel build/optcarrot-single.rb -o build/optcarrot-single
+	@out=$$($(TIMEOUT60) ./build/optcarrot-single 2>&1); \
+	echo "$$out"; \
+	if echo "$$out" | grep -qE "^fps: [0-9.]+$$" && echo "$$out" | grep -q "^checksum: 59662$$"; then \
+	  echo "Optcarrot: OK"; \
+	else \
+	  echo "Optcarrot: FAIL — expected 'fps: <num>' and 'checksum: 59662'"; \
+	  exit 1; \
+	fi
 
 # ---- Install ----
 

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -17819,6 +17819,14 @@ class Compiler
 
   # ---- Forward declarations ----
   def emit_forward_decls
+    # ARGV (sp_argv) is referenced from any function that uses
+    # `ARGV.length` / `ARGV[i]`, so the declaration has to precede
+    # all function bodies — not just main()'s.  emit_main keeps the
+    # runtime initialization (`sp_argv.len = argc - 1; ...`) where
+    # main() can fill it in from `argc` / `argv`.
+    emit_raw("typedef struct{const char**data;mrb_int len;}sp_Argv;")
+    emit_raw("static sp_Argv sp_argv;")
+    emit_raw("")
     # Emit block helper functions accumulated during collection
     if @block_funcs != ""
       emit_raw(@block_funcs)
@@ -20806,9 +20814,6 @@ class Compiler
 
   def emit_main
     stmts = get_body_stmts(@root_id)
-    emit_raw("typedef struct{const char**data;mrb_int len;}sp_Argv;")
-    emit_raw("static sp_Argv sp_argv;")
-    emit_raw("")
     emit_raw("int main(int argc,char**argv){")
     emit_raw("  sp_argv.len=argc-1;sp_argv.data=(const char**)malloc(sizeof(const char*)*(argc>1?argc-1:1));{int _i;for(_i=0;_i<sp_argv.len;_i++)sp_argv.data[_i]=sp_str_dup_external(argv[_i+1]);}")
     if @needs_rand == 1


### PR DESCRIPTION
## Summary

Adds `make optcarrot` — an integration test that clones the
de-facto Ruby benchmark optcarrot, packs it into a single Ruby
file, compiles through spinel, and verifies the resulting binary
produces `fps: <num>` and `checksum: 59662` against
`examples/Lan_Master.nes`.

Two commits:

1. **`fix(codegen): emit sp_Argv typedef before function bodies`** —
   pack-for-spinel's bootstrap wraps the entry-point in a top-level
   `def main` so the `argv` local doesn't end up as a
   setjmp-`volatile` in C `main()`.  That moves `ARGV.length` /
   `ARGV[i]` into a user-defined function emitted earlier in the C
   source than the `typedef ... sp_Argv;` / `static sp_Argv sp_argv;`
   declarations, breaking compilation with `'sp_argv' undeclared`.
   Hoist the two declarations into `emit_forward_decls` so they
   precede every function body; the runtime initialization
   (`sp_argv.len = argc - 1; ...`) stays in `emit_main`.

2. **`chore(test): add optcarrot integration target`** — the
   `make optcarrot` recipe itself.  Clone is cached in
   `build/optcarrot/`.

## Manual run

Equivalent of `make optcarrot`, step by step:

~~~
$ git clone -b experiment/spinel https://github.com/mame/optcarrot.git
$ ruby optcarrot/tools/pack-for-spinel.rb > optcarrot-single.rb
$ ./spinel optcarrot-single.rb
$ ./optcarrot-single
fps: 1037.53
checksum: 59662
~~~

## Test plan

- [x] `make bootstrap` — `gen2 == gen3 (bootstrap OK)`
- [x] `make test` — 326 pass / 0 fail / 0 error
- [x] `make optcarrot` from a fresh clone — emits the snippet
      above plus `Optcarrot: OK`

## Notes

CI isn't wired to call `make optcarrot` in this PR — it's a
network-dependent step (~50 MB clone) and worth a separate
follow-up if desired.