### PR TITLE
fix(codegen): wrap Symbol#inspect ":" prefix in SPL marker

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -15720,7 +15720,7 @@ class Compiler
       return "sp_sym_intern(sp_str_" + mname + "(sp_sym_to_s(" + rc + ")))"
     end
     if mname == "inspect"
-      return "sp_str_concat(\":\", sp_sym_to_s(" + rc + "))"
+      return "sp_str_concat(SPL(\":\"), sp_sym_to_s(" + rc + "))"
     end
     if mname == "length" || mname == "size"
       return "((mrb_int)strlen(sp_sym_to_s(" + rc + ")))"
@@ -28937,7 +28937,7 @@ class Compiler
       return "sp_str_inspect(" + val + "->data)"
     end
     if at == "symbol"
-      return "sp_str_concat(\":\", sp_sym_to_s(" + val + "))"
+      return "sp_str_concat(SPL(\":\"), sp_sym_to_s(" + val + "))"
     end
     if at == "bool"
       return "(" + val + " ? \"true\" : \"false\")"

--- a/test/symbol_inspect_spl_marker.rb
+++ b/test/symbol_inspect_spl_marker.rb
@@ -1,0 +1,9 @@
+# Symbol#inspect literal prefix must use SPL marker so sp_str_byte_len's
+# s[-1] marker check is well-defined (avoids -O2 __builtin_trap).
+
+puts :hello.inspect          # :hello
+
+sym = :world
+puts sym.inspect             # :world
+
+puts "done"

--- a/test/symbol_inspect_spl_marker.rb.expected
+++ b/test/symbol_inspect_spl_marker.rb.expected
@@ -1,0 +1,3 @@
+:hello
+:world
+done


### PR DESCRIPTION
## Summary

- `sp_str_concat(":", sp_sym_to_s(s))` passes a bare C string literal where `sp_str_byte_len` reads the marker byte at `s[-1]`. Under `-O2`, GCC promotes this to `__builtin_trap`.
- Wrap the prefix with `SPL(":")` so the marker check is well-defined. Two call sites in `compile_call_expr`: the Symbol#inspect statement arm and the Symbol#inspect expression arm.
- Pure-defensive fix: no behavior change for any input that didn't already trap.

## Test plan

- [x] `make bootstrap` (self-compile fixpoint clean — analyze.rb + codegen.rb IR/C fixpoints OK)
- [x] `make retest`
- [x] New regression `test/symbol_inspect_spl_marker.rb` covers `:hello.inspect` literal and a variable-bound `sym.inspect` (expression arm).