### PR TITLE
fix: mark sp_argv strings during GC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,6 +277,8 @@ build/test-results/%.ok: test/%.rb $(SP_RT_LIB) $(CODEGEN_STAMP) $(PARSE_STAMP) 
 	bin=$$tmpdir/test_bin$(EXE); \
 	exp=$$tmpdir/expected; \
 	act=$$tmpdir/actual; \
+	args=""; \
+	if [ -f "$<.args" ]; then args=$$(cat "$<.args"); fi; \
 	rm -f "$@.diff"; \
 	./spinel_parse$(EXE) "$<" "$$ast" 2>/dev/null && \
 	./spinel_codegen$(EXE) "$$ast" "$$cfile" 2>/dev/null && \
@@ -286,14 +288,14 @@ build/test-results/%.ok: test/%.rb $(SP_RT_LIB) $(CODEGEN_STAMP) $(PARSE_STAMP) 
 	  if [ -f "$<.expected" ]; then \
 	    LC_ALL=C sed 's/\r$$//' "$<.expected" >"$$exp.n"; \
 	  else \
-	    $(TIMEOUT10) $(REF_RUBY) "$<" >"$$exp" 2>/dev/null; \
+	    $(TIMEOUT10) $(REF_RUBY) "$<" $$args >"$$exp" 2>/dev/null; \
 	    ruby_rc=$$?; \
 	    if [ $$ruby_rc -ne 0 ] && [ "$(REF_RUBY)" != "ruby" ]; then \
-	      $(TIMEOUT10) ruby "$<" >"$$exp" 2>/dev/null; \
+	      $(TIMEOUT10) ruby "$<" $$args >"$$exp" 2>/dev/null; \
 	    fi; \
 	    LC_ALL=C sed 's/\r$$//' "$$exp" >"$$exp.n"; \
 	  fi; \
-	  $(TIMEOUT10) "$$bin" >"$$act" 2>/dev/null; \
+	  $(TIMEOUT10) "$$bin" $$args >"$$act" 2>/dev/null; \
 	  LC_ALL=C sed 's/\r$$//' "$$act" >"$$act.n"; \
 	  if cmp -s "$$exp.n" "$$act.n"; then \
 	    echo PASS > "$@"; \

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -648,6 +648,17 @@ static const char *sp_re_match_str = NULL;
 static const char *sp_re_match_pre = NULL;
 static const char *sp_re_match_post = NULL;
 
+/* ARGV runtime: argv[i] strings are dup'd via sp_str_dup_external on
+   main() entry, which allocates from the str-heap with mark byte
+   0xfe. Without explicit marking they get reaped on the first
+   sp_str_sweep, leaving sp_argv.data[i] as a dangling pointer that
+   later `ARGV[i]` reads dereference. The exact length boundary
+   triggering the segfault depends on malloc's reuse pattern (so the
+   bug surfaces non-deterministically by string length), but the
+   underlying issue is unconditional. */
+typedef struct{const char**data;mrb_int len;}sp_Argv;
+static sp_Argv sp_argv;
+
 /* Mark the regex globals as live during GC. Each holds a pointer to a
    string allocated via sp_str_alloc_raw on the str-heap; without this
    sp_str_sweep would reap them on the next collect, leaving dangling
@@ -660,6 +671,7 @@ static void sp_re_mark_globals(void) {
   sp_mark_string(sp_re_match_str);
   sp_mark_string(sp_re_match_pre);
   sp_mark_string(sp_re_match_post);
+  for (mrb_int i = 0; i < sp_argv.len; i++) sp_mark_string(sp_argv.data[i]);
 }
 
 static void sp_re_set_captures(const char *str, int *caps, int ncaps) {

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -17979,14 +17979,10 @@ class Compiler
 
   # ---- Forward declarations ----
   def emit_forward_decls
-    # ARGV (sp_argv) is referenced from any function that uses
-    # `ARGV.length` / `ARGV[i]`, so the declaration has to precede
-    # all function bodies — not just main()'s.  emit_main keeps the
-    # runtime initialization (`sp_argv.len = argc - 1; ...`) where
-    # main() can fill it in from `argc` / `argv`.
-    emit_raw("typedef struct{const char**data;mrb_int len;}sp_Argv;")
-    emit_raw("static sp_Argv sp_argv;")
-    emit_raw("")
+    # ARGV (sp_argv) is declared in lib/sp_runtime.h so the runtime's
+    # sp_re_mark_globals can mark its strings during GC; emit_main
+    # fills in `sp_argv.len = argc - 1; sp_argv.data = ...` from main().
+
     # Emit block helper functions accumulated during collection
     if @block_funcs != ""
       emit_raw(@block_funcs)

--- a/test/argv_gc.rb
+++ b/test/argv_gc.rb
@@ -1,0 +1,45 @@
+# sp_argv stores `const char *` pointers into the str-heap (via
+# sp_str_dup_external on main entry). Without explicit GC marking,
+# sp_str_sweep reaps them on the first collect, leaving sp_argv.data
+# entries as dangling pointers that any later `ARGV[i]` read
+# dereferences.
+#
+# Triggering the bug requires:
+#  - Reading ARGV[i] (just the read, not even a method call).
+#  - GC pressure that actually fires sp_gc_collect — string allocs
+#    don't accrue to sp_gc_bytes per sp_str_alloc's threshold note,
+#    so we need object allocations to push past 256 KB.
+#  - Reading ARGV[i] again after GC; the dangling pointer either
+#    segfaults outright or yields freed memory.
+#
+# The fix marks sp_argv.data[*] alongside the regex globals in
+# sp_re_mark_globals, so sp_str_sweep keeps argv strings alive.
+# argv_gc.rb.args feeds five short args so the harness exercises a
+# non-empty ARGV (short strings hit the segfault path under the bug).
+
+class Trash
+  def initialize(n)
+    @n = n
+    @s = "padding payload " * 64    # ~1 KB heap string per Trash
+  end
+  attr_reader :n
+end
+
+# Allocate ~5000 Trash instances (~5 MB) — far past the 256 KB GC
+# threshold — to force sp_gc_collect / sp_str_sweep cycles.
+junk = []
+j = 0
+while j < 5000
+  junk << Trash.new(j)
+  j = j + 1
+end
+puts junk.length     # 5000
+
+# Read ARGV[i] after GC. With the bug, sp_argv.data[i] points to
+# freed memory; reading it (and its length) crashes or returns
+# garbage.
+i = 0
+while i < ARGV.length
+  puts ARGV[i] + ":" + ARGV[i].length.to_s
+  i = i + 1
+end

--- a/test/argv_gc.rb.args
+++ b/test/argv_gc.rb.args
@@ -1,0 +1,1 @@
+first second third fourth fifth

--- a/test/argv_gc.rb.expected
+++ b/test/argv_gc.rb.expected
@@ -1,0 +1,6 @@
+5000
+first:5
+second:6
+third:5
+fourth:6
+fifth:5


### PR DESCRIPTION
## Reproduction

`test/argv_gc.rb` (committed alongside the fix), invoked through the
new `.args` test-harness extension that lets a per-test
`<test>.rb.args` file feed argv:

~~~ruby
class Trash
  def initialize(n)
    @n = n
    @s = "padding payload " * 64    # ~1 KB heap string per Trash
  end
  attr_reader :n
end

# Allocate ~5000 Trash instances (~5 MB) — far past the 256 KB GC
# threshold — to force sp_gc_collect / sp_str_sweep cycles.
junk = []
j = 0
while j < 5000
  junk << Trash.new(j)
  j = j + 1
end
puts junk.length     # 5000

# Read ARGV[i] after GC. With the bug, sp_argv.data[i] points to
# freed memory; reading it (and its length) crashes or returns
# garbage.
i = 0
while i < ARGV.length
  puts ARGV[i] + ":" + ARGV[i].length.to_s
  i = i + 1
end
~~~

`test/argv_gc.rb.args`:

~~~
first second third fourth fifth
~~~

## Expected behavior

~~~
$ ruby test/argv_gc.rb first second third fourth fifth
5000
first:5
second:6
third:5
fourth:6
fifth:5
~~~

## Actual behavior on master

The compiled binary segfaults during the post-GC ARGV read, or
prints garbage where the original argv strings used to live:

~~~
$ ./argv_gc first second third fourth fifth
5000
Segmentation fault (core dumped)
~~~

The exact cutoff depends on string length and malloc's reuse
pattern, so the bug surfaces non-deterministically — short ARGV
elements (≤ 6 chars) and long ones (≥ 23 chars) tend to crash
sooner than 7–22-char strings, but all of them are equally
unrooted.

## Root cause

`sp_argv.data[i]` points at strings allocated by `sp_str_dup_external` on
main() entry:

~~~c
int main(int argc, char**argv) {
  sp_argv.len = argc - 1;
  sp_argv.data = (const char**)malloc(...);
  for (int _i = 0; _i < sp_argv.len; _i++)
    sp_argv.data[_i] = sp_str_dup_external(argv[_i + 1]);
}
~~~

`sp_str_dup_external` allocates from the str-heap with mark byte
`0xfe` ("alive but unmarked at start of sweep"). `sp_str_sweep`
then frees anything that isn't `0xfc` (marked). Strings get
flipped to `0xfc` by `sp_mark_string`, which is called for every
GC root, but `sp_argv` is not in `sp_gc_roots` and is not visited
by `sp_re_mark_globals` either — so the first sp_gc_collect after
main starts reaps every argv string and `sp_argv.data[i]` becomes
a dangling pointer.

## Fix

Move the `sp_Argv` typedef and `sp_argv` definition from
`emit_forward_decls` into `sp_runtime.h`, then walk `sp_argv.data`
inside `sp_re_mark_globals` so sweep keeps each entry. The shape
mirrors how the regex `$1..$9 / $& / $` / $'` globals a few lines
above are kept alive across collects.

~~~diff
+/* ARGV runtime: argv[i] strings are dup'd via sp_str_dup_external on
+   main() entry, which allocates from the str-heap with mark byte
+   0xfe. Without explicit marking they get reaped on the first
+   sp_str_sweep, leaving sp_argv.data[i] as a dangling pointer that
+   later `ARGV[i]` reads dereference. The exact length boundary
+   triggering the segfault depends on malloc's reuse pattern (so the
+   bug surfaces non-deterministically by string length), but the
+   underlying issue is unconditional. */
+typedef struct{const char**data;mrb_int len;}sp_Argv;
+static sp_Argv sp_argv;
+
 static void sp_re_mark_globals(void) {
   sp_mark_string(sp_re_last_str);
   for (int i = 0; i < 10; i++) sp_mark_string(sp_re_captures[i]);
   sp_mark_string(sp_re_match_str);
   sp_mark_string(sp_re_match_pre);
   sp_mark_string(sp_re_match_post);
+  for (mrb_int i = 0; i < sp_argv.len; i++) sp_mark_string(sp_argv.data[i]);
 }
~~~

Codegen drops the corresponding `static sp_Argv sp_argv;` from
`emit_forward_decls` so the runtime header owns the declaration.

The Makefile change adds `<test>.rb.args` support to the `make
test` rule — without it the harness invokes the binary with no
arguments, which leaves `sp_argv.len = 0` and never exercises the
str-heap entries the fix protects.

## Diff stat

~~~
 Makefile                 |  8 +++++---
 lib/sp_runtime.h         | 12 ++++++++++++
 spinel_codegen.rb        | 12 ++++--------
 test/argv_gc.rb          | 45 +++++++++++++++++++++++++++++++++++++++++++++
 test/argv_gc.rb.args     |  1 +
 test/argv_gc.rb.expected |  6 ++++++
 6 files changed, 73 insertions(+), 11 deletions(-)
~~~

## Test plan

- [x] `make bootstrap` green (gen2.c == gen3.c).
- [x] `make retest` 336 pass / 0 fail (335 pre-existing + 1 new
      `argv_gc` test).