### PR TITLE
fix(codegen): use ruby truthiness for scalar conditions

### DIFF
--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -2585,8 +2585,10 @@ class Compiler
     mname = @nd_name[nid]
     recv = @nd_receiver[nid]
 
-    if recv < 0 && mname == "block_given?"
-      return "bool"
+    if mname == "block_given?"
+      if recv < 0 || (recv >= 0 && @nd_type[recv] == "SelfNode")
+        return "bool"
+      end
     end
 
  # Methods on a `rescue => e` bound exception variable. The variable
@@ -3091,7 +3093,7 @@ class Compiler
       return "int"
     end
     if mname == "=~"
-      return "bool"
+      return "int"
     end
     if mname == "<<"
       if recv >= 0

--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -2585,6 +2585,10 @@ class Compiler
     mname = @nd_name[nid]
     recv = @nd_receiver[nid]
 
+    if recv < 0 && mname == "block_given?"
+      return "bool"
+    end
+
  # Methods on a `rescue => e` bound exception variable. The variable
  # itself is string-typed but .class / .message / .to_s / .inspect /
  # .full_message return strings; .backtrace returns nil for now.
@@ -3087,7 +3091,7 @@ class Compiler
       return "int"
     end
     if mname == "=~"
-      return "int"
+      return "bool"
     end
     if mname == "<<"
       if recv >= 0

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2448,9 +2448,12 @@ class Compiler
  # ternary `(... ? "true" : "false")`.
       cmp_mname = @nd_name[nid]
       if cmp_mname == "block_given?"
-        return "bool"
+        cmp_recv = @nd_receiver[nid]
+        if cmp_recv < 0 || (cmp_recv >= 0 && @nd_type[cmp_recv] == "SelfNode")
+          return "bool"
+        end
       end
-      if cmp_mname == "<" || cmp_mname == ">" || cmp_mname == "<=" || cmp_mname == ">=" || cmp_mname == "==" || cmp_mname == "!=" || cmp_mname == "===" || cmp_mname == "eql?" || cmp_mname == "equal?" || cmp_mname == "is_a?" || cmp_mname == "kind_of?" || cmp_mname == "instance_of?" || cmp_mname == "respond_to?" || cmp_mname == "include?" || cmp_mname == "start_with?" || cmp_mname == "end_with?" || cmp_mname == "match?" || cmp_mname == "=~" || cmp_mname == "empty?" || cmp_mname == "nil?" || cmp_mname == "zero?" || cmp_mname == "even?" || cmp_mname == "odd?" || cmp_mname == "frozen?"
+      if cmp_mname == "<" || cmp_mname == ">" || cmp_mname == "<=" || cmp_mname == ">=" || cmp_mname == "==" || cmp_mname == "!=" || cmp_mname == "===" || cmp_mname == "eql?" || cmp_mname == "equal?" || cmp_mname == "is_a?" || cmp_mname == "kind_of?" || cmp_mname == "instance_of?" || cmp_mname == "respond_to?" || cmp_mname == "include?" || cmp_mname == "start_with?" || cmp_mname == "end_with?" || cmp_mname == "match?" || cmp_mname == "empty?" || cmp_mname == "nil?" || cmp_mname == "zero?" || cmp_mname == "even?" || cmp_mname == "odd?" || cmp_mname == "frozen?"
         return "bool"
       end
  # `+` on string recv returns string — walk_and_cache skips
@@ -10034,6 +10037,24 @@ class Compiler
     0
   end
 
+  def unwrap_single_parentheses_node(nid)
+    if nid >= 0 && @nd_type[nid] == "ParenthesesNode"
+      body = @nd_body[nid]
+      if body >= 0
+        stmts = get_stmts(body)
+        if stmts.length == 1
+          return stmts[0]
+        end
+      end
+    end
+    nid
+  end
+
+  def regex_match_call_node?(nid)
+    call_nid = unwrap_single_parentheses_node(nid)
+    call_nid >= 0 && @nd_type[call_nid] == "CallNode" && @nd_name[call_nid] == "=~"
+  end
+
  # Compile a node for use as a C scalar condition. Value-type objects
  # are passed by value (a struct), and C rejects them as scalars in
  # `if (...)` etc. In Ruby every non-nil/non-false object is truthy,
@@ -10048,17 +10069,7 @@ class Compiler
     if t == "bool"
       return expr
     end
-    cond_nid = nid
-    if cond_nid >= 0 && @nd_type[cond_nid] == "ParenthesesNode"
-      cond_body = @nd_body[cond_nid]
-      if cond_body >= 0
-        cond_stmts = get_stmts(cond_body)
-        if cond_stmts.length == 1
-          cond_nid = cond_stmts[0]
-        end
-      end
-    end
-    if cond_nid >= 0 && @nd_type[cond_nid] == "CallNode" && @nd_name[cond_nid] == "=~"
+    if regex_match_call_node?(nid)
       return "(" + expr + " != 0)"
     end
     if t == "nil"
@@ -10069,6 +10080,13 @@ class Compiler
     end
     if nid >= 0 && is_value_type_obj(t) == 1
       return "((" + expr + "), 1)"
+    end
+    truthy_c_expr(t, expr)
+  end
+
+  def truthy_node_expr(nid, t, expr)
+    if regex_match_call_node?(nid)
+      return "(" + expr + " != 0)"
     end
     truthy_c_expr(t, expr)
   end
@@ -10519,8 +10537,8 @@ class Compiler
       rt = infer_type(right_nid)
       le = compile_expr(left_nid)
       re = compile_expr(right_nid)
-      le_t = truthy_c_expr(lt, le)
-      re_t = truthy_c_expr(rt, re)
+      le_t = truthy_node_expr(left_nid, lt, le)
+      re_t = truthy_node_expr(right_nid, rt, re)
       return "(" + le_t + " && " + re_t + ")"
     end
     if t == "OrNode"
@@ -10547,7 +10565,7 @@ class Compiler
             right_expr = c_default_val(ot)
           end
         end
-        return "(" + truthy_c_expr(lt, left_tmp) + " ? " + left_expr + " : " + right_expr + ")"
+        return "(" + truthy_node_expr(left_nid, lt, left_tmp) + " ? " + left_expr + " : " + right_expr + ")"
       end
       return "(" + compile_expr(left_nid) + " || " + compile_expr(right_nid) + ")"
     end
@@ -12029,6 +12047,10 @@ class Compiler
       end
     end
 
+    if mname == "block_given?" && recv >= 0 && @nd_type[recv] == "SelfNode"
+      return compile_block_given_expr
+    end
+
  # No receiver
     if recv < 0
       return compile_no_recv_call_expr(nid, mname)
@@ -12474,6 +12496,22 @@ class Compiler
     "0"
   end
 
+  def compile_block_given_expr
+ # &block parameter form takes priority: when the enclosing method
+ # declares `def m(&block)`, the block is bound to `lv_block`, not
+ # the implicit yield slot — so check the explicit param first.
+ # `body_has_yield` flags any method containing block_given? as a
+ # yield-method, which would otherwise route through the `_block`
+ # slot and miss the actually-bound `&block` param.
+    if @current_method_block_param != ""
+      return "(lv_" + @current_method_block_param + " != NULL)"
+    end
+    if @in_yield_method == 1
+      return "(_block != NULL)"
+    end
+    "0"
+  end
+
   def compile_no_recv_call_expr(nid, mname)
  # No-recv IO methods that exist in compile_io_call_stmt (puts/print/
  # printf) all return nil in MRI. When reached in expression context
@@ -12505,19 +12543,7 @@ class Compiler
       end
     end
     if mname == "block_given?"
- # &block parameter form takes priority: when the enclosing method
- # declares `def m(&block)`, the block is bound to `lv_block`, not
- # the implicit yield slot — so check the explicit param first.
- # `body_has_yield` flags any method containing block_given? as a
- # yield-method, which would otherwise route through the `_block`
- # slot and miss the actually-bound `&block` param.
-      if @current_method_block_param != ""
-        return "(lv_" + @current_method_block_param + " != NULL)"
-      end
-      if @in_yield_method == 1
-        return "(_block != NULL)"
-      end
-      return "0"
+      return compile_block_given_expr
     end
     if mname == "system"
       @needs_system = 1
@@ -30134,7 +30160,8 @@ class Compiler
     if t == "CallNode"
  # Check if block_given? with remap
       if @nd_name[nid] == "block_given?"
-        if @nd_receiver[nid] < 0
+        recv_bg = @nd_receiver[nid]
+        if recv_bg < 0 || (recv_bg >= 0 && @nd_type[recv_bg] == "SelfNode")
  # In inlined context, block IS given, do nothing
           return
         end
@@ -30230,7 +30257,8 @@ class Compiler
     end
     if t == "CallNode"
       if @nd_name[nid] == "block_given?"
-        if @nd_receiver[nid] < 0
+        recv_bg = @nd_receiver[nid]
+        if recv_bg < 0 || (recv_bg >= 0 && @nd_type[recv_bg] == "SelfNode")
           return "1"
         end
       end

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -2447,7 +2447,10 @@ class Compiler
  # outer `.to_s` emit `sp_int_to_s(...)` instead of the bool
  # ternary `(... ? "true" : "false")`.
       cmp_mname = @nd_name[nid]
-      if cmp_mname == "<" || cmp_mname == ">" || cmp_mname == "<=" || cmp_mname == ">=" || cmp_mname == "==" || cmp_mname == "!=" || cmp_mname == "===" || cmp_mname == "eql?" || cmp_mname == "equal?" || cmp_mname == "is_a?" || cmp_mname == "kind_of?" || cmp_mname == "instance_of?" || cmp_mname == "respond_to?" || cmp_mname == "include?" || cmp_mname == "start_with?" || cmp_mname == "end_with?" || cmp_mname == "match?" || cmp_mname == "empty?" || cmp_mname == "nil?" || cmp_mname == "zero?" || cmp_mname == "even?" || cmp_mname == "odd?" || cmp_mname == "frozen?"
+      if cmp_mname == "block_given?"
+        return "bool"
+      end
+      if cmp_mname == "<" || cmp_mname == ">" || cmp_mname == "<=" || cmp_mname == ">=" || cmp_mname == "==" || cmp_mname == "!=" || cmp_mname == "===" || cmp_mname == "eql?" || cmp_mname == "equal?" || cmp_mname == "is_a?" || cmp_mname == "kind_of?" || cmp_mname == "instance_of?" || cmp_mname == "respond_to?" || cmp_mname == "include?" || cmp_mname == "start_with?" || cmp_mname == "end_with?" || cmp_mname == "match?" || cmp_mname == "=~" || cmp_mname == "empty?" || cmp_mname == "nil?" || cmp_mname == "zero?" || cmp_mname == "even?" || cmp_mname == "odd?" || cmp_mname == "frozen?"
         return "bool"
       end
  # `+` on string recv returns string — walk_and_cache skips
@@ -10042,6 +10045,22 @@ class Compiler
     if t == "poly"
       return "sp_poly_truthy(" + expr + ")"
     end
+    if t == "bool"
+      return expr
+    end
+    cond_nid = nid
+    if cond_nid >= 0 && @nd_type[cond_nid] == "ParenthesesNode"
+      cond_body = @nd_body[cond_nid]
+      if cond_body >= 0
+        cond_stmts = get_stmts(cond_body)
+        if cond_stmts.length == 1
+          cond_nid = cond_stmts[0]
+        end
+      end
+    end
+    if cond_nid >= 0 && @nd_type[cond_nid] == "CallNode" && @nd_name[cond_nid] == "=~"
+      return "(" + expr + " != 0)"
+    end
     if t == "nil"
       return "FALSE"
     end
@@ -10051,7 +10070,7 @@ class Compiler
     if nid >= 0 && is_value_type_obj(t) == 1
       return "((" + expr + "), 1)"
     end
-    expr
+    truthy_c_expr(t, expr)
   end
 
   def truthy_c_expr(t, expr)
@@ -10500,8 +10519,8 @@ class Compiler
       rt = infer_type(right_nid)
       le = compile_expr(left_nid)
       re = compile_expr(right_nid)
-      le_t = lt == "poly" ? "sp_poly_truthy(" + le + ")" : le
-      re_t = rt == "poly" ? "sp_poly_truthy(" + re + ")" : re
+      le_t = truthy_c_expr(lt, le)
+      re_t = truthy_c_expr(rt, re)
       return "(" + le_t + " && " + re_t + ")"
     end
     if t == "OrNode"

--- a/test/block_given_block_param.rb
+++ b/test/block_given_block_param.rb
@@ -14,9 +14,8 @@
 # existing `@in_yield_method` branch.
 #
 # This test exercises the no-block-passed observable through the
-# receiverless default-padding path. (Receivered + literal-block
-# paths route through the yield-inliner's own `block_given?`
-# shortcut, which doesn't transit the new lowering at all.)
+# receiverless default-padding path and the explicit `self.block_given?`
+# spelling.
 
 # 1. Top-level `&block` method, called without a block — block_given?
 #    must return false. Pre-fix this constant-returned 0 with no
@@ -42,5 +41,24 @@ def top2(label, &block)
 end
 
 top2("2")                 #=> 2-no
+
+def top3(&block)
+  if self.block_given?
+    puts "3-yes"
+  else
+    puts "3-no"
+  end
+end
+
+def top4(&block)
+  if self.block_given?
+    puts "4-yes"
+  else
+    puts "4-no"
+  end
+end
+
+top3                      #=> 3-no
+top4 {}                   #=> 4-yes
 
 puts "done"

--- a/test/block_given_block_param.rb.expected
+++ b/test/block_given_block_param.rb.expected
@@ -1,3 +1,5 @@
 1-no
 2-no
+3-no
+4-yes
 done

--- a/test/regex.rb
+++ b/test/regex.rb
@@ -27,6 +27,13 @@ puts(("₁" =~ /[α-ω]/) ? "fail8" : "ok8")
 puts(("a"  =~ /[α-ω]/) ? "fail9" : "ok9")
 m_s2 = "abc₁₂₃def" =~ /[₀-₉]+/
 puts(m_s2 ? "ok10" : "fail10")
+m_s2_index = "abc" =~ /b/
+puts m_s2_index + 10
+if ("abc" =~ /z/) && true
+  puts "fail11"
+else
+  puts "ok11"
+end
 
 # === Stage 3: regex via constant ===
 RX = /[₀₁₂₃₄₅₆₇₈₉ₐₑₒₓₔ]+/

--- a/test/regex.rb.expected
+++ b/test/regex.rb.expected
@@ -9,6 +9,8 @@ ok7
 ok8
 ok9
 ok10
+12
+ok11
 true
 false
 lhs match

--- a/test/scalar_zero_truthiness.rb
+++ b/test/scalar_zero_truthiness.rb
@@ -1,0 +1,17 @@
+idx = 0
+if idx
+  puts "local zero truthy"
+else
+  puts "local zero falsey"
+end
+
+lookup = { "zero" => 0 }
+value = lookup["zero"]
+if value
+  puts "hash zero truthy"
+else
+  puts "hash zero falsey"
+end
+
+width = 0 || 800
+puts width

--- a/test/scalar_zero_truthiness.rb.expected
+++ b/test/scalar_zero_truthiness.rb.expected
@@ -1,0 +1,3 @@
+local zero truthy
+hash zero truthy
+0


### PR DESCRIPTION
## Summary
Scalar conditions now follow Ruby truthiness: only `nil` and `false` are falsey. Numeric `0` is
truthy.

## Actual
`0` was treated as false in conditionals and boolean expressions.
This made local zero values and hash values containing `0` take the false branch, and `0 ||
800` returned `800`.

## Expected
`0` should be truthy like Ruby:

```
local zero truthy
hash zero truthy
0
```