### PR TITLE
fix(analyze): collect kwrest/posts ptypes for top-level methods

### DIFF
--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -8703,70 +8703,16 @@ class Compiler
     mname = @nd_name[nid]
     body_id = @nd_body[nid]
     params_str = collect_params_str(nid)
-    ptypes_str = ""
+ # Use the shared ptypes builder so kwrest (`**kw`) and post-rest
+ # required params (`def f(*r, x, y)`) get slots that match the
+ # names emitted by collect_params_str above. An earlier inline
+ # build here omitted both, leaving param_names.length one (or
+ # more) ahead of param_types.length — the per-method scope build
+ # in infer_function_body_call_types then pushed nil into the
+ # scope_types array for any missing slot, which later tripped
+ # base_type / unify_call_types when a body referenced that local.
+    ptypes_str = collect_ptypes_str(nid, -1)
     defaults_str = collect_defaults_str(nid)
-
- # Infer param types from defaults
-    params = @nd_parameters[nid]
-    if params >= 0
-      reqs = parse_id_list(@nd_requireds[params])
-      opts = parse_id_list(@nd_optionals[params])
-      kws = parse_id_list(@nd_keywords[params])
-      k = 0
-      while k < reqs.length
-        if ptypes_str != ""
-          ptypes_str = ptypes_str + ","
-        end
-        ptypes_str = ptypes_str + "int"
-        k = k + 1
-      end
-      k = 0
-      while k < opts.length
-        if ptypes_str != ""
-          ptypes_str = ptypes_str + ","
-        end
-        def_id = @nd_expression[opts[k]]
-        if def_id >= 0
-          ptypes_str = ptypes_str + infer_type(def_id)
-        else
-          ptypes_str = ptypes_str + "int"
-        end
-        k = k + 1
-      end
-      k = 0
-      while k < kws.length
-        if ptypes_str != ""
-          ptypes_str = ptypes_str + ","
-        end
-        def_id = @nd_expression[kws[k]]
-        if def_id >= 0
-          ptypes_str = ptypes_str + infer_type(def_id)
-        else
-          ptypes_str = ptypes_str + "int"
-        end
-        k = k + 1
-      end
- # Rest param (splat)
-      rest = @nd_rest[params]
-      if rest >= 0
-        if @nd_type[rest] == "RestParameterNode"
-          if ptypes_str != ""
-            ptypes_str = ptypes_str + ","
-          end
-          ptypes_str = ptypes_str + "int_array"
-        end
-      end
- # Block param (&block)
-      blk = @nd_block[params]
-      if blk >= 0
-        if @nd_type[blk] == "BlockParameterNode"
-          if ptypes_str != ""
-            ptypes_str = ptypes_str + ","
-          end
-          ptypes_str = ptypes_str + "proc"
-        end
-      end
-    end
 
     @meth_names.push(mname)
     @meth_param_names.push(params_str)

--- a/test/toplevel_kwrest_block_param.rb
+++ b/test/toplevel_kwrest_block_param.rb
@@ -1,0 +1,19 @@
+class App
+  def initialize(title:, body:)
+    @title = title
+    @body = body
+  end
+
+  def render
+    puts @title
+    @body.call
+  end
+end
+
+# Top-level def combining `**kwrest` with `&block`, passing the block local
+# as a kwarg to a `.new` call site.
+def app(title = nil, **_chrome, &block)
+  App.new(title: title || "default", body: block)
+end
+
+app("hello") { puts "ran" }.render

--- a/test/toplevel_kwrest_block_param.rb.expected
+++ b/test/toplevel_kwrest_block_param.rb.expected
@@ -1,0 +1,2 @@
+hello
+ran


### PR DESCRIPTION
## Summary
`collect_toplevel_method` built its `ptypes_str` inline and only handled reqs / opts / kws / rest / block — it omitted the kwrest (`**kw`) slot and the post-rest required slots (`*r, x, y`) that the parallel `collect_params_str` does emit. A method like:

```ruby
def app(title = nil, **_chrome, &block)
  App.new(title: title || "default", body: block)
end
```

ended up with `param_names.length == 6` and `param_types.length == 5`. The per-method scope build in `infer_function_body_call_types` walked `pnames` and pushed `ptypes[pk]` (nil for the missing slot) onto `@scope_types`. When the body later read `body: block`, `unify_call_types` tripped through `base_type` (no nil guard):

```
spinel_analyze.rb:5569:in 'Compiler#base_type'
  NoMethodError: undefined method 'length' for nil
```

Switches the inline builder to `collect_ptypes_str(nid, -1)`, the shared helper already used by class-method registration. That helper emits `sym_poly_hash` for kwrest and `int` for posts, so `pnames`/`ptypes` counts stay aligned and the body's `LocalVariableReadNode` for the block param resolves to its declared `proc` type.

## Test plan
- [x] New regression test `test/toplevel_kwrest_block_param.rb` (top-level def with `**kwrest` and `&block`, body passes the block local to a `.new` call site)
- [x] Full test suite passes
- [x] `make bootstrap` stays at fixpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
