### PR TITLE
feat(codegen): string interpolation renders array containers, not pointers

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -14681,6 +14681,41 @@ class Compiler
  # a long long.
                         fmt = fmt + "%s"
                         arg_exprs.push("sp_exc_message(" + compile_expr(inner) + ")")
+                      elsif it == "nil"
+ # CRuby: `"#{nil}"` -> `""`. Without an arm,
+ # the default int path emitted `"0"`.
+                        fmt = fmt + "%s"
+                        arg_exprs.push("\"\"")
+                      elsif it == "int_array"
+                        fmt = fmt + "%s"
+                        arg_exprs.push("sp_IntArray_inspect(" + compile_expr(inner) + ")")
+                      elsif it == "float_array"
+                        fmt = fmt + "%s"
+                        arg_exprs.push("sp_FloatArray_inspect(" + compile_expr(inner) + ")")
+                      elsif it == "str_array"
+                        fmt = fmt + "%s"
+                        arg_exprs.push("sp_StrArray_inspect(" + compile_expr(inner) + ")")
+                      elsif it == "sym_array"
+ # sym_array stores ids in an sp_IntArray
+ # backing; sp_SymArray_inspect renders each
+ # element as `:name` via sp_sym_to_s.
+                        fmt = fmt + "%s"
+                        arg_exprs.push("sp_SymArray_inspect(" + compile_expr(inner) + ")")
+                      elsif it == "poly_array"
+                        fmt = fmt + "%s"
+                        arg_exprs.push("sp_PolyArray_inspect(" + compile_expr(inner) + ")")
+                      elsif it == "int_array_ptr_array"
+                        fmt = fmt + "%s"
+                        arg_exprs.push("sp_IntArrayPtrArray_inspect(" + compile_expr(inner) + ")")
+                      elsif it == "float_array_ptr_array"
+                        fmt = fmt + "%s"
+                        arg_exprs.push("sp_FloatArrayPtrArray_inspect(" + compile_expr(inner) + ")")
+                      elsif it == "str_array_ptr_array"
+                        fmt = fmt + "%s"
+                        arg_exprs.push("sp_StrArrayPtrArray_inspect(" + compile_expr(inner) + ")")
+                      elsif it == "sym_array_ptr_array"
+                        fmt = fmt + "%s"
+                        arg_exprs.push("sp_SymArrayPtrArray_inspect(" + compile_expr(inner) + ")")
                       else
                         fmt = fmt + "%lld"
                         arg_exprs.push("(long long)" + compile_expr(inner))

--- a/test/interp_array_container.rb
+++ b/test/interp_array_container.rb
@@ -1,0 +1,41 @@
+# String interpolation of typed-array containers.
+#
+# `93d04586` fixed Symbol interpolation (`"#{:foo}"` -> `"foo"`).
+# This extends the same idea to typed array containers: `#{arr}`
+# previously fell through the default int path and printed the
+# pointer as a long long (e.g. "4318536016") instead of CRuby's
+# `Array#to_s` shape.
+#
+# Each Array variant has an existing `sp_*Array_inspect` runtime
+# helper that emits the bracketed form `[elem, elem, ...]` byte-
+# identical to CRuby; we just route to it from compile_interpolated.
+
+# int_array
+ints = [1, 2, 3]
+puts "ints: #{ints}"
+
+# str_array
+strs = ["a", "b", "c"]
+puts "strs: #{strs}"
+
+# sym_array
+syms = [:x, :y, :z]
+puts "syms: #{syms}"
+
+# float_array
+floats = [1.5, 2.5, 3.5]
+puts "floats: #{floats}"
+
+# poly_array (heterogeneous)
+mix = [1, "two", :three, nil]
+puts "mix: #{mix}"
+
+# Empty arrays
+puts "empty ints: #{[]}"
+
+# Nested arrays
+puts "nested: #{[[1, 2], [3, 4]]}"
+
+# nil interpolation (CRuby: empty string, not "0")
+n = nil
+puts "n: '#{n}'"

--- a/test/interp_array_container.rb.expected
+++ b/test/interp_array_container.rb.expected
@@ -1,0 +1,8 @@
+ints: [1, 2, 3]
+strs: ["a", "b", "c"]
+syms: [:x, :y, :z]
+floats: [1.5, 2.5, 3.5]
+mix: [1, "two", :three, nil]
+empty ints: []
+nested: [[1, 2], [3, 4]]
+n: ''


### PR DESCRIPTION
## Summary

`93d04586` fixed Symbol interpolation (`"#{:foo}"` → `"foo"` instead of the
raw sp_sym id). The same default-int fall-through bit every container type
stored as a pointer: `puts "ints: #{[1,2,3]}"` printed a memory address like
`4318536016` rather than CRuby's `"ints: [1, 2, 3]"`. Direct `.inspect` calls
on the same arrays already routed to `sp_IntArray_inspect` and friends, so
the value shape was right — the gap was only in `compile_interpolated`.

* Add arms to `compile_interpolated` for `int_array`, `float_array`,
  `str_array`, `sym_array`, `poly_array`, and the four one-level nested
  `<x>_array_ptr_array` variants. Each routes to the matching
  `sp_*Array_inspect` runtime helper that already exists.
* Add a `nil` arm so `"#{nil}"` renders `""` (CRuby behaviour) instead of
  `"0"` from the default int path.

Hash interpolation (`"#{ {a: 1} }"`) is also broken via the same default
path, but fixing it needs new `sp_*Hash_inspect` helpers for the eight
typed-Hash variants — defer to a follow-up. Direct `Hash#to_s` / `Hash#inspect`
calls emit a "cannot resolve" warning on every typed-hash variant; same root
cause, same follow-up.

## Test plan

- [x] `test/interp_array_container.rb` covers each variant plus an empty
  literal, a nested-array literal, and a nil interpolation
- [x] `make clean && make bootstrap` — all 4 fixpoint OK lines
- [x] `make test` — 619 / 619 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)