### PR TITLE
codegen: case/in raises NoMatchingPatternError on exhaustive miss

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -8563,6 +8563,8 @@ class Compiler
       ["SystemCallError", "StandardError"],
       ["LocalJumpError", "StandardError"],
       ["FiberError", "StandardError"],
+      ["NoMatchingPatternError", "StandardError"],
+      ["NoMatchingPatternKeyError", "NoMatchingPatternError"],
       ["Exception", ""],
     ]
     bp = 0
@@ -32876,6 +32878,17 @@ class Compiler
       @indent = @indent + 1
       compile_stmts_body(@nd_body[ec])
       @indent = @indent - 1
+    elsif conds.length > 0
+ # No `else` clause: CRuby raises NoMatchingPatternError when no
+ # `in` arm matched. The message includes the inspected scrutinee
+ # value (we drop the `=== val does not return true` tail since
+ # spinel doesn't carry the pattern's source text at codegen).
+      ins_msg = compile_inspect_for(pred_type, tmp)
+      if ins_msg != ""
+        emit("  } else { sp_raise_cls(\"NoMatchingPatternError\", " + ins_msg + ");")
+      else
+        emit("  } else { sp_raise_cls(\"NoMatchingPatternError\", \"no matching pattern\");")
+      end
     end
     if conds.length > 0
       emit("  }")

--- a/test/case_in_no_match_error.rb
+++ b/test/case_in_no_match_error.rb
@@ -1,0 +1,54 @@
+begin
+  case 5
+  in 3
+    puts "three"
+  in 4
+    puts "four"
+  end
+rescue NoMatchingPatternError => e
+  puts "caught int miss"
+end
+
+# Match still works
+case 5
+in 3
+  puts "three"
+in 5
+  puts "matched five"
+end
+
+# With else: no raise
+case 99
+in 1
+  puts "one"
+else
+  puts "else clause"
+end
+
+# String scrutinee
+begin
+  case "x"
+  in "y"
+  end
+rescue NoMatchingPatternError => e
+  puts "caught str miss"
+end
+
+# Symbol scrutinee
+begin
+  case :foo
+  in :bar
+  end
+rescue NoMatchingPatternError => e
+  puts "caught sym miss"
+end
+
+# StandardError parent catches NoMatchingPatternError
+begin
+  case 7
+  in 1
+  in 2
+  end
+rescue StandardError => e
+  puts "caught via parent"
+end

--- a/test/case_in_no_match_error.rb.expected
+++ b/test/case_in_no_match_error.rb.expected
@@ -1,0 +1,6 @@
+caught int miss
+matched five
+else clause
+caught str miss
+caught sym miss
+caught via parent


### PR DESCRIPTION
`case 5; in 3; end` previously did nothing when no arm matched
and no `else` clause was present — the codegen chain just closed
its trailing `}` and fell through. CRuby raises
NoMatchingPatternError with a message containing the inspected
scrutinee value.

In `compile_case_match_stmt` (after the per-arm if/elsif chain),
detect the "no else, at least one in" shape and emit
`sp_raise_cls("NoMatchingPatternError", <scrutinee inspect>)` as
the else branch. Use `compile_inspect_for` for the scrutinee
message so we get a CRuby-shaped prefix (`5`, `"x"`, `:sym`, ...);
fall back to the literal "no matching pattern" string for types
whose inspect isn't wired.

Register NoMatchingPatternError + NoMatchingPatternKeyError in
the built-in exception hierarchy table at sp_exc_parent_of so a
`rescue NoMatchingPatternError` (or its parent StandardError /
Exception) catches the raise. Per CRuby 3.0:
  NoMatchingPatternError < StandardError
  NoMatchingPatternKeyError < NoMatchingPatternError

Class-pattern shape (`case x in String`) and the full CRuby
message format (`<val>: <pattern> === <val> does not return true`)
are separate gaps — class-pattern always-matches because
ConstantReadNode in compile_in_pattern doesn't `===`-check, and
the pattern source text isn't carried at codegen.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

## Test plan
- [x] make bootstrap (4 fixpoint OK lines)
- [x] make test (527/527, includes new test/case_in_no_match_error.rb)
- [x] StandardError parent rescue catches the new error class

🤖 Generated with [Claude Code](https://claude.com/claude-code)