### PR TITLE
feat(parse,codegen): pattern matching for `^var` / `^(expr)` pin patterns

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -27824,22 +27824,29 @@ class Compiler
     pred_type = infer_type(pred)
     pred_val = compile_expr(pred)
     tmp = new_temp
+ # For typed containers (int_array, sym_array, str_array, hash
+ # variants, range, time, user-class obj_*, ...) the temp must be
+ # declared with the receiver's actual C type so the pattern arms
+ # can dereference `tmp->len` / `tmp->data[i]` and per-variant hash
+ # lookups can pass the right pointer type. Without this the temp
+ # was declared as `mrb_int` for everything non-poly/string/float
+ # and any pattern shape touching the scrutinee structurally
+ # crashed at cc time. Primitive shapes (int/bool/symbol/nil) keep
+ # the historic `mrb_int` slot.
     if pred_type == "poly"
       emit("  sp_RbVal " + tmp + " = " + pred_val + ";")
+    elsif pred_type == "string"
+      emit("  const char *" + tmp + " = " + pred_val + ";")
+    elsif pred_type == "float"
+      emit("  mrb_float " + tmp + " = " + pred_val + ";")
+    elsif pred_type == "bigint"
+      @needs_bigint = 1
+      emit("  mrb_int " + tmp + " = sp_bigint_to_int((sp_Bigint *)" + pred_val + ");")
+      pred_type = "int"
+    elsif pred_type == "int" || pred_type == "bool" || pred_type == "symbol" || pred_type == "nil" || pred_type == ""
+      emit("  mrb_int " + tmp + " = " + pred_val + ";")
     else
-      if pred_type == "string"
-        emit("  const char *" + tmp + " = " + pred_val + ";")
-      else
-        if pred_type == "float"
-          emit("  mrb_float " + tmp + " = " + pred_val + ";")
-        elsif pred_type == "bigint"
-          @needs_bigint = 1
-          emit("  mrb_int " + tmp + " = sp_bigint_to_int((sp_Bigint *)" + pred_val + ");")
-          pred_type = "int"
-        else
-          emit("  mrb_int " + tmp + " = " + pred_val + ";")
-        end
-      end
+      emit("  " + c_type(pred_type) + " " + tmp + " = " + pred_val + ";")
     end
     conds = parse_id_list(@nd_conditions[nid])
     k = 0
@@ -27931,10 +27938,65 @@ class Compiler
       end
       return tmp + " == 0"
     end
+    if pt == "SymbolNode"
+ # `case sym in :foo` -- literal symbol pattern. Without this arm
+ # the dispatch fell through to the trailing "1" fallback and any
+ # symbol pattern silently always matched.
+      sym_lit = compile_symbol_literal(@nd_content[pat_id])
+      if pred_type == "poly"
+        return "(" + tmp + ".tag == SP_TAG_SYM && (sp_sym)" + tmp + ".v.i == (" + sym_lit + "))"
+      end
+      return "(sp_sym)(" + tmp + ") == (" + sym_lit + ")"
+    end
+    if pt == "FloatNode"
+ # `case f in 3.14` -- literal float pattern. Same fallthrough
+ # silent-match bug as SymbolNode.
+      fval = @nd_value[pat_id]
+      if pred_type == "poly"
+        return "(" + tmp + ".tag == SP_TAG_FLT && " + tmp + ".v.f == " + fval + ")"
+      end
+      return tmp + " == " + fval
+    end
     if pt == "AlternationPatternNode"
       left = compile_in_pattern(@nd_left[pat_id], tmp, pred_type)
       right = compile_in_pattern(@nd_right[pat_id], tmp, pred_type)
       return "(" + left + " || " + right + ")"
+    end
+ # PinnedVariableNode / PinnedExpressionNode: `case x in ^var` /
+ # `in ^(expr)`. Both share the `@nd_expression` slot -- the parse
+ # layer routes the variable into the expression field so codegen
+ # treats them uniformly. Match by `==` against the pinned value;
+ # poly-tagged scrutinees get both tag and value checks so a pinned
+ # Integer doesn't spuriously match against a string with the same
+ # underlying byte pattern.
+    if pt == "PinnedVariableNode" || pt == "PinnedExpressionNode"
+      pinned = compile_expr(@nd_expression[pat_id])
+      pinned_type = infer_type(@nd_expression[pat_id])
+      if pred_type == "poly"
+        if pinned_type == "int"
+          return "(" + tmp + ".tag == SP_TAG_INT && " + tmp + ".v.i == (" + pinned + "))"
+        end
+        if pinned_type == "string"
+          return "(" + tmp + ".tag == SP_TAG_STR && strcmp(" + tmp + ".v.s, " + pinned + ") == 0)"
+        end
+        if pinned_type == "symbol"
+          return "(" + tmp + ".tag == SP_TAG_SYM && (sp_sym)" + tmp + ".v.i == (" + pinned + "))"
+        end
+        if pinned_type == "float"
+          return "(" + tmp + ".tag == SP_TAG_FLT && " + tmp + ".v.f == (" + pinned + "))"
+        end
+        if pinned_type == "bool"
+          return "(" + tmp + ".tag == SP_TAG_BOOL && " + tmp + ".v.b == (" + pinned + "))"
+        end
+        if pinned_type == "nil"
+          return tmp + ".tag == SP_TAG_NIL"
+        end
+        return "0"
+      end
+      if pinned_type == "string" && pred_type == "string"
+        return "strcmp(" + tmp + ", " + pinned + ") == 0"
+      end
+      return "(" + tmp + ") == (" + pinned + ")"
     end
     "1"
   end

--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -1040,6 +1040,28 @@ static int flatten(pm_node_t *node) {
     R("right", n->right);
     break;
   }
+  case PM_PINNED_EXPRESSION_NODE: {
+    /* `case x in ^(expr)`. The pinned expression is evaluated at
+       match time and compared by `==` against the scrutinee. */
+    pm_pinned_expression_node_t *n = (pm_pinned_expression_node_t *)node;
+    N("PinnedExpressionNode");
+    R("expression", n->expression);
+    break;
+  }
+  case PM_PINNED_VARIABLE_NODE: {
+    /* `case x in ^var`. The wrapped variable can be any read-shape
+       node prism emits for `^var` -- LocalVariableReadNode,
+       InstanceVariableReadNode, ClassVariableReadNode,
+       GlobalVariableReadNode, ConstantReadNode,
+       NumberedReferenceReadNode, BackReferenceReadNode. Routed to
+       the same `@nd_expression` slot as PinnedExpressionNode so the
+       codegen treats them uniformly -- both are "match the scrutinee
+       by `==` against this expression". */
+    pm_pinned_variable_node_t *n = (pm_pinned_variable_node_t *)node;
+    N("PinnedVariableNode");
+    R("expression", n->variable);
+    break;
+  }
   case PM_NUMBERED_PARAMETERS_NODE: {
     pm_numbered_parameters_node_t *n = (pm_numbered_parameters_node_t *)node;
     N("NumberedParametersNode");

--- a/test/pattern_pin.rb
+++ b/test/pattern_pin.rb
@@ -1,0 +1,105 @@
+# Pattern matching: PinnedExpressionNode + PinnedVariableNode.
+#
+# Pin patterns match the scrutinee by `==` against the value of an
+# existing local / ivar / arbitrary expression -- they do not bind
+# new variables. Both prism node types (PinnedVariableNode for `^var`
+# and PinnedExpressionNode for `^(expr)`) are routed through the
+# shared `@nd_expression` slot so the codegen treats them uniformly.
+
+# --- Pin against int local
+x = 42
+case 42
+in ^x
+  puts "pin int match"
+in 0
+  puts "zero"
+end
+
+# --- Pin miss falls through to next arm / else
+y = 10
+case 42
+in ^y
+  puts "pin y match"
+else
+  puts "no pin y"
+end
+
+# --- Pin against string local
+s = "hello"
+case "hello"
+in ^s
+  puts "pin str match"
+end
+
+# Pin string miss
+t = "goodbye"
+case "hello"
+in ^t
+  puts "pin t"
+else
+  puts "no pin t"
+end
+
+# --- Pin against arbitrary expression `^(expr)`
+val = 7
+case 21
+in ^(val * 3)
+  puts "pin expr 21"
+else
+  puts "miss"
+end
+
+# Pin expression with method call
+def double(n)
+  n * 2
+end
+case 14
+in ^(double(7))
+  puts "pin call 14"
+end
+
+# --- Pin against symbol
+sym = :foo
+case :foo
+in ^sym
+  puts "pin sym match"
+end
+
+# Symbol miss
+case :bar
+in ^sym
+  puts "pin sym bar"
+else
+  puts "no sym bar"
+end
+
+# --- Pin works alongside literal arms in same case
+mode = :verbose
+case :verbose
+in :quiet
+  puts "q"
+in ^mode
+  puts "pin mode hit"
+in :other
+  puts "o"
+end
+
+# --- Pin against ivar
+class Box
+  def initialize(v)
+    @v = v
+  end
+
+  def matches(x)
+    case x
+    in ^@v
+      "ivar match"
+    else
+      "no match"
+    end
+  end
+end
+
+b = Box.new(99)
+puts b.matches(99)
+puts b.matches(100)

--- a/test/pattern_pin.rb.expected
+++ b/test/pattern_pin.rb.expected
@@ -1,0 +1,11 @@
+pin int match
+no pin y
+pin str match
+no pin t
+pin expr 21
+pin call 14
+pin sym match
+no sym bar
+pin mode hit
+ivar match
+no match


### PR DESCRIPTION
## Summary

Implements `case x in ^var` (`PinnedVariableNode`) and `case x in ^(expr)` (`PinnedExpressionNode`)

Previously: prism delivered both pin node types but `spinel_parse` didn't emit them. The unknown-node passthrough routed them through `compile_in_pattern`'s "always-match" fallback, so every pin pattern silently matched whatever scrutinee it saw.

## Changes

* **Parse layer** (`spinel_parse.c`): emit both pin nodes; route
  `PinnedVariableNode.variable` into the shared `@nd_expression` slot
  so codegen treats them uniformly.
* **Codegen** (`compile_in_pattern` in `spinel_codegen.rb`):
  - For a typed scrutinee (int / string / sym / etc.) emit the direct
    comparison (`tmp == pinned` or `strcmp(tmp, pinned) == 0`).
  - For a poly-tagged scrutinee, double-check tag AND value so a pinned
    Integer doesn't spuriously match a string with the same byte pattern.
* **Shared infrastructure**: `compile_case_match_stmt` widens its temp
  declaration to `c_type(pred_type)` for non-primitive scrutinee types
  (int_array, sym_array, hashes, etc.). Pin patterns don't hit this
  path directly, but the fix is small and broadly useful.

## Adjacent fixes uncovered while testing

* `SymbolNode` literal pattern (`case sym in :foo`): was silently
  always-matching due to missing arm. Added.
* `FloatNode` literal pattern (`case f in 3.14`): same bug. Added.

## Test plan

- [x] `test/pattern_pin.rb` covers: int pin match + miss, string pin
  match + miss, expression pin `^(val * 3)`, method-call expression
  pin, symbol pin match + miss, pin alongside literal-symbol arms in
  the same case, ivar pin inside an instance method
- [x] `make clean && make bootstrap` — all 4 fixpoint OK lines
- [x] `make test` — 626 / 626 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)