### PR TITLE
fix(runtime): raise Errno::EISDIR for directory file I/O

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -1743,8 +1743,35 @@ static mrb_bool sp_file_file(const char *path) {
    and `\r\n` becomes `\r\r\n`. fread's actual byte count drives
    null-termination because text mode shrinks the byte count below
    ftell's raw-file size. */
-static const char *sp_file_read(const char *path) { if (sp_file_directory(path)) sp_raise_cls("Errno::EISDIR", sp_sprintf("Is a directory @ io_fread - %s", path)); FILE *f = fopen(path, "r"); if (!f) return &("\xff" "")[1]; fseek(f, 0, SEEK_END); long sz = ftell(f); fseek(f, 0, SEEK_SET); char *buf = sp_str_alloc(sz); size_t n = 0; if (sz > 0) { n = fread(buf, 1, sz, f); } buf[n] = 0; fclose(f); return buf; }
-static void sp_file_write(const char *path, const char *data) { if (sp_file_directory(path)) sp_raise_cls("Errno::EISDIR", sp_sprintf("Is a directory @ rb_sysopen - %s", path)); FILE *f = fopen(path, "wb"); if (f) { fwrite(data, 1, sp_str_byte_len(data), f); fclose(f); } }
+static const char *sp_file_read(const char *path) {
+  if (sp_file_directory(path)) {
+    sp_raise_cls("Errno::EISDIR", sp_sprintf("Is a directory @ io_fread - %s", path));
+  }
+  FILE *f = fopen(path, "r");
+  if (!f) return &("\xff" "")[1];
+  fseek(f, 0, SEEK_END);
+  long sz = ftell(f);
+  fseek(f, 0, SEEK_SET);
+  char *buf = sp_str_alloc(sz);
+  size_t n = 0;
+  if (sz > 0) {
+    n = fread(buf, 1, sz, f);
+  }
+  buf[n] = 0;
+  fclose(f);
+  return buf;
+}
+
+static void sp_file_write(const char *path, const char *data) {
+  if (sp_file_directory(path)) {
+    sp_raise_cls("Errno::EISDIR", sp_sprintf("Is a directory @ rb_sysopen - %s", path));
+  }
+  FILE *f = fopen(path, "wb");
+  if (f) {
+    fwrite(data, 1, sp_str_byte_len(data), f);
+    fclose(f);
+  }
+}
 static mrb_bool sp_file_exist(const char *path) { FILE *f = fopen(path, "r"); if (f) { fclose(f); return TRUE; } return FALSE; }
 static void sp_file_delete(const char *path) { remove(path); }
 static const char *sp_backtick(const char *cmd) { FILE *p = popen(cmd, "r"); if (!p) return sp_str_empty; char *buf = sp_str_alloc_raw(4096); size_t n = fread(buf, 1, 4095, p); buf[n] = 0; pclose(p); return buf; }
@@ -1767,7 +1794,9 @@ static const char *sp_file_basename(const char *path) {
    null-termination and stops at the first 0x00 byte — wrong for
    binary data (e.g. .nes ROM files). */
 static sp_IntArray *sp_file_binread_bytes(const char *path) {
-  if (sp_file_directory(path)) sp_raise_cls("Errno::EISDIR", sp_sprintf("Is a directory @ io_fread - %s", path));
+  if (sp_file_directory(path)) {
+    sp_raise_cls("Errno::EISDIR", sp_sprintf("Is a directory @ io_fread - %s", path));
+  }
   FILE *f = fopen(path, "rb");
   sp_IntArray *a = sp_IntArray_new();
   if (!f) return a;

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -1767,6 +1767,7 @@ static const char *sp_file_basename(const char *path) {
    null-termination and stops at the first 0x00 byte — wrong for
    binary data (e.g. .nes ROM files). */
 static sp_IntArray *sp_file_binread_bytes(const char *path) {
+  if (sp_file_directory(path)) sp_raise_cls("Errno::EISDIR", sp_sprintf("Is a directory @ io_fread - %s", path));
   FILE *f = fopen(path, "rb");
   sp_IntArray *a = sp_IntArray_new();
   if (!f) return a;

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -1744,7 +1744,7 @@ static mrb_bool sp_file_file(const char *path) {
    null-termination because text mode shrinks the byte count below
    ftell's raw-file size. */
 static const char *sp_file_read(const char *path) { if (sp_file_directory(path)) sp_raise_cls("Errno::EISDIR", sp_sprintf("Is a directory @ io_fread - %s", path)); FILE *f = fopen(path, "r"); if (!f) return &("\xff" "")[1]; fseek(f, 0, SEEK_END); long sz = ftell(f); fseek(f, 0, SEEK_SET); char *buf = sp_str_alloc(sz); size_t n = 0; if (sz > 0) { n = fread(buf, 1, sz, f); } buf[n] = 0; fclose(f); return buf; }
-static void sp_file_write(const char *path, const char *data) { FILE *f = fopen(path, "wb"); if (f) { fwrite(data, 1, sp_str_byte_len(data), f); fclose(f); } }
+static void sp_file_write(const char *path, const char *data) { if (sp_file_directory(path)) sp_raise_cls("Errno::EISDIR", sp_sprintf("Is a directory @ rb_sysopen - %s", path)); FILE *f = fopen(path, "wb"); if (f) { fwrite(data, 1, sp_str_byte_len(data), f); fclose(f); } }
 static mrb_bool sp_file_exist(const char *path) { FILE *f = fopen(path, "r"); if (f) { fclose(f); return TRUE; } return FALSE; }
 static void sp_file_delete(const char *path) { remove(path); }
 static const char *sp_backtick(const char *cmd) { FILE *p = popen(cmd, "r"); if (!p) return sp_str_empty; char *buf = sp_str_alloc_raw(4096); size_t n = fread(buf, 1, 4095, p); buf[n] = 0; pclose(p); return buf; }

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -1743,7 +1743,7 @@ static mrb_bool sp_file_file(const char *path) {
    and `\r\n` becomes `\r\r\n`. fread's actual byte count drives
    null-termination because text mode shrinks the byte count below
    ftell's raw-file size. */
-static const char *sp_file_read(const char *path) { FILE *f = fopen(path, "r"); if (!f) return &("\xff" "")[1]; fseek(f, 0, SEEK_END); long sz = ftell(f); fseek(f, 0, SEEK_SET); char *buf = sp_str_alloc(sz); size_t n = 0; if (sz > 0) { n = fread(buf, 1, sz, f); } buf[n] = 0; fclose(f); return buf; }
+static const char *sp_file_read(const char *path) { if (sp_file_directory(path)) sp_raise_cls("Errno::EISDIR", sp_sprintf("Is a directory @ io_fread - %s", path)); FILE *f = fopen(path, "r"); if (!f) return &("\xff" "")[1]; fseek(f, 0, SEEK_END); long sz = ftell(f); fseek(f, 0, SEEK_SET); char *buf = sp_str_alloc(sz); size_t n = 0; if (sz > 0) { n = fread(buf, 1, sz, f); } buf[n] = 0; fclose(f); return buf; }
 static void sp_file_write(const char *path, const char *data) { FILE *f = fopen(path, "wb"); if (f) { fwrite(data, 1, sp_str_byte_len(data), f); fclose(f); } }
 static mrb_bool sp_file_exist(const char *path) { FILE *f = fopen(path, "r"); if (f) { fclose(f); return TRUE; } return FALSE; }
 static void sp_file_delete(const char *path) { remove(path); }

--- a/test/file_binread_directory_error.rb
+++ b/test/file_binread_directory_error.rb
@@ -1,0 +1,15 @@
+begin
+  File.binread(".")
+  puts "binread string succeeded"
+rescue => e
+  puts e.class
+  puts e.message.include?("Is a directory")
+end
+
+begin
+  File.binread(".").bytes
+  puts "binread bytes succeeded"
+rescue => e
+  puts e.class
+  puts e.message.include?("Is a directory")
+end

--- a/test/file_binread_directory_error.rb.expected
+++ b/test/file_binread_directory_error.rb.expected
@@ -1,0 +1,4 @@
+Errno::EISDIR
+true
+Errno::EISDIR
+true

--- a/test/file_read_directory_error.rb
+++ b/test/file_read_directory_error.rb
@@ -1,0 +1,7 @@
+begin
+  File.read(".")
+  puts "read succeeded"
+rescue => e
+  puts e.class
+  puts e.message.include?("Is a directory")
+end

--- a/test/file_read_directory_error.rb.expected
+++ b/test/file_read_directory_error.rb.expected
@@ -1,0 +1,2 @@
+Errno::EISDIR
+true

--- a/test/file_write_directory_error.rb
+++ b/test/file_write_directory_error.rb
@@ -1,0 +1,7 @@
+begin
+  File.write(".", "hello")
+  puts "write succeeded"
+rescue => e
+  puts e.class
+  puts e.message.include?("Is a directory")
+end

--- a/test/file_write_directory_error.rb.expected
+++ b/test/file_write_directory_error.rb.expected
@@ -1,0 +1,2 @@
+Errno::EISDIR
+true


### PR DESCRIPTION
## Summary

Make `File.read`, `File.binread`, and `File.write` raise `Errno::EISDIR` when the target path is a directory.

## Expected

Directory paths should fail with `Errno::EISDIR`, matching CRuby behavior.

For example:

```ruby
begin
  File.read(".")
rescue => e
  puts e.class
end

begin
  File.binread(".").bytes
rescue => e
  puts e.class
end

begin
  File.write(".", "hello")
rescue => e
  puts e.class
end
```

should produce:

```text
Errno::EISDIR
Errno::EISDIR
Errno::EISDIR
```

## Actual

The runtime did not check whether the path was a directory before file I/O.

`File.read` and `File.binread(...).bytes` could treat a directory as empty content, making a directory path indistinguishable from an empty file.

`File.write` ignored the failed open and returned as if the write succeeded, so writing to a directory could appear successful.