### PR TITLE
fix(codegen): resolve qualified-constant arg in is_a?/kind_of?/instance_of?

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -17126,9 +17126,29 @@ class Compiler
     ""
   end
 
+  def is_static_const_ref(aid)
+    if @nd_type[aid] == "ConstantReadNode" || @nd_type[aid] == "ConstantPathNode"
+      return 1
+    end
+    0
+  end
+
+ # Resolve an is_a?/kind_of?/instance_of? argument to its registered
+ # class name. ConstantPathNode (`Foo::Bar`) walks the path via
+ # resolve_const_ref_name; ConstantReadNode (`Foo`) carries the leaf
+ # in @nd_name. Other shapes fall back to @nd_name so static lookup
+ # still has a name to try.
+  def resolve_introspection_arg_name(aid)
+    if @nd_type[aid] == "ConstantPathNode"
+      return resolve_const_ref_name(aid)
+    end
+    @nd_name[aid]
+  end
+
   def compile_introspection_expr(nid, mname, rc, recv_type)
- # is_a? - check class hierarchy
-    if mname == "is_a?"
+ # is_a? / kind_of? — kind_of? is an exact alias of is_a? in MRI.
+ # Both walk the class hierarchy: cname is or inherits from arg0 → TRUE.
+    if mname == "is_a?" || mname == "kind_of?"
       if is_obj_type(recv_type) == 1
         cname = recv_type[4, recv_type.length - 4]
         arg0 = ""
@@ -17136,12 +17156,12 @@ class Compiler
         if args_id >= 0
           a = get_args(args_id)
           if a.length > 0
- # dynamic Class arg. The
- # statically-typed recv knows its own cls_id; the arg
- # carries the target cls_id at runtime. sp_class_le walks
- # the precomputed ancestors table to decide membership.
+ # Dynamic Class arg (a non-const expression evaluating to a class).
+ # The statically-typed recv knows its own cls_id; the arg carries
+ # the target cls_id at runtime. sp_class_le walks the precomputed
+ # ancestors table to decide membership.
             arg_t = infer_type(a[0])
-            if arg_t == "class" && @nd_type[a[0]] != "ConstantReadNode"
+            if arg_t == "class" && is_static_const_ref(a[0]) == 0
               ci = find_class_idx(cname)
               if ci >= 0
                 @needs_class_table = 1
@@ -17149,11 +17169,33 @@ class Compiler
                 return "sp_class_le((sp_Class){" + cls_id_for_user_internal(ci).to_s + "LL}, " + compile_expr(a[0]) + ")"
               end
             end
-            arg0 = @nd_name[a[0]]
+            arg0 = resolve_introspection_arg_name(a[0])
           end
         end
- # Check if cname is or inherits from arg0
         if is_class_or_ancestor(cname, arg0) == 1
+          return "TRUE"
+        else
+          return "FALSE"
+        end
+      end
+      return "FALSE"
+    end
+
+ # instance_of? — exact class identity, no ancestor walk. A parent
+ # instance is never an exact-subclass match, so descendant resolution
+ # is not relevant here; static comparison suffices.
+    if mname == "instance_of?"
+      if is_obj_type(recv_type) == 1
+        cname = recv_type[4, recv_type.length - 4]
+        arg0 = ""
+        args_id = @nd_arguments[nid]
+        if args_id >= 0
+          a = get_args(args_id)
+          if a.length > 0
+            arg0 = resolve_introspection_arg_name(a[0])
+          end
+        end
+        if cname == arg0
           return "TRUE"
         else
           return "FALSE"

--- a/test/introspection_constant_path.rb
+++ b/test/introspection_constant_path.rb
@@ -1,0 +1,60 @@
+# `is_a?` / `kind_of?` / `instance_of?` with a qualified-constant
+# argument (ConstantPathNode like `Mod::Klass`). The dynamic-arg
+# branch in compile_introspection_expr previously excluded only the
+# bare ConstantReadNode shape; a qualified constant fell through and
+# emitted compile_expr(arg) as a bare C identifier with no declaration,
+# producing "use of undeclared identifier" at C compile time. The
+# is_a? branch also didn't route kind_of? or instance_of? through
+# the same static collapse, so those names silently fell through to
+# warn_unresolved_call. Fix: resolve the constant name via the path
+# walker, and dispatch the whole introspection family uniformly.
+#
+# Coverage:
+# - Same-class match (is_a?/kind_of?/instance_of? all true)
+# - Unrelated-sibling mismatch (all false)
+# - Ancestor case (is_a?/kind_of? true; instance_of? false, exact only)
+# - Deeper constant path (Mod::Sub::Deep — three-level path walk)
+#
+# Out of scope for this PR:
+# - Class-as-local (`k = Mod::Klass; obj.is_a?(k)`) emits the const
+#   name as a bare C identifier — a separate ConstantPathNode-to-local
+#   assignment bug, distinct from the introspection-arg fix here.
+# - Built-in ancestor (`obj.is_a?(Object)`) returns false in spinel
+#   today; spinel's class registry doesn't materialize Object as an
+#   ancestor of user classes. Separate gap.
+
+module Mod
+  class Base
+    def base_name; "base"; end
+  end
+  class Klass < Base
+    def initialize(v); @v = v; end
+    def get; @v; end
+  end
+  class Other
+    def initialize(v); @v = v; end
+  end
+  module Sub
+    class Deep
+      def initialize(v); @v = v; end
+      def get; @v; end
+    end
+  end
+end
+
+k = Mod::Klass.new(7)
+puts k.is_a?(Mod::Klass)
+puts k.kind_of?(Mod::Klass)
+puts k.instance_of?(Mod::Klass)
+puts k.is_a?(Mod::Other)
+puts k.instance_of?(Mod::Other)
+puts k.is_a?(Mod::Base)
+puts k.kind_of?(Mod::Base)
+puts k.instance_of?(Mod::Base)
+puts k.get
+
+d = Mod::Sub::Deep.new(42)
+puts d.is_a?(Mod::Sub::Deep)
+puts d.kind_of?(Mod::Sub::Deep)
+puts d.instance_of?(Mod::Sub::Deep)
+puts d.get

--- a/test/introspection_constant_path.rb.expected
+++ b/test/introspection_constant_path.rb.expected
@@ -1,0 +1,13 @@
+true
+true
+true
+false
+false
+true
+true
+false
+7
+true
+true
+true
+42


### PR DESCRIPTION
## Summary

`obj.is_a?(Mod::Klass)` previously fell through to `compile_expr(arg)` and emitted a bare C identifier (`Mod_Klass`) with no declaration — "use of undeclared identifier" at C compile time. The dynamic-arg guard in `compile_introspection_expr` only excluded the `ConstantReadNode` shape, so any qualified constant (`ConstantPathNode`) fell off the static-resolution path entirely. Compounding it: `compile_introspection_expr` only matched `is_a?` — neither `kind_of?` (alias) nor `instance_of?` (exact-class) were routed through it.

Fix:
- Extract `is_static_const_ref` and `resolve_introspection_arg_name` helpers.
- Widen the `is_a?` branch to also match `kind_of?` (shared ancestor-walk semantics in MRI).
- Add an `instance_of?` branch using exact-class comparison.

## Test plan

- [x] `make test` — 417/417 pass
- [x] `test/introspection_constant_path.rb` covers: same-class match, unrelated-sibling, ancestor case (via `Mod::Klass < Mod::Base`), deeper constant path (`Mod::Sub::Deep`)

## Out of scope (documented in fixture header)

- Class-as-local (`k = Mod::Klass; obj.is_a?(k)`) — separate ConstantPathNode-to-local assignment bug.
- Built-in ancestor (`obj.is_a?(Object)`) — spinel's class registry doesn't materialize `Object` as a user-class ancestor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)