### PR TITLE
fix(analyze): preserve nil state for scalar ivars

### DIFF
--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -7560,6 +7560,15 @@ class Compiler
     end
   end
 
+  def scalar_ivar_type?(t)
+    t == "int" || t == "float" || t == "bool" || t == "symbol"
+  end
+
+  def nil_scalar_ivar_mix?(old_type, new_type)
+    (old_type == "nil" && scalar_ivar_type?(new_type)) ||
+      (new_type == "nil" && scalar_ivar_type?(old_type))
+  end
+
   def update_ivar_type(ci, iname, new_type)
     names = @cls_ivar_names[ci].split(";")
     types = @cls_ivar_types[ci].split(";")
@@ -7612,18 +7621,8 @@ class Compiler
  # `@m = method(:foo)` initially scans as int and a
  # refinement promotes it to `obj_Method` — no heterogeneity
  # to widen for).
-          nil_scalar_mix = 0
-          if old == "nil" && (new_type == "int" || new_type == "float" || new_type == "bool" || new_type == "symbol")
-            nil_scalar_mix = 1
-          elsif new_type == "nil" && (old == "int" || old == "float" || old == "bool" || old == "symbol")
-            nil_scalar_mix = 1
-          end
-          if nil_scalar_mix == 1
-            types[k] = "poly"
-            @needs_rb_value = 1
-            @cls_ivar_types[ci] = types.join(";")
-            @cls_ivar_types_version = @cls_ivar_types_version + 1
-          elsif (old == "int" || old == "nil") && is_obj_type(new_type) == 1 && cls_ivar_definite_flag(ci, iname) == 1
+          if nil_scalar_ivar_mix?(old, new_type) ||
+              ((old == "int" || old == "nil") && is_obj_type(new_type) == 1 && cls_ivar_definite_flag(ci, iname) == 1)
             types[k] = "poly"
             @needs_rb_value = 1
             @cls_ivar_types[ci] = types.join(";")
@@ -10840,11 +10839,13 @@ class Compiler
                           if ij < ivar_types.length
                             if ivar_names[ij] == iname
                               if ptypes[pi] != ""
-                                if ivar_types[ij] == "nil" && (ptypes[pi] == "int" || ptypes[pi] == "float" || ptypes[pi] == "bool" || ptypes[pi] == "symbol")
+                                old_t = ivar_types[ij]
+                                new_t = ptypes[pi]
+                                if nil_scalar_ivar_mix?(old_t, new_t)
                                   ivar_types[ij] = "poly"
                                   @needs_rb_value = 1
                                 else
-                                  ivar_types[ij] = unify_call_types(ivar_types[ij], ptypes[pi], -1)
+                                  ivar_types[ij] = unify_call_types(old_t, new_t, -1)
                                 end
                               end
                             end
@@ -13435,23 +13436,21 @@ class Compiler
  # Chain participants bypass the `int` guard so that
  # `@string_slot = @int_slot = expr_returning_int` widens
  # the head to poly instead of leaving it stuck at
- # `string`. The `nil` guard stays in place even for
- # chains: `@a = @b = ... = nil` is handled at emit time
- # by `compile_chained_ivar_writes`'s per-slot recurse
- # path (NilNode lowers to a literal `0`, a null pointer
- # constant valid for any slot type), and forcing nil
- # into the slot type interacts badly with parent-cascade
- # update_ivar_type — a subclass write that pins the same
- # slot to a concrete obj type ping-pongs between obj_X
- # and obj_X? across iter rounds and lands on poly,
- # breaking the typed-pointer store at emit time.
+ # `string`. Plain `nil` writes are routed through
+ # update_ivar_type when the current slot is scalar; object
+ # nil writes stay on the existing nullable/finalize paths to
+ # avoid parent-cascade ping-pong across passes.
           if chain_inames.length > 1 && at == "int"
             ci_idx = 0
             while ci_idx < chain_inames.length
               update_ivar_type(@current_class_idx, chain_inames[ci_idx], at)
               ci_idx = ci_idx + 1
             end
-          elsif at != "nil" && (at != "int" || cls_ivar_type(@current_class_idx, iname) == "nil")
+          elsif at == "nil"
+            if scalar_ivar_type?(cls_ivar_type(@current_class_idx, iname))
+              update_ivar_type(@current_class_idx, iname, at)
+            end
+          elsif at != "int" || cls_ivar_type(@current_class_idx, iname) == "nil"
             update_ivar_type(@current_class_idx, iname, at)
           end
         end

--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -7612,7 +7612,18 @@ class Compiler
  # `@m = method(:foo)` initially scans as int and a
  # refinement promotes it to `obj_Method` — no heterogeneity
  # to widen for).
-          if (old == "int" || old == "nil") && is_obj_type(new_type) == 1 && cls_ivar_definite_flag(ci, iname) == 1
+          nil_scalar_mix = 0
+          if old == "nil" && (new_type == "int" || new_type == "float" || new_type == "bool" || new_type == "symbol")
+            nil_scalar_mix = 1
+          elsif new_type == "nil" && (old == "int" || old == "float" || old == "bool" || old == "symbol")
+            nil_scalar_mix = 1
+          end
+          if nil_scalar_mix == 1
+            types[k] = "poly"
+            @needs_rb_value = 1
+            @cls_ivar_types[ci] = types.join(";")
+            @cls_ivar_types_version = @cls_ivar_types_version + 1
+          elsif (old == "int" || old == "nil") && is_obj_type(new_type) == 1 && cls_ivar_definite_flag(ci, iname) == 1
             types[k] = "poly"
             @needs_rb_value = 1
             @cls_ivar_types[ci] = types.join(";")
@@ -7904,7 +7915,7 @@ class Compiler
             if new_def == 1 && cur_def == 1 && cur != vtype && cur != "poly"
               replace_ivar_type(ci, iname, "poly")
               @needs_rb_value = 1
-            elsif vtype != "int"
+            elsif vtype != "int" || cur == "nil"
               update_ivar_type(ci, iname, vtype)
             end
           end
@@ -10829,7 +10840,12 @@ class Compiler
                           if ij < ivar_types.length
                             if ivar_names[ij] == iname
                               if ptypes[pi] != ""
-                                ivar_types[ij] = unify_call_types(ivar_types[ij], ptypes[pi], -1)
+                                if ivar_types[ij] == "nil" && (ptypes[pi] == "int" || ptypes[pi] == "float" || ptypes[pi] == "bool" || ptypes[pi] == "symbol")
+                                  ivar_types[ij] = "poly"
+                                  @needs_rb_value = 1
+                                else
+                                  ivar_types[ij] = unify_call_types(ivar_types[ij], ptypes[pi], -1)
+                                end
                               end
                             end
                           end
@@ -13435,7 +13451,7 @@ class Compiler
               update_ivar_type(@current_class_idx, chain_inames[ci_idx], at)
               ci_idx = ci_idx + 1
             end
-          elsif at != "int" && at != "nil"
+          elsif at != "nil" && (at != "int" || cls_ivar_type(@current_class_idx, iname) == "nil")
             update_ivar_type(@current_class_idx, iname, at)
           end
         end

--- a/test/nil_scalar_ivar_widen.rb
+++ b/test/nil_scalar_ivar_widen.rb
@@ -16,3 +16,41 @@ state = HitState.new
 puts state.label
 state.hit!(0)
 puts state.label
+
+class ResetState
+  def initialize
+    @material_index = 0
+  end
+
+  def clear!
+    @material_index = nil
+  end
+
+  def label
+    @material_index.nil? ? "miss" : "hit"
+  end
+end
+
+reset = ResetState.new
+puts reset.label
+reset.clear!
+puts reset.label
+
+class ParamResetState
+  def initialize
+    @material_index = 0
+  end
+
+  def set(idx)
+    @material_index = idx
+  end
+
+  def label
+    @material_index.nil? ? "miss" : "hit"
+  end
+end
+
+param_reset = ParamResetState.new
+puts param_reset.label
+param_reset.set(nil)
+puts param_reset.label

--- a/test/nil_scalar_ivar_widen.rb
+++ b/test/nil_scalar_ivar_widen.rb
@@ -1,0 +1,18 @@
+class HitState
+  def initialize
+    @material_index = nil
+  end
+
+  def hit!(idx)
+    @material_index = idx
+  end
+
+  def label
+    @material_index.nil? ? "miss" : "hit"
+  end
+end
+
+state = HitState.new
+puts state.label
+state.hit!(0)
+puts state.label

--- a/test/nil_scalar_ivar_widen.rb.expected
+++ b/test/nil_scalar_ivar_widen.rb.expected
@@ -1,0 +1,2 @@
+miss
+hit

--- a/test/nil_scalar_ivar_widen.rb.expected
+++ b/test/nil_scalar_ivar_widen.rb.expected
@@ -1,2 +1,6 @@
 miss
 hit
+hit
+miss
+hit
+miss


### PR DESCRIPTION
### Summary

Instance variables initialized with `nil` and later assigned numeric values can be generated as plain numeric fields, making `nil?` checks invalid.

### Repro

```ruby
@hit_material_index = nil

# later
@hit_material_index = obj.material_index

return background if @hit_material_index.nil?
```

### Actual

The ivar was generated as an integer field initialized to `0`, and the `nil?` control flow did not behave like Ruby.

### Expected

Spinel should either support nilable ivar types or preserve correct `nil?` semantics for mixed nil/numeric ivars.
