### PR TITLE
docs(readme): mention RBS seed input

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,18 @@ RUBY
 ./spinel app.rb -o myapp     # compiles to ./myapp
 ./spinel app.rb -c           # generates app.c only
 ./spinel app.rb -S           # prints C to stdout
+./spinel app.rb --rbs sig    # seed inference from .rbs files under sig/
 ```
+
+### RBS type signatures
+
+Spinel can read RBS files to seed the analyzer. `spinel_rbs_extract`
+scans a directory of `*.rbs` files (the same layout `rbs` and Steep
+use) and emits seed records that `spinel_analyze` consumes via
+`--rbs DIR`. Seeds are advisory — inference still runs on top and
+widens on observed contradiction, so a wrong or unrepresentable seed
+is at worst a no-op. See [docs/RBS-EXTRACT.md](docs/RBS-EXTRACT.md)
+for the supported subset.
 
 ## Self-Hosting
 

--- a/README.md
+++ b/README.md
@@ -86,10 +86,11 @@ RUBY
 
 ### RBS type signatures
 
-Spinel can read RBS files to seed the analyzer. `spinel_rbs_extract`
-scans a directory of `*.rbs` files (the same layout `rbs` and Steep
-use) and emits seed records that `spinel_analyze` consumes via
-`--rbs DIR`. Seeds are advisory — inference still runs on top and
+Spinel can read RBS files to seed the analyzer. When invoked with
+`--rbs DIR`, the `spinel` wrapper runs `spinel_rbs_extract` over a
+directory of `*.rbs` files (the same layout `rbs` and Steep use) and
+passes the resulting seed file to `spinel_analyze` as a positional
+argument. Seeds are advisory — inference still runs on top and
 widens on observed contradiction, so a wrong or unrepresentable seed
 is at worst a no-op. See [docs/RBS-EXTRACT.md](docs/RBS-EXTRACT.md)
 for the supported subset.


### PR DESCRIPTION
## Summary
- Document the `--rbs DIR` flag in the Options section
- Add a short subsection clarifying that RBS seeds are advisory (inference still runs on top and widens on contradiction)
- Link to the existing `docs/RBS-EXTRACT.md` for the supported subset

## Test plan
- [x] No code changes; README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)