### PR TITLE
fix(codegen): emit runtime cls_id check for is_a? / kind_of? / instance_of? on parent-typed recv

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2989,6 +2989,31 @@ class Compiler
     0
   end
 
+ # `is_descendant(child, ancestor)` — 1 iff `child` is a strict
+ # (proper) descendant of `ancestor` in the class hierarchy; 0
+ # otherwise (including when they're identical). Wraps
+ # is_class_or_ancestor, which is descendant-OR-EQUAL.
+  def is_descendant(child, ancestor)
+    if child == ancestor
+      return 0
+    end
+    is_class_or_ancestor(child, ancestor)
+  end
+
+ # `is_value_type_class(cname)` — 1 iff `cname` is a user class
+ # marked value-type (stack-allocated, no subclasses by design,
+ # no `cls_id` field on the struct). emit_class_fields gates the
+ # cls_id emission on the inverse of this; runtime cls_id checks
+ # must guard against value-type recvs to avoid referencing a
+ # nonexistent struct member.
+  def is_value_type_class(cname)
+    ci = find_class_idx(cname)
+    if ci >= 0 && @cls_is_value_type[ci] == 1
+      return 1
+    end
+    0
+  end
+
   def is_operator_name(name)
     if name == "+"
       return 1
@@ -17315,16 +17340,41 @@ class Compiler
         end
         if is_class_or_ancestor(cname, arg0) == 1
           return "TRUE"
-        else
-          return "FALSE"
         end
+ # Descendant case: arg0 is a proper subclass of cname (recv's
+ # static type). The recv's static type only bounds the runtime
+ # class above; the instance can be cname or any descendant
+ # including arg0. Consult the recv's actual cls_id slot.
+        target_ci = find_class_idx(arg0)
+        if target_ci >= 0 && is_descendant(arg0, cname) == 1
+          @needs_class_table = 1
+          @needs_class_ancestors = 1
+          recv_id = @nd_receiver[nid]
+          if recv_id >= 0
+            return "sp_class_le((sp_Class){" + compile_expr(recv_id) + "->cls_id}, (sp_Class){" + cls_id_for_user_internal(target_ci).to_s + "LL})"
+          end
+        end
+ # Unrelated classes — neither ancestor nor descendant. Always FALSE.
+        return "FALSE"
       end
       return "FALSE"
     end
 
- # instance_of? — exact class identity, no ancestor walk. A parent
- # instance is never an exact-subclass match, so descendant resolution
- # is not relevant here; static comparison suffices.
+ # instance_of? — exact class identity, no ancestor walk.
+ # The recv's static type only bounds the runtime class above; the
+ # instance can be the static type OR any descendant. The runtime
+ # class can therefore equal arg0 only if arg0 is in that set —
+ # i.e., arg0 is cname or a descendant of cname. Other shapes
+ # (arg0 is an ancestor of cname, or unrelated) make the equality
+ # statically impossible and collapse to FALSE.
+ #
+ # `cname == arg0` does NOT in general collapse to TRUE — a parent-
+ # typed local holding a descendant returns FALSE for
+ # `instance_of?(parent)`. The check is runtime via the recv's
+ # cls_id slot. EXCEPTION: value-type classes have no subclasses
+ # by design (no cls_id field on the struct, no polymorphism), so
+ # for value-type cname the runtime is always exactly cname and
+ # the cname == arg0 check collapses back to static TRUE.
     if mname == "instance_of?"
       if is_obj_type(recv_type) == 1
         cname = recv_type[4, recv_type.length - 4]
@@ -17336,11 +17386,18 @@ class Compiler
             arg0 = resolve_introspection_arg_name(a[0])
           end
         end
-        if cname == arg0
-          return "TRUE"
-        else
-          return "FALSE"
+        target_ci = find_class_idx(arg0)
+        if target_ci >= 0 && (cname == arg0 || is_descendant(arg0, cname) == 1)
+          if is_value_type_class(cname) == 1
+            return "TRUE"
+          end
+          @needs_class_table = 1
+          recv_id = @nd_receiver[nid]
+          if recv_id >= 0
+            return "(" + compile_expr(recv_id) + "->cls_id == " + cls_id_for_user_internal(target_ci).to_s + "LL)"
+          end
         end
+        return "FALSE"
       end
       return "FALSE"
     end

--- a/test/is_a_descendant_runtime.rb
+++ b/test/is_a_descendant_runtime.rb
@@ -1,0 +1,59 @@
+# Static-vs-runtime class lattice for `is_a?` / `kind_of?` /
+# `instance_of?` when the recv's static type is a parent class but
+# the runtime instance can be any descendant. Previously spinel
+# collapsed the descendant-target case to literal FALSE because
+# is_class_or_ancestor(parent, child) returns 0; the recv's runtime
+# cls_id was never consulted.
+#
+# Fix: when the target is identical to, ancestor of, or descendant
+# of the static recv type, consult the actual cls_id slot.
+# `is_a?` / `kind_of?` use ancestor-walk (sp_class_le); `instance_of?`
+# uses exact equality.
+
+class Animal
+end
+class Dog < Animal
+end
+class Cat < Animal
+end
+class Puppy < Dog
+end
+
+# is_a? / kind_of? — recv typed Animal, target a proper descendant.
+def kind(a)
+  if a.is_a?(Dog)
+    "dog"
+  elsif a.kind_of?(Cat)
+    "cat"
+  else
+    "animal"
+  end
+end
+
+puts kind(Dog.new)      # dog
+puts kind(Cat.new)      # cat
+puts kind(Animal.new)   # animal
+puts kind(Puppy.new)    # dog (Puppy is_a? Dog)
+
+# instance_of? — recv typed Animal, target a proper descendant.
+# Pre-fix this collapsed to literal FALSE; runtime instance is
+# never consulted.
+def exact_is_dog(a)
+  a.instance_of?(Dog)
+end
+
+puts exact_is_dog(Dog.new)      # true  — runtime cls_id matches Dog
+puts exact_is_dog(Puppy.new)    # false — Puppy is_a? Dog but not instance_of? Dog
+puts exact_is_dog(Cat.new)      # false — unrelated descendant
+puts exact_is_dog(Animal.new)   # false — runtime cls_id is Animal, not Dog
+
+# instance_of? — recv typed Animal, target IS the static type.
+# Pre-fix this collapsed to literal TRUE (`cname == arg0`); a
+# parent-typed local holding a descendant should fail this.
+def exact_is_animal(a)
+  a.instance_of?(Animal)
+end
+
+puts exact_is_animal(Animal.new)  # true  — runtime cls_id matches Animal
+puts exact_is_animal(Dog.new)     # false — runtime cls_id is Dog, not Animal
+puts exact_is_animal(Puppy.new)   # false — runtime cls_id is Puppy

--- a/test/is_a_descendant_runtime.rb.expected
+++ b/test/is_a_descendant_runtime.rb.expected
@@ -1,0 +1,11 @@
+dog
+cat
+animal
+dog
+true
+false
+false
+false
+true
+false
+false


### PR DESCRIPTION
## Summary

For `recv.M?(target)` with `M` ∈ {`is_a?`, `kind_of?`, `instance_of?`}, where recv has static type R and target is class T, the class lattice has three cases:

| Case                                | `is_a?` / `kind_of?` | `instance_of?` |
|-------------------------------------|----------------------|----------------|
| R ⊆ T (R is T or descendant of T)   | TRUE                 | depends on runtime |
| R and T unrelated                   | FALSE                | FALSE          |
| T ⊊ R (T is proper descendant of R) | depends on runtime   | depends on runtime |

The recv's static type only bounds the runtime class above; the actual instance can be R or any descendant. Cases marked "depends on runtime" were previously collapsing to literal TRUE or FALSE statically, breaking CRuby parity:

```ruby
class Parent; end
class Child < Parent; end

def lookup(p)             # p typed as Parent
  p.is_a?(Child)          # CRuby: depends on runtime class
end                       # Spinel before: always false
puts lookup(Child.new)    # CRuby: true ; Spinel before: false ✗

def exact(p)              # p typed as Parent
  p.instance_of?(Parent)  # CRuby: TRUE only if runtime class is exactly Parent
end                       # Spinel before: always true
puts exact(Child.new)     # CRuby: false ; Spinel before: true ✗
```

## Fix

- **`is_a?` / `kind_of?` case 3** (target T proper-descendant of static R): emit `sp_class_le(recv->cls_id, T)` so a parent-typed recv holding a descendant matches when appropriate.
- **`instance_of?` case 3**: emit `recv->cls_id == T` for exact equality (no ancestor walk; `instance_of?` is stricter than `is_a?`).
- **`instance_of?` case 1** (cname == arg0): the previous code returned literal TRUE, which was wrong when a parent-typed recv held a descendant. Now emits the same runtime `recv->cls_id == arg0` check. The single exception is value-type classes (`@cls_is_value_type`), which have **no subclasses by design** (see `emit_class_fields`) and no `cls_id` field on the struct — these collapse back to static TRUE because the runtime is always exactly cname.

### Refactor

- Extract `is_descendant(child, ancestor)` from `is_class_or_ancestor` (which is descendant-or-equal) for clearer call sites on the lattice classification.
- Add `is_value_type_class(cname)` to gate the `instance_of?` case-1 runtime-check carve-out.

## Out of scope

- Cross-module ancestor matching via `include` chains — the lattice walker uses class inheritance only.
- Singleton-class membership (`obj.is_a?(obj.singleton_class)`) — Spinel doesn't materialize singleton classes as runtime values.

## Test plan

- [x] `make` — builds clean
- [x] `make bootstrap` — gen2.c == gen3.c (bootstrap OK)
- [x] `make test` — full suite passes
- [x] `test/is_a_descendant_runtime.rb` covers:
  - `is_a?` / `kind_of?` on parent-typed param holding Dog, Cat, Animal, and Puppy (case 3 runtime check)
  - `instance_of?(Dog)` on parent-typed param: TRUE for `Dog.new`, FALSE for `Puppy.new` (case 3, exact equality not ancestor walk)
  - `instance_of?(Animal)` on parent-typed param: TRUE for `Animal.new`, FALSE for `Dog.new` / `Puppy.new` (case 1 runtime check — the bug the literal-TRUE collapse would have hidden)
- [x] `test/introspection_constant_path.rb` continues to pass — value-type classes (`Mod::Sub::Deep` and friends) take the static-TRUE carve-out since they have no subclasses and no `cls_id` field