### PR TITLE
fix(codegen): emit side-effect stmts in consumed if-expr branches

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -20202,12 +20202,90 @@ class Compiler
     "sp_" + owner + "_" + sanitize_name(op) + "(" + cast + recv_c + ", " + rhs_c + ")"
   end
 
+  def if_branch_has_multi_stmt(body)
+    if body < 0
+      return 0
+    end
+    if get_stmts(body).length > 1
+      return 1
+    end
+    0
+  end
+
+ # Assign the value of an if-arm body to a temp, executing any
+ # leading side-effect statements before the assignment. Body
+ # convention: stmts[0..n-2] run for their side-effects;
+ # stmts[n-1] supplies the arm's value. Empty/missing body → "0".
+  def compile_if_arm_to_tmp(body, tmp, unified_t)
+    if body < 0
+      emit("  " + tmp + " = 0;")
+      return
+    end
+    stmts = get_stmts(body)
+    if stmts.length == 0
+      emit("  " + tmp + " = 0;")
+      return
+    end
+    i = 0
+    while i < stmts.length - 1
+      compile_stmt(stmts[i])
+      i = i + 1
+    end
+    last_id = stmts.last
+    val = compile_expr(last_id)
+    if unified_t == "poly" && infer_type(last_id) != "poly"
+      val = box_value_to_poly(infer_type(last_id), val)
+    end
+    emit("  " + tmp + " = " + val + ";")
+  end
+
   def compile_if_expr(nid)
     cond = compile_cond_expr(@nd_predicate[nid])
     unified_t = infer_type(nid)
+    body = @nd_body[nid]
+    sub = @nd_subsequent[nid]
+
+ # Side-effect-aware path: when any branch holds more than one
+ # statement, the leading stmts must execute conditionally. The
+ # plain ternary form drops them. Emit a real if-statement that
+ # assigns to a temp and return the temp as the expression value.
+ # Elsif chains recurse — the inner call returns either a temp or
+ # a ternary string, both valid expressions.
+    has_then_multi = if_branch_has_multi_stmt(body)
+    has_else_multi = 0
+    if sub >= 0 && @nd_type[sub] == "ElseNode"
+      has_else_multi = if_branch_has_multi_stmt(@nd_body[sub])
+    end
+    if has_then_multi == 1 || has_else_multi == 1
+      tmp = new_temp
+      emit("  " + c_type(unified_t) + " " + tmp + ";")
+      emit("  if (" + cond + ") {")
+      @indent = @indent + 1
+      compile_if_arm_to_tmp(body, tmp, unified_t)
+      @indent = @indent - 1
+      emit("  } else {")
+      @indent = @indent + 1
+      if sub >= 0 && @nd_type[sub] == "ElseNode"
+        compile_if_arm_to_tmp(@nd_body[sub], tmp, unified_t)
+      elsif sub >= 0
+        sub_val = compile_if_expr(sub)
+        sub_t = infer_type(sub)
+        if unified_t == "poly" && sub_t != "poly"
+          sub_val = box_value_to_poly(sub_t, sub_val)
+        end
+        emit("  " + tmp + " = " + sub_val + ";")
+      else
+        emit("  " + tmp + " = 0;")
+      end
+      @indent = @indent - 1
+      emit("  }")
+      return tmp
+    end
+
+ # Fast path: every branch is at most one statement, so the
+ # whole if-expression collapses to a C ternary.
     then_val = "0"
     then_t = "nil"
-    body = @nd_body[nid]
     if body >= 0
       stmts = get_stmts(body)
       if stmts.length > 0
@@ -20217,7 +20295,6 @@ class Compiler
     end
     else_val = "0"
     else_t = "nil"
-    sub = @nd_subsequent[nid]
     if sub >= 0
       if @nd_type[sub] == "ElseNode"
         eb = @nd_body[sub]

--- a/test/if_expr_multi_stmt_body.rb
+++ b/test/if_expr_multi_stmt_body.rb
@@ -1,0 +1,78 @@
+# When an `if` expression's value is consumed (assignment, return,
+# ternary slot, etc.) and a branch holds multiple statements,
+# compile_if_expr previously kept only the last statement of each
+# branch — emitting `(cond ? lastexpr : ...)`. Any leading
+# side-effect statements in the branch were silently dropped.
+#
+# Fix: detect multi-stmt branches, emit a real `if (cond) { ... }
+# else { ... }` that compiles each leading statement for its side
+# effect and assigns the final expression to a temp. Return the
+# temp as the if-expression's value. Single-stmt / no-stmt branches
+# keep using the original ternary fast path.
+#
+# Coverage:
+# - Multi-stmt then- and else-branches assigned to a local
+# - Elsif chain recursion (multi-stmt branches inside the else slot)
+# - Nested if-expression used as a method argument
+# - Mixed branch lengths (single-stmt then, multi-stmt else)
+# - Empty/missing else (implicit nil → 0)
+#
+# Out of scope:
+# - Poly type-unification of mixed concrete branches (int/string).
+#   Spinel's inference picks one concrete type as the unified type
+#   rather than `poly`, so `tmp = 1LL;` is emitted against a
+#   `const char *` slot. The bug isn't in this PR's multi-stmt
+#   restructuring — the ternary fast path has the same inference
+#   issue. Separate fix.
+
+x = if true
+      puts "a"
+      1
+    else
+      puts "z"
+      0
+    end
+puts x
+
+y = if false
+      puts "skipped"
+      99
+    else
+      puts "b"
+      puts "c"
+      42
+    end
+puts y
+
+# Elsif chain recursion.
+z = if false
+      1
+    elsif true
+      puts "elsif"
+      2
+    else
+      3
+    end
+puts z
+
+# Nested if-expression as a method argument.
+puts(if true
+       puts "nested"
+       10
+     end)
+
+# Mixed branch lengths.
+m = if false
+      99
+    else
+      puts "else-multi"
+      100
+    end
+puts m
+
+# Empty/missing else.
+n = if true
+      puts "no-else"
+      77
+    end
+puts n

--- a/test/if_expr_multi_stmt_body.rb.expected
+++ b/test/if_expr_multi_stmt_body.rb.expected
@@ -1,0 +1,13 @@
+a
+1
+b
+c
+42
+elsif
+2
+nested
+10
+else-multi
+100
+no-else
+77


### PR DESCRIPTION
## Summary

When an `if` is consumed for its value (RHS of assignment, return slot, ternary arm, etc.), `compile_if_expr` previously kept only the last statement of each branch — emitting `(cond ? lastexpr : ...)`. Any leading side-effect statements (`puts`, ivar writes, method calls, etc.) in the branch body were silently dropped.

  ```ruby
  x = if true
        puts "a"   # this was being dropped
        1
      end
  ```

Fix: detect multi-stmt branches and switch from the ternary form to a real `if (cond) { ... tmp = lastexpr; } else { ... tmp = lastexpr; }` that compiles each non-final statement with `compile_stmt`, assigns the final statement's expression to a temp, and returns the temp. Single-stmt branches stay on the ternary fast path. Elsif chains recurse; poly-unified branches keep the existing `box_value_to_poly` wrapping.

## Test plan

- [x] `make test` — 417/417 pass
- [x] `test/if_expr_multi_stmt_body.rb` covers: multi-stmt then- and else-branches, elsif chain recursion, nested if-expr as method argument, mixed branch lengths, empty/missing else.

## Out of scope (documented in fixture header)

- **Poly type-unification of mixed concrete branches** (int/string). Spinel's inference picks one concrete type as the unified type rather than `poly`, so `tmp = 1LL;` is emitted against a `const char *` slot. The bug isn't in this PR's multi-stmt restructuring — the ternary fast path has the same inference issue. Separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)