### PR TITLE
[codex] Share text AST node loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ PRISM_LIB    = build/libprism.a
 
 CODEGEN_STAMP := build/stamps/spinel_codegen.rb.stamp
 ANALYZE_STAMP := build/stamps/spinel_analyze.rb.stamp
+NODE_TABLE_LOADER_STAMP := build/stamps/node_table_loader.rb.stamp
 PARSE_STAMP   := build/stamps/spinel_parse.c.stamp
 
 .PHONY: all parse bootstrap codegen test retest clean-test-results regen-expected bench optcarrot clean install uninstall deps
@@ -218,13 +219,13 @@ regexp: $(SP_RT_LIB)
 
 codegen: spinel_analyze$(EXE) spinel_codegen$(EXE)
 
-spinel_analyze$(EXE): $(ANALYZE_STAMP) spinel_parse$(EXE)
+spinel_analyze$(EXE): $(ANALYZE_STAMP) $(NODE_TABLE_LOADER_STAMP) spinel_parse$(EXE)
 	./spinel_parse$(EXE) spinel_analyze.rb build/analyze.ast
 	ruby spinel_analyze.rb build/analyze.ast build/analyze.ir
 	ruby spinel_codegen.rb build/analyze.ast build/analyze.ir build/analyze1.c
 	$(CC) $(BOOTSTRAP_CFLAGS) -Ilib build/analyze1.c $(LDFLAGS) -lm -o spinel_analyze$(EXE)
 
-spinel_codegen$(EXE): $(CODEGEN_STAMP) spinel_parse$(EXE)
+spinel_codegen$(EXE): $(CODEGEN_STAMP) $(NODE_TABLE_LOADER_STAMP) spinel_parse$(EXE)
 	./spinel_parse$(EXE) spinel_codegen.rb build/codegen.ast
 	ruby spinel_analyze.rb build/codegen.ast build/codegen.ir
 	ruby spinel_codegen.rb build/codegen.ast build/codegen.ir build/codegen1.c
@@ -314,7 +315,7 @@ retest: clean-test-results
 # The .ok target is the test's stamp; mtime tracking gives per-test
 # caching for free. Order-only spinel_parse$(EXE) / spinel_analyze$(EXE)
 # / spinel_codegen$(EXE) stop a bootstrap relink from invalidating every test.
-build/test-results/%.ok: test/%.rb $(SP_RT_LIB) $(CODEGEN_STAMP) $(ANALYZE_STAMP) $(PARSE_STAMP) | spinel_parse$(EXE) spinel_analyze$(EXE) spinel_codegen$(EXE)
+build/test-results/%.ok: test/%.rb $(SP_RT_LIB) $(CODEGEN_STAMP) $(ANALYZE_STAMP) $(NODE_TABLE_LOADER_STAMP) $(PARSE_STAMP) | spinel_parse$(EXE) spinel_analyze$(EXE) spinel_codegen$(EXE)
 	@mkdir -p build/test-results
 	@tmpdir=$$(mktemp -d /tmp/spinel-test.XXXXXX); \
 	ast=$$tmpdir/test.ast; \
@@ -467,6 +468,7 @@ install: all
 	install -m 755 spinel_parse$(EXE)    $(SPNLDIR)/
 	install -m 755 spinel_analyze$(EXE)  $(SPNLDIR)/
 	install -m 755 spinel_codegen$(EXE)  $(SPNLDIR)/
+	install -m 644 node_table_loader.rb  $(SPNLDIR)/
 	install -m 644 spinel_analyze.rb     $(SPNLDIR)/
 	install -m 644 spinel_codegen.rb     $(SPNLDIR)/
 	install -m 644 lib/libspinel_rt.a    $(SPNLDIR)/lib/

--- a/node_table_loader.rb
+++ b/node_table_loader.rb
@@ -1,0 +1,131 @@
+# Loads Spinel's text AST format into a node table object.
+#
+# The table object supplies the parallel-array storage operations used by
+# Compiler: alloc_node, set_root_id, set_node_type, set_node_content, and
+# set_*_field.
+
+class NodeTableLoader
+  def initialize(table)
+    @table = table
+  end
+
+  def read_text_ast(data)
+    lines = data.split(10.chr)
+ # Pass 1: find max node ID
+    max_id = 0
+    i = 0
+    while i < lines.length
+      line = lines[i]
+      if line.length > 0
+        parts = line.split(" ")
+        if parts.length >= 2
+          if parts.first == "ROOT"
+            @table.set_root_id(parts[1].to_i)
+          end
+          if parts.first == "N"
+            nid = parts[1].to_i
+            if nid > max_id
+              max_id = nid
+            end
+          end
+        end
+      end
+      i = i + 1
+    end
+ # Allocate nodes
+    j = 0
+    while j <= max_id
+      @table.alloc_node
+      j = j + 1
+    end
+ # Pass 2: populate fields
+    i = 0
+    while i < lines.length
+      line = lines[i]
+      if line.length > 0
+        ast_parse_line(line)
+      end
+      i = i + 1
+    end
+  end
+
+  def ast_parse_line(line)
+    parts = line.split(" ")
+    if parts.length < 3
+      return
+    end
+    tag = parts.first
+    nid = parts[1].to_i
+    if tag == "N"
+      @table.set_node_type(nid, parts[2])
+    elsif tag == "S"
+      field = parts[2]
+      val = ""
+      if parts.length >= 4
+        val = unescape_str(parts[3])
+      end
+      @table.set_string_field(nid, field, val)
+    elsif tag == "I"
+      field = parts[2]
+      ival = 0
+      if parts.length >= 4
+        ival = parts[3].to_i
+      end
+      @table.set_int_field(nid, field, ival)
+    elsif tag == "F"
+      if parts.length >= 4
+        @table.set_node_content(nid, parts[3])
+      end
+    elsif tag == "R"
+      field = parts[2]
+      ref_id = -1
+      if parts.length >= 4
+        ref_id = parts[3].to_i
+      end
+      @table.set_ref_field(nid, field, ref_id)
+    elsif tag == "A"
+      field = parts[2]
+      ids_str = ""
+      if parts.length >= 4
+        ids_str = parts[3]
+      end
+      @table.set_array_field(nid, field, ids_str)
+    end
+    0
+  end
+
+  def unescape_str(s)
+    result = ""
+    i = 0
+    while i < s.length
+      ch = s[i]
+      if ch == "%"
+        if i + 2 < s.length
+          hex = s[i + 1] + s[i + 2]
+          case hex
+          when "0A"
+            result = result + 10.chr
+          when "0D"
+            result = result + 13.chr
+          when "09"
+            result = result + 9.chr
+          when "20"
+            result = result + " "
+          when "25"
+            result = result + "%"
+          else
+            result = result + "%" + hex
+          end
+          i = i + 3
+        else
+          result = result + ch
+          i = i + 1
+        end
+      else
+        result = result + ch
+        i = i + 1
+      end
+    end
+    result
+  end
+end

--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -8,6 +8,8 @@
 # All data structures use parallel arrays (no arrays of objects).
 # Node fields stored as parallel arrays indexed by integer node ID.
 
+require_relative "node_table_loader"
+
 class Compiler
   attr_accessor :out
 
@@ -662,140 +664,20 @@ class Compiler
   end
 
   def read_text_ast(data)
-    lines = data.split(10.chr)
- # Pass 1: find max node ID
-    max_id = 0
-    i = 0
-    while i < lines.length
-      line = lines[i]
-      if line.length > 0
-        parts = line.split(" ")
-        if parts.length >= 2
-          if parts.first == "ROOT"
-            @root_id = parts[1].to_i
-          end
-          if parts.first == "N"
-            nid = parts[1].to_i
-            if nid > max_id
-              max_id = nid
-            end
-          end
-        end
-      end
-      i = i + 1
-    end
- # Allocate nodes
-    j = 0
-    while j <= max_id
-      alloc_node
-      j = j + 1
-    end
- # Pass 2: populate fields
-    i = 0
-    while i < lines.length
-      line = lines[i]
-      if line.length > 0
-        ast_parse_line(line)
-      end
-      i = i + 1
-    end
+    loader = NodeTableLoader.new(self)
+    loader.read_text_ast(data)
   end
 
-  def ast_parse_line(line)
-    parts = line.split(" ")
-    if parts.length < 3
-      return
-    end
-    tag = parts.first
-    nid = parts[1].to_i
-    if tag == "N"
-      @nd_type[nid] = parts[2]
-    end
-    if tag == "S"
-      field = parts[2]
-      val = ""
-      if parts.length >= 4
-        val = unescape_str(parts[3])
-      end
-      set_string_field(nid, field, val)
-    end
-    if tag == "I"
-      field = parts[2]
-      ival = 0
-      if parts.length >= 4
-        ival = parts[3].to_i
-      end
-      set_int_field(nid, field, ival)
-    end
-    if tag == "F"
-      if parts.length >= 4
-        @nd_content[nid] = parts[3]
-      end
-    end
-    if tag == "R"
-      field = parts[2]
-      ref_id = -1
-      if parts.length >= 4
-        ref_id = parts[3].to_i
-      end
-      set_ref_field(nid, field, ref_id)
-    end
-    if tag == "A"
-      field = parts[2]
-      ids_str = ""
-      if parts.length >= 4
-        ids_str = parts[3]
-      end
-      set_array_field(nid, field, ids_str)
-    end
-    0
+  def set_root_id(root_id)
+    @root_id = root_id
   end
 
-  def unescape_str(s)
-    result = ""
-    i = 0
-    while i < s.length
-      ch = s[i]
-      if ch == "%"
-        if i + 2 < s.length
-          hex = s[i + 1] + s[i + 2]
-          if hex == "0A"
-            result = result + 10.chr
-            i = i + 3
-          else
-            if hex == "0D"
-              result = result + 13.chr
-              i = i + 3
-            else
-              if hex == "09"
-                result = result + 9.chr
-                i = i + 3
-              else
-                if hex == "20"
-                  result = result + " "
-                  i = i + 3
-                else
-                  if hex == "25"
-                    result = result + "%"
-                    i = i + 3
-                  else
-                    result = result + "%" + hex
-                    i = i + 3
-                  end
-                end
-              end
-            end
-          end
-        else
-          result = result + ch
-          i = i + 1
-        end
-      else
-        result = result + ch
-        i = i + 1
-      end
-    end
-    result
+  def set_node_type(nid, node_type)
+    @nd_type[nid] = node_type
+  end
+
+  def set_node_content(nid, content)
+    @nd_content[nid] = content
   end
 
   def set_string_field(nid, field, val)

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -8,6 +8,8 @@
 # All data structures use parallel arrays (no arrays of objects).
 # Node fields stored as parallel arrays indexed by integer node ID.
 
+require_relative "node_table_loader"
+
 class Compiler
   attr_accessor :out
 
@@ -690,140 +692,20 @@ class Compiler
   end
 
   def read_text_ast(data)
-    lines = data.split(10.chr)
- # Pass 1: find max node ID
-    max_id = 0
-    i = 0
-    while i < lines.length
-      line = lines[i]
-      if line.length > 0
-        parts = line.split(" ")
-        if parts.length >= 2
-          if parts.first == "ROOT"
-            @root_id = parts[1].to_i
-          end
-          if parts.first == "N"
-            nid = parts[1].to_i
-            if nid > max_id
-              max_id = nid
-            end
-          end
-        end
-      end
-      i = i + 1
-    end
- # Allocate nodes
-    j = 0
-    while j <= max_id
-      alloc_node
-      j = j + 1
-    end
- # Pass 2: populate fields
-    i = 0
-    while i < lines.length
-      line = lines[i]
-      if line.length > 0
-        ast_parse_line(line)
-      end
-      i = i + 1
-    end
+    loader = NodeTableLoader.new(self)
+    loader.read_text_ast(data)
   end
 
-  def ast_parse_line(line)
-    parts = line.split(" ")
-    if parts.length < 3
-      return
-    end
-    tag = parts.first
-    nid = parts[1].to_i
-    if tag == "N"
-      @nd_type[nid] = parts[2]
-    end
-    if tag == "S"
-      field = parts[2]
-      val = ""
-      if parts.length >= 4
-        val = unescape_str(parts[3])
-      end
-      set_string_field(nid, field, val)
-    end
-    if tag == "I"
-      field = parts[2]
-      ival = 0
-      if parts.length >= 4
-        ival = parts[3].to_i
-      end
-      set_int_field(nid, field, ival)
-    end
-    if tag == "F"
-      if parts.length >= 4
-        @nd_content[nid] = parts[3]
-      end
-    end
-    if tag == "R"
-      field = parts[2]
-      ref_id = -1
-      if parts.length >= 4
-        ref_id = parts[3].to_i
-      end
-      set_ref_field(nid, field, ref_id)
-    end
-    if tag == "A"
-      field = parts[2]
-      ids_str = ""
-      if parts.length >= 4
-        ids_str = parts[3]
-      end
-      set_array_field(nid, field, ids_str)
-    end
-    0
+  def set_root_id(root_id)
+    @root_id = root_id
   end
 
-  def unescape_str(s)
-    result = ""
-    i = 0
-    while i < s.length
-      ch = s[i]
-      if ch == "%"
-        if i + 2 < s.length
-          hex = s[i + 1] + s[i + 2]
-          if hex == "0A"
-            result = result + 10.chr
-            i = i + 3
-          else
-            if hex == "0D"
-              result = result + 13.chr
-              i = i + 3
-            else
-              if hex == "09"
-                result = result + 9.chr
-                i = i + 3
-              else
-                if hex == "20"
-                  result = result + " "
-                  i = i + 3
-                else
-                  if hex == "25"
-                    result = result + "%"
-                    i = i + 3
-                  else
-                    result = result + "%" + hex
-                    i = i + 3
-                  end
-                end
-              end
-            end
-          end
-        else
-          result = result + ch
-          i = i + 1
-        end
-      else
-        result = result + ch
-        i = i + 1
-      end
-    end
-    result
+  def set_node_type(nid, node_type)
+    @nd_type[nid] = node_type
+  end
+
+  def set_node_content(nid, content)
+    @nd_content[nid] = content
   end
 
   def set_string_field(nid, field, val)


### PR DESCRIPTION
## Summary

- Extract the text AST loading logic into `node_table_loader.rb`.
- Keep `Compiler#read_text_ast` in both `spinel_analyze.rb` and `spinel_codegen.rb` as a compatibility wrapper that delegates to `NodeTableLoader`.
- Add the shared loader to the bootstrap/test dependencies and install target so changes to it rebuild the generated tools.
- Simplify `NodeTableLoader#unescape_str` escape dispatch with `case`, factoring out the repeated index advance.
- Convert the AST line tag dispatch from independent `if` checks to an `elsif` chain so each line stops after the matching tag branch.

## Performance

I checked the bootstrap-relevant Ruby execution paths with `hyperfine`, following the approach of measuring the Ruby phase directly and excluding AST generation / C compilation from the timed command.

For the original extraction, `spinel_codegen.rb` on the generated `spinel_codegen.rb` AST/IR did not regress:

- before -> after: before `14.481s ± 0.532s`, after `12.758s ± 1.195s`
- after -> before: after `13.277s ± 0.322s`, before `14.553s ± 0.260s`
- combined means: before `14.517s`, after `13.017s`

For the original extraction, `spinel_analyze.rb` on the generated `spinel_codegen.rb` AST also showed no meaningful regression:

- before -> after: before `50.426s ± 1.010s`, after `50.100s ± 2.473s`
- after -> before: after `54.540s ± 5.321s`, before `52.113s ± 3.232s`
- combined medians: before `50.555s`, after `50.905s`

After changing `unescape_str` to use `case`, I re-measured against the previous PR revision:

- `spinel_codegen.rb`: before-case `15.008s ± 0.441s`, after-case `14.250s ± 1.571s` (`--runs 5`)
- `spinel_analyze.rb`: before-case `52.788s ± 0.384s`, after-case `54.060s ± 0.516s` (`--runs 3`, before -> after)
- `spinel_analyze.rb` reverse order: after-case `54.384s ± 0.890s`, before-case `57.548s ± 3.658s` (`--runs 3`)
- combined analyze means for the case change: before-case `55.168s`, after-case `54.222s`

I also tested changing the hot tag dispatch to `case`, but that showed a noticeable analyze slowdown, so this PR uses an `elsif` chain instead. Re-measured against the previous PR revision:

- `spinel_codegen.rb`: before-elsif `14.706s ± 2.796s`, after-elsif `9.813s ± 2.313s` (`--runs 5`; noisy run, no slowdown observed)
- `spinel_analyze.rb`: before-elsif `51.251s ± 4.779s`, after-elsif `51.304s ± 1.163s` (`--runs 3`)

Overall I did not find a meaningful performance regression from the extraction or follow-up dispatch simplifications.

## Validation

- `ruby -c node_table_loader.rb`
- `ruby -c spinel_analyze.rb`
- `ruby -c spinel_codegen.rb`
- `make codegen`
- `make test` (`Tests: 434 pass, 0 fail, 0 error`)
- Verified `spinel_parse` inlines `require_relative "node_table_loader"` into the self-compiled AST before the final rebase.
