### PR TITLE
fix(codegen): coerce poly args in chained concat and `print` to const char*

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -15412,6 +15412,23 @@ class Compiler
               parts.push("sp_bigint_to_s((sp_Bigint *)" + compile_expr(aargs[0]) + ")")
             elsif at == "float"
               parts.push("sp_float_to_s(" + compile_expr(aargs[0]) + ")")
+            elsif at == "poly"
+ # `"a" + poly_local + "b"` -- the 2-arg sp_str_concat path at
+ # the single-`+` site already coerces via sp_poly_to_s; mirror
+ # that here for chained concat collapsing into sp_str_concat3 /
+ # sp_str_concat_arr. Without this, the chained form silently
+ # passed an sp_RbVal into a `const char *` parameter and cc
+ # rejected the generated code. Common shape: a local typed
+ # through `if x.nil?; ""; else; x; end` when x came from a
+ # poly-valued hash lookup -- the union stays sp_RbVal but its
+ # string-side payload is always a valid c-string at runtime.
+              parts.push("sp_poly_to_s(" + compile_expr(aargs[0]) + ")")
+            elsif at == "symbol"
+              parts.push("sp_sym_to_s(" + compile_expr(aargs[0]) + ")")
+            elsif at == "mutable_str"
+              parts.push("(" + compile_expr(aargs[0]) + ")->data")
+            elsif at == "bigint"
+              parts.push("sp_bigint_to_s(" + compile_expr(aargs[0]) + ")")
             else
               parts.push(compile_expr(aargs[0]))
             end
@@ -32150,16 +32167,25 @@ class Compiler
       end
       if at == "int"
         emit("  printf(\"%lld\", (long long)" + val + ");")
+      elsif at == "mutable_str"
+        emit("  fputs(" + val + "->data, stdout);")
+      elsif at == "string" || at == "string?"
+        emit("  if (" + val + ") fputs(" + val + ", stdout);")
+      elsif at == "float"
+        emit("  fputs(sp_float_to_s(" + val + "), stdout);")
+      elsif at == "bool"
+        emit("  fputs(" + val + " ? \"true\" : \"false\", stdout);")
+      elsif at == "poly"
+ # `print poly_local` -- route through sp_poly_to_s rather than
+ # falling through to the `printf("%lld", (long long)val)` path,
+ # which is a C-level type error (sp_RbVal is a struct; the cast
+ # rejects). sp_poly_to_s switches on the tag and returns a
+ # valid c-string for every variant, matching CRuby's
+ # `print obj` -> `obj.to_s` semantics.
+        @needs_rb_value = 1
+        emit("  fputs(sp_poly_to_s(" + val + "), stdout);")
       else
-        if at == "mutable_str"
-          emit("  fputs(" + val + "->data, stdout);")
-        else
-          if at == "string"
-            emit("  fputs(" + val + ", stdout);")
-          else
-            emit("  printf(\"%lld\", (long long)" + val + ");")
-          end
-        end
+        emit("  printf(\"%lld\", (long long)" + val + ");")
       end
       k = k + 1
     end

--- a/test/concat_print_poly_unbox.rb
+++ b/test/concat_print_poly_unbox.rb
@@ -1,0 +1,115 @@
+# Conditional-assign of a poly value (e.g. nullable hash lookup
+# fused with a nil-guard fallback) leaves the local typed sp_RbVal
+# even when both branches produce strings. Downstream concat and
+# print sites must coerce on the sp_RbVal -> const char * boundary
+# rather than fall through to a struct-into-pointer cc error.
+#
+#   * `"a" + poly + "b"` -- chained concat collapses to
+#     sp_str_concat3; collect_concat_parts now wraps poly with
+#     sp_poly_to_s (mirrors the existing 2-arg sp_str_concat
+#     coercion at the single-`+` site).
+#   * `print poly` -- compile_print routes through sp_poly_to_s
+#     instead of the broken `printf("%lld", (long long)val)`
+#     fallback (sp_RbVal is a struct; the cast rejects).
+#
+# str_poly_hash lookup is the canonical shape that triggers the
+# poly local: { "text" => "hi", "n" => 42 }["text"] is sp_RbVal
+# because the value union spans String and Integer.
+
+def show_concat(node)
+  raw = node["text"]
+  text = if raw.nil?
+           ""
+         else
+           raw
+         end
+  puts "[ " + text + " ]"
+end
+
+def show_print(node)
+  raw = node["text"]
+  text = if raw.nil?
+           ""
+         else
+           raw
+         end
+  print "[ "
+  print text
+  print " ]\n"
+end
+
+# --- Present-key String value (the canonical bug-report shape).
+# Mixed-value hash -> str_poly_hash; the else branch produces a poly
+# value (raw), the if branch produces a string literal. The union of
+# the two branches stays sp_RbVal. Without the codegen-side coercion,
+# the downstream concat / print sites emit cc-rejected C.
+h_present = { "text" => "hello", "n" => 42 }
+show_concat(h_present)
+show_print(h_present)
+
+# --- Missing-key fallback. Exercises the if-true branch of the
+# nil-guard: raw is nil, text becomes "", concat / print emit
+# "[  ]" / "[  ]\n". h_missing keeps the same str_poly_hash shape
+# (mixed String + Integer values so the value union widens to
+# poly) but omits the "text" key so the lookup returns nil.
+# Without this case the if-branch of the conditional assignment
+# was untested.
+h_missing = { "other" => "x", "n" => 42 }
+show_concat(h_missing)
+show_print(h_missing)
+
+# --- Symbol-valued poly via `print`. CRuby's `print :sym` calls
+# `Symbol#to_s` -> "sym"; spinel's compile_print poly arm routes
+# through `sp_poly_to_s` whose SP_TAG_SYM case returns the same
+# rendering. Exercises the tag dispatch beyond SP_TAG_STR.
+def show_print_sym(node)
+  raw = node["k"]
+  text = raw.nil? ? "" : raw
+  print "sym="
+  print text
+  puts ""
+end
+h_sym = { "k" => :hello, "n" => 42 }
+show_print_sym(h_sym)
+
+# --- Integer-valued poly via `print`. SP_TAG_INT path through
+# `sp_poly_to_s` returns `sp_int_to_s(...)`; CRuby's `print 42`
+# calls `Integer#to_s`. (Skipped for concat: CRuby raises
+# TypeError on `String + Integer`; the coercion path stays
+# behind `print` to preserve parity.)
+def show_print_int(node)
+  raw = node["k"]
+  text = raw.nil? ? "" : raw
+  print "int="
+  print text
+  puts ""
+end
+h_int = { "k" => 42, "n" => "x" }
+show_print_int(h_int)
+
+# --- Explicit 4-part chained concat that exercises sp_str_concat4.
+# Uses bound prefix/suffix locals (rather than bare string literals)
+# so the part shape is unambiguous regardless of any literal-folding
+# optimization pass.
+def label_concat4(node)
+  raw = node["text"]
+  text = raw.nil? ? "" : raw
+  prefix = "OPEN"
+  suffix = "CLOSE"
+  puts prefix + " " + text + " " + suffix
+end
+label_concat4(h_present)
+label_concat4(h_missing)
+
+# --- Variable-length sp_str_concat_arr (>= 5 parts) with bound
+# prefix / suffix to ensure the chain stays unambiguous.
+def label_wrap(node)
+  raw = node["text"]
+  text = raw.nil? ? "" : raw
+  pre1 = "<"
+  pre2 = "open "
+  post1 = " close"
+  post2 = ">"
+  puts pre1 + pre2 + text + post1 + post2
+end
+label_wrap(h_present)

--- a/test/concat_print_poly_unbox.rb.expected
+++ b/test/concat_print_poly_unbox.rb.expected
@@ -1,0 +1,9 @@
+[ hello ]
+[ hello ]
+[  ]
+[  ]
+sym=hello
+int=42
+OPEN hello CLOSE
+OPEN  CLOSE
+<open hello close>


### PR DESCRIPTION
## Summary

A poly local that survives an if/else conditional assignment landed as
`sp_RbVal` in two codegen sites that downstream expected `const char *`.
Both produced cc-rejected C:

* `puts "[ " + text + " ]"` — chained-concat collapse routes through
  `collect_concat_parts` → `sp_str_concat3(a, b, c)` which takes three
  `const char *`s. The collector handled string/int/float arg shapes but
  fell through with the raw expression for poly. The matching 2-arg
  `sp_str_concat` site upstream already coerced poly via `sp_poly_to_s`;
  mirror that here, and add the same coercion for symbol / mutable_str /
  bigint so any chained shape that types its leaves through those slots
  also concats cleanly.

* `print text` where `text` is poly — `compile_print`'s fallback emitted
  `printf("%lld", (long long)<val>)`, which cc rejects because `sp_RbVal`
  is a struct (no scalar cast). Route poly through `sp_poly_to_s` to
  mirror the puts-side `sp_poly_puts` dispatch (without the trailing
  newline that `print` shouldn't emit).

## Canonical trigger shape

```ruby
def show(node)
  raw = node["text"]
  text = if raw.nil?
           ""
         else
           raw
         end
  puts "[ " + text + " ]"     # sp_str_concat3 cc error
  print text                   # printf %lld struct-cast cc error
end
show({ "text" => "hi", "n" => 42 })   # str_poly_hash recv
```

The union stays `sp_RbVal` because the analyze pass widens to poly when
the if and else branches produce different static types — `""` is `string`
but the else branch is `poly`. Re-narrowing across conditional assignments
would be the more principled fix; this patch closes the cc-error gap that
blocked any source touching this shape.

## Notes

The `sp_poly_to_s` route is more permissive than CRuby's `String#+` (which
raises `TypeError` on non-String operands). Aligning to the strict-raise
behaviour would need a new `sp_poly_as_string_or_raise` helper; defer that
to a separate PR once the narrowing-pass fix lands and the coercion path
becomes a fallback rather than the common path.

## Test plan

- [x] `test/concat_print_poly_unbox.rb` covers concat3, 4-part chain, and
  `print` with a `str_poly_hash` lookup driving the poly local
- [x] `make clean && make bootstrap` — all 4 fixpoint OK lines
- [x] `make test` — 619 / 619 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)