### PR TITLE
feat(runtime): add File.directory? and File.file? predicates

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -1699,8 +1699,42 @@ static mrb_int sp_catch_val[SP_CATCH_STACK_MAX];
 static volatile int sp_catch_top = 0;
 static void sp_throw(const char *tag, mrb_int val) { int i = sp_catch_top - 1; while (i >= 0) { if (strcmp(sp_catch_tag[i], tag) == 0) { sp_catch_val[i] = val; sp_catch_top = i + 1; longjmp(sp_catch_stack[i], 1); } i--; } fprintf(stderr, "uncaught throw: %s\n", tag); exit(1); }
 
-static mrb_bool sp_file_directory(const char *path) { struct stat st; return path && stat(path, &st) == 0 && S_ISDIR(st.st_mode); }
-static mrb_bool sp_file_regular(const char *path) { struct stat st; return path && stat(path, &st) == 0 && S_ISREG(st.st_mode); }
+#ifdef _WIN32
+static DWORD sp_file_attributes(const char *path) {
+  if (!path) return INVALID_FILE_ATTRIBUTES;
+  int len = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, NULL, 0);
+  if (len <= 0) return INVALID_FILE_ATTRIBUTES;
+  wchar_t *wpath = (wchar_t *)malloc(sizeof(wchar_t) * (size_t)len);
+  if (!wpath) return INVALID_FILE_ATTRIBUTES;
+  if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, wpath, len) <= 0) {
+    free(wpath);
+    return INVALID_FILE_ATTRIBUTES;
+  }
+  DWORD attrs = GetFileAttributesW(wpath);
+  free(wpath);
+  return attrs;
+}
+
+static mrb_bool sp_file_directory(const char *path) {
+  DWORD attrs = sp_file_attributes(path);
+  return attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_DIRECTORY);
+}
+
+static mrb_bool sp_file_file(const char *path) {
+  DWORD attrs = sp_file_attributes(path);
+  return attrs != INVALID_FILE_ATTRIBUTES && !(attrs & FILE_ATTRIBUTE_DIRECTORY);
+}
+#else
+static mrb_bool sp_file_directory(const char *path) {
+  struct stat st;
+  return path && stat(path, &st) == 0 && S_ISDIR(st.st_mode);
+}
+
+static mrb_bool sp_file_file(const char *path) {
+  struct stat st;
+  return path && stat(path, &st) == 0 && S_ISREG(st.st_mode);
+}
+#endif
 
 /* Text mode ("r") matches CRuby's File.read: on Windows, CRLF is
    normalized to LF on read, which cancels out fopen("w")'s

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -25,6 +25,7 @@
 #include <time.h>
 #include <setjmp.h>
 #include <errno.h>
+#include <sys/stat.h>
 #ifdef _WIN32
 #include <windows.h>
 #include <process.h>
@@ -51,6 +52,12 @@
 #endif
 #ifndef MAP_ANONYMOUS
 #define MAP_ANONYMOUS MAP_ANON
+#endif
+#ifndef S_ISDIR
+#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
+#endif
+#ifndef S_ISREG
+#define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
 #endif
 
 typedef int64_t mrb_int;
@@ -1691,6 +1698,9 @@ static const char *sp_catch_tag[SP_CATCH_STACK_MAX];
 static mrb_int sp_catch_val[SP_CATCH_STACK_MAX];
 static volatile int sp_catch_top = 0;
 static void sp_throw(const char *tag, mrb_int val) { int i = sp_catch_top - 1; while (i >= 0) { if (strcmp(sp_catch_tag[i], tag) == 0) { sp_catch_val[i] = val; sp_catch_top = i + 1; longjmp(sp_catch_stack[i], 1); } i--; } fprintf(stderr, "uncaught throw: %s\n", tag); exit(1); }
+
+static mrb_bool sp_file_directory(const char *path) { struct stat st; return path && stat(path, &st) == 0 && S_ISDIR(st.st_mode); }
+static mrb_bool sp_file_regular(const char *path) { struct stat st; return path && stat(path, &st) == 0 && S_ISREG(st.st_mode); }
 
 /* Text mode ("r") matches CRuby's File.read: on Windows, CRLF is
    normalized to LF on read, which cancels out fopen("w")'s

--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -5257,7 +5257,7 @@ class Compiler
           if mname == "read" || mname == "binread"
             return "string"
           end
-          if mname == "exist?" || mname == "readable?"
+          if mname == "exist?" || mname == "readable?" || mname == "directory?" || mname == "file?"
             return "bool"
           end
           if mname == "join"

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -18248,7 +18248,7 @@ class Compiler
           return "sp_file_directory(" + compile_arg0(nid) + ")"
         end
         if mname == "file?"
-          return "sp_file_regular(" + compile_arg0(nid) + ")"
+          return "sp_file_file(" + compile_arg0(nid) + ")"
         end
         if mname == "readable?"
  # Reuse the exist check: on every platform Spinel

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -18244,6 +18244,12 @@ class Compiler
         if mname == "exist?"
           return "sp_file_exist(" + compile_arg0(nid) + ")"
         end
+        if mname == "directory?"
+          return "sp_file_directory(" + compile_arg0(nid) + ")"
+        end
+        if mname == "file?"
+          return "sp_file_regular(" + compile_arg0(nid) + ")"
+        end
         if mname == "readable?"
  # Reuse the exist check: on every platform Spinel
  # targets, a fopen-able file is also readable from

--- a/test/file_directory_predicates.rb
+++ b/test/file_directory_predicates.rb
@@ -2,6 +2,7 @@ path = "spinel_file_predicate_test.txt"
 File.write(path, "x")
 
 puts File.directory?(".")
+puts File.directory?("./")
 puts File.directory?(path)
 puts File.file?(path)
 puts File.file?(".")

--- a/test/file_directory_predicates.rb
+++ b/test/file_directory_predicates.rb
@@ -1,0 +1,11 @@
+path = "spinel_file_predicate_test.txt"
+File.write(path, "x")
+
+puts File.directory?(".")
+puts File.directory?(path)
+puts File.file?(path)
+puts File.file?(".")
+puts File.directory?("spinel_missing_predicate_path")
+puts File.file?("spinel_missing_predicate_path")
+
+File.delete(path)

--- a/test/file_directory_predicates.rb.expected
+++ b/test/file_directory_predicates.rb.expected
@@ -1,0 +1,6 @@
+true
+false
+true
+false
+false
+false

--- a/test/file_directory_predicates.rb.expected
+++ b/test/file_directory_predicates.rb.expected
@@ -1,4 +1,5 @@
 true
+true
 false
 true
 false


### PR DESCRIPTION
## Summary

Add `File.directory?` and `File.file?` so compiled programs can reliably distinguish directories from regular files.

## Expected

Applications should be able to detect directory and regular-file paths before doing file I/O, matching CRuby predicate behavior.

For example:

```ruby
path = "spinel_file_predicate_test.txt"
File.write(path, "x")

puts File.directory?(".")
puts File.directory?(path)
puts File.file?(path)
puts File.file?(".")
puts File.directory?("spinel_missing_predicate_path")
puts File.file?("spinel_missing_predicate_path")

File.delete(path)
```

should produce:

```text
true
false
true
false
false
false
```

## Actual

Spinel did not lower `File.directory?` or `File.file?` as supported File class methods.

Calls to these predicates fell through to the unresolved class-method path and produced falsey `0` values, so compiled applications could not reliably distinguish a directory like `.` from other unsupported or missing paths.