### PR TITLE
fix(codegen): dispatch .call on anonymous proc receiver (incl. chained / ternary)

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -13011,6 +13011,20 @@ class Compiler
           return "sp_proc_call(lv_" + rname + ", (mrb_int[]){" + ca + "})"
         end
       end
+
+ # Anonymous-proc-receiver dispatch — `proc { ... }.call`, or any
+ # expression chain whose inferred type is `proc` (e.g.
+ # `factory().call`). The LocalVariableReadNode branch above handles
+ # the named-proc case directly; this generic branch compiles the
+ # receiver expression and feeds it to sp_proc_call, using the same
+ # arg-array packing convention.
+      if infer_type(recv) == "proc"
+        ca_anon = compile_call_args(nid)
+        if ca_anon == ""
+          ca_anon = "0"
+        end
+        return "sp_proc_call(" + compile_expr(recv) + ", (mrb_int[]){" + ca_anon + "})"
+      end
     end
     ""
   end

--- a/test/proc_anon_dot_call.rb
+++ b/test/proc_anon_dot_call.rb
@@ -1,0 +1,50 @@
+# `proc { ... }.call` — the receiver is the inline `proc { ... }` call,
+# not a local variable holding the proc. compile_dot_call_expr only
+# matched LocalVariableReadNode receivers and emitted sp_proc_call
+# against `lv_<name>`; the inline form fell through to
+# warn_unresolved_call and the proc body was never invoked.
+#
+# Fix: after the LocalVariableReadNode special-case, fall through to
+# a generic branch keyed on `infer_type(recv) == "proc"` that compiles
+# the receiver expression and feeds it to sp_proc_call. The check is
+# node-shape-agnostic — any receiver whose inferred type is `proc`
+# routes through the same emitter.
+#
+# Coverage scope (all routed through `infer_type(recv) == "proc"`):
+# - Anonymous proc literal `.call`           — CallNode receiver
+# - Anonymous proc with args                 — CallNode receiver
+# - Method returning a proc, immediately called (factory pattern)
+# - Ternary returning a proc                 — IfNode receiver
+#
+# Out of scope (separate code paths / pre-existing limitations):
+# - lambda { ... }.call / ->() { ... }.()
+#     Lambdas have a separate handler (`compile_lambda_call_expr` at
+#     ~line 11941 in master). Not exercised by this PR.
+# - @ivar = proc { ... }; @ivar.call
+#     Spinel's ivar codegen rejects assigning sp_Proc* to the ivar
+#     slot today. Pre-existing inference/codegen gap on proc ivars,
+#     independent of this PR.
+# - $global = proc { ... }; $global.call
+#     Spinel's $global proc inference is unverified. Separate concern.
+# - [proc1, proc2].each(&:call)
+#     Symbol#to_proc (`&:sym`) is unsupported in master (see
+#     `spinel_codegen.rb:1067` TODO). Added in rs-no-recv-io-expr-bridge.
+
+def show(s)
+  puts s
+end
+
+# Anonymous proc literal — the original bug.
+proc { show("anon") }.call
+proc { show("second") }.call
+proc { |n| show((n * 2).to_s) }.call(7)
+
+# CallNode receiver returning a proc (factory pattern).
+def factory
+  proc { show("factory") }
+end
+factory.call
+
+# Ternary returning a proc — both branches must unify to `proc`.
+cond = true
+(cond ? proc { show("ternary-true") } : proc { show("ternary-false") }).call

--- a/test/proc_anon_dot_call.rb.expected
+++ b/test/proc_anon_dot_call.rb.expected
@@ -1,0 +1,5 @@
+anon
+second
+14
+factory
+ternary-true


### PR DESCRIPTION
## Summary

`proc { ... }.call` — where the receiver is the inline `proc { ... }` call rather than a local variable — fell through to `warn_unresolved_call` ("cannot resolve call to 'call' on proc"). `compile_dot_call_expr` only matched `LocalVariableReadNode` receivers.

Fix: after the LocalVariableReadNode special-case, fall through to a generic branch keyed on `infer_type(recv) == "proc"`. The check is node-shape-agnostic, so any receiver whose inferred type is `proc` routes through the same emitter.

## Test plan

- [x] `make test` — 417/417 pass
- [x] `test/proc_anon_dot_call.rb` covers: anonymous proc literal, anonymous proc with args, method returning proc (factory pattern), ternary returning proc.

## Out of scope (documented in fixture header)

- `lambda { ... }.call` — separate `compile_lambda_call_expr` handler.
- `@ivar = proc { ... }; @ivar.call` — pre-existing ivar/proc codegen gap.
- `$global = proc { ... }; $global.call` — unverified inference.
- `[procs].each(&:call)` — Symbol#to_proc unsupported; addressed by rs-no-recv-io-expr-bridge with the explicit-block form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)