### PR TITLE
feat(analyze,codegen): instance_eval returns last-expression value

### DIFF
--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -578,9 +578,14 @@ class Compiler
  # instance_eval block hoisting: parallel arrays indexed by synthetic
  # function id N. Each lifted block becomes a file-scope static
  # function `sp_ieval_<N>` that takes a typed `self` parameter.
+ # @ieval_return_types is the inferred ctype of the lifted body's last
+ # expression ("void" when assignment-only); codegen reads it to pick
+ # the lifted function's signature and whether the call site emits a
+ # direct call or the receiver-comma-expr fallback.
     @ieval_counter = 0
     @ieval_class_idxs = []
     @ieval_body_ids = []
+    @ieval_return_types = "".split(",")
 
  # RBS-derived seed lines. Populated by load_rbs_seeds before
  # analyze_phase; consumed by apply_rbs_seeds after collect_all
@@ -2967,19 +2972,25 @@ class Compiler
  # `recv.__sp_ieval_<N>(...)`: the rewritten form of an
  # `recv.instance_eval { ... }` call. v1 only fired on top-level call
  # sites, where the call's value was always discarded — so its return
- # type didn't matter and the warn-fallback "int" was harmless. Now
- # that the rewrite can land inside a class method body whose tail
- # expression IS the instance_eval call, the enclosing method's
- # signature has to match the value the lift actually emits:
- # `compile_ieval_call_expr` returns the receiver via a comma
- # expression, so the type is recv's class. Read the synthetic id's
- # registered class directly from `@ieval_class_idxs` rather than
- # re-inferring recv — by the time this runs (compile-side type
- # iteration), recv's type may have been refined and the registered
- # class is the canonical answer.
+ # `recv.__sp_ieval_<N>(...)` is the rewritten form of an
+ # `recv.instance_eval { ... }` call. compile_ieval_call_expr emits
+ # a direct call to sp_ieval_<N> when the body's last expression has
+ # a non-void inferred type, or the comma-expression form yielding
+ # the receiver when void. Mirror that here: non-void return type
+ # from @ieval_return_types when known, else fall through to the
+ # receiver's registered class (obj_<C>).
     if is_ieval_call_name(mname) == 1
       suffix = mname[11, mname.length - 11]
       n = suffix.to_i
+ # Non-void lifted body: the call's value is the block's last
+ # expression. Void body: the comma-expr fallback yields the
+ # receiver, so the call types as obj_<C>.
+      if n >= 0 && n < @ieval_return_types.length
+        rt = @ieval_return_types[n]
+        if rt != "" && rt != "void"
+          return rt
+        end
+      end
       if n >= 0 && n < @ieval_class_idxs.length
         return "obj_" + @cls_names[@ieval_class_idxs[n]]
       end
@@ -6876,6 +6887,7 @@ class Compiler
  # from analyze get appended to instead of replaced.
     @ieval_class_idxs = []
     @ieval_body_ids = []
+    @ieval_return_types = "".split(",")
  # Widen class-method ptypes through obj-typed receivers before the
  # walk so a method-param receiver (e.g. `def configure(app);
  # app.instance_eval { } end` invoked as `cfg.configure(routes)`)
@@ -7154,6 +7166,10 @@ class Compiler
     @ieval_counter = @ieval_counter + 1
     @ieval_class_idxs.push(ci)
     @ieval_body_ids.push(body_id)
+ # Seed return type as "void"; infer_ieval_body_return_types runs
+ # after the main return-type fixpoint converges and overwrites with
+ # the body's last-expression ctype when non-void.
+    @ieval_return_types.push("void")
  # Mark the call site: the function name doubles as the synthetic id.
  # compile_call_expr / compile_call_stmt recognise the prefix and
  # emit a direct C call to `sp_ieval_<N>`.
@@ -7183,6 +7199,45 @@ class Compiler
       end
       n = n + 1
     end
+  end
+
+ # Last-expression return-type inference for each lifted ieval body.
+ # Runs after the main `infer_all_returns` fixpoint converges so
+ # receiverless calls inside the body see their final return types.
+ # When the body's last expression is assignment-only the result stays
+ # "void" -- compile_ieval_call_expr falls back to the comma-expr form
+ # yielding the receiver so truthy contexts still type-check. Only
+ # caches "simple" ctypes (scalars + obj_<C>); array / hash / poly
+ # bodies stay "void" so they take the comma-expr fallback, matching
+ # the pre-existing receiver-typed signature. Broader coverage belongs
+ # in a follow-up.
+  def infer_ieval_body_return_types
+    n = 0
+    while n < @ieval_class_idxs.length
+      ci = @ieval_class_idxs[n]
+      bid = @ieval_body_ids[n]
+      if bid >= 0
+        @current_class_idx = ci
+        push_scope
+        rt = infer_body_return(bid)
+        if ieval_return_type_is_simple(rt) == 1
+          @ieval_return_types[n] = rt
+        end
+        pop_scope
+        @current_class_idx = -1
+      end
+      n = n + 1
+    end
+  end
+
+  def ieval_return_type_is_simple(rt)
+    if rt == "int" || rt == "bool" || rt == "float" || rt == "string" || rt == "mutable_str" || rt == "nil"
+      return 1
+    end
+    if rt.length > 4 && rt[0, 4] == "obj_"
+      return 1
+    end
+    0
   end
 
   def is_ieval_call_name(mname)
@@ -19871,6 +19926,10 @@ class Compiler
     unify_imeth_override_returns
     infer_all_returns
     unify_imeth_override_returns
+ # Lifted ieval bodies: now that all method return types are stable,
+ # walk each block body once and cache the last-expression ctype per
+ # synthetic id. compile_ieval_call_expr consults the cache.
+    infer_ieval_body_return_types
  # Widen function return types to poly when explicit `return X`
  # and the implicit final-expression return disagree on the
  # value-vs-pointer axis. Runs post-fixpoint so the iterative
@@ -25190,6 +25249,7 @@ class Compiler
     buf = ir_emit_sa(buf, "@poly_param_types", @poly_param_types)
     buf = ir_emit_ia(buf, "@ieval_class_idxs", @ieval_class_idxs)
     buf = ir_emit_ia(buf, "@ieval_body_ids", @ieval_body_ids)
+    buf = ir_emit_sa(buf, "@ieval_return_types", @ieval_return_types)
     buf = ir_emit_ia(buf, "@pre_execution_blocks", @pre_execution_blocks)
     buf = ir_emit_ia(buf, "@post_execution_blocks", @post_execution_blocks)
     buf = ir_emit_sa(buf, "@toplevel_ivar_names", @toplevel_ivar_names)

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -596,9 +596,14 @@ class Compiler
  # instance_eval block hoisting: parallel arrays indexed by synthetic
  # function id N. Each lifted block becomes a file-scope static
  # function `sp_ieval_<N>` that takes a typed `self` parameter.
+ # @ieval_return_types is the inferred ctype of the lifted body's last
+ # expression ("void" when assignment-only); read by
+ # compile_ieval_call_expr to pick direct-call vs receiver-comma-expr
+ # and by emit_ieval_func to size the function signature.
     @ieval_counter = 0
     @ieval_class_idxs = []
     @ieval_body_ids = []
+    @ieval_return_types = "".split(",")
   end
 
  # Backslash-n for C string literals - bootstrap-safe (avoids escape level issues)
@@ -4710,29 +4715,90 @@ class Compiler
     "sp_ieval_" + suffix + "(" + compile_expr(@nd_receiver[nid]) + ")"
   end
 
- # v1 lifts blocks into void-returning functions (Ruby's
- # instance_eval-as-expression value isn't supported yet). When a
- # call appears in expression position, return the recv pointer as a
- # truthy default via a comma expression so callers like
- # `if obj.instance_eval { ... }` still type-check. Real expression
- # support — return the block's last expression — is a v2 follow-up.
+ # Non-void lifted body: the function returns the block's last
+ # expression (CRuby semantics), emit a direct call. Void body
+ # (assignment-only last statement): fall back to the comma-expr
+ # form yielding the receiver so `if obj.instance_eval { @f = 1 }`
+ # and other truthy contexts still type-check.
   def compile_ieval_call_expr(nid)
+    mname = @nd_name[nid]
+    suffix = mname[11, mname.length - 11]
+    n = suffix.to_i
+    is_void = 1
+    if n >= 0 && n < @ieval_return_types.length
+      rt = @ieval_return_types[n]
+      if rt != "" && rt != "void"
+        is_void = 0
+      end
+    end
+    if is_void == 0
+      return compile_ieval_call(nid)
+    end
     "(" + compile_ieval_call(nid) + ", " + compile_expr(@nd_receiver[nid]) + ")"
+  end
+
+ # Map a lifted body's inferred return type to its C signature
+ # spelling. Inlined to keep the analyzer's flow-typing narrow --
+ # routing through c_type widens the result variable into a union
+ # broad enough to cascade-widen unrelated parameters (specifically
+ # Compiler#type_is_pointer's `t`) via the @out_lines push chain.
+  def ieval_sig_ret(t)
+    if t == "" || t == "void"
+      return "void"
+    end
+    if t == "int"
+      return "mrb_int"
+    end
+    if t == "bool"
+      return "mrb_bool"
+    end
+    if t == "float"
+      return "mrb_float"
+    end
+    if t == "string"
+      return "const char *"
+    end
+    if t == "mutable_str"
+      return "sp_String *"
+    end
+    if t == "nil"
+      return "mrb_int"
+    end
+    if t == "poly"
+      return "sp_RbVal"
+    end
+    if t[0, 4] == "obj_"
+      return "sp_" + t[4, t.length - 4] + " *"
+    end
+ # Other narrow shapes (arrays / hashes / etc.) are not currently
+ # reachable as ieval body return types -- their inference returns
+ # one of the cases above, or "void". If a new shape appears here,
+ # extend the table rather than routing through c_type (see the WHY
+ # in this method's docstring).
+    "void"
   end
 
   def emit_ieval_func(n, ci, bid)
     cname = @cls_names[ci]
+    ret_type = "void"
+    if n < @ieval_return_types.length
+      rt = @ieval_return_types[n]
+      if rt != ""
+        ret_type = rt
+      end
+    end
+    sig_ret = ieval_sig_ret(ret_type)
     @current_class_idx = ci
     @current_method_name = "__sp_ieval_" + n.to_s
-    @current_method_return = "void"
+    @current_method_return = ret_type
     @indent = 1
     @in_gc_scope = 0
     @in_yield_method = 0
 
     if @cls_is_value_type[ci] == 1
-      emit_raw("static void sp_ieval_" + n.to_s + "(sp_" + cname + " self) {")
+      emit_raw("static " + sig_ret + " sp_ieval_" + n.to_s + "(sp_" + cname + " self) {")
     else
-      emit_raw("static void sp_ieval_" + n.to_s + "(sp_" + cname + " *self) {")
+      emit_raw("static " + sig_ret + " sp_ieval_" + n.to_s + "(sp_" + cname + " *self) {")
     end
 
     push_scope
@@ -4745,7 +4811,7 @@ class Compiler
           emit("  SP_GC_ROOT(self);")
         end
       end
-      compile_body_return(bid, "void")
+      compile_body_return(bid, ret_type)
     end
     pop_scope
 
@@ -8322,10 +8388,17 @@ class Compiler
     n = 0
     while n < @ieval_class_idxs.length
       icn = @cls_names[@ieval_class_idxs[n]]
+      proto_ret = "void"
+      if n < @ieval_return_types.length
+        rt_ie = @ieval_return_types[n]
+        if rt_ie != "" && rt_ie != "void"
+          proto_ret = ieval_sig_ret(rt_ie)
+        end
+      end
       if @cls_is_value_type[@ieval_class_idxs[n]] == 1
-        emit_raw("static void sp_ieval_" + n.to_s + "(sp_" + icn + " self);")
+        emit_raw("static " + proto_ret + " sp_ieval_" + n.to_s + "(sp_" + icn + " self);")
       else
-        emit_raw("static void sp_ieval_" + n.to_s + "(sp_" + icn + " *self);")
+        emit_raw("static " + proto_ret + " sp_ieval_" + n.to_s + "(sp_" + icn + " *self);")
       end
       n = n + 1
     end
@@ -35074,6 +35147,8 @@ class Compiler
       @lambda_var_ret_types = val
     elsif name == "@multi_const_inits"
       @multi_const_inits = val
+    elsif name == "@ieval_return_types"
+      @ieval_return_types = val
     end
   end
 

--- a/test/bm_instance_eval.rb
+++ b/test/bm_instance_eval.rb
@@ -127,10 +127,9 @@ puts boot.routes.entries[1]      # POST /ivar
 
 # ---- 9. Ivar receiver in tail position of a class method ----
 # Same lift but the instance_eval call is the method body's last
-# expression. The pre-existing v1 path always emitted the lift in
-# statement form; here it must round-trip through compile_ieval_call_expr
-# (the comma-expression form) so the enclosing method can still
-# return the receiver. Sister-class with a typed return signature.
+# expression. The block's last call (`get("/tail")`) returns the
+# entries array, so the lift's value would flow out; explicitly
+# return @routes to keep `setup` returning the receiver.
 class Configure
   attr_accessor :routes
 
@@ -140,6 +139,7 @@ class Configure
 
   def setup
     @routes.instance_eval { get("/tail") }
+    @routes
   end
 end
 
@@ -171,13 +171,14 @@ puts shared.entries.length  # 1
 puts shared.entries[0]      # GET /param
 
 # ---- 11. Param receiver in tail position ----
-# Same as §10 but the lift is the method body's last expression so
-# the wire_param signature has to match the comma-expression return
-# value. infer_call_type's synthetic-name early case (PR #15
-# follow-up landed in PR #158) handles this once the rewrite fires.
+# Same as §10 but the lift is the method body's last expression.
+# Block's last call (`get("/tail-param")`) returns the entries
+# array; explicitly return `r` to keep wire_param returning the
+# receiver.
 class WireTail
   def wire_param(r)
     r.instance_eval { get("/tail-param") }
+    r
   end
 end
 

--- a/test/instance_eval_return_value.rb
+++ b/test/instance_eval_return_value.rb
@@ -1,0 +1,56 @@
+# instance_eval as an expression: the block's last expression is the
+# call's value (CRuby semantics). Void-bodied blocks (assignment-only)
+# fall through to a truthy receiver so `if obj.instance_eval { @f = 1 }`
+# still works.
+
+class Counter
+  def initialize
+    @count = 0
+  end
+  def inc
+    @count = @count + 1
+  end
+end
+
+c = Counter.new
+c.inc
+c.inc
+c.inc
+
+# Int-valued block returns the ivar, not the receiver.
+n = c.instance_eval { @count }
+puts n   # 3
+
+# Boolean-valued block.
+big = c.instance_eval { @count > 2 }
+puts big # true
+
+# Arithmetic expression body.
+doubled = c.instance_eval { @count + @count }
+puts doubled # 6
+
+# String-valued block (pointer-typed return).
+class Greeter
+  def initialize
+    @greeting = "hello"
+  end
+end
+
+g = Greeter.new
+msg = g.instance_eval { @greeting }
+puts msg # hello
+
+# Void body: receiver flows out via comma-expr fallback, keeping the
+# `if` arm truthy.
+class Flag
+  def initialize
+    @flag = 0
+  end
+end
+
+f = Flag.new
+if f.instance_eval { @flag = 1 }
+  puts "truthy"
+end
+
+puts "done"

--- a/test/instance_eval_return_value.rb.expected
+++ b/test/instance_eval_return_value.rb.expected
@@ -1,0 +1,6 @@
+3
+true
+6
+hello
+truthy
+done


### PR DESCRIPTION
## Summary

- The existing `instance_eval` lift returned the receiver via a comma-expression hack: `n = obj.instance_eval { @count }` yielded the Counter instead of the int.
- New `infer_ieval_body_return_types` post-fixpoint pass in analyze caches the inferred return ctype per ieval id (gated to "simple" shapes -- see Guards). `emit_ieval_func` and the forward-prototype emit consume it for the lifted function signature; `compile_ieval_call_expr` emits a direct call when non-void or the legacy comma-expr form otherwise.
- Void-bodied blocks (assignment-only) keep the comma-expr fallback so `if obj.instance_eval { @flag = 1 }` still reads truthy.

## Guards

- `ieval_return_type_is_simple` restricts the cached return type to `int` / `bool` / `float` / `string` / `mutable_str` / `nil` / `obj_<C>`. Array, hash, and poly bodies stay `void` and route through the receiver-comma-expr fallback. Broader coverage belongs in a follow-up.
- `ieval_sig_ret` inlines the C-type mapping rather than routing through `c_type`. Direct `c_type` calls in this path cascade-widen `Compiler#type_is_pointer`'s `t` parameter via the `@out_lines` push chain (an analyzer flow-typing fragility). Inline mapping keeps the result narrow.

## Test plan

- [x] `make bootstrap` (analyze.rb + codegen.rb IR/C fixpoints clean)
- [x] `make retest` (578 pass / 0 fail / 0 error -- baseline 577 + 1 new test)
- [x] `test/instance_eval_return_value.rb` covers int / bool / arith / string return bodies plus the void-fallback truthy case.
- [x] `test/bm_instance_eval.rb` sections 9 and 11 updated to add explicit receiver returns (tail-position ivar / param receivers); existing `.expected` output unchanged.