### PR TITLE
perf(analyze): stop class body call inference after convergence

### DIFF
--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -14230,6 +14230,12 @@ class Compiler
     # Update called method param types from argument types at call sites.
     # Run multiple passes for propagation.
     pass = 0
+    # Stop this local propagation loop once the class-body call type tables
+    # stop changing; later passes would rescan the same bodies without
+    # teaching any callee a new argument type. Keep the previous pass's
+    # signature instead of recomputing it at the top of every pass, because
+    # the prior `cur_sig` is exactly the next pass's `prev_sig`.
+    prev_sig = class_body_call_type_signature
     while pass < 5
       ci = 0
       while ci < @cls_names.length
@@ -14342,6 +14348,11 @@ class Compiler
         @current_method_name = saved_meth_cb
         ci = ci + 1
       end
+      cur_sig = class_body_call_type_signature
+      if cur_sig == prev_sig
+        break
+      end
+      prev_sig = cur_sig
       pass = pass + 1
     end
   end
@@ -14503,6 +14514,15 @@ class Compiler
   # fixed point has been reached and further iterations are wasted work.
   def inference_signature
     @meth_return_types.join("|") + "/" + @cls_ivar_types.join("|") + "/" + @meth_param_types.join("|") + "/" + @cls_meth_ptypes.join("/")
+  end
+
+  # `inference_signature` covers the wider analyze-phase fixpoint, including
+  # return and ivar types that `infer_class_body_call_types` does not refine
+  # directly. This narrower fingerprint tracks only the param-type tables that
+  # can affect the next class-body call pass, so an unrelated wider signature
+  # change does not force this local loop to spend all five passes.
+  def class_body_call_type_signature
+    @meth_param_types.join("|") + "/" + @cls_meth_ptypes.join("/") + "/" + @cls_cmeth_ptypes.join("/")
   end
 
 


### PR DESCRIPTION
## Summary

`infer_class_body_call_types` currently runs a fixed 5 passes every time it is called. This adds a local convergence check so the loop stops once the class-body call param-type tables stop changing.

The max pass count remains 5, so cases that still need deeper propagation keep the same exploration limit.

## Details

The new `class_body_call_type_signature` intentionally stays separate from `inference_signature`.

`inference_signature` is for the wider analyze-phase fixpoint and includes return types and ivar types. Those can change elsewhere in analysis, but they are not the local state this loop directly refines. For this loop, only these tables determine whether another class-body call pass can teach callees new argument types:

- `@meth_param_types`
- `@cls_meth_ptypes`
- `@cls_cmeth_ptypes`

If that narrower signature is unchanged after a pass, the remaining passes would rescan the same bodies without changing call-derived param types.

## Correctness

Compared this branch against `origin/master` at:

```text
0f66aaf ci: run `make optcarrot` on the ubuntu-latest gcc job
```

using the same input ASTs:

| input | result |
|---|---|
| `spinel_codegen.rb` -> IR | identical |
| `spinel_analyze.rb` -> IR | identical |

## Verification

```sh
ruby -c spinel_analyze.rb
make codegen
make test
```

`make test` result:

```text
Tests: 364 pass, 0 fail, 0 error
```

## Performance

Single-run `GC.stat` measurement was taken before the final CI-only rebase, comparing:

```text
base: c225458 fix(runtime): portable Time#iso8601 offset (#414 CI follow-up)
head: 4a66df4 perf(analyze): stop class body call inference after convergence
```

The current PR head is:

```text
e8994ef perf(analyze): stop class body call inference after convergence
```

The later rebase to `0f66aaf` only added CI workflow changes, so the analyzer source used for the measured base is unchanged and the PR patch is the same analyzer change.

| input | before | after |
|---|---:|---:|
| `spinel_codegen.rb` analyze time | 68.884s | 47.071s |
| `spinel_codegen.rb` allocated objects | 748,181,293 | 530,329,214 |
| `spinel_codegen.rb` minor GC | 555 | 364 |
| `spinel_analyze.rb` analyze time | 31.447s | 22.180s |
| `spinel_analyze.rb` allocated objects | 360,072,905 | 256,963,378 |
| `spinel_analyze.rb` minor GC | 372 | 215 |
