### PR TITLE
fix(codegen): case/when on value-type class and qualified-constant arm

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -10625,12 +10625,11 @@ class Compiler
         if pred_type == "string"
           emit("  const char *" + ptmp + " = " + pred_val + ";")
         elsif is_obj_type(pred_type) == 1
- # See compile_case_stmt — the temp must be the right pointer
- # type so compile_when_conds can resolve `when ClassName` to
- # a static match. .
-          bt = base_type(pred_type)
-          obj_cname = bt[4, bt.length - 4]
-          emit("  sp_" + obj_cname + " *" + ptmp + " = " + pred_val + ";")
+ # See compile_case_stmt — route the temp declaration through
+ # c_type so value-type classes get `sp_<X>` (no pointer) and
+ # standard heap classes get `sp_<X> *`. compile_when_conds then
+ # resolves `when ClassName` against the right shape.
+          emit("  " + c_type(pred_type) + " " + ptmp + " = " + pred_val + ";")
         else
           emit("  mrb_int " + ptmp + " = " + pred_val + ";")
         end
@@ -22423,13 +22422,12 @@ class Compiler
     if pred_type == "string"
       emit("  const char *" + tmp + " = " + pred_val + ";")
     elsif is_obj_type(pred_type) == 1
- # `case obj when ClassName` — keep the temp as the right pointer
- # type so the when arms can read its NULLability and the static
- # class match in compile_when_conds picks the matching cls_id
- # path. .
-      bt = base_type(pred_type)
-      obj_cname = bt[4, bt.length - 4]
-      emit("  sp_" + obj_cname + " *" + tmp + " = " + pred_val + ";")
+ # `case obj when ClassName` — declare the temp at the C type
+ # c_type uses for this obj kind. That picks `sp_<X>` for
+ # value-type classes (per-class free-list pool) and `sp_<X> *`
+ # for the standard pointer representation, so the assignment
+ # matches the predicate's actual storage shape.
+      emit("  " + c_type(pred_type) + " " + tmp + " = " + pred_val + ";")
     elsif pred_type == "poly"
  # `case <poly_value> when ...` — keep the receiver tagged so
  # each when-arm can do tag-check + value-compare. .
@@ -22510,19 +22508,18 @@ class Compiler
         right = compile_expr(@nd_right[cid])
         cmp = range_excl_end(cid) == 1 ? "<" : "<="
         result = result + "(" + tmp + " >= " + left + " && " + tmp + " " + cmp + " " + right + ")"
-      elsif is_obj_type(pred_type) == 1 && @nd_type[cid] == "ConstantReadNode"
+      elsif is_obj_type(pred_type) == 1 && (@nd_type[cid] == "ConstantReadNode" || @nd_type[cid] == "ConstantPathNode")
  # `case obj when ClassName` — resolve statically against the
- # predicate's known class. Predicate type `obj_X`:
+ # predicate's known class. ConstantPathNode (`Mod::Klass`) is
+ # routed through resolve_const_ref_name so the walked name
+ # matches the class registry. Predicate type `obj_X`:
  # when X (or any ancestor of X) → match (with a NULL guard
- # when the predicate is
- # nullable, since `nil` is
- # not a class instance)
- # when anything else → no match
- # Subclass matching across an `obj_<Parent>` predicate that
- # actually carries an `obj_<Child>` instance needs a runtime
- # cls_id check; that's a separate enhancement only
- # covers the static-class form of the bug).
-        cname = @nd_name[cid]
+ # when the predicate is nullable, since `nil` is not a class
+ # instance); anything else → no match. Subclass matching
+ # across an `obj_<Parent>` predicate that actually carries an
+ # `obj_<Child>` instance needs a runtime cls_id check; covered
+ # by the descendant runtime branch in is_a?, separate concern.
+        cname = @nd_type[cid] == "ConstantPathNode" ? resolve_const_ref_name(cid) : @nd_name[cid]
         if find_class_idx(cname) >= 0
           bt = base_type(pred_type)
           pred_cname = bt[4, bt.length - 4]

--- a/test/case_when_qualified_class.rb
+++ b/test/case_when_qualified_class.rb
@@ -1,0 +1,47 @@
+# `case obj when Mod::Klass` had two bugs:
+#
+# 1. compile_case_stmt emitted the predicate tmp as `sp_<X> *` even
+#    when the predicate's actual storage was a value type
+#    (`sp_<X>` without the pointer) — producing C errors of the
+#    form "initializing 'sp_X *' with an expression of incompatible
+#    type 'sp_X'; take the address with &". The fix routes the
+#    declaration through c_type so value-type classes get the
+#    right C shape.
+#
+# 2. The static-resolution branch in compile_when_conds only matched
+#    ConstantReadNode arguments, so qualified constants
+#    (ConstantPathNode like `Mod::Klass`) fell through to the
+#    poly-receiver path and emitted `<undeclared identifier>` C.
+#    Fix: also accept ConstantPathNode and route through
+#    resolve_const_ref_name to get the registered class name.
+
+module Mod
+  class Klass
+    def initialize(v); @v = v; end
+    def get; @v; end
+  end
+  class Other
+    def initialize(v); @v = v; end
+    def get; @v; end
+  end
+end
+
+k = Mod::Klass.new(1)
+result = case k
+         when Mod::Klass then "match"
+         when Mod::Other then "other"
+         else "neither"
+         end
+puts result
+
+# Plain (non-namespaced) class also exercises the c_type fix, since
+# the pointer-vs-value mismatch was independent of namespacing.
+class Plain
+  def initialize; @x = 1; end
+end
+p_inst = Plain.new
+result2 = case p_inst
+          when Plain then "plain"
+          else "?"
+          end
+puts result2

--- a/test/case_when_qualified_class.rb.expected
+++ b/test/case_when_qualified_class.rb.expected
@@ -1,0 +1,2 @@
+match
+plain


### PR DESCRIPTION
## Summary

`case obj when ClassName` had two C-compile-blocking bugs when the predicate's class was a value-type instance (per-class free-list pool layouts where `lv_x` is `sp_X` rather than `sp_X *`):

1. **Pointer/value tmp mismatch.** `compile_case_stmt` and the case-as-expression branch in `compile_expr` always emitted the predicate tmp as `sp_<X> *`, regardless of whether the predicate's actual storage was a value type. The generated C failed with "initializing 'sp_X *' with an expression of incompatible type 'sp_X'; take the address with &".

2. **ConstantPathNode when-arm.** The static-resolution branch in `compile_when_conds` only matched the bare `ConstantReadNode` arg shape, so a qualified `when Mod::Klass` (`ConstantPathNode`) fell through to the poly-recv path and emitted `<undeclared identifier> Mod_Klass` against a non-poly predicate.

Fix:
- Route both tmp declarations through `c_type(pred_type)` so value-type classes get `sp_<X>` (no pointer) and standard heap classes get `sp_<X> *`. Assignment then matches the predicate's actual storage shape.
- Extend the const-shape guard in `compile_when_conds` to also match `ConstantPathNode`, resolving the qualified name via the existing `resolve_const_ref_name` helper.

## Test plan

- [x] `make test` — 417/417 pass
- [x] `test/case_when_qualified_class.rb` exercises both fixes via a value-type module-namespaced class and a value-type plain class

🤖 Generated with [Claude Code](https://claude.com/claude-code)