### PR TITLE
feat(analyze,codegen): support top-level `include <Mod>` dispatch

### DIFF
--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -448,6 +448,13 @@ class Compiler
     @parse_id_cache = {}
     @parse_id_pool = [[0]]
 
+ # Tracks bare names whose @meth_* row was added by
+ # collect_toplevel_module_includes. Entries marked here are
+ # overwriteable by a later top-level `include` (last-include-
+ # wins). User-defined `def <m>` rows aren't marked, so they
+ # win over any subsequent include.
+    @toplevel_include_alias = {}
+
     @needs_stringio = 0
     @proc_counter = 0
     @proc_funcs = ""
@@ -6139,6 +6146,13 @@ class Compiler
       end
     }
 
+ # Top-level `include <Mod>` aliases the module's module_function
+ # methods into @meth_* under their bare names so unprefixed calls
+ # dispatch through the existing find_method_idx path. Later
+ # includes overwrite earlier aliases for the same bare name
+ # (last-include-wins); user-defined top-level `def`s are preserved.
+ # Must run after module-function entries are registered.
+    collect_toplevel_module_includes
  # Pass 2.6: hoist `recv.instance_eval do ... end` blocks into
  # file-scope static functions. Receiver-class flow analysis picks the
  # receiver's class, the block body is later compiled as a function
@@ -8697,6 +8711,98 @@ class Compiler
       return "poly"
     end
     "int"
+  end
+
+ # Walk root statements for bare `include <Mod>` and alias the
+ # module's `<Mod>_cls_<m>` entries into @meth_* under their
+ # bare names. Skips unregistered modules (e.g. Comparable);
+ # collisions with user-defined top-level defs are preserved
+ # while overlap with prior alias entries is overwritten (see
+ # alias_module_methods_at_toplevel). `Foo.include(M)` is
+ # handled separately by collect_class_with_prefix.
+  def collect_toplevel_module_includes
+    root = @root_id
+    if @nd_type[root] != "ProgramNode"
+      return
+    end
+    stmts = get_body_stmts(root)
+    si = 0
+    while si < stmts.length
+      sid = stmts[si]
+      if @nd_type[sid] == "CallNode" && @nd_receiver[sid] < 0 && @nd_name[sid] == "include"
+        inc_args = @nd_arguments[sid]
+        if inc_args >= 0
+          inc_ids = get_args(inc_args)
+          ik = 0
+          while ik < inc_ids.length
+            inc_t = @nd_type[inc_ids[ik]]
+            if inc_t == "ConstantReadNode" || inc_t == "ConstantPathNode"
+              mod_name = const_ref_flat_name(inc_ids[ik])
+              if mod_name != "" && module_name_exists(mod_name) == 1
+                alias_module_methods_at_toplevel(mod_name)
+              end
+            end
+            ik = ik + 1
+          end
+        end
+      end
+      si = si + 1
+    end
+  end
+
+ # Copy each `<mod_name>_cls_<m>` row in @meth_* to a parallel
+ # bare-name row sharing body_id. On collision: an entry already
+ # marked in @toplevel_include_alias is overwritten in place
+ # (last-include-wins); user-def rows are unmarked and preserved.
+ # A one-shot bare-name → row-index map keeps collision checks O(1).
+  def alias_module_methods_at_toplevel(mod_name)
+    prefix = mod_name + "_cls_"
+    plen = prefix.length
+
+    name_to_idx = {}
+    k = 0
+    while k < @meth_names.length
+      if !name_to_idx.key?(@meth_names[k])
+        name_to_idx[@meth_names[k]] = k
+      end
+      k = k + 1
+    end
+
+    src_count = @meth_names.length
+    si = 0
+    while si < src_count
+      full = @meth_names[si]
+      if full.length > plen && full[0, plen] == prefix
+        bare = full[plen, full.length - plen]
+        existing = -1
+        if name_to_idx.key?(bare)
+          existing = name_to_idx[bare]
+        end
+        if existing < 0
+          @meth_names.push(bare)
+          @meth_param_names.push(@meth_param_names[si])
+          @meth_param_types.push(@meth_param_types[si])
+          @meth_param_empty.push(@meth_param_empty[si])
+          @meth_return_types.push(@meth_return_types[si])
+          @meth_body_ids.push(@meth_body_ids[si])
+          @meth_has_defaults.push(@meth_has_defaults[si])
+          @meth_has_yield.push(@meth_has_yield[si])
+          @meth_rest_index.push(@meth_rest_index[si])
+          @toplevel_include_alias[bare] = 1
+          name_to_idx[bare] = @meth_names.length - 1
+        elsif @toplevel_include_alias.key?(bare)
+          @meth_param_names[existing] = @meth_param_names[si]
+          @meth_param_types[existing] = @meth_param_types[si]
+          @meth_param_empty[existing] = @meth_param_empty[si]
+          @meth_return_types[existing] = @meth_return_types[si]
+          @meth_body_ids[existing] = @meth_body_ids[si]
+          @meth_has_defaults[existing] = @meth_has_defaults[si]
+          @meth_has_yield[existing] = @meth_has_yield[si]
+          @meth_rest_index[existing] = @meth_rest_index[si]
+        end
+      end
+      si = si + 1
+    end
   end
 
   def collect_toplevel_method(nid)

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -12587,6 +12587,11 @@ class Compiler
       end
     end
 
+ # `include` is handled at analyze time; at codegen it returns nil.
+    if mname == "include"
+      return "0"
+    end
+
  # Bare `new` inside a `def self.<m>` body resolves to
  # <CurrentClass>.new. Dispatched here rather than via the
  # later `mname == "new"` branch in compile_call_expr because

--- a/test/toplevel_include_module_function.rb
+++ b/test/toplevel_include_module_function.rb
@@ -1,0 +1,101 @@
+# Top-level `include <Mod>` mixes the module's module_function
+# methods into the main scope so bare `<m>` calls dispatch to
+# them. CRuby installs them on Object; Spinel registers parallel
+# bare-name entries in @meth_* pointing at the same body_id.
+
+module Greeter
+  module_function
+
+  def hello(name)
+    "hello, " + name + "!"
+  end
+
+  def bye
+    "bye"
+  end
+end
+
+include Greeter
+
+puts hello("world")
+puts bye
+
+# ---
+# `include Outer::Inner` (ConstantPathNode arg) at top level.
+
+module Outer
+  module Inner
+    module_function
+
+    def greet
+      "hi-from-Outer-Inner"
+    end
+  end
+end
+
+include Outer::Inner
+
+puts greet
+
+# ---
+# Multi-include with overlap: a later include shadows the earlier
+# alias for the same bare name (CRuby: last-include wins via the
+# linearised ancestor chain). Non-overlapping methods from both
+# modules stay available.
+
+module First
+  module_function
+
+  def shared
+    "shared-from-First"
+  end
+
+  def only_in_first
+    "only-First"
+  end
+end
+
+module Second
+  module_function
+
+  def shared
+    "shared-from-Second"
+  end
+
+  def only_in_second
+    "only-Second"
+  end
+end
+
+include First
+include Second
+
+puts shared           # Second wins
+puts only_in_first    # still resolvable via First
+puts only_in_second   # newly available via Second
+
+# ---
+# A user-defined top-level `def` is not shadowed by a later
+# `include` of a module with the same method name. CRuby's
+# method-lookup places user defs above the include chain.
+
+module Tail
+  module_function
+
+  def kept_for_user
+    "from-Tail"
+  end
+
+  def tail_only
+    "tail-only"
+  end
+end
+
+def kept_for_user
+  "user-defined"
+end
+
+include Tail
+
+puts kept_for_user   # user-defined wins
+puts tail_only       # still resolvable

--- a/test/toplevel_include_module_function.rb.expected
+++ b/test/toplevel_include_module_function.rb.expected
@@ -1,0 +1,8 @@
+hello, world!
+bye
+hi-from-Outer-Inner
+shared-from-Second
+only-First
+only-Second
+user-defined
+tail-only


### PR DESCRIPTION
Top-level `include <Mod>` at root scope previously fell through the analyzer with no effect — bare `<m>` calls following the include went unresolved with "cannot resolve call to '<m>' on (no receiver)". CRuby installs the module's instance-side methods on Object so they resolve via normal method lookup; Spinel doesn't model the Object mixin chain.

Analyze gains a small pass after module-function registration: `collect_toplevel_module_includes` walks root statements, finds bare `include <Mod>` (ConstantReadNode or ConstantPathNode arg), and for each `<Mod>_cls_<m>` entry in @meth_* copies a parallel row keyed by the bare `<m>` name with the same body_id. The existing `find_method_idx` + `sp_<name>` dispatch path then picks the right body for an unprefixed call without any IR schema or dispatch changes. Guards: unregistered modules (e.g. Comparable, which Spinel doesn't model) are skipped; bare-name collisions with user-defined top-level methods are skipped (first-registration wins, matching CRuby's no-shadow semantic for subsequent `include` calls).

Codegen treats the `include` call itself as a no-op returning "0" (CRuby returns nil from include) so the otherwise-unhandled bare call doesn't emit a spurious diagnostic.

Adds test/toplevel_include_module_function.rb covering the canonical `include Greeter` shape and the `include Outer::Inner` ConstantPathNode shape. Full test suite (474 tests) passes; bootstrap fixpoint (IR + C, analyze + codegen) holds.