### PR TITLE
fix(runtime): walk sp_fiber_root.saved_roots in suspended-fiber GC (#636 follow-up)

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -2297,7 +2297,13 @@ static void sp_fiber_save_roots(sp_Fiber*f){if(f->saved_roots_cap<sp_gc_nroots){
 static void sp_fiber_restore_roots(sp_Fiber*f){if(f->saved_nroots>0)memcpy(sp_gc_roots,f->saved_roots,sizeof(void**)*f->saved_nroots);sp_gc_nroots=f->saved_nroots;}
 static void sp_fiber_list_add(sp_Fiber*f){f->fiber_prev=NULL;f->fiber_next=sp_fiber_list_head;if(sp_fiber_list_head)sp_fiber_list_head->fiber_prev=f;sp_fiber_list_head=f;}
 static void sp_fiber_list_remove(sp_Fiber*f){if(f->fiber_prev)f->fiber_prev->fiber_next=f->fiber_next;else if(sp_fiber_list_head==f)sp_fiber_list_head=f->fiber_next;if(f->fiber_next)f->fiber_next->fiber_prev=f->fiber_prev;f->fiber_prev=NULL;f->fiber_next=NULL;}
-static void sp_mark_suspended_fibers(void){sp_Fiber*f=sp_fiber_list_head;while(f){if(f!=sp_fiber_current){int i;for(i=0;i<f->saved_nroots;i++){void*obj=*f->saved_roots[i];if(obj)sp_gc_mark(obj);}}f=f->fiber_next;}}
+/* Mark roots saved by every suspended fiber. Includes sp_fiber_root
+   (the main-thread synthetic fiber): when a Fiber.new'd fiber is
+   running and triggers a GC pass, main's roots are sitting in
+   sp_fiber_root.saved_roots (the resume side stashed them there)
+   but sp_fiber_root is NOT in sp_fiber_list_head, so walking the
+   list alone would miss them and free main's live locals. */
+static void sp_mark_suspended_fibers(void){if(&sp_fiber_root!=sp_fiber_current){int i;for(i=0;i<sp_fiber_root.saved_nroots;i++){void*obj=*sp_fiber_root.saved_roots[i];if(obj)sp_gc_mark(obj);}}sp_Fiber*f=sp_fiber_list_head;while(f){if(f!=sp_fiber_current){int i;for(i=0;i<f->saved_nroots;i++){void*obj=*f->saved_roots[i];if(obj)sp_gc_mark(obj);}}f=f->fiber_next;}}
 static void sp_fiber_install_gc_hook(void){if(!sp_gc_mark_suspended_fibers_hook)sp_gc_mark_suspended_fibers_hook=sp_mark_suspended_fibers;}
 static void sp_Fiber_fin(void*p){sp_Fiber*f=(sp_Fiber*)p;if(f->ctx)DeleteFiber(f->ctx);if(f->saved_roots)free(f->saved_roots);sp_fiber_list_remove(f);}
 static void sp_Fiber_scan(void*p){sp_Fiber*f=(sp_Fiber*)p;if(f->user_data)sp_gc_mark(f->user_data);if(f->storage)sp_gc_mark(f->storage);}
@@ -2324,7 +2330,13 @@ static void sp_fiber_save_roots(sp_Fiber*f){if(f->saved_roots_cap<sp_gc_nroots){
 static void sp_fiber_restore_roots(sp_Fiber*f){if(f->saved_nroots>0)memcpy(sp_gc_roots,f->saved_roots,sizeof(void**)*f->saved_nroots);sp_gc_nroots=f->saved_nroots;}
 static void sp_fiber_list_add(sp_Fiber*f){f->fiber_prev=NULL;f->fiber_next=sp_fiber_list_head;if(sp_fiber_list_head)sp_fiber_list_head->fiber_prev=f;sp_fiber_list_head=f;}
 static void sp_fiber_list_remove(sp_Fiber*f){if(f->fiber_prev)f->fiber_prev->fiber_next=f->fiber_next;else if(sp_fiber_list_head==f)sp_fiber_list_head=f->fiber_next;if(f->fiber_next)f->fiber_next->fiber_prev=f->fiber_prev;f->fiber_prev=NULL;f->fiber_next=NULL;}
-static void sp_mark_suspended_fibers(void){sp_Fiber*f=sp_fiber_list_head;while(f){if(f!=sp_fiber_current){int i;for(i=0;i<f->saved_nroots;i++){void*obj=*f->saved_roots[i];if(obj)sp_gc_mark(obj);}}f=f->fiber_next;}}
+/* Mark roots saved by every suspended fiber. Includes sp_fiber_root
+   (the main-thread synthetic fiber): when a Fiber.new'd fiber is
+   running and triggers a GC pass, main's roots are sitting in
+   sp_fiber_root.saved_roots (the resume side stashed them there)
+   but sp_fiber_root is NOT in sp_fiber_list_head, so walking the
+   list alone would miss them and free main's live locals. */
+static void sp_mark_suspended_fibers(void){if(&sp_fiber_root!=sp_fiber_current){int i;for(i=0;i<sp_fiber_root.saved_nroots;i++){void*obj=*sp_fiber_root.saved_roots[i];if(obj)sp_gc_mark(obj);}}sp_Fiber*f=sp_fiber_list_head;while(f){if(f!=sp_fiber_current){int i;for(i=0;i<f->saved_nroots;i++){void*obj=*f->saved_roots[i];if(obj)sp_gc_mark(obj);}}f=f->fiber_next;}}
 static void sp_fiber_install_gc_hook(void){if(!sp_gc_mark_suspended_fibers_hook)sp_gc_mark_suspended_fibers_hook=sp_mark_suspended_fibers;}
 static void sp_Fiber_fin(void*p){sp_Fiber*f=(sp_Fiber*)p;if(f->stack)munmap(f->stack,SP_FIBER_STACK_SIZE);if(f->saved_roots)free(f->saved_roots);sp_fiber_list_remove(f);}
 static void sp_Fiber_scan(void*p){sp_Fiber*f=(sp_Fiber*)p;if(f->user_data)sp_gc_mark(f->user_data);if(f->storage)sp_gc_mark(f->storage);}

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -2303,7 +2303,8 @@ static void sp_fiber_list_remove(sp_Fiber*f){if(f->fiber_prev)f->fiber_prev->fib
    sp_fiber_root.saved_roots (the resume side stashed them there)
    but sp_fiber_root is NOT in sp_fiber_list_head, so walking the
    list alone would miss them and free main's live locals. */
-static void sp_mark_suspended_fibers(void){if(&sp_fiber_root!=sp_fiber_current){int i;for(i=0;i<sp_fiber_root.saved_nroots;i++){void*obj=*sp_fiber_root.saved_roots[i];if(obj)sp_gc_mark(obj);}}sp_Fiber*f=sp_fiber_list_head;while(f){if(f!=sp_fiber_current){int i;for(i=0;i<f->saved_nroots;i++){void*obj=*f->saved_roots[i];if(obj)sp_gc_mark(obj);}}f=f->fiber_next;}}
+static void sp_mark_fiber_roots(sp_Fiber*f){if(f==sp_fiber_current)return;int i;for(i=0;i<f->saved_nroots;i++){void*obj=*f->saved_roots[i];if(obj)sp_gc_mark(obj);}}
+static void sp_mark_suspended_fibers(void){sp_mark_fiber_roots(&sp_fiber_root);sp_Fiber*f=sp_fiber_list_head;while(f){sp_mark_fiber_roots(f);f=f->fiber_next;}}
 static void sp_fiber_install_gc_hook(void){if(!sp_gc_mark_suspended_fibers_hook)sp_gc_mark_suspended_fibers_hook=sp_mark_suspended_fibers;}
 static void sp_Fiber_fin(void*p){sp_Fiber*f=(sp_Fiber*)p;if(f->ctx)DeleteFiber(f->ctx);if(f->saved_roots)free(f->saved_roots);sp_fiber_list_remove(f);}
 static void sp_Fiber_scan(void*p){sp_Fiber*f=(sp_Fiber*)p;if(f->user_data)sp_gc_mark(f->user_data);if(f->storage)sp_gc_mark(f->storage);}
@@ -2336,7 +2337,8 @@ static void sp_fiber_list_remove(sp_Fiber*f){if(f->fiber_prev)f->fiber_prev->fib
    sp_fiber_root.saved_roots (the resume side stashed them there)
    but sp_fiber_root is NOT in sp_fiber_list_head, so walking the
    list alone would miss them and free main's live locals. */
-static void sp_mark_suspended_fibers(void){if(&sp_fiber_root!=sp_fiber_current){int i;for(i=0;i<sp_fiber_root.saved_nroots;i++){void*obj=*sp_fiber_root.saved_roots[i];if(obj)sp_gc_mark(obj);}}sp_Fiber*f=sp_fiber_list_head;while(f){if(f!=sp_fiber_current){int i;for(i=0;i<f->saved_nroots;i++){void*obj=*f->saved_roots[i];if(obj)sp_gc_mark(obj);}}f=f->fiber_next;}}
+static void sp_mark_fiber_roots(sp_Fiber*f){if(f==sp_fiber_current)return;int i;for(i=0;i<f->saved_nroots;i++){void*obj=*f->saved_roots[i];if(obj)sp_gc_mark(obj);}}
+static void sp_mark_suspended_fibers(void){sp_mark_fiber_roots(&sp_fiber_root);sp_Fiber*f=sp_fiber_list_head;while(f){sp_mark_fiber_roots(f);f=f->fiber_next;}}
 static void sp_fiber_install_gc_hook(void){if(!sp_gc_mark_suspended_fibers_hook)sp_gc_mark_suspended_fibers_hook=sp_mark_suspended_fibers;}
 static void sp_Fiber_fin(void*p){sp_Fiber*f=(sp_Fiber*)p;if(f->stack)munmap(f->stack,SP_FIBER_STACK_SIZE);if(f->saved_roots)free(f->saved_roots);sp_fiber_list_remove(f);}
 static void sp_Fiber_scan(void*p){sp_Fiber*f=(sp_Fiber*)p;if(f->user_data)sp_gc_mark(f->user_data);if(f->storage)sp_gc_mark(f->storage);}


### PR DESCRIPTION
The post-#636 fix (`c7d247b`) moved per-fiber GC roots into a save/restore model on every `Fiber#resume` but missed walking `sp_fiber_root`'s saved region. When a `Fiber.new`'d fiber is current and a GC pass fires, main's roots — stashed in `sp_fiber_root.saved_roots` by the resume side — are never marked. Main's live references get freed, including the `Fiber*` objects themselves (held only via main's locals). The next walk of `sp_fiber_list_head` dereferences a stale `sp_Fiber*` and segfaults at a high-pointer address: the same shape #636 was meant to fix.

## Empirical bisect

The bug is reachable via tep's Scheduled-server burst load. The original repro from #636 (2 fibers × 100 keepalive requests) now runs clean post-fix, but a slightly different shape (1 fiber × 200 keepalive requests, plus higher-concurrency variants) SEGVs consistently after 60–90 requests. Bisect against [`OriPekelman/tep@test/spinel_scheduled_burst_segv_repro.rb`](https://github.com/OriPekelman/tep/blob/main/test/spinel_scheduled_burst_segv_repro.rb):

| spinel | tep case A (1 conn × 200 keepalive) |
|---|---|
| `6513d2d` (pre-fix) | ok=200/200 |
| `1bbf3d7` (commit before #636) | ok=200/200 |
| `c7d247b` (#636 fix) | **ok=87, SEGV** |
| `c7d247b` + this patch | ok=200/200 |

Higher-load variants (4×50, 8×100, 200 fresh non-keepalive, 1000 short-conn churn) all crash on `c7d247b` and all run clean with the patch.

## Fix

`sp_mark_suspended_fibers` walks `sp_fiber_root.saved_roots` unconditionally (when `sp_fiber_root != sp_fiber_current`), in addition to iterating `sp_fiber_list_head`. Mirrored in both the Windows and the Linux/ucontext variants.

## Note on the test

I tried to build a self-contained Ruby regression test that reproduces the bug, but spinel's 2-generation GC (full sweep every 8 cycles) shelters the small synthetic test cases — promoted survivors aren't swept on partial cycles. The tep integration repro is the most reliable trigger I could land on. Happy to iterate on a tighter standalone test if there's a preferred shape.

Refs #636.