### PR TITLE
rbs_extract: emit kwarg types instead of dropping signatures

### DIFF
--- a/spinel_rbs_extract.c
+++ b/spinel_rbs_extract.c
@@ -388,13 +388,26 @@ static void emit_method(rbs_parser_t *p, rbs_ast_members_method_definition_t *m,
     }
     rbs_types_function_t *fn = (rbs_types_function_t *) mt->type;
 
-    /* Out-of-subset shapes: optional / rest / keyword params. Skip
-     * the whole signature rather than emit a partial one. */
-    if ((fn->optional_positionals != NULL && fn->optional_positionals->length > 0)
+    /* Out-of-subset shapes: rest-positional / rest-keyword / optional
+     * or trailing positionals. These break the fixed-arity contract
+     * the seed format expects (one ptype slot per Ruby def param).
+     * Required + optional keywords ARE handled — we walk them in
+     * insertion order (head/next linked list; rbs_hash_set appends
+     * to tail, matching RBS source order) and append the value types
+     * to the ptype list after the required positionals. The arity
+     * lines up with the Ruby def order spinel's collect_all sees.
+     *
+     * NOTE: rbs_hash_t.length is not incremented by rbs_hash_set
+     * (upstream rbs/ast.c#rbs_hash_set inserts into head/tail without
+     * updating length). Detect emptiness via `head == NULL`, not via
+     * `length`. Same applies in the walking code below.
+     *
+     * Positional rbs_node_list_t.length IS maintained by rbs_node_list_
+     * append — so the optional/trailing positional checks below use
+     * `head == NULL` as the safer cross-cutting "is empty" predicate. */
+    if ((fn->optional_positionals != NULL && fn->optional_positionals->head != NULL)
         || fn->rest_positionals != NULL
-        || (fn->trailing_positionals != NULL && fn->trailing_positionals->length > 0)
-        || (fn->required_keywords != NULL && fn->required_keywords->length > 0)
-        || (fn->optional_keywords != NULL && fn->optional_keywords->length > 0)
+        || (fn->trailing_positionals != NULL && fn->trailing_positionals->head != NULL)
         || fn->rest_keywords != NULL) {
         return;
     }
@@ -421,6 +434,51 @@ static void emit_method(rbs_parser_t *p, rbs_ast_members_method_definition_t *m,
             cur = cur->next;
         }
     }
+
+    /* Required keywords, then optional keywords. Both are stored as
+     * rbs_hash mapping name-Symbol → function_param. The hash is
+     * insertion-ordered (head/tail linked list); RBS's parser inserts
+     * kwargs in source order. We walk in that order, mapping each
+     * param's value type. The arity adds up to (positionals +
+     * required_kwargs + optional_kwargs), matching Ruby's def in
+     * source-order — same shape collect_all sees. Optionality is
+     * an arity-affecting source property and doesn't change the
+     * type slot the seed targets. */
+    if (fn->required_keywords != NULL) {
+        rbs_hash_node_t *cur = fn->required_keywords->head;
+        while (cur != NULL) {
+            if (cur->value == NULL || cur->value->type != RBS_TYPES_FUNCTION_PARAM) {
+                sbuf_free(&ptypes); return;
+            }
+            rbs_types_function_param_t *pp = (rbs_types_function_param_t *) cur->value;
+            sbuf_t t;
+            sbuf_init(&t);
+            if (!map_type(p, pp->type, enclosing_scope, &t)) { sbuf_free(&t); sbuf_free(&ptypes); return; }
+            if (!first_p) sbuf_append_cstr(&ptypes, ",");
+            sbuf_append(&ptypes, t.buf, t.len);
+            first_p = false;
+            sbuf_free(&t);
+            cur = cur->next;
+        }
+    }
+    if (fn->optional_keywords != NULL) {
+        rbs_hash_node_t *cur = fn->optional_keywords->head;
+        while (cur != NULL) {
+            if (cur->value == NULL || cur->value->type != RBS_TYPES_FUNCTION_PARAM) {
+                sbuf_free(&ptypes); return;
+            }
+            rbs_types_function_param_t *pp = (rbs_types_function_param_t *) cur->value;
+            sbuf_t t;
+            sbuf_init(&t);
+            if (!map_type(p, pp->type, enclosing_scope, &t)) { sbuf_free(&t); sbuf_free(&ptypes); return; }
+            if (!first_p) sbuf_append_cstr(&ptypes, ",");
+            sbuf_append(&ptypes, t.buf, t.len);
+            first_p = false;
+            sbuf_free(&t);
+            cur = cur->next;
+        }
+    }
+
     if (ptypes.len == 0) sbuf_append_cstr(&ptypes, "-");
 
     sbuf_t ret;

--- a/spinel_rbs_extract.c
+++ b/spinel_rbs_extract.c
@@ -435,35 +435,28 @@ static void emit_method(rbs_parser_t *p, rbs_ast_members_method_definition_t *m,
         }
     }
 
-    /* Required keywords, then optional keywords. Both are stored as
-     * rbs_hash mapping name-Symbol → function_param. The hash is
-     * insertion-ordered (head/tail linked list); RBS's parser inserts
-     * kwargs in source order. We walk in that order, mapping each
+    /* Required + optional keywords. Both are stored as rbs_hash
+     * mapping name-Symbol → function_param. The hash is insertion-
+     * ordered (head/tail linked list); RBS's parser inserts kwargs in
+     * source order. We walk required then optional, mapping each
      * param's value type. The arity adds up to (positionals +
      * required_kwargs + optional_kwargs), matching Ruby's def in
-     * source-order — same shape collect_all sees. Optionality is
-     * an arity-affecting source property and doesn't change the
-     * type slot the seed targets. */
-    if (fn->required_keywords != NULL) {
-        rbs_hash_node_t *cur = fn->required_keywords->head;
+     * source-order — same shape collect_all sees. Optionality is an
+     * arity-affecting source property and doesn't change the type
+     * slot the seed targets. */
+    const rbs_hash_t *kw_hashes[] = { fn->required_keywords, fn->optional_keywords };
+    for (size_t ki = 0; ki < sizeof(kw_hashes)/sizeof(kw_hashes[0]); ki++) {
+        const rbs_hash_t *hash = kw_hashes[ki];
+        if (hash == NULL) continue;
+        rbs_hash_node_t *cur = hash->head;
         while (cur != NULL) {
-            if (cur->value == NULL || cur->value->type != RBS_TYPES_FUNCTION_PARAM) {
-                sbuf_free(&ptypes); return;
-            }
-            rbs_types_function_param_t *pp = (rbs_types_function_param_t *) cur->value;
-            sbuf_t t;
-            sbuf_init(&t);
-            if (!map_type(p, pp->type, enclosing_scope, &t)) { sbuf_free(&t); sbuf_free(&ptypes); return; }
-            if (!first_p) sbuf_append_cstr(&ptypes, ",");
-            sbuf_append(&ptypes, t.buf, t.len);
-            first_p = false;
-            sbuf_free(&t);
-            cur = cur->next;
-        }
-    }
-    if (fn->optional_keywords != NULL) {
-        rbs_hash_node_t *cur = fn->optional_keywords->head;
-        while (cur != NULL) {
+            /* Defensive: an upstream rbs change adding a different
+             * value-node type would land here. Skipping the whole
+             * signature (rather than producing a partial seed) keeps
+             * the analyzer consistent — apply_rbs_seeds overwrites a
+             * method's ptype list wholesale, so a half-populated entry
+             * is worse than no entry. Same policy as the positional
+             * loop above and the existing out-of-subset early-return. */
             if (cur->value == NULL || cur->value->type != RBS_TYPES_FUNCTION_PARAM) {
                 sbuf_free(&ptypes); return;
             }


### PR DESCRIPTION
## Problem

`def render: (String body, ?status: Symbol, ?content_type: String?, ?location: String?) -> void` extracts as `meth render nil string` — just the positional type, kwargs silently dropped. `apply_rbs_seeds` then overwrites `@cls_meth_ptypes[render]` with `[\"string\"]`, **truncating** the slots `collect_all` populated for the three kwargs. Those slots default to `int`, and callers passing `Symbol` / `String?` hit type mismatches at the C boundary.

Surfaces in Sam Ruby's roundhouse spinel-toolchain when `--rbs sig` is passed against any RBS file with kwarg-bearing methods (the Rails framework runtime sidecars do this heavily — `render`, `redirect_to`, `head`, `form_with`, etc.). Without this PR, enabling RBS seeding makes the project fail to compile.

## Fix

Walk `fn->required_keywords` and `fn->optional_keywords` as linked lists via `head`/`next`, map each param's value type, and append to the ptype list after the required positionals. The resulting arity matches what `collect_all` populates from the Ruby `def` (positionals + kwargs in source order, since rbs_hash_set inserts at the tail).

Drop the early-return for `required_keywords->length > 0` / `optional_keywords->length > 0`. Switch other emptiness checks (optional / trailing positionals) from `length > 0` to `head != NULL`.

## Side note: rbs_hash_t.length

While debugging this, found that `rbs_hash_set` (upstream rbs `ast.c:253`) inserts into `head`/`tail` but **doesn't increment `length`**. The field stays 0 even after entries are added. That's why the old `length > 0` check never fired — kwargs were silently falling through to "emit positionals only," producing the truncated seed.

The new code uses `head`-based emptiness throughout to be robust regardless of upstream's length-maintenance contract. Filing the length issue upstream may be worthwhile separately; not in scope here.

## Test cases

```rbs
class Foo
  def render: (String body, ?status: Symbol, ?content_type: String?, ?location: String?) -> void
  def required_kw_only: (Integer count, name: String) -> bool
  def positional_only: (String s, Integer n) -> String
  def rest_args: (*String args) -> nil
end
```

Before:
```
class Foo
meth render nil string
meth required_kw_only bool int
meth positional_only string string,int
```

After:
```
class Foo
meth render nil string,symbol,string?,string?
meth required_kw_only bool int,string
meth positional_only string string,int
```

`rest_args` correctly dropped in both (rest_positionals still triggers early-return).

## Verification

- `make test`: 538 pass, 0 fail, 0 error.
- Manual probe across the four shapes above produces correct output.

## Context

Filed in support of matz/spinel#572 / matz/spinel#573 follow-up work. With this PR, roundhouse can pass `--rbs sig` against its emitted RBS tree and get useful type-inference seeding instead of compile errors.