### PR TITLE
feat(codegen,runtime): regex back-reference `$+` returns last paren match

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -1393,6 +1393,19 @@ static void sp_re_mark_globals(void) {
   sp_mark_fiber_root_storage();
 }
 
+/* `$+` / `$LAST_PAREN_MATCH` — contents of the highest-indexed group
+   that participated in the match. Walks sp_re_captures[] from 9 down
+   and returns the first non-NULL entry. NULL when no group matched
+   (codegen ternary falls back to ""). Matches CRuby's behaviour:
+   for /(a)(b)?/ matching "a", $+ is "a"; for /(a)(b)/ matching "ab",
+   $+ is "b". */
+static const char *sp_re_last_paren_match(void) {
+  for (int i = 9; i >= 1; i--) {
+    if (sp_re_captures[i]) return sp_re_captures[i];
+  }
+  return NULL;
+}
+
 static void sp_re_set_captures(const char *str, int *caps, int ncaps) {
   sp_re_last_str = str;
   for (int i = 0; i < 10; i++) sp_re_captures[i] = NULL;

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -11556,12 +11556,13 @@ class Compiler
       return compile_interpolated(nid)
     end
     if t == "BackReferenceReadNode"
- # `$&`, `$~`, `$'`, `$`. Spinel populates sp_re_match_str /
+ # `$&`, `$~`, `$'`, `$`, `$+`. Spinel populates sp_re_match_str /
  # _pre / _post in sp_re_set_captures alongside sp_re_captures
  # (used by NumberedReferenceReadNode for $1..$9). Each accessor
  # is null-guarded so unused reads return "" -- matches CRuby's
  # post-no-match behavior. $~ falls back to $& since Spinel
- # has no MatchData wrapper to expose.
+ # has no MatchData wrapper to expose. $+ walks the captures
+ # backward via sp_re_last_paren_match.
       n = @nd_name[nid]
       if n == "$&" || n == "$~"
         return "(sp_re_match_str ? sp_re_match_str : \"\")"
@@ -11571,6 +11572,9 @@ class Compiler
       end
       if n == "$'"
         return "(sp_re_match_post ? sp_re_match_post : \"\")"
+      end
+      if n == "$+"
+        return "(sp_re_last_paren_match() ? sp_re_last_paren_match() : \"\")"
       end
       $stderr.puts "Spinel: BackReferenceReadNode `" + n + "` not supported"
       exit(1)
@@ -12280,14 +12284,18 @@ class Compiler
       if gname == "$?"
         return "sp_last_status"
       end
- # Regex match globals -- Prism delivers `$~`, `$&`, `$``, `$'`
+ # Regex match globals -- Prism delivers `$~`, `$&`, `$``, `$'`, `$+`
  # as GlobalVariableReadNode rather than BackReferenceReadNode.
  # spinel populates sp_re_match_str / _pre / _post in
  # sp_re_set_captures; $~ falls back to $& since there's no
  # MatchData wrapper. Null-guards match the BackReferenceReadNode
  # arm above so unused reads return "" (CRuby returns nil for
  # post-no-match $~; that divergence is the same one this arm
- # already had for the BackReferenceReadNode path).
+ # already had for the BackReferenceReadNode path). $+ walks the
+ # captures backward via sp_re_last_paren_match. The English-name
+ # aliases ($LAST_MATCH_INFO, $LAST_PAREN_MATCH) are intentionally
+ # not auto-resolved here -- in CRuby they require `require 'English'`
+ # and arriving without that should match CRuby's "unset global" nil.
       if gname == "$&" || gname == "$~"
         return "(sp_re_match_str ? sp_re_match_str : \"\")"
       end
@@ -12296,6 +12304,9 @@ class Compiler
       end
       if gname == "$'"
         return "(sp_re_match_post ? sp_re_match_post : \"\")"
+      end
+      if gname == "$+"
+        return "(sp_re_last_paren_match() ? sp_re_last_paren_match() : \"\")"
       end
  # General global variable
       return sanitize_gvar(gname)

--- a/test/back_ref.rb
+++ b/test/back_ref.rb
@@ -1,4 +1,4 @@
-# BackReferenceReadNode -- `$&`, `$~`, `$'`, $`.
+# BackReferenceReadNode -- `$&`, `$~`, `$'`, $`, `$+`.
 #
 # Special globals populated by regex matches. Spinel's regex engine
 # already populates sp_re_match* state for $1..$9 (NumberedReferenceReadNode);
@@ -8,6 +8,7 @@
 #   $~  -- the MatchData object (aliased to $& in Spinel; no MatchData wrapper)
 #   $`  -- the substring before the match
 #   $'  -- the substring after the match
+#   $+  -- the contents of the last group matched
 
 "hello world" =~ /lo wo/
 puts $&     # lo wo
@@ -19,3 +20,16 @@ puts $'     # rld
 puts $&     # cd
 puts $`     # ab
 puts $'     # ef
+
+# $+ -- last group matched. For a multi-group pattern, $+ holds the
+# highest-indexed group that successfully participated.
+"abc123" =~ /([a-z]+)(\d+)/
+puts $1     # abc
+puts $2     # 123
+puts $+     # 123
+
+# When the last optional group doesn't participate, $+ steps back to
+# the previous successful group.
+"abc" =~ /([a-z]+)(\d+)?/
+puts $1     # abc
+puts $+     # abc

--- a/test/back_ref.rb.expected
+++ b/test/back_ref.rb.expected
@@ -4,3 +4,8 @@ rld
 cd
 ab
 ef
+abc
+123
+123
+abc
+abc


### PR DESCRIPTION
## Summary

Closes a small CRuby parity gap: the symbolic regex back-reference `$+`
(the contents of the highest-indexed capture group that participated in
the match) was the last unsupported BackReferenceReadNode arm. The
other symbolic back-references (`$&`, `$~`, `$``, `$'`) were already
threaded through `sp_re_set_captures` runtime state.

* Runtime helper `sp_re_last_paren_match` in `lib/sp_runtime.h` walks
  `sp_re_captures[]` from index 9 down and returns the first non-NULL
  entry. NULL when no group matched — the codegen ternary falls back
  to `""` mirroring the existing `$&` / `$`` / `$'` idiom.
* Codegen arms in `spinel_codegen.rb` for both the `BackReferenceReadNode`
  shape and the `GlobalVariableReadNode` shape that prism uses for the
  symbolic globals when they arrive as bare reads.

## Notes

The English-name aliases `$LAST_MATCH_INFO` / `$LAST_PAREN_MATCH`
intentionally fall through to the bare-global path. In CRuby those
require `require 'English'`; without it they're nil, and spinel without
an `English` stdlib should match that "unbound global" behaviour rather
than diverge by silently aliasing.

## Test plan

- [x] Extend `test/back_ref.rb` with two `$+` shapes:
  - last-group participates (`/(a)(b)/` against `"abc123"`)
  - last-optional-group does not (`/(a)(b)?/` against `"abc"`)
- [x] `make clean && make bootstrap` — all 4 fixpoint OK lines
- [x] `make test` — 618 / 618 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)