### PR TITLE
fix(runtime): support FreeBSD - compilation fixes for FreeBSD

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -40,7 +40,7 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #endif
-#if !defined(__APPLE__) && !defined(_WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32) && !defined(__FreeBSD__)
 #include <malloc.h>
 #else
 /* Darwin's libc has no malloc_trim; make it a no-op so call sites stay portable. */
@@ -620,6 +620,14 @@ static const char*sp_IntArrayPtrArray_inspect(sp_PtrArray*a){sp_String*s=sp_Stri
 static const char*sp_FloatArrayPtrArray_inspect(sp_PtrArray*a){sp_String*s=sp_String_new("[");for(mrb_int i=0;i<a->len;i++){if(i>0)sp_String_append(s,", ");sp_String_append(s,sp_FloatArray_inspect((sp_FloatArray*)a->data[i]));}sp_String_append(s,"]");return s->data;}
 static const char*sp_StrArrayPtrArray_inspect(sp_PtrArray*a){sp_String*s=sp_String_new("[");for(mrb_int i=0;i<a->len;i++){if(i>0)sp_String_append(s,", ");sp_String_append(s,sp_StrArray_inspect((sp_StrArray*)a->data[i]));}sp_String_append(s,"]");return s->data;}
 static const char*sp_SymArrayPtrArray_inspect(sp_PtrArray*a){sp_String*s=sp_String_new("[");for(mrb_int i=0;i<a->len;i++){if(i>0)sp_String_append(s,", ");sp_String_append(s,sp_SymArray_inspect((sp_IntArray*)a->data[i]));}sp_String_append(s,"]");return s->data;}
+
+#ifdef __FreeBSD__
+
+#define re_exec spinel_re_exec
+
+#define MAP_NORESERVE 0
+
+#endif
 
 /* Regexp engine (link with libspre.a from lib/regexp/) */
 typedef struct mrb_regexp_pattern mrb_regexp_pattern;


### PR DESCRIPTION
fixes the following compilation errors that occurred when attempting to compile on FreeBSD:

```
cc -O3 -flto=auto -Wno-all -Ilib build/gen1.c  -lm -o spinel_codegen
In file included from build/gen1.c:2:
lib/sp_runtime.h:628:5: error: conflicting types for 're_exec'
```

```
cc -O3 -flto=auto -Wno-all -Ilib build/gen1.c  -lm -o spinel_codegen
In file included from build/gen1.c:2:
lib/sp_runtime.h:1298:178: error: use of undeclared identifier 'MAP_NORESERVE'
 1298 | static void *sp_lam_alloc(size_t sz) { sz = (sz + 7) & ~(size_t)7; if (!sp_arena) { sp_arena = (char *)mmap(NULL, SP_ARENA_SIZE, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_NORESERVE, -1, 0); if (sp_arena == MAP_FAILED) { perror("mmap"); exit(1); } sp_arena_pos = 0; } if (sp_arena_pos + sz > SP_ARENA_SIZE) { fprintf(stderr, "arena exhausted\n"); exit(1); } void *p = sp_arena + sp_arena_pos; sp_arena_pos += sz; return p; }
```

```
 $ cc -O3 -flto=auto -Wno-all -Ilib build/gen1.c  -lm
-o spinel_codegen
ld: error: undefined symbol: malloc_trim
>>> referenced by ld-temp.o
>>>               spinel_codegen.lto.o:(sp_gc_alloc)
cc: error: linker command failed with exit code 1 (use -v to see invocation)
```

Tested on:

```
$ uname -a
FreeBSD quincy 14.3-RELEASE-p8 FreeBSD 14.3-RELEASE-p8 releng/14.3-n271467-2e63e671a93c GENERIC amd64
```