### PR TITLE
fix(spinel): avoid BSD mktemp tail-template collision on macOS

### DIFF
--- a/spinel
+++ b/spinel
@@ -148,7 +148,12 @@ fi
 if [ $C_ONLY -eq 1 ]; then
   C_FILE="${OUTPUT:-$BASENAME.c}"
 else
-  C_TMP="$(mktemp /tmp/spinel_out.XXXXXX.c)"
+  # BSD mktemp only substitutes X's at the path tail, so a suffix
+  # after XXXXXX collapses to the literal template and collides
+  # across concurrent invocations. Mint a tail-only temp, rename .c.
+  C_TMP_BASE="$(mktemp /tmp/spinel_out.XXXXXX)"
+  C_TMP="${C_TMP_BASE}.c"
+  mv "$C_TMP_BASE" "$C_TMP"
   C_FILE="$C_TMP"
 fi
 


### PR DESCRIPTION
## Summary

- BSD `mktemp` on macOS only substitutes the trailing run of X's in the template, so `mktemp /tmp/spinel_out.XXXXXX.c` collapses to the literal template name instead of producing a unique path.
- Concurrent `spinel foo.rb` invocations race on the same file, truncating each other's emitted C and crashing the codegen pipeline.
- Mint a tail-only temp then rename with the `.c` suffix the compiler needs.

## Test plan

- [x] `make test` — 416/416 pass.
- [x] Manual: two concurrent `./spinel test/X.rb` invocations no longer share a tempfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)