### PR TITLE
fix(parse,runtime,analyze,codegen): __ENCODING__ returns Encoding

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -508,6 +508,18 @@ static inline mrb_int sp_process_ppid(void) {
 }
 
 static void sp_oom_die(void);
+
+/* ---- Encoding runtime ----
+   Spinel currently assumes UTF-8 source and string data. Keep Encoding
+   as a tiny value type so `__ENCODING__` and `String#encoding` can
+   answer Ruby's Encoding-shaped protocol without carrying full
+   transcoding state. */
+typedef struct{const char *name;}sp_Encoding;
+static inline sp_Encoding sp_encoding_utf8(void){return(sp_Encoding){"UTF-8"};}
+static inline const char*sp_encoding_name(sp_Encoding e){return e.name?e.name:sp_str_empty;}
+static inline const char*sp_encoding_inspect(sp_Encoding e){return sp_sprintf("#<Encoding:%s>",sp_encoding_name(e));}
+static inline mrb_bool sp_encoding_eq(sp_Encoding a,sp_Encoding b){const char*an=sp_encoding_name(a);const char*bn=sp_encoding_name(b);return strcmp(an,bn)==0;}
+
 static char *sp_str_alloc(size_t len) {
   size_t total = sizeof(sp_str_hdr) + 1 + len + 1;
   sp_str_hdr *h = (sp_str_hdr *)malloc(total);
@@ -1925,6 +1937,9 @@ typedef uint64_t sp_RbValue;
    the boxed sp_Class's cls_id directly so unboxing is just a
    field read. */
 #define SP_TAG_CLASS 7
+/* Encoding values boxed into a poly slot. v.s carries the canonical
+   encoding name (`"UTF-8"` in Spinel's current runtime model). */
+#define SP_TAG_ENCODING 8
 /* Negative cls_id values let SP_TAG_OBJ also carry built-in pointer
    types (IntArray, FloatArray, ...) — avoids minting a new SP_TAG_*
    per type. Non-negative cls_id stays an index into the user-class
@@ -1960,6 +1975,7 @@ static sp_RbVal sp_box_obj(void *p, int cls_id) { sp_RbVal r; r.tag = SP_TAG_OBJ
 static sp_RbVal sp_box_sym(sp_sym v) { sp_RbVal r; r.tag = SP_TAG_SYM; r.cls_id = 0; r.v.i = (mrb_int)v; return r; }
 /* box a sp_Class into a poly slot. */
 static sp_RbVal sp_box_class(sp_Class c) { sp_RbVal r; r.tag = SP_TAG_CLASS; r.cls_id = (int)c.cls_id; r.v.i = c.cls_id; return r; }
+static sp_RbVal sp_box_encoding(sp_Encoding e) { sp_RbVal r; r.tag = SP_TAG_ENCODING; r.cls_id = 0; r.v.s = sp_encoding_name(e); return r; }
 
 /* every non-value-type sp_<C> starts
    with `mrb_int cls_id`. Read it back from a void* when
@@ -2130,6 +2146,7 @@ static inline void sp_poly_puts(sp_RbVal v) {
     case SP_TAG_BOOL: puts(v.v.b ? "true" : "false"); break;
     case SP_TAG_NIL: putchar('\n'); break;
     case SP_TAG_SYM: { const char *_ss = sp_sym_to_s((sp_sym)v.v.i); fputs(_ss, stdout); putchar('\n'); break; }
+    case SP_TAG_ENCODING: { const char *_es = v.v.s ? v.v.s : sp_str_empty; fputs(_es, stdout); putchar('\n'); break; }
     case SP_TAG_OBJ: {
       /* MRI's `puts arr` iterates an Array, printing one element per
          line (using to_s on each); a non-Array OBJ falls back to
@@ -2191,6 +2208,7 @@ static inline const char *sp_poly_to_s(sp_RbVal v) {
     case SP_TAG_NIL: return sp_str_empty;
     case SP_TAG_SYM: return sp_sym_to_s((sp_sym)v.v.i);
     case SP_TAG_CLASS: { sp_Class c = {v.v.i}; return sp_class_to_s(c); }
+    case SP_TAG_ENCODING: return v.v.s ? v.v.s : sp_str_empty;
     case SP_TAG_OBJ:
       switch (v.cls_id) {
         case SP_BUILTIN_INT_ARRAY: return sp_IntArray_inspect((sp_IntArray *)v.v.p);
@@ -2211,7 +2229,7 @@ static sp_RbVal sp_poly_mul(sp_RbVal a, sp_RbVal b) { if (a.tag == SP_TAG_INT &&
 static mrb_int sp_poly_to_i(sp_RbVal v) { if (v.tag == SP_TAG_INT || v.tag == SP_TAG_SYM) return v.v.i; if (v.tag == SP_TAG_STR) return (mrb_int)strtoll(v.v.s ? v.v.s : sp_str_empty, NULL, 10); if (v.tag == SP_TAG_FLT) return (mrb_int)v.v.f; if (v.tag == SP_TAG_BOOL) return v.v.b ? 1 : 0; return 0; }
 static mrb_float sp_poly_to_f(sp_RbVal v) { if (v.tag == SP_TAG_FLT) return v.v.f; if (v.tag == SP_TAG_INT || v.tag == SP_TAG_SYM) return (mrb_float)v.v.i; if (v.tag == SP_TAG_BOOL) return v.v.b ? 1.0 : 0.0; return 0.0; }
 static mrb_bool sp_poly_numeric_p(sp_RbVal v) { return v.tag == SP_TAG_INT || v.tag == SP_TAG_FLT; }
-static mrb_bool sp_poly_eq(sp_RbVal a, sp_RbVal b) { if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) return sp_poly_to_f(a) == sp_poly_to_f(b); if (a.tag != b.tag) return FALSE; switch (a.tag) { case SP_TAG_INT: return a.v.i == b.v.i; case SP_TAG_STR: return (a.v.s == NULL || b.v.s == NULL) ? (a.v.s == b.v.s) : (strcmp(a.v.s, b.v.s) == 0); case SP_TAG_FLT: return a.v.f == b.v.f; case SP_TAG_BOOL: return a.v.b == b.v.b; case SP_TAG_NIL: return TRUE; case SP_TAG_SYM: return a.v.i == b.v.i; case SP_TAG_OBJ: return a.cls_id == b.cls_id && a.v.p == b.v.p; default: return FALSE; } }
+static mrb_bool sp_poly_eq(sp_RbVal a, sp_RbVal b) { if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) return sp_poly_to_f(a) == sp_poly_to_f(b); if (a.tag != b.tag) return FALSE; switch (a.tag) { case SP_TAG_INT: return a.v.i == b.v.i; case SP_TAG_STR: return (a.v.s == NULL || b.v.s == NULL) ? (a.v.s == b.v.s) : (strcmp(a.v.s, b.v.s) == 0); case SP_TAG_FLT: return a.v.f == b.v.f; case SP_TAG_BOOL: return a.v.b == b.v.b; case SP_TAG_NIL: return TRUE; case SP_TAG_SYM: return a.v.i == b.v.i; case SP_TAG_ENCODING: return (a.v.s == NULL || b.v.s == NULL) ? (a.v.s == b.v.s) : (strcmp(a.v.s, b.v.s) == 0); case SP_TAG_OBJ: return a.cls_id == b.cls_id && a.v.p == b.v.p; default: return FALSE; } }
 static mrb_int sp_poly_cmp(sp_RbVal a, sp_RbVal b, mrb_bool *comparable) { if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) { mrb_float af = sp_poly_to_f(a), bf = sp_poly_to_f(b); *comparable = TRUE; return (af > bf) - (af < bf); } if (a.tag == SP_TAG_STR && b.tag == SP_TAG_STR) { if (a.v.s == NULL || b.v.s == NULL) { *comparable = (a.v.s == b.v.s); return 0; } *comparable = TRUE; return strcmp(a.v.s, b.v.s); } if (a.tag == SP_TAG_SYM && b.tag == SP_TAG_SYM) { *comparable = TRUE; return (a.v.i > b.v.i) - (a.v.i < b.v.i); } *comparable = FALSE; return 0; }
 static mrb_bool sp_poly_lt(sp_RbVal a, sp_RbVal b) { mrb_bool comparable; mrb_int cmp = sp_poly_cmp(a, b, &comparable); return comparable ? (cmp < 0) : FALSE; }
 static mrb_bool sp_poly_le(sp_RbVal a, sp_RbVal b) { mrb_bool comparable; mrb_int cmp = sp_poly_cmp(a, b, &comparable); return comparable ? (cmp <= 0) : FALSE; }
@@ -2332,6 +2350,7 @@ static inline const char *sp_poly_inspect(sp_RbVal v) {
     case SP_TAG_BOOL: return v.v.b ? SPL("true") : SPL("false");
     case SP_TAG_NIL:  return SPL("nil");
     case SP_TAG_SYM:  return sp_str_concat(SPL(":"), sp_sym_to_s((sp_sym)v.v.i));
+    case SP_TAG_ENCODING: return sp_sprintf("#<Encoding:%s>", v.v.s ? v.v.s : "");
     case SP_TAG_OBJ:
  /* Built-in container / value-type tags get their typed inspect
     helper. Matches the dispatch shape in sp_poly_to_s above and the
@@ -2459,6 +2478,8 @@ static mrb_int sp_rbval_hash_key(sp_RbVal v) {
       return (mrb_int)v.v.i;
     case SP_TAG_STR:
       return v.v.s ? (mrb_int)sp_str_hash(v.v.s) : 0;
+    case SP_TAG_ENCODING:
+      return v.v.s ? (mrb_int)sp_str_hash(v.v.s) : 0;
     case SP_TAG_FLT: { uint64_t b; memcpy(&b, &v.v.f, sizeof(b)); return (mrb_int)b; }
     case SP_TAG_OBJ:
       if (sp_obj_hash_hook) return sp_obj_hash_hook(v.cls_id, v.v.p);
@@ -2472,6 +2493,10 @@ static mrb_bool sp_rbval_eql_key(sp_RbVal a, sp_RbVal b) {
     case SP_TAG_INT: case SP_TAG_BOOL: case SP_TAG_NIL: case SP_TAG_SYM:
       return a.v.i == b.v.i;
     case SP_TAG_STR:
+      if (a.v.s == b.v.s) return TRUE;
+      if (!a.v.s || !b.v.s) return FALSE;
+      return strcmp(a.v.s, b.v.s) == 0;
+    case SP_TAG_ENCODING:
       if (a.v.s == b.v.s) return TRUE;
       if (!a.v.s || !b.v.s) return FALSE;
       return strcmp(a.v.s, b.v.s) == 0;

--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -1225,6 +1225,9 @@ class Compiler
     if cname == "Range"
       return "range"
     end
+    if cname == "Encoding"
+      return "encoding"
+    end
  # User-defined class: narrow to obj_<C> when the class is
  # registered. Otherwise return "" — narrow is a no-op.
     if find_class_idx(cname) >= 0
@@ -2000,7 +2003,7 @@ class Compiler
       return "string"
     end
     if t == "SourceEncodingNode"
-      return "string"
+      return "encoding"
     end
     if t == "SymbolNode"
       return "symbol"
@@ -3946,6 +3949,9 @@ class Compiler
  # a string. Aliases `.to_s` at the runtime helper level
  # (sp_class_to_s), so the return type is the same.
     if mname == "name"
+      if recv >= 0 && infer_type(recv) == "encoding"
+        return "string"
+      end
       if recv >= 0 && infer_type(recv) == "class"
         return "string"
       end
@@ -4056,12 +4062,13 @@ class Compiler
           return "class"
         end
  # Primitive .class -- Integer / Float / String / Symbol /
- # NilClass / TrueClass / FalseClass / Range / Time / Array /
- # Hash / Proc -- all return a `class` value. Issue #715.
+ # NilClass / TrueClass / FalseClass / Range / Time / Encoding /
+ # Array / Hash / Proc -- all return a `class` value. Issue #715.
         bt_pc = base_type(rt)
         if bt_pc == "int" || bt_pc == "bigint" || bt_pc == "float" ||
            bt_pc == "string" || bt_pc == "mutable_str" || bt_pc == "symbol" ||
            bt_pc == "bool" || bt_pc == "nil" || bt_pc == "range" || bt_pc == "time" ||
+           bt_pc == "encoding" ||
            is_array_type(bt_pc) == 1 || is_hash_type(bt_pc) == 1 ||
            bt_pc == "proc" || bt_pc == "lambda"
           return "class"
@@ -4217,12 +4224,10 @@ class Compiler
  # the shortest collision target; struct field accessors etc.
  # commonly take that single-letter shape).
     if mname == "encoding"
- # spinel doesn't model Encoding objects; treat the return as a
- # plain string label (`"UTF-8"`). Issue #723.
       if recv >= 0
         rt_enc = infer_type(recv)
         if rt_enc == "string" || rt_enc == "mutable_str"
-          return "string"
+          return "encoding"
         end
       end
     end
@@ -7849,7 +7854,7 @@ class Compiler
   end
 
  # built-in class / module names that
- # get a reserved cls_id (0..20). Kept in sync with
+ # get a reserved cls_id. Kept in sync with
  # spinel_codegen.rb's @builtin_class_names array.
   def is_builtin_class_const_name(name)
     if name == "BasicObject" || name == "Object" || name == "Kernel" || name == "Comparable" || name == "Enumerable"
@@ -7892,6 +7897,9 @@ class Compiler
       return 1
     end
     if name == "LocalJumpError" || name == "FiberError"
+      return 1
+    end
+    if name == "Encoding"
       return 1
     end
     0
@@ -19794,6 +19802,8 @@ class Compiler
           if is_nullable_type(t) == 1
             result = t
           end
+        elsif (result == "encoding" && t == "int") || (result == "int" && t == "encoding")
+          return "poly"
         elsif result == "int"
  # int is default/unresolved — real type takes priority
           result = t

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -170,8 +170,10 @@ class Compiler
  # 0..20 are reserved for Ruby primitive classes / modules per
  # docs/CLASS-OBJECT.md (minus Method which the existing
  # register_builtin_classes pushes as a user-class entry).
- # User @cls_names entries shift to cls_id 21 + internal_ci;
- # modules shift to 21 + N + module_idx. Lets sp_class_for_poly
+ # Additional built-ins (exceptions, Encoding, etc.) follow that
+ # primitive prefix. User @cls_names entries shift by
+ # @builtin_class_count; modules shift after user classes. Lets
+ # sp_class_for_poly
  # map primitive tags to the built-in cls_id so
  # `5.is_a?(Integer)` against a dynamic klass resolves via
  # the same sp_class_le path as user-class checks.
@@ -197,7 +199,8 @@ class Compiler
                                "ScriptError", "NotImplementedError", "LoadError", "SyntaxError",
                                "StopIteration", "RegexpError",
                                "EncodingError", "SystemCallError",
-                               "LocalJumpError", "FiberError"]
+                               "LocalJumpError", "FiberError",
+                               "Encoding"]
  # -1 = no parent (root). Module entries (Kernel, Comparable,
  # Enumerable) intentionally have -1 since modules don't
  # have superclasses.
@@ -218,7 +221,8 @@ class Compiler
                                 21, 36, 36, 36,
                                 26, 22,
                                 22, 22,
-                                22, 22]
+                                22, 22,
+                                1]
  # Semicolon-separated module-name includes per built-in class.
     @builtin_class_includes = ["", "Kernel", "", "", "",
                                "", "", "",
@@ -237,7 +241,8 @@ class Compiler
                                "", "", "", "",
                                "", "",
                                "", "",
-                               "", ""]
+                               "", "",
+                               ""]
     @builtin_class_count = @builtin_class_names.length
  # emit-time toggle for the per-program
  # sp_class_names[] table + sp_class_to_s helper. compile_expr's
@@ -917,7 +922,7 @@ class Compiler
     if name == "Math" || name == "File" || name == "Dir" || name == "Time" || name == "IO" || name == "Process" || name == "Kernel" || name == "Comparable" || name == "Enumerable" || name == "Complex"
       return 1
     end
-    if name == "Object" || name == "Integer" || name == "String" || name == "Float" || name == "Symbol" || name == "Array" || name == "Hash" || name == "Range" || name == "Numeric" || name == "TrueClass" || name == "FalseClass" || name == "NilClass" || name == "Proc" || name == "Lambda" || name == "Regexp" || name == "MatchData" || name == "StringIO" || name == "Fiber"
+    if name == "Object" || name == "Integer" || name == "String" || name == "Float" || name == "Symbol" || name == "Array" || name == "Hash" || name == "Range" || name == "Numeric" || name == "TrueClass" || name == "FalseClass" || name == "NilClass" || name == "Proc" || name == "Lambda" || name == "Regexp" || name == "MatchData" || name == "StringIO" || name == "Fiber" || name == "Encoding"
       return 1
     end
  # Common exception classes referenced by raise / rescue. We
@@ -1604,6 +1609,12 @@ class Compiler
       end
       return is_a_static_negative(eb)
     end
+    if cname == "Encoding"
+      if eb == "encoding"
+        return "TRUE"
+      end
+      return is_a_static_negative(eb)
+    end
  # User-defined class
     if find_class_idx(cname) >= 0
       if is_obj_type(eb) == 1
@@ -1663,6 +1674,9 @@ class Compiler
     end
     if cname == "Range"
       return "range"
+    end
+    if cname == "Encoding"
+      return "encoding"
     end
     if find_class_idx(cname) >= 0
       return "obj_" + cname
@@ -2956,8 +2970,11 @@ class Compiler
     if t == "FloatNode"
       return "float"
     end
-    if t == "StringNode" || t == "SourceFileNode" || t == "SourceEncodingNode" || t == "NumberedReferenceReadNode" || t == "InterpolatedStringNode" || t == "InterpolatedSymbolNode" || t == "BackReferenceReadNode" || t == "XStringNode" || t == "InterpolatedXStringNode"
+    if t == "StringNode" || t == "SourceFileNode" || t == "NumberedReferenceReadNode" || t == "InterpolatedStringNode" || t == "InterpolatedSymbolNode" || t == "BackReferenceReadNode" || t == "XStringNode" || t == "InterpolatedXStringNode"
       return "string"
+    end
+    if t == "SourceEncodingNode"
+      return "encoding"
     end
     if t == "SymbolNode"
       return "symbol"
@@ -4561,6 +4578,9 @@ class Compiler
       @needs_class_table = 1
       return "sp_Class"
     end
+    if t == "encoding"
+      return "sp_Encoding"
+    end
     if t == "proc"
       return "sp_Proc *"
     end
@@ -4655,6 +4675,9 @@ class Compiler
  # returns "" for it. Locals declared `sp_Class lv_x = ((sp_Class){-1})`
  # are equivalent to nil for to_s purposes.
       return "((sp_Class){-1LL})"
+    end
+    if t == "encoding"
+      return "((sp_Encoding){NULL})"
     end
     if t == "stringio"
       return "NULL"
@@ -7514,6 +7537,8 @@ class Compiler
           if is_nullable_type(t) == 1
             result = t
           end
+        elsif (result == "encoding" && t == "int") || (result == "int" && t == "encoding")
+          return "poly"
         elsif result == "int"
  # int is default/unresolved — real type takes priority
           result = t
@@ -8235,8 +8260,9 @@ class Compiler
  # maps to Array / Hash / Range / Time / Proc. SP_TAG_CLASS
  # returns itself; SP_TAG_OBJ with non-negative cls_id is a
  # user-class instance.
+      enc_cls_id = builtin_class_id_for_name("Encoding")
       emit_raw("static sp_Class sp_class_for_poly(sp_RbVal v) __attribute__((unused));")
-      emit_raw("static sp_Class sp_class_for_poly(sp_RbVal v){switch(v.tag){case SP_TAG_NIL:return (sp_Class){5};case SP_TAG_BOOL:return (sp_Class){v.v.b?6:7};case SP_TAG_INT:return (sp_Class){9};case SP_TAG_FLT:return (sp_Class){10};case SP_TAG_STR:return (sp_Class){11};case SP_TAG_SYM:return (sp_Class){12};case SP_TAG_CLASS:return (sp_Class){(mrb_int)v.cls_id};case SP_TAG_OBJ:if(v.cls_id>=0)return (sp_Class){(mrb_int)v.cls_id};switch(v.cls_id){case SP_BUILTIN_INT_ARRAY:case SP_BUILTIN_STR_ARRAY:case SP_BUILTIN_FLT_ARRAY:case SP_BUILTIN_SYM_ARRAY:case SP_BUILTIN_PTR_ARRAY:case SP_BUILTIN_POLY_ARRAY:return (sp_Class){13};case SP_BUILTIN_STR_INT_HASH:case SP_BUILTIN_STR_STR_HASH:case SP_BUILTIN_INT_STR_HASH:case SP_BUILTIN_SYM_INT_HASH:case SP_BUILTIN_SYM_STR_HASH:case SP_BUILTIN_STR_POLY_HASH:case SP_BUILTIN_SYM_POLY_HASH:case SP_BUILTIN_POLY_POLY_HASH:return (sp_Class){14};case SP_BUILTIN_RANGE:return (sp_Class){15};case SP_BUILTIN_TIME:return (sp_Class){16};case SP_BUILTIN_PROC:return (sp_Class){20};default:return (sp_Class){-1};}}return (sp_Class){-1};}")
+      emit_raw("static sp_Class sp_class_for_poly(sp_RbVal v){switch(v.tag){case SP_TAG_NIL:return (sp_Class){5};case SP_TAG_BOOL:return (sp_Class){v.v.b?6:7};case SP_TAG_INT:return (sp_Class){9};case SP_TAG_FLT:return (sp_Class){10};case SP_TAG_STR:return (sp_Class){11};case SP_TAG_SYM:return (sp_Class){12};case SP_TAG_CLASS:return (sp_Class){(mrb_int)v.cls_id};case SP_TAG_ENCODING:return (sp_Class){" + enc_cls_id.to_s + "};case SP_TAG_OBJ:if(v.cls_id>=0)return (sp_Class){(mrb_int)v.cls_id};switch(v.cls_id){case SP_BUILTIN_INT_ARRAY:case SP_BUILTIN_STR_ARRAY:case SP_BUILTIN_FLT_ARRAY:case SP_BUILTIN_SYM_ARRAY:case SP_BUILTIN_PTR_ARRAY:case SP_BUILTIN_POLY_ARRAY:return (sp_Class){13};case SP_BUILTIN_STR_INT_HASH:case SP_BUILTIN_STR_STR_HASH:case SP_BUILTIN_INT_STR_HASH:case SP_BUILTIN_SYM_INT_HASH:case SP_BUILTIN_SYM_STR_HASH:case SP_BUILTIN_STR_POLY_HASH:case SP_BUILTIN_SYM_POLY_HASH:case SP_BUILTIN_POLY_POLY_HASH:return (sp_Class){14};case SP_BUILTIN_RANGE:return (sp_Class){15};case SP_BUILTIN_TIME:return (sp_Class){16};case SP_BUILTIN_PROC:return (sp_Class){20};default:return (sp_Class){-1};}}return (sp_Class){-1};}")
     end
     emit_raw("")
   end
@@ -8602,6 +8628,9 @@ class Compiler
     t = infer_type(nid)
     if t == "symbol"
       return "sp_sym_to_s(" + s + ")"
+    end
+    if t == "encoding"
+      return "sp_encoding_name(" + s + ")"
     end
  # Issue #651: a poly-typed value (commonly an ivar inferred as
  # poly because a `kwarg: nil`-defaulted param writes it) flowing
@@ -13615,9 +13644,9 @@ class Compiler
       return c_string_literal(@nd_content[nid])
     end
     if t == "SourceEncodingNode"
- # __ENCODING__ — Spinel has no Encoding runtime; we return
- # the canonical "UTF-8" string. Documented in test/source_encoding.rb.
-      return c_string_literal("UTF-8")
+ # __ENCODING__ — Spinel sources are UTF-8, represented as a
+ # small Encoding value so `.class` and `.name` match Ruby.
+      return "sp_encoding_utf8()"
     end
     if t == "ArgumentsNode"
       arg_ids = parse_id_list(@nd_args[nid])
@@ -14225,6 +14254,9 @@ class Compiler
                         @needs_class_table = 1
                         fmt = fmt + "%s"
                         arg_exprs.push("sp_class_to_s(" + compile_expr(inner) + ")")
+                      elsif it == "encoding"
+                        fmt = fmt + "%s"
+                        arg_exprs.push("sp_encoding_name(" + compile_expr(inner) + ")")
                       elsif it == "symbol"
  # Symbol values carry the sp_sym int id;
  # interpolation must render the registered
@@ -19143,11 +19175,8 @@ class Compiler
     if mname == "encode" || mname == "force_encoding" || mname == "b"
       return rc
     end
- # `.encoding` -- spinel doesn't model Encoding objects; return a
- # plain string label so `puts s.encoding` prints "UTF-8". Issue
- # #723.
     if mname == "encoding"
-      return "((const char*)\"UTF-8\")"
+      return "sp_encoding_utf8()"
     end
     if mname == "strip"
       return "sp_str_strip(" + rc + ")"
@@ -23357,6 +23386,20 @@ class Compiler
  # is_a? / kind_of? — kind_of? is an exact alias of is_a? in MRI.
  # Both walk the class hierarchy: cname is or inherits from arg0 → TRUE.
     if mname == "is_a?" || mname == "kind_of?"
+      if base_type(recv_type) == "encoding"
+        arg0_enc_isa = ""
+        args_id_enc_isa = @nd_arguments[nid]
+        if args_id_enc_isa >= 0
+          a_enc_isa = get_args(args_id_enc_isa)
+          if a_enc_isa.length > 0
+            arg0_enc_isa = resolve_introspection_arg_name(a_enc_isa[0])
+          end
+        end
+        if arg0_enc_isa == "Encoding" || arg0_enc_isa == "Object" || arg0_enc_isa == "Kernel" || arg0_enc_isa == "BasicObject"
+          return "TRUE"
+        end
+        return "FALSE"
+      end
       if is_obj_type(recv_type) == 1
         cname = recv_type[4, recv_type.length - 4]
         arg0 = ""
@@ -23435,6 +23478,12 @@ class Compiler
       end
       if arg0 == "Hash" && is_hash_type(recv_type) == 1
         return "TRUE"
+      end
+      if base_type(recv_type) == "encoding"
+        if arg0 == "Encoding"
+          return "TRUE"
+        end
+        return "FALSE"
       end
       if is_obj_type(recv_type) == 1
         cname = recv_type[4, recv_type.length - 4]
@@ -23574,6 +23623,52 @@ class Compiler
       if recv_n >= 0 && @nd_type[recv_n] == "SelfNode"
         @needs_class_table = 1
         return "sp_class_to_s(((sp_Class){" + cls_id_for_user_internal(@current_class_idx).to_s + "LL}))"
+      end
+    end
+    if recv_type == "encoding"
+      if mname == "name" || mname == "to_s"
+        return "sp_encoding_name(" + rc + ")"
+      end
+      if mname == "inspect"
+        return "sp_encoding_inspect(" + rc + ")"
+      end
+      if mname == "==" || mname == "eql?"
+        arg0_enc_eq = -1
+        if @nd_arguments[nid] >= 0
+          args_enc_eq = get_args(@nd_arguments[nid])
+          if args_enc_eq.length > 0
+            arg0_enc_eq = args_enc_eq[0]
+          end
+        end
+        if arg0_enc_eq >= 0 && infer_type(arg0_enc_eq) == "encoding"
+          rhs_enc_eq = compile_expr(arg0_enc_eq)
+          return "sp_encoding_eq(" + rc + ", " + rhs_enc_eq + ")"
+        end
+        return "FALSE"
+      end
+      if mname == "!="
+        arg0_enc_ne = -1
+        if @nd_arguments[nid] >= 0
+          args_enc_ne = get_args(@nd_arguments[nid])
+          if args_enc_ne.length > 0
+            arg0_enc_ne = args_enc_ne[0]
+          end
+        end
+        if arg0_enc_ne >= 0 && infer_type(arg0_enc_ne) == "encoding"
+          rhs_enc_ne = compile_expr(arg0_enc_ne)
+          return "(!sp_encoding_eq(" + rc + ", " + rhs_enc_ne + "))"
+        end
+        return "TRUE"
+      end
+      if mname == "class"
+        bid_enc = builtin_class_id_for_name("Encoding")
+        if bid_enc >= 0
+          @needs_class_table = 1
+          return "((sp_Class){" + bid_enc.to_s + "LL})"
+        end
+      end
+      if mname == "nil?"
+        return "FALSE"
       end
     end
  # methods on a sp_Class value.
@@ -23864,6 +23959,8 @@ class Compiler
         prim_class_name_pc = "Range"
       elsif bt_pc == "time"
         prim_class_name_pc = "Time"
+      elsif bt_pc == "encoding"
+        prim_class_name_pc = "Encoding"
       elsif is_array_type(bt_pc) == 1
         prim_class_name_pc = "Array"
       elsif is_hash_type(bt_pc) == 1
@@ -24429,6 +24526,9 @@ class Compiler
     end
     if klass == "Symbol"
       return "(" + recv_tmp + ".tag == SP_TAG_SYM)"
+    end
+    if klass == "Encoding"
+      return "(" + recv_tmp + ".tag == SP_TAG_ENCODING)"
     end
     if klass == "NilClass"
       return "(" + recv_tmp + ".tag == SP_TAG_NIL)"
@@ -25802,6 +25902,18 @@ class Compiler
       end
       return "(!sp_class_eq(" + lc_cls + ", " + rc_cls + "))"
     end
+ # Encoding is a value-type struct, so plain C `==` is invalid.
+ # Encoding only compares equal to another Encoding value.
+    if lt == "encoding" && at == "encoding"
+      lc_enc = compile_expr(recv)
+      rc_enc = arg_id >= 0 ? compile_expr(arg_id) : "sp_encoding_utf8()"
+      if op == "=="
+        return "sp_encoding_eq(" + lc_enc + ", " + rc_enc + ")"
+      end
+      return "(!sp_encoding_eq(" + lc_enc + ", " + rc_enc + "))"
+    elsif (lt == "encoding" || at == "encoding") && lt != "poly" && at != "poly"
+      return op == "==" ? "FALSE" : "TRUE"
+    end
  # Time == Time / != — equal instant (tv_sec and tv_nsec). Plain
  # `==` on the struct isn't valid C. Same-instant times compare
  # equal regardless of the is_utc presentation flag.
@@ -26104,6 +26216,9 @@ class Compiler
     if base == "symbol"
       return "(sp_sym)(" + val + ").v.i"
     end
+    if base == "encoding"
+      return "((sp_Encoding){(" + val + ").v.s})"
+    end
     if base == "int_array"
       return "(sp_IntArray *)(" + val + ").v.p"
     end
@@ -26234,6 +26349,9 @@ class Compiler
     end
     if at == "symbol"
       return "sp_box_sym(" + val + ")"
+    end
+    if at == "encoding"
+      return "sp_box_encoding(" + val + ")"
     end
     if at == "int_array"
       return "sp_box_int_array(" + val + ")"
@@ -35977,6 +36095,10 @@ class Compiler
       emit("  { const char *_rs = sp_rational_inspect(" + val + "); fputs(_rs, stdout); putchar('" + bsl_n + "'); }")
       return
     end
+    if at == "encoding"
+      emit("  puts(sp_encoding_name(" + val + "));")
+      return
+    end
     if at == "time"
       emit("  { const char *_ts = sp_time_inspect_v(" + val + "); fputs(_ts, stdout); putchar('" + bsl_n + "'); }")
       return
@@ -36088,6 +36210,11 @@ class Compiler
         k = k + 1
         next
       end
+      if at == "encoding"
+        emit("  puts(sp_encoding_name(" + val + "));")
+        k = k + 1
+        next
+      end
  # `puts <exc>` -- print the message (CRuby calls to_s).
       if at == "exception"
         emit("  { const char *_ps = sp_exc_message(" + val + "); if (_ps) { fputs(_ps, stdout); if (!*_ps || _ps[strlen(_ps)-1] != '" + bsl_n + "') putchar('" + bsl_n + "'); } else putchar('" + bsl_n + "'); }")
@@ -36162,6 +36289,8 @@ class Compiler
       val = compile_expr(arg_ids[k])
       if at == "string"
         emit("  fprintf(stderr, \"%s" + bsl_n + "\", " + val + ");")
+      elsif at == "encoding"
+        emit("  fprintf(stderr, \"%s" + bsl_n + "\", sp_encoding_name(" + val + "));")
       else
         emit("  fprintf(stderr, \"%lld" + bsl_n + "\", (long long)" + val + ");")
       end
@@ -36266,6 +36395,11 @@ class Compiler
       end
       if at == "symbol"
         emit("  fputs(sp_sym_to_s(" + val + "), stdout);")
+        k = k + 1
+        next
+      end
+      if at == "encoding"
+        emit("  fputs(sp_encoding_name(" + val + "), stdout);")
         k = k + 1
         next
       end

--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -940,9 +940,8 @@ static int flatten(pm_node_t *node) {
     break;
   }
   case PM_SOURCE_ENCODING_NODE: {
-    /* `__ENCODING__`. CRuby returns an Encoding object; Spinel has
-       no Encoding runtime, so we return the canonical name as a
-       frozen string. All Spinel sources are UTF-8. */
+    /* `__ENCODING__`. Spinel sources are UTF-8; codegen returns a
+       small Encoding value for Ruby-compatible `.class` / `.name`. */
     N("SourceEncodingNode");
     break;
   }

--- a/test/bundle_sym.rb
+++ b/test/bundle_sym.rb
@@ -292,11 +292,9 @@ t_symbol_upcase_downcase
 def t_source_encoding
   # SourceEncodingNode — the `__ENCODING__` keyword.
   #
-  # CRuby returns an Encoding object; Spinel has no Encoding runtime,
-  # so __ENCODING__ returns the canonical name as a string. All Spinel
-  # sources are assumed to be UTF-8. We compare against to_s for parity.
+  # Spinel sources are assumed to be UTF-8; __ENCODING__ is a small
+  # Encoding value whose to_s returns the canonical name.
   
   puts __ENCODING__.to_s
 end
 t_source_encoding
-

--- a/test/source_encoding.rb
+++ b/test/source_encoding.rb
@@ -1,0 +1,19 @@
+# Issue #843. `__ENCODING__` should behave like an Encoding value,
+# not a plain String.
+
+puts __ENCODING__.class
+puts __ENCODING__.name
+puts __ENCODING__.to_s
+puts __ENCODING__.is_a?(Encoding)
+puts __ENCODING__ == __ENCODING__
+puts __ENCODING__ != "UTF-8"
+
+values = [__ENCODING__, 1]
+puts values[0]
+
+enc_hash = {}
+enc_hash[__ENCODING__] = 7
+puts enc_hash[__ENCODING__]
+
+mixed = ARGV.length > 0 ? __ENCODING__ : 1
+puts mixed

--- a/test/source_encoding.rb.expected
+++ b/test/source_encoding.rb.expected
@@ -1,0 +1,9 @@
+Encoding
+UTF-8
+UTF-8
+true
+true
+true
+UTF-8
+7
+1

--- a/test/string_encoding.rb
+++ b/test/string_encoding.rb
@@ -1,8 +1,8 @@
 # Issue #723. `.encoding` returns the source label (spinel uses
-# UTF-8 throughout, so the constant "UTF-8" is the right answer).
-# spinel doesn't model Encoding objects -- the return is a plain
-# string, not an Encoding instance.
+# UTF-8 throughout) as a small Encoding value.
 
 puts "hello".encoding
 puts "x".encode.encoding
 puts "y".b.encoding
+puts "hello".encoding.class
+puts "hello".encoding.name

--- a/test/string_encoding.rb.expected
+++ b/test/string_encoding.rb.expected
@@ -1,3 +1,5 @@
 UTF-8
 UTF-8
 UTF-8
+Encoding
+UTF-8


### PR DESCRIPTION
Fix `__ENCODING__` so it returns an `Encoding` value instead of a plain `"UTF-8"` string.

Fixes #843.