### PR TITLE
fix(spinel): avoid BSD mktemp tail-template collision on macOS

### DIFF
--- a/spinel
+++ b/spinel
@@ -42,6 +42,7 @@ OPT_LEVEL="2"
 CC_CMD="cc"
 EXTRA_FLAGS=""
 C_TMP=""
+C_TMP_DIR=""
 EVAL_SCRIPT=""
 EVAL_USED=0
 EVAL_TMP=""
@@ -110,7 +111,7 @@ else
 fi
 AST_TMP="$(mktemp /tmp/spinel_ast.XXXXXX)"
 IR_TMP="$(mktemp /tmp/spinel_ir.XXXXXX)"
-trap 'rm -f "$AST_TMP" "$IR_TMP" "$C_TMP" "$EVAL_TMP"' EXIT
+trap 'rm -f "$AST_TMP" "$IR_TMP" "$EVAL_TMP"; [ -n "$C_TMP_DIR" ] && rm -rf "$C_TMP_DIR"' EXIT
 
 # Step 1: Parse. spinel_parse is C-only; build it via `make parse`
 # (or `make all`) before invoking spinel.
@@ -148,7 +149,8 @@ fi
 if [ $C_ONLY -eq 1 ]; then
   C_FILE="${OUTPUT:-$BASENAME.c}"
 else
-  C_TMP="$(mktemp /tmp/spinel_out.XXXXXX.c)"
+  C_TMP_DIR="$(mktemp -d /tmp/spinel_out.XXXXXX)" || { echo "spinel: mktemp -d failed" >&2; exit 1; }
+  C_TMP="$C_TMP_DIR/out.c"
   C_FILE="$C_TMP"
 fi
 


### PR DESCRIPTION
BSD `mktemp` (macOS) only substitutes the trailing run of X's in the template, so `mktemp /tmp/spinel_out.XXXXXX.c` collapses to the literal name `/tmp/spinel_out.XXXXXX.c` instead of producing a unique path. Concurrent `spinel foo.rb` invocations then race on the same file, truncating each other's emitted C and crashing the codegen pipeline.

## Approach

Mint a unique 0700 temp directory via `mktemp -d` and place the `.c` file inside it under a known name.

```diff
-  C_TMP="$(mktemp /tmp/spinel_out.XXXXXX.c)"
+  C_TMP_DIR="$(mktemp -d /tmp/spinel_out.XXXXXX)" || { echo "spinel: mktemp -d failed" >&2; exit 1; }
+  C_TMP="$C_TMP_DIR/out.c"
```

Compared to the obvious `mktemp ...).c` trick (the original form of this PR), the directory-based fix:

- **No leaked sibling**: the bare-name file `mktemp` creates without `-d` is never written to once the shell appends `.c` to the variable; here the directory holds the only `.c` and the trap removes it.
- **Explicit error path**: `|| exit 1` fires if `mktemp -d` fails (e.g. `/tmp` not writable); previously `$C_TMP` would silently become `.c` and downstream `rm` would target the wrong path.
- **Permissions**: the 0700 directory hides the `.c` filename from other local users, where `> file` under the default umask would have created a 0644 file.

Cleanup trap rewritten to do `rm -rf "$C_TMP_DIR"` guarded by a non-empty check so an early-exit before the dir is minted is a no-op.

## Verification

`./spinel -e 'puts "hello"'` round-trips with no `/tmp/spinel_out.*` left behind. Concurrent invocations no longer race.