### PR TITLE
feat(analyze,codegen): trap accepts Signal receiver and expr position

### DIFF
--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -3200,6 +3200,11 @@ class Compiler
     if mname == "system"
       return "bool"
     end
+ # trap / Signal.trap stub returns the previous-handler string;
+ # codegen emits SPL("DEFAULT") since per-signal state is not tracked.
+    if mname == "trap"
+      return "string"
+    end
 
  # Constructor .new
     r = infer_constructor_type(nid, mname, recv)

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -12671,6 +12671,13 @@ class Compiler
     mname = @nd_name[nid]
     recv = @nd_receiver[nid]
 
+ # Return CRuby's first-call default ("DEFAULT") since Spinel does
+ # not track per-signal state. Covers both implicit-self and
+ # explicit Signal / ::Signal receivers via trap_call_is_signal_stub.
+    if mname == "trap" && trap_call_is_signal_stub(nid) == 1
+      return "SPL(\"DEFAULT\")"
+    end
+
  # `recv.send(:method_name, args...)` with a SymbolNode method
  # name reduces to the direct call -- temporarily mutate the
  # outer CallNode's @nd_name and the inner ArgumentsNode's
@@ -26090,6 +26097,25 @@ class Compiler
   end
 
 
+ # Match the CRuby shapes that resolve to Kernel#trap. Spinel has
+ # no signal-handler runtime so all variants compile to a no-op.
+  def trap_call_is_signal_stub(nid)
+    rcv = @nd_receiver[nid]
+    if rcv < 0
+      return 1
+    end
+    rt = @nd_type[rcv]
+    if rt == "ConstantReadNode" && @nd_name[rcv] == "Signal"
+      return 1
+    end
+ # `::Signal.trap` parses as ConstantPathNode with parent < 0
+ # (toplevel). Reject `Foo::Signal.trap` -- that's a different module.
+    if rt == "ConstantPathNode" && @nd_name[rcv] == "Signal" && @nd_receiver[rcv] < 0
+      return 1
+    end
+    0
+  end
+
   def compile_call_stmt(nid)
     mname = @nd_name[nid]
     recv = @nd_receiver[nid]
@@ -27240,11 +27266,10 @@ class Compiler
       end
     end
 
- # trap (just ignore)
-    if mname == "trap"
-      if recv < 0
-        return 1
-      end
+ # trap / Signal.trap: no-op at every shape (implicit-self or
+ # explicit receiver, with or without block, stmt or expr position).
+    if mname == "trap" && trap_call_is_signal_stub(nid) == 1
+      return 1
     end
 
  # catch/throw

--- a/test/signal_trap_stub.rb
+++ b/test/signal_trap_stub.rb
@@ -1,0 +1,30 @@
+# trap / Signal.trap / ::Signal.trap compile to no-ops at every shape;
+# Spinel has no signal-handler runtime, so the block body (if any)
+# never fires. Expression position returns "DEFAULT" -- CRuby's value
+# for any signal that was never previously trapped.
+#
+# Each section uses a distinct signal name so no signal's state is
+# observed twice (CRuby would return the prior handler on the second
+# touch, which Spinel does not yet model).
+
+# Stmt position, implicit-self.
+trap("INT") { puts "handler" }
+
+# Stmt position, explicit Signal receiver (ConstantReadNode).
+Signal.trap("TERM") { puts "handler" }
+
+# Stmt position, toplevel ::Signal receiver (ConstantPathNode).
+::Signal.trap("HUP") { puts "handler" }
+
+# Stmt position, no block.
+trap("QUIT", "EXIT")
+
+# Expr position, first call on a never-trapped signal returns "DEFAULT".
+prev = trap("USR1") { puts "x" }
+puts prev
+
+# Expr position via Signal receiver, also returns "DEFAULT" on first call.
+prev2 = Signal.trap("USR2") { puts "y" }
+puts prev2
+
+puts "done"

--- a/test/signal_trap_stub.rb.expected
+++ b/test/signal_trap_stub.rb.expected
@@ -1,0 +1,3 @@
+DEFAULT
+DEFAULT
+done


### PR DESCRIPTION
## Summary

- The existing `trap` no-op stub matched only implicit-self statement-position calls. Three CRuby-equivalent shapes errored at compile time: explicit receiver `Signal.trap(...)`, toplevel-qualified `::Signal.trap(...)`, and expression position `prev = trap(...) { ... }`.
- New `trap_call_is_signal_stub(nid)` matches implicit-self (`recv < 0`), `ConstantReadNode("Signal")`, and `ConstantPathNode` with tail `Signal` AND parent `< 0` (only the toplevel `::Signal` — `Foo::Signal.trap` is intentionally not matched since that names a different module).
- Expression-arm now returns `SPL("DEFAULT")` — matches CRuby's first-call return value for any unset signal. Subsequent calls also return `"DEFAULT"` since Spinel does not yet track per-signal state; full state tracking is filed as a follow-up.
- `infer_call_type` adds `"trap" -> "string"` so callers like `prev = trap("INT") { }` type-infer `prev` as a string. Without this, the analyzer would treat trap's return as `int` and reject the `SPL("DEFAULT")` assignment with `incompatible pointer to integer conversion`.

## Guards

- User-defined `def trap` is shadowed by the stub. This matches the **pre-existing behavior** of every other `Kernel#` no-op stub in the file (`system`, `catch`, `sleep`, `loop`, `format`, `sprintf`) — original `if mname == "trap"; if recv < 0` had the same shadowing. A consistent user-override gate across the whole family belongs in its own PR.
- `Foo::Signal.trap` (non-toplevel `Signal` constant path) is intentionally **not** matched — that names a different module under Spinel's resolution model.

## CRuby 4+ semantic check (local `ruby` experiments)

| Call | CRuby returns | Spinel returns | Match |
|------|---------------|----------------|-------|
| `trap("X") { }` first call | `"DEFAULT"` (String) | `"DEFAULT"` | yes |
| `trap("X") { }` second call | prior Proc | `"DEFAULT"` | no (deferred — needs state tracking) |
| `Signal.trap("X")` | works | works | yes |
| `::Signal.trap("X")` | works | works | yes (this PR) |
| `Foo::Signal.trap("X")` | depends on Foo | not matched | acceptable |

## Follow-up

- `feat(codegen,runtime): track per-signal handler state` — add `sp_signal_table` so subsequent `trap` calls return the actual prior handler string.
- `feat(codegen,runtime): real Signal.trap with POSIX delivery` — install handlers via `signal()` and pump pending signals at safe points so blocks actually fire on signal arrival.

## Test plan

- [x] `make bootstrap` (self-compile fixpoint clean — analyze.rb + codegen.rb IR/C fixpoints OK)
- [x] `make retest` (567 pass / 0 fail / 0 error — baseline 566 + 1 new test)
- [x] `test/signal_trap_stub.rb` covers six shapes: implicit-self stmt, `Signal.trap` stmt, `::Signal.trap` stmt, no-block stmt, expr returning `"DEFAULT"` via implicit-self, expr returning `"DEFAULT"` via `Signal.trap`.