### PR TITLE
fix(codegen): Float#divmod(0) raises ZeroDivisionError

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -15062,9 +15062,24 @@ class Compiler
       tname = tuple_c_name(tt)
       arg = compile_arg0(nid)
       tmp = new_temp
+      @needs_setjmp = 1
+      # CRuby raises:
+      #   ZeroDivisionError on `1.0.divmod(0)` / `divmod(0.0)`.
+      #   FloatDomainError("NaN") on NaN dividend or NaN divisor.
+      # Bind both operands to float locals before the raise checks so
+      # they're each evaluated exactly once and so gcc can't constant-
+      # fold `1.0 / 0LL` and trip -Wdiv-by-zero on the literal-zero
+      # path below. The (mrb_int)floor cast on a NaN result would also
+      # be C undefined behaviour; raise before reaching it.
+      recv_tmp = new_temp
+      arg_tmp = new_temp
+      emit("  mrb_float " + recv_tmp + " = (mrb_float)(" + rc + ");")
+      emit("  mrb_float " + arg_tmp + " = (mrb_float)(" + arg + ");")
+      emit("  if (" + arg_tmp + " == 0.0) sp_raise_cls(\"ZeroDivisionError\", \"divided by 0\");")
+      emit("  if (" + arg_tmp + " != " + arg_tmp + " || " + recv_tmp + " != " + recv_tmp + ") sp_raise_cls(\"FloatDomainError\", \"NaN\");")
       emit("  " + tname + " *" + tmp + " = (" + tname + " *)sp_gc_alloc(sizeof(" + tname + "), NULL, " + tuple_scan_name(tt) + ");")
-      emit("  " + tmp + "->_0 = (mrb_int)floor(" + rc + " / " + arg + ");")
-      emit("  " + tmp + "->_1 = " + rc + " - " + tmp + "->_0 * " + arg + ";")
+      emit("  " + tmp + "->_0 = (mrb_int)floor(" + recv_tmp + " / " + arg_tmp + ");")
+      emit("  " + tmp + "->_1 = " + recv_tmp + " - " + tmp + "->_0 * " + arg_tmp + ";")
       return tmp
     end
     ""

--- a/test/float_divmod_zerodiv.rb
+++ b/test/float_divmod_zerodiv.rb
@@ -1,0 +1,57 @@
+# Float#divmod(0) / Float#divmod(0.0) raises ZeroDivisionError.
+#
+# Sibling of Integer#divmod(0) which was fixed in the parent
+# rescue/raise overhaul (test/integer_div_by_zero.rb). Without
+# this guard, `(mrb_int)floor(rc / 0.0)` would consume an
+# Infinity/NaN and produce undefined C behaviour at the cast.
+#
+# Test uses `puts e` directly (which prints the message string in
+# spinel) — exception object methods like .message live on a
+# separate exception-bindings PR.
+
+# Sanity: divmod with non-zero divisor still works.
+q, r = 5.0.divmod(2.0)
+puts q
+puts r
+
+# Float / int divisor
+begin
+  1.0.divmod(0)
+  puts "no raise"
+rescue ZeroDivisionError => e
+  puts "caught int divisor: #{e}"
+end
+
+# Float / float divisor
+begin
+  1.0.divmod(0.0)
+  puts "no raise"
+rescue ZeroDivisionError => e
+  puts "caught float divisor: #{e}"
+end
+
+# Bare rescue catches it.
+begin
+  3.5.divmod(0.0)
+rescue => e
+  puts "bare-rescue: #{e}"
+end
+
+# NaN divisor → FloatDomainError("NaN"). Without this guard the
+# `(mrb_int)floor(1.0 / NaN)` cast on the result would also be
+# C undefined behaviour.
+nan = 0.0 / 0.0
+begin
+  1.0.divmod(nan)
+  puts "no raise nan divisor"
+rescue FloatDomainError => e
+  puts "caught nan divisor: #{e}"
+end
+
+# NaN dividend → FloatDomainError("NaN"). Same UB risk on the cast.
+begin
+  nan.divmod(2.0)
+  puts "no raise nan dividend"
+rescue FloatDomainError => e
+  puts "caught nan dividend: #{e}"
+end

--- a/test/float_divmod_zerodiv.rb.expected
+++ b/test/float_divmod_zerodiv.rb.expected
@@ -1,0 +1,7 @@
+2
+1.0
+caught int divisor: divided by 0
+caught float divisor: divided by 0
+bare-rescue: divided by 0
+caught nan divisor: NaN
+caught nan dividend: NaN


### PR DESCRIPTION
## Summary

CRuby raises `ZeroDivisionError` on `1.0.divmod(0)` and `1.0.divmod(0.0)` in 3.x. Spinel previously emitted `(mrb_int)floor(rc / 0.0)` which triggers undefined C behaviour at the cast (Infinity/NaN consumed by integer cast).

```ruby
1.0.divmod(0) rescue puts "caught"   # CRuby: caught
                                     # Spinel before: SIGFPE / garbage
```

## What changed

`compile_float_method_expr` divmod arm now emits an `if (arg == 0.0) sp_raise_cls("ZeroDivisionError", "divided by 0");` guard before the floor cast. `@needs_setjmp = 1` set so the rescue infrastructure is wired in.

The divisor is bound to a `mrb_float` local before the raise check, so a literal-zero argument (`1.0.divmod(0)`) doesn't trip `-Wdiv-by-zero` at compile time on the floor expression below. The runtime raise fires before any division actually happens, but the static warning fires regardless because gcc sees the literal `/ 0` in source. With the divisor through a temp, gcc can't constant-fold across the assignment and the warning is suppressed.

## Out of scope

Float `**` with negative base + non-integer exponent (CRuby raises `Math::DomainError`; covered by a separate change in the Math domain-error pass).

## Test plan

- [x] `make` — builds clean
- [x] `make bootstrap` — gen2.c == gen3.c (bootstrap OK)
- [x] `make test` — full suite passes
- [x] `test/float_divmod_zerodiv.rb` covers non-zero divisor baseline, int divisor zero, float divisor zero, and bare rescue