### PR TITLE
codegen: Class#superclass returns Object for parentless classes

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -8419,6 +8419,10 @@ class Compiler
  # Parent name might be a built-in (e.g., `class Foo < Numeric`)
             ppidx = builtin_class_id_for_name(ppname)
           end
+        else
+ # No explicit parent → Object. Without this default, `A.superclass`
+ # returned the -1 nil sentinel and printed empty instead of `Object`.
+          ppidx = builtin_class_id_for_name("Object")
         end
         parents_line = parents_line + ppidx.to_s + "LL"
         pi_pl = pi_pl + 1

--- a/test/class_hierarchy.rb
+++ b/test/class_hierarchy.rb
@@ -15,8 +15,8 @@ end
 # .superclass walks @cls_parents one step.
 puts B.superclass.to_s  # => A
 puts C.superclass.to_s  # => B
-# A's superclass is the sp_Class sentinel (cls_id == -1, prints "").
-puts A.superclass.to_s.length == 0 ? "A-root-ok" : "A-root-bad"
+# A's superclass is Object per CRuby.
+puts A.superclass == Object ? "A-root-ok" : "A-root-bad"
 
 # .ancestors returns a PolyArray of boxed sp_Class. Iterate and
 # concatenate the names so the output exercises sp_box_class +

--- a/test/class_superclass.rb
+++ b/test/class_superclass.rb
@@ -1,0 +1,15 @@
+class A
+end
+
+class B < A
+end
+
+class C
+  def foo
+    1
+  end
+end
+
+puts A.superclass
+puts B.superclass
+puts C.superclass

--- a/test/class_superclass.rb.expected
+++ b/test/class_superclass.rb.expected
@@ -1,0 +1,3 @@
+Object
+A
+Object


### PR DESCRIPTION
`class A; end; puts A.superclass` printed empty: the `sp_class_parents[]` table entry stored -1 (no explicit parent) and `sp_class_to_s(-1)` returns the empty string for the nil-sentinel cls_id. CRuby's `A.superclass` returns `Object` — every class implicitly inherits from Object.

When emitting the per-user-class entry of `sp_class_parents[]` (at the point where `ppname == ""` means no `< Parent` clause), default the parent index to the builtin Object cls_id instead of -1. Modules keep their existing -1 (no superclass concept). Classes that DO declare a parent (`class B < A`) still resolve to that parent — only the no-parent case changes.

Existing tests already exercise the explicit-parent path; the new test adds the no-parent case.