### PR TITLE
analyze,codegen: Module#const_defined? folds to TRUE / FALSE statically

### DIFF
--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -4311,6 +4311,9 @@ class Compiler
     if mname == "cover?"
       return "bool"
     end
+    if mname == "const_defined?"
+      return "bool"
+    end
     if mname == "==="
       return "bool"
     end

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -24304,6 +24304,27 @@ class Compiler
         @needs_class_table = 1
         return "sp_class_to_s(" + rc + ")"
       end
+ # Module#const_defined?(:X) — static-class + literal-symbol-arg
+ # fast path. Spinel emits one C global per user-class constant
+ # named `cst_<Class>_<X>`, and the analyzer tracks those names
+ # in `@const_names`. Look up via `find_const_idx` to fold to
+ # TRUE / FALSE at compile time. Dynamic receivers or non-
+ # literal symbol args (or builtin classes whose constants live
+ # outside @const_names — Math::PI etc.) keep falling through.
+      if mname == "const_defined?"
+        recv_id_cd = @nd_receiver[nid]
+        args_id_cd = @nd_arguments[nid]
+        if recv_id_cd >= 0 && @nd_type[recv_id_cd] == "ConstantReadNode" && args_id_cd >= 0
+          aa_cd = get_args(args_id_cd)
+          if aa_cd.length >= 1 && @nd_type[aa_cd[0]] == "SymbolNode"
+            qname_cd = @nd_name[recv_id_cd] + "_" + @nd_content[aa_cd[0]]
+            if find_const_idx(qname_cd) >= 0
+              return "TRUE"
+            end
+            return "FALSE"
+          end
+        end
+      end
       if mname == "==" || mname == "eql?"
         rhs_eq = compile_arg0(nid)
         return "sp_class_eq(" + rc + ", " + rhs_eq + ")"

--- a/test/module_const_defined.rb
+++ b/test/module_const_defined.rb
@@ -1,0 +1,13 @@
+class A
+  X = 1
+  Y = "two"
+end
+
+puts A.const_defined?(:X)
+puts A.const_defined?(:Y)
+puts A.const_defined?(:Z)
+
+class B
+end
+
+puts B.const_defined?(:W)

--- a/test/module_const_defined.rb.expected
+++ b/test/module_const_defined.rb.expected
@@ -1,0 +1,4 @@
+true
+true
+false
+false


### PR DESCRIPTION
`A.const_defined?(:X)` previously fell through `compile_object_method_expr`'s `recv_type == "class"` arm (which only handled to_s / name / inspect / superclass / ancestors / nil? / ==/!= / </<=/>/>=) and raised `undefined method 'const_defined?' for class`. Even where it "worked" via a fallback it would have returned `1` / `0` rather than CRuby's `true` / `false`.

Spinel emits one C global per user-class constant named `cst_<Class>_<X>`, and the analyzer tracks those names in `@const_names`. The static case — literal class receiver (`ConstantReadNode`) + literal symbol arg (`SymbolNode`) — reduces to a `find_const_idx("<Class>_<X>")` lookup and folds to `TRUE` or `FALSE` at compile time.

Dynamic receivers, non-literal symbol args, and builtin classes whose constants live outside `@const_names` (Math::PI etc.) fall through and keep raising — the const-table introspection needed to cover those is its own structural change.

Analyzer side: return-type arm alongside include? / cover? so `puts` formats the result as `true` / `false`.