### PR TITLE
fix(codegen,runtime): pass system argument lists

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -24,8 +24,10 @@
 #include <stdarg.h>
 #include <time.h>
 #include <setjmp.h>
+#include <errno.h>
 #ifdef _WIN32
 #include <windows.h>
+#include <process.h>
 /* POSIX compat shims for MinGW */
 #define mmap(a,l,p,f,fd,off) VirtualAlloc(NULL,(l),MEM_RESERVE|MEM_COMMIT,PAGE_READWRITE)
 #define munmap(a,l) (VirtualFree((a),0,MEM_RELEASE)?0:-1)
@@ -39,6 +41,7 @@
 #include <ucontext.h>
 #include <unistd.h>
 #include <sys/mman.h>
+#include <sys/wait.h>
 #endif
 #if !defined(__APPLE__) && !defined(_WIN32) && !defined(__FreeBSD__)
 #include <malloc.h>
@@ -1748,6 +1751,40 @@ void sp_bigint_free(sp_Bigint *b);
 
 /* System/backtick support */
 static int sp_last_status = 0;
+static mrb_bool sp_system_args(int argc, const char *const *argv) {
+  if (argc <= 0 || argv == NULL || argv[0] == NULL) {
+    sp_last_status = -1;
+    return FALSE;
+  }
+  fflush(stdout);
+#ifdef _WIN32
+  intptr_t rc = _spawnvp(_P_WAIT, argv[0], argv);
+  if (rc < 0) {
+    sp_last_status = -1;
+    return FALSE;
+  }
+  sp_last_status = (int)rc;
+  return rc == 0 ? TRUE : FALSE;
+#else
+  pid_t pid = fork();
+  if (pid < 0) {
+    sp_last_status = -1;
+    return FALSE;
+  }
+  if (pid == 0) {
+    execvp(argv[0], (char * const *)argv);
+    _exit(127);
+  }
+  int status = 0;
+  while (waitpid(pid, &status, 0) < 0) {
+    if (errno == EINTR) continue;
+    sp_last_status = -1;
+    return FALSE;
+  }
+  sp_last_status = status;
+  return (WIFEXITED(status) && WEXITSTATUS(status) == 0) ? TRUE : FALSE;
+#endif
+}
 
 /* Bigint (linked from libspinel_rt.a) */
 typedef struct sp_Bigint sp_Bigint;

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -1751,19 +1751,126 @@ void sp_bigint_free(sp_Bigint *b);
 
 /* System/backtick support */
 static int sp_last_status = 0;
+#ifdef _WIN32
+static char *sp_win_quote_arg(const char *arg) {
+  const char *p = arg;
+  size_t len = 2;
+  mrb_bool quote = (*p == '\0') ? TRUE : FALSE;
+  while (*p) {
+    if (isspace((unsigned char)*p) || *p == '"') quote = TRUE;
+    if (*p == '"') {
+      len += 2;
+    }
+    else {
+      len += 1;
+    }
+    p++;
+  }
+  if (!quote) {
+    char *copy = (char *)malloc(len - 1);
+    if (copy) memcpy(copy, arg, len - 1);
+    return copy;
+  }
+
+  p = arg;
+  size_t bs = 0;
+  len = 3;
+  while (*p) {
+    if (*p == '\\') {
+      bs++;
+    }
+    else if (*p == '"') {
+      len += bs * 2 + 2;
+      bs = 0;
+    }
+    else {
+      len += bs + 1;
+      bs = 0;
+    }
+    p++;
+  }
+  len += bs * 2;
+
+  char *out = (char *)malloc(len);
+  if (!out) return NULL;
+  char *q = out;
+  *q++ = '"';
+  p = arg;
+  bs = 0;
+  while (*p) {
+    if (*p == '\\') {
+      bs++;
+    }
+    else if (*p == '"') {
+      while (bs > 0) {
+        *q++ = '\\';
+        *q++ = '\\';
+        bs--;
+      }
+      *q++ = '\\';
+      *q++ = '"';
+      bs = 0;
+    }
+    else {
+      while (bs > 0) {
+        *q++ = '\\';
+        bs--;
+      }
+      *q++ = *p;
+      bs = 0;
+    }
+    p++;
+  }
+  while (bs > 0) {
+    *q++ = '\\';
+    *q++ = '\\';
+    bs--;
+  }
+  *q++ = '"';
+  *q = '\0';
+  return out;
+}
+#endif
+
 static mrb_bool sp_system_args(int argc, const char *const *argv) {
   if (argc <= 0 || argv == NULL || argv[0] == NULL) {
     sp_last_status = -1;
     return FALSE;
   }
-  fflush(stdout);
+  fflush(NULL);
 #ifdef _WIN32
-  intptr_t rc = _spawnvp(_P_WAIT, argv[0], argv);
+  char **quoted_argv = (char **)malloc(sizeof(char *) * (size_t)(argc + 1));
+  if (!quoted_argv) {
+    sp_last_status = -1;
+    return FALSE;
+  }
+  int i = 0;
+  while (i < argc) {
+    if (argv[i] == NULL) {
+      while (i-- > 0) free(quoted_argv[i]);
+      free(quoted_argv);
+      sp_last_status = -1;
+      return FALSE;
+    }
+    quoted_argv[i] = sp_win_quote_arg(argv[i]);
+    if (!quoted_argv[i]) {
+      while (i-- > 0) free(quoted_argv[i]);
+      free(quoted_argv);
+      sp_last_status = -1;
+      return FALSE;
+    }
+    i++;
+  }
+  quoted_argv[argc] = NULL;
+
+  intptr_t rc = _spawnvp(_P_WAIT, argv[0], (const char *const *)quoted_argv);
+  for (i = 0; i < argc; i++) free(quoted_argv[i]);
+  free(quoted_argv);
   if (rc < 0) {
     sp_last_status = -1;
     return FALSE;
   }
-  sp_last_status = (int)rc;
+  sp_last_status = (int)rc << 8;
   return rc == 0 ? TRUE : FALSE;
 #else
   pid_t pid = fork();

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -11205,6 +11205,30 @@ class Compiler
     "0"
   end
 
+  def compile_system_call(nid)
+    @needs_system = 1
+    args_id = @nd_arguments[nid]
+    arg_ids = []
+    if args_id >= 0
+      arg_ids = get_args(args_id)
+    end
+    if arg_ids.length <= 1
+      return "({ fflush(stdout); sp_last_status = system(" + compile_arg0(nid) + "); sp_last_status == 0; })"
+    end
+
+    argv = ""
+    i = 0
+    while i < arg_ids.length
+      if i > 0
+        argv = argv + ", "
+      end
+      argv = argv + compile_expr(arg_ids[i])
+      i += 1
+    end
+    argv = argv + ", NULL"
+    "sp_system_args(" + arg_ids.length.to_s + ", (const char*[]){" + argv + "})"
+  end
+
  # Like compile_arg0, but unboxes the result to mrb_int when the
  # argument's static type is poly. Use at call sites that pass the
  # arg directly to a C function expecting `mrb_int` (sp_IntArray_get,
@@ -12693,8 +12717,7 @@ class Compiler
       return compile_block_given_expr
     end
     if mname == "system"
-      @needs_system = 1
-      return "({ fflush(stdout); sp_last_status = system(" + compile_arg0(nid) + "); sp_last_status == 0; })"
+      return compile_system_call(nid)
     end
     if mname == "__method__"
       return "\"" + @current_method_name + "\""
@@ -25100,8 +25123,7 @@ class Compiler
  # system
     if mname == "system"
       if recv < 0
-        emit("  fflush(stdout);")
-        emit("  sp_last_status = system(" + compile_arg0(nid) + ");")
+        emit("  " + compile_system_call(nid) + ";")
         return 1
       end
     end

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -11213,7 +11213,7 @@ class Compiler
       arg_ids = get_args(args_id)
     end
     if arg_ids.length <= 1
-      return "({ fflush(stdout); sp_last_status = system(" + compile_arg0(nid) + "); sp_last_status == 0; })"
+      return "({ fflush(NULL); sp_last_status = system(" + compile_arg0(nid) + "); sp_last_status == 0; })"
     end
 
     argv = ""
@@ -24129,9 +24129,8 @@ class Compiler
  # Important on Windows where stdio is fully-buffered when stdout
  # is a pipe — without an explicit flush, output written via puts
  # before a `system(...)` call appears after the child process's
- # output. The expression-context system path already emits
- # fflush(stdout) implicitly; this lets user code do the same
- # explicitly.
+ # output. The expression-context system path already flushes open
+ # streams implicitly; this lets user code do the same explicitly.
     if mname == "flush" && recv >= 0
       stream = ""
       if @nd_type[recv] == "GlobalVariableReadNode"

--- a/test/system_argument_list.rb
+++ b/test/system_argument_list.rb
@@ -1,0 +1,15 @@
+# Multi-argument system calls execute the command directly with its argv list.
+
+system("ruby", "-e", "puts 'stmt_ok'")
+
+ok = system("ruby", "-e", "exit 0")
+puts ok
+puts($? == 0)
+
+ok = system("ruby", "-e", "exit 1")
+puts ok
+puts($? == 0)
+
+ok = system("ruby", "-e", "exit(ARGV[0] == 'ok' ? 0 : 1)", "ok")
+puts ok
+puts($? == 0)

--- a/test/system_argument_list.rb.expected
+++ b/test/system_argument_list.rb.expected
@@ -1,0 +1,7 @@
+stmt_ok
+true
+true
+false
+false
+true
+true


### PR DESCRIPTION
## Summary

Fix multi-argument `system` calls so generated binaries execute the command with its argv list.

## Expected

The multi-argument form should pass all arguments to the child process.

For example:

```ruby
ok = system("ruby", "-e", "exit 1")
puts ok
puts($? == 0)
```

should produce:

```text
false
false
```

and statement calls such as:

```ruby
system("ruby", "-e", "puts 'stmt_ok'")
```

should print:

```text
stmt_ok
```

## Actual

Only the first argument was passed to C `system()`, so the generated binary executed `ruby` without the `-e` script.

The same expression example produced:

```text
true
true
```

and the statement example printed nothing.