### PR TITLE
Two small codegen additions: ENV.fetch(k,d) + module-scope @@cvars

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -4802,6 +4802,9 @@ class Compiler
           if mname == "[]"
             return "string"
           end
+          if mname == "fetch"
+            return "string"
+          end
         end
         if rcname == "Dir"
           if mname == "home"
@@ -27915,6 +27918,29 @@ class Compiler
       if rcname == "ENV"
         if mname == "[]"
           return "sp_str_dup_external(getenv(" + compile_arg0(nid) + "))"
+        end
+        if mname == "fetch"
+          # Two-arg form: ENV.fetch(key, default). If the env var is
+          # set, return its value; otherwise return the supplied
+          # default. The single-arg form (`ENV.fetch("X")`) raises
+          # KeyError in CRuby; spinel doesn't model that, so it
+          # behaves like ENV[] -- callers wanting strict behaviour
+          # should pass an explicit default.
+          args_id = @nd_arguments[nid]
+          if args_id >= 0
+            argz = get_args(args_id)
+            if argz.length >= 2
+              key = compile_expr(argz[0])
+              dfl = compile_expr_as_string(argz[1])
+              tmp = new_temp
+              return "({ const char *" + tmp + " = getenv(" + key + "); " +
+                     tmp + " ? sp_str_dup_external(" + tmp + ") : (" + dfl + "); })"
+            end
+            if argz.length == 1
+              return "sp_str_dup_external(getenv(" + compile_arg0(nid) + "))"
+            end
+          end
+          return "(&(\"\\xff\")[1])"
         end
       end
       # Dir

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2539,6 +2539,16 @@ class Compiler
       end
       return "int"
     end
+    if t == "ClassVariableWriteNode"
+      # `@@x = expr` as an expression returns the assigned value, so
+      # the static type is the rhs's type. Without this case the
+      # caller's `infer_type` falls through to the default (int) and
+      # surrounding code -- e.g. a method whose body's last
+      # expression is `@@x = v` -- gets `mrb_int` as the inferred
+      # return, producing a const char* / mrb_int mismatch when v
+      # is a string.
+      return infer_type(@nd_expression[nid])
+    end
     if t == "ConstantReadNode"
       if @nd_name[nid] == "ARGV"
         return "argv"
@@ -7031,29 +7041,23 @@ class Compiler
     collect_class_with_prefix(nid, "")
   end
 
-  # Walk every class body for class-var writes; register each
-  # (class, name) pair so the static-declaration pass can emit
-  # `static <type> cvar_<qname> = <default>;` ahead of the
-  # functions that touch it.
+  # Walk class bodies, module bodies, and the top-level statement
+  # list for class-var writes; register each (class-or-Toplevel,
+  # name) pair so the static-declaration pass can emit
+  # `static <type> cvar_<qname> = <default>;` ahead of the functions
+  # that touch it.
+  #
+  # Module-scope and top-level `@@x = ...` writes belong to the
+  # `Toplevel` namespace -- spinel models cvars per-class, modules
+  # don't have a cls_id of their own, and tying them to "Toplevel"
+  # matches what the read/write codegen already emits when
+  # `@current_class_idx == -1`.
   def collect_cvars
     root = @root_id
     if @nd_type[root] != "ProgramNode"
       return
     end
-    stmts = get_body_stmts(root)
-    stmts.each { |sid|
-      if @nd_type[sid] == "ClassNode"
-        cp = @nd_constant_path[sid]
-        if cp >= 0
-          cname = const_ref_flat_name(cp)
-          ci = find_class_idx(cname)
-          if ci >= 0
-            body_id = @nd_body[sid]
-            collect_cvars_in(body_id, ci)
-          end
-        end
-      end
-    }
+    collect_cvars_in(root, -1)
   end
 
   # Recursively scan `nid`'s subtree for ClassVariable*WriteNode and
@@ -7062,11 +7066,41 @@ class Compiler
   # registered when their parent ClassVariableWriteNode is seen, OR
   # lazily during compile_stmt if no plain Write precedes them in
   # the same class.
+  #
+  # When the walk crosses into a nested ClassNode or ModuleNode the
+  # context flips: nested ClassNode switches to that class's
+  # @cls_names index, ModuleNode keeps the Toplevel namespace.
   def collect_cvars_in(nid, class_idx)
     if nid < 0
       return
     end
     t = @nd_type[nid]
+    if t == "ClassNode"
+      cp = @nd_constant_path[nid]
+      if cp >= 0
+        cname = const_ref_flat_name(cp)
+        ci = find_class_idx(cname)
+        if ci >= 0
+          collect_cvars_in(@nd_body[nid], ci)
+        end
+      end
+      return
+    end
+    if t == "ModuleNode"
+      collect_cvars_in(@nd_body[nid], -1)
+      return
+    end
+    if t == "DefNode"
+      # Method bodies aren't walked at collect-time. A `@@x = v`
+      # inside a method writes during the call, but `v`'s type isn't
+      # yet resolved (LocalVariableReadNode falls back to "int" when
+      # the var-type table hasn't been populated), which would
+      # spuriously widen a class-body literal's `string`/`float`
+      # initialization to poly. The method-body write is registered
+      # defensively at compile_stmt time anyway, when v's call-site-
+      # resolved type is known.
+      return
+    end
     if t == "ClassVariableWriteNode"
       qname = cvar_qname(class_idx, @nd_name[nid])
       val_t = infer_type(@nd_expression[nid])

--- a/test/env_fetch.rb
+++ b/test/env_fetch.rb
@@ -1,0 +1,17 @@
+# Regression: `ENV.fetch(key, default)` returns the env value when
+# set, otherwise `default`. Pre-fix the codegen emitted "cannot
+# resolve call to 'fetch' on int" and segfaulted at runtime.
+#
+# This test exercises the unset / default-fallback branch, since
+# spinel doesn't currently expose `ENV[]=` for setting a var from
+# Ruby. The set branch shares the same getenv() path.
+
+# Literal default.
+puts ENV.fetch("DEFINITELY_UNSET_VAR_XYZ_42", "fallback-value")
+
+# Default expression need not be a literal.
+default = "computed-default"
+puts ENV.fetch("ANOTHER_UNSET_VAR_XYZ_42", default)
+
+# Default by string concatenation.
+puts ENV.fetch("THIRD_UNSET_VAR_XYZ_42", "pre-" + "fix")

--- a/test/env_fetch.rb
+++ b/test/env_fetch.rb
@@ -1,10 +1,8 @@
 # Regression: `ENV.fetch(key, default)` returns the env value when
 # set, otherwise `default`. Pre-fix the codegen emitted "cannot
 # resolve call to 'fetch' on int" and segfaulted at runtime.
-#
-# This test exercises the unset / default-fallback branch, since
-# spinel doesn't currently expose `ENV[]=` for setting a var from
-# Ruby. The set branch shares the same getenv() path.
+
+# ---- unset / default branch ----
 
 # Literal default.
 puts ENV.fetch("DEFINITELY_UNSET_VAR_XYZ_42", "fallback-value")
@@ -15,3 +13,24 @@ puts ENV.fetch("ANOTHER_UNSET_VAR_XYZ_42", default)
 
 # Default by string concatenation.
 puts ENV.fetch("THIRD_UNSET_VAR_XYZ_42", "pre-" + "fix")
+
+# ---- set / retrieval branch ----
+# Spinel doesn't currently expose `ENV[]=` from Ruby, so we can't
+# set a var ourselves. HOME is always exported by POSIX `make` and
+# in CI, so we use that as the "set" probe. We only assert "non-
+# empty + not the fallback string" so the test stays portable
+# across runners (the actual home value differs per machine).
+# A regression that inverted the getenv-result ternary would
+# return the fallback here and print "set=fallback-not-used".
+home = ENV.fetch("HOME", "fallback-not-used")
+if home.length > 0 && home != "fallback-not-used"
+  puts "set=ok"
+else
+  puts "set=" + home
+end
+
+# Symmetric: an unset var with a literal default round-trips
+# through the same ternary. (Would catch a regression that always
+# returned the env value -- empty string -- regardless.)
+maybe = ENV.fetch("DEFINITELY_UNSET_VAR_ABC_99", "fallback-used")
+puts "unset=" + maybe

--- a/test/env_fetch.rb.expected
+++ b/test/env_fetch.rb.expected
@@ -1,3 +1,5 @@
 fallback-value
 computed-default
 pre-fix
+set=ok
+unset=fallback-used

--- a/test/env_fetch.rb.expected
+++ b/test/env_fetch.rb.expected
@@ -1,0 +1,3 @@
+fallback-value
+computed-default
+pre-fix

--- a/test/module_cvars.rb
+++ b/test/module_cvars.rb
@@ -1,0 +1,32 @@
+# Regression: class variables (`@@var`) declared at module scope or
+# top-level scope generate references to a `cvar_Toplevel_X` C
+# global, but the declaration walker (`collect_cvars`) used to only
+# descend into ClassNode bodies. The result: `cvar_Toplevel_X` was
+# referenced but never declared, breaking the C compile.
+
+module Tep
+  @@session_secret = ""
+
+  def self.session_secret
+    @@session_secret
+  end
+
+  def self.session_secret=(v)
+    @@session_secret = v
+  end
+end
+
+# Read default
+puts Tep.session_secret.length    # 0
+
+# Write + read back
+Tep.session_secret = "hello"
+puts Tep.session_secret           # hello
+
+# Read again to confirm the global persists
+puts Tep.session_secret           # hello
+
+# Bare top-level `@@x` (legal in Ruby though unusual) -- same
+# Toplevel namespace, just no enclosing module/class.
+@@plain = 42
+puts @@plain                      # 42

--- a/test/module_cvars.rb.expected
+++ b/test/module_cvars.rb.expected
@@ -1,0 +1,4 @@
+0
+hello
+hello
+42


### PR DESCRIPTION
## Two small additions found while building tep on master

Both surfaced while iterating on a Sinatra clone. Neither is a hard
miscompile in spinel itself — they're holes in the supported Ruby
surface that user code reasonably reaches for.

### 1. `ENV.fetch(key, default)`

`ENV[k]` works today; `ENV.fetch(k, dflt)` doesn't — the codegen
emits `cannot resolve call to 'fetch' on int (emitting 0)` and the
program segfaults at runtime when the result is touched.

CRuby semantics for the two-arg form:

```ruby
ENV.fetch("HOME", "/tmp")          # => "/usr/me"   (or "/tmp" if unset)
```

Patch adds the type-inference and codegen arms:

```ruby
ENV.fetch(key, default)
# expands to:
({ const char *_t = getenv(key); _t ? sp_str_dup_external(_t) : (default); })
```

The block form (`ENV.fetch("X") { computed }`) is not handled —
keeps the patch small. KeyError-on-missing for the single-arg form
isn't modeled either; that already gracefully returns the
`getenv()` result (NULL → empty string), matching `ENV[]`.

Repro: `test/env_fetch.rb` (reads three configurations: missing
with literal default, set with explicit value, missing with
non-literal default).

### 2. Module-scope `@@cvars`

`@@var = ...` works inside `class Foo; ...; end`. Inside a module
body, or at top level, the codegen emits references to
`cvar_Toplevel_X` but the `collect_cvars` walker only descended
into `ClassNode` subtrees, so the corresponding `static <type>
cvar_Toplevel_X = ...;` declaration was never written and the C
compile failed with `use of undeclared identifier`.

```ruby
module Tep
  @@session_secret = ""           # collected? -> no, before fix
  def self.session_secret;     @@session_secret;     end
  def self.session_secret=(v); @@session_secret = v; end
end
```

Patch flips `collect_cvars` to start from the program root with
`class_idx = -1` (the Toplevel namespace) and lets `collect_cvars_in`
re-enter the class/module distinction itself: nested `ClassNode`
switches the namespace to the class's index, `ModuleNode` keeps
Toplevel, everything else recurses. Module-scope, top-level, and
class-body cvars all flow through the same registration path now.

Repro: `test/module_cvars.rb` (covers module-scope `@@var`,
read+write through `def self.x` accessors, and a bare top-level
`@@plain` for completeness).

### Why these came up

Building `tep` (a Sinatra clone targeting spinel-AOT) hits both
patterns naturally:

  - `Tep.session_secret = ENV.fetch("TEP_SESSION_SECRET")` is the
    canonical app-startup line.
  - `module Tep; @@session_secret = ""; ...` is the most idiomatic
    place to keep that secret.

We had workarounds (an instance var on a singleton, plus
`ENV[k] || default`), but figured shipping the spinel-side fixes
was cheaper than maintaining workarounds long-term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)