### PR TITLE
codegen: Hash#fetch(k) { default } runs block on miss

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -5167,6 +5167,20 @@ class Compiler
     ""
   end
 
+ # Per-variant info for the shared Hash#fetch(k) { block } arm.
+ # Returns a 4-tuple [value_type, value_c_type, has_key_fn,
+ # get_fn] or nil for unsupported variants. The block-form
+ # arm uses these to emit the runtime check + dispatch.
+  def hash_fetch_block_info(t)
+    if t == "sym_int_hash";  return ["int", "mrb_int", "sp_SymIntHash_has_key", "sp_SymIntHash_get"]; end
+    if t == "sym_str_hash";  return ["string", "const char *", "sp_SymStrHash_has_key", "sp_SymStrHash_get"]; end
+    if t == "sym_poly_hash"; return ["poly", "sp_RbVal", "sp_SymPolyHash_has_key", "sp_SymPolyHash_get"]; end
+    if t == "str_int_hash";  return ["int", "mrb_int", "sp_StrIntHash_has_key", "sp_StrIntHash_get"]; end
+    if t == "str_str_hash";  return ["string", "const char *", "sp_StrStrHash_has_key", "sp_StrStrHash_get"]; end
+    if t == "str_poly_hash"; return ["poly", "sp_RbVal", "sp_StrPolyHash_has_key", "sp_StrPolyHash_get"]; end
+    nil
+  end
+
  # CRuby returns nil for static mismatches (e.g. `{a: 1}.dig("a")`)
  # since no key compares equal — Hash#dig short-circuits to nil here.
   def hash_key_matches_recv(recv_type, key_type)
@@ -22108,6 +22122,36 @@ class Compiler
       ins_h = compile_inspect_for(recv_type, rc)
       if ins_h != ""
         return ins_h
+      end
+    end
+ # Hash#fetch(k) { |k| default } — block form. `compile_body_into`
+ # walks the block body emitting all statements; the final
+ # expression assigns into a temp that we return. The non-block
+ # 2-arg fetch (default value) stays in the per-variant arms
+ # below; this arm is for the block-default form which they
+ # didn't cover.
+    if mname == "fetch" && @nd_block[nid] >= 0
+      fi = hash_fetch_block_info(recv_type)
+      if fi != nil
+        args_id_fb = @nd_arguments[nid]
+        if args_id_fb >= 0
+          aargs_fb = get_args(args_id_fb)
+          if aargs_fb.length >= 1
+            key_fb = compile_expr(aargs_fb[0])
+            tmp_fb = new_temp
+            emit("  " + fi[1] + " " + tmp_fb + ";")
+            emit("  if (" + fi[2] + "(" + rc + ", " + key_fb + ")) {")
+            emit("    " + tmp_fb + " = " + fi[3] + "(" + rc + ", " + key_fb + ");")
+            emit("  } else {")
+            @indent = @indent + 1
+            push_scope
+            compile_body_into(@nd_body[@nd_block[nid]], tmp_fb, fi[0])
+            pop_scope
+            @indent = @indent - 1
+            emit("  }")
+            return tmp_fb
+          end
+        end
       end
     end
     if recv_type == "sym_int_hash"
@@ -42366,6 +42410,8 @@ class Compiler
     elsif base_type(return_type) == "int" && last_t_cbi == "bigint"
       @needs_bigint = 1
       expr = "sp_bigint_to_int((sp_Bigint *)" + expr + ")"
+    elsif base_type(return_type) == "poly" && last_t_cbi != "poly" && last_t_cbi != ""
+      expr = box_value_to_poly(last_t_cbi, expr)
     end
     emit("  " + ret_tmp + " = " + expr + ";")
   end

--- a/test/hash_fetch_block.rb
+++ b/test/hash_fetch_block.rb
@@ -1,0 +1,31 @@
+h_si = { a: 1, b: 2 }
+puts h_si.fetch(:a) { 99 }
+puts h_si.fetch(:missing) { 99 }
+
+h_ss = { x: "one", y: "two" }
+puts h_ss.fetch(:x) { "fallback" }
+puts h_ss.fetch(:missing) { "fallback" }
+
+h_sp = { a: 1, b: "two" }
+puts h_sp.fetch(:b) { "fallback" }
+puts h_sp.fetch(:missing) { "fallback" }
+
+h_str_int = { "a" => 1, "b" => 2 }
+puts h_str_int.fetch("a") { 99 }
+puts h_str_int.fetch("missing") { 99 }
+
+h_str_str = { "x" => "one", "y" => "two" }
+puts h_str_str.fetch("x") { "fallback" }
+puts h_str_str.fetch("missing") { "fallback" }
+
+h_str_p = { "a" => 1, "b" => "two" }
+puts h_str_p.fetch("b") { "fallback" }
+puts h_str_p.fetch("missing") { "fallback" }
+
+# block can be multi-statement
+result = h_si.fetch(:missing) {
+  x = 10
+  y = 20
+  x + y
+}
+puts result

--- a/test/hash_fetch_block.rb.expected
+++ b/test/hash_fetch_block.rb.expected
@@ -1,0 +1,13 @@
+1
+99
+one
+fallback
+two
+fallback
+1
+99
+one
+fallback
+two
+fallback
+30


### PR DESCRIPTION
`{a:1}.fetch(:missing) { 99 }` previously dropped the block: the per-variant fetch arms in `compile_hash_method_expr` only covered the 2-arg form (`fetch(k, default)`) and 1-arg form (`fetch(k)` — raises). With a block attached the call still matched the 1-arg arm and emitted `sp_<Variant>_get(...)`, which returns 0 (the default sentinel) instead of running the block.

Add a shared block-form fetch arm before the per-variant blocks. It emits a conditional that picks `_get` when the key is present and routes through `compile_body_into` for the block body when it's missing. `compile_body_into` already handles multi-statement blocks (assigns the last expression to the temp), so `fetch(k) { x = 1; x + 2 }` works without extra plumbing.

A small `hash_fetch_block_info` helper maps each variant to its `_has_key` / `_get` pair and the value's analyzer type (needed by `compile_body_into` for type-conversion at the last expression). Currently covers sym_int / sym_str / sym_poly / str_int / str_str / str_poly. int-keyed and poly_poly variants left for follow-up — their key-arg compilation differs (compile_arg0_as_int / box_expr_to_poly).