### PR TITLE
docs(examples/ffi/sqlite): retire stale "MVP FFI can't construct :ptr from sentinel" note

### DIFF
--- a/examples/ffi/sqlite/README.md
+++ b/examples/ffi/sqlite/README.md
@@ -65,9 +65,10 @@ Comments on the FFI post:
 
 ## Notes
 
-The demo uses inline-quoted SQL with `Sql.q` for escaping, not bound
-parameters. The reason: `sqlite3_bind_text`'s last argument is a
-destructor callback (the `SQLITE_TRANSIENT` sentinel is `(void *)-1`),
-and the MVP FFI can't yet construct a `:ptr` from a sentinel integer.
-For real applications you'd write a tiny C helper that wraps `bind_text`
-with `SQLITE_TRANSIENT` baked in and link it alongside.
+The demo uses inline-quoted SQL with `Sql.q` for escaping, kept as the
+minimal path through `prepare_v2` / `step` / `finalize`. For bound
+parameters, `sqlite3_bind_text` is supported directly — pass `-1` as
+the destructor argument to get `SQLITE_TRANSIENT` (`(void *)-1`); the
+FFI accepts an integer literal in a `:ptr` arg slot and emits
+`((void *)-1LL)`. See `sqlite3_lib.rb` for the `ffi_func` declaration
+and `test/ffi_ptr_int_literal.rb` for the regression test.


### PR DESCRIPTION
## Summary

- The Notes section of `examples/ffi/sqlite/README.md` still claimed the FFI "can't yet construct a `:ptr` from a sentinel integer" — that constraint was lifted by #576, and `test/ffi_ptr_int_literal.rb` guards the primitive.
- The same README's header and `sqlite3_lib.rb`'s header comment (after 3db7ff0) already describe `sqlite3_bind_text` as supported, so the Notes paragraph contradicts the same example's other voices.
- Rewrite the Notes to match: demo keeps inline-quoting as the minimal path through `prepare_v2`/`step`/`finalize`, but `bind_text` works directly with `-1` as the destructor argument, with pointers to `sqlite3_lib.rb` and the regression test.

## Test plan

- [x] `git diff` confirms only `examples/ffi/sqlite/README.md` changes
- [x] New paragraph matches the existing `sqlite3_lib.rb` header comment and `test/ffi_ptr_int_literal.rb` docstring

🤖 Generated with [Claude Code](https://claude.com/claude-code)