### PR TITLE
fix(analyze): recognize include with ConstantPathNode argument

### DIFF
--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -6900,18 +6900,11 @@ class Compiler
               inc_ids = get_args(inc_args)
               ik = 0
               while ik < inc_ids.length
-                if @nd_type[inc_ids[ik]] == "ConstantReadNode"
-                  mod_name = @nd_name[inc_ids[ik]]
- # when this class is nested inside a
- # module (module_prefix != ""), the include arg is
- # a bare ConstantReadNode but the registered module
- # name is `<prefix>_<name>`. Try the qualified form
- # first; fall back to the bare name for top-level
- # modules.
-                  resolved_mod_name = resolve_include_module_name(mod_name, module_prefix)
-                  collect_module_methods_into_class(ci, resolved_mod_name)
-                  record_class_include(ci, resolved_mod_name)
-                end
+ # `include Mod` / `A::B::C` / `::Top`. Shared helper
+ # flattens the path, distinguishes absolute from
+ # relative for prefix selection, and records the
+ # include on @cls_includes.
+                include_module_on_class(ci, inc_ids[ik], module_prefix)
                 ik = ik + 1
               end
             end
@@ -7135,21 +7128,13 @@ class Compiler
             inc_ids = get_args(inc_args)
             ik = 0
             while ik < inc_ids.length
-              if @nd_type[inc_ids[ik]] == "ConstantReadNode"
-                mod_name = @nd_name[inc_ids[ik]]
- # same prefix resolution as the
- # class-reopening branch -- the include arg is a
- # bare name but the registered module's name is
- # `<prefix>_<name>` when nested in a module.
-                resolved_mod_name = resolve_include_module_name(mod_name, module_prefix)
-                collect_module_methods_into_class(ci, resolved_mod_name)
- # record the include
- # relationship for ancestors-table emission. The
- # methods are already merged into the class above;
- # this pass keeps the module link alive so the
- # codegen can weave it into the MRO.
-                record_class_include(ci, resolved_mod_name)
-              end
+ # Same resolution as the class-reopening branch:
+ # the shared helper accepts ConstantReadNode and
+ # qualified ConstantPathNode (`include Foo::Bar`,
+ # `include ::Top`), routes through the prefix-
+ # aware resolver for relative paths, and records
+ # the include for ancestors-table emission.
+              include_module_on_class(ci, inc_ids[ik], module_prefix)
               ik = ik + 1
             end
           end
@@ -7308,6 +7293,32 @@ class Compiler
       end
     end
     mod_name
+  end
+
+ # Resolve and record an `include` argument on a class. Shared between
+ # the class-reopening and fresh-class branches of
+ # collect_class_with_prefix. `inc_nid` is the AST node for the include
+ # argument; accepts bare ConstantReadNode (`include Helper`) and
+ # qualified ConstantPathNode (`include A::B::Foo`, `include ::Top`).
+ # Absolute paths (`::A::B`) bypass the lexical-scope prefix so a
+ # top-level `A_B` wins over a nested `Outer_A_B`; relative paths
+ # prefer the nested form via resolve_include_module_name.
+  def include_module_on_class(ci, inc_nid, module_prefix)
+    inc_t = @nd_type[inc_nid]
+    if inc_t != "ConstantReadNode" && inc_t != "ConstantPathNode"
+      return
+    end
+    mod_name = const_ref_flat_name(inc_nid)
+    if mod_name == ""
+      return
+    end
+    effective_prefix = module_prefix
+    if const_ref_is_relative(inc_nid) == 0
+      effective_prefix = ""
+    end
+    resolved_mod_name = resolve_include_module_name(mod_name, effective_prefix)
+    collect_module_methods_into_class(ci, resolved_mod_name)
+    record_class_include(ci, resolved_mod_name)
   end
 
   def collect_module_methods_into_class(ci, mod_name)

--- a/test/include_constant_path.rb
+++ b/test/include_constant_path.rb
@@ -1,0 +1,98 @@
+# `include` with a ConstantPathNode argument
+# (`include A::B`, not just bare `include B`).
+#
+# Root cause: `collect_class_with_prefix`'s two include handlers
+# (the reopen branch and the fresh-class branch) gated module
+# extraction on `@nd_type[arg] == "ConstantReadNode"` only. A
+# qualified path like `Foo::Bar::Baz` parses as a
+# ConstantPathNode and silently fell through, so the included
+# module's methods never landed on the class's method table and
+# the analyzer warned `cannot resolve call to '<m>' on obj_<C>`
+# at every call site.
+#
+# Fix: both sites also accept ConstantPathNode and flatten the
+# path via `const_ref_flat_name` (`A::B` -> `A_B`) before passing
+# through the existing prefix-aware resolver. The resolver
+# already tries `<prefix>_<name>` first and falls back to the
+# flat name, so cross-namespace and nested-class includes both
+# stay correct.
+
+module A
+  module B
+    def foo
+      "foo-from-AB"
+    end
+
+    def greet(name)
+      "hello, " + name + "!"
+    end
+  end
+end
+
+class Host
+  include A::B
+end
+
+puts Host.new.foo
+puts Host.new.greet("world")
+
+# Three-deep path: `X::Y::Z` -> `X_Y_Z`.
+module X
+  module Y
+    module Z
+      def deep
+        "deep-from-XYZ"
+      end
+    end
+  end
+end
+
+class DeepHost
+  include X::Y::Z
+end
+
+puts DeepHost.new.deep
+
+# Including via a path also from a class nested under a module.
+# The lexical-prefix probe misses (`Nested_A_B` isn't registered),
+# so the resolver falls back to the flat name `A_B` and finds the
+# top-level module.
+module Nested
+  class Sub
+    include A::B
+
+    def via_nested
+      foo + " (via nested)"
+    end
+  end
+end
+
+puts Nested::Sub.new.via_nested
+
+# Absolute-path include (`::Top`). Inside `module Outer` the lexical-
+# prefix probe would otherwise pick `Outer_Helper` because such a
+# module is registered; an absolute path must bypass that and
+# resolve to the top-level `Helper`. const_ref_is_relative returns 0
+# for ConstantPathNode whose receiver chain bottoms out at another
+# ConstantPathNode (no ConstantReadNode root) -- that's the AST
+# shape for `::Helper`.
+module Helper
+  def from_top
+    "top-helper"
+  end
+end
+
+module Outer
+  module Helper
+    def from_top
+      "outer-helper"
+    end
+  end
+
+  class Inside
+    include ::Helper
+  end
+end
+
+puts Outer::Inside.new.from_top
+

--- a/test/include_constant_path.rb.expected
+++ b/test/include_constant_path.rb.expected
@@ -1,0 +1,5 @@
+foo-from-AB
+hello, world!
+deep-from-XYZ
+foo-from-AB (via nested)
+top-helper


### PR DESCRIPTION
## Summary

- \`collect_class_with_prefix\`'s two include handlers gated module extraction on \`@nd_type[arg] == \"ConstantReadNode\"\`. A qualified path like \`Foo::Bar::Baz\` parses as ConstantPathNode and silently fell through, leaving the included module's methods off the class's method table.
- Both sites now also accept ConstantPathNode and flatten via the existing \`const_ref_flat_name\` helper before passing through the prefix-aware \`resolve_include_module_name\` resolver.

## Test plan

- [x] \`make bootstrap\` (self-compile fixpoint clean)
- [x] \`make retest\` (496 pass / 0 fail / 0 error)
- [x] New \`test/include_constant_path.rb\` regression fixture added