### PR TITLE
fix(analyze,codegen): dispatch String#match and Regexp#match

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -2700,6 +2700,36 @@ static void sp_PolyArray_scan(void *p) { sp_PolyArray *a = (sp_PolyArray *)p; fo
 static void sp_PolyArray_fin(void *p) { sp_PolyArray *a = (sp_PolyArray *)p; sp_gc_hdr *h = (sp_gc_hdr *)((char *)a - sizeof(sp_gc_hdr)); sp_gc_bytes -= sizeof(sp_RbVal) * a->cap; h->size -= sizeof(sp_RbVal) * a->cap; free(a->data); }
 static sp_PolyArray *sp_PolyArray_new(void) { sp_PolyArray *a = (sp_PolyArray *)sp_gc_alloc(sizeof(sp_PolyArray), sp_PolyArray_fin, sp_PolyArray_scan); a->cap = 16; a->data = (sp_RbVal *)malloc(sizeof(sp_RbVal) * a->cap); if (!a->data) sp_oom_die(); a->len = 0; { sp_gc_hdr *h = (sp_gc_hdr *)((char *)a - sizeof(sp_gc_hdr)); h->size += sizeof(sp_RbVal) * a->cap; sp_gc_bytes += sizeof(sp_RbVal) * a->cap; } return a; }
 static void sp_PolyArray_push(sp_PolyArray *a, sp_RbVal v) { if (!a) return; if (a->len >= a->cap) { sp_gc_hdr *h = (sp_gc_hdr *)((char *)a - sizeof(sp_gc_hdr)); sp_gc_bytes -= sizeof(sp_RbVal) * a->cap; h->size -= sizeof(sp_RbVal) * a->cap; a->cap = a->cap * 2 + 1; void *nd = realloc(a->data, sizeof(sp_RbVal) * a->cap); if (!nd) sp_oom_die(); a->data = (sp_RbVal *)nd; h->size += sizeof(sp_RbVal) * a->cap; sp_gc_bytes += sizeof(sp_RbVal) * a->cap; } a->data[a->len++] = v; }
+static sp_PolyArray *sp_re_match_data(mrb_regexp_pattern *pat, const char *str) {
+  int64_t slen = (int64_t)strlen(str);
+  int ncaps = 64;
+  int n = re_exec(pat, str, slen, 0, sp_re_caps, ncaps);
+  if (n <= 0 || sp_re_caps[0] < 0) {
+    for (int i = 0; i < 10; i++) sp_re_captures[i] = NULL;
+    sp_re_last_str = NULL;
+    sp_re_match_str = NULL;
+    sp_re_match_pre = NULL;
+    sp_re_match_post = NULL;
+    return NULL;
+  }
+  int pairs = (n > ncaps ? ncaps : n) / 2;
+  sp_re_set_captures(str, sp_re_caps, pairs);
+  sp_PolyArray *arr = sp_PolyArray_new();
+  for (int i = 0; i < pairs; i++) {
+    int start = sp_re_caps[i * 2];
+    int end = sp_re_caps[i * 2 + 1];
+    if (start >= 0 && end >= start) {
+      int len = end - start;
+      char *buf = sp_str_alloc_raw(len + 1);
+      memcpy(buf, str + start, len);
+      buf[len] = 0;
+      sp_PolyArray_push(arr, sp_box_str(buf));
+    } else {
+      sp_PolyArray_push(arr, sp_box_nil());
+    }
+  }
+  return arr;
+}
 static sp_RbVal sp_poly_shl(sp_RbVal a, sp_RbVal b) {
   /* Dispatch by recv cls_id: an IntArray / PolyArray / etc. boxed
      into a poly slot still wants Array#<< (push), not Integer#<<

--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -4741,6 +4741,16 @@ class Compiler
     if mname == "scan"
       return "str_array"
     end
+    if mname == "match"
+      if recv >= 0
+        rt_match = base_type(infer_type(recv))
+        if rt_match == "string" || rt_match == "regexp"
+          @needs_rb_value = 1
+          @needs_gc = 1
+          return "poly_array?"
+        end
+      end
+    end
     if mname == "gets" || mname == "readline"
       return "string"
     end

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -16103,7 +16103,9 @@ class Compiler
               @needs_rb_value = 1
               return "sp_re_match_poly(" + rpat + ", " + sc + ")"
             end
-            return "sp_re_match(" + rpat + ", " + sc + ")"
+            @needs_rb_value = 1
+            @needs_gc = 1
+            return "sp_re_match_data(" + rpat + ", " + sc + ")"
           end
         end
       end
@@ -19858,6 +19860,20 @@ class Compiler
               @needs_str_array = 1
               return "sp_re_scan(" + rpat + ", " + rc + ")"
             end
+          end
+        end
+      end
+    end
+    if mname == "match"
+      re_args_id_m = @nd_arguments[nid]
+      if re_args_id_m >= 0
+        argl_m = get_args(re_args_id_m)
+        if argl_m.length > 0
+          rpat_m = regex_pat_c_expr(argl_m[0])
+          if rpat_m != ""
+            @needs_rb_value = 1
+            @needs_gc = 1
+            return "sp_re_match_data(" + rpat_m + ", " + rc + ")"
           end
         end
       end

--- a/test/regexp_match_data.rb
+++ b/test/regexp_match_data.rb
@@ -1,0 +1,17 @@
+# Issue #867: String#match and Regexp#match return a MatchData-like
+# object instead of falling through to unresolved-call emit-0.
+md1 = "hello world".match(/\w+/)
+puts md1[0]
+
+md2 = /(\w+) (\w+)/.match("hello world")
+puts md2[0]
+puts md2[1]
+puts md2[2]
+
+md3 = "a".match(/(a)(b)?/)
+puts md3[2].nil? ? "nil capture" : "bad capture"
+puts "abc".match(/z/).nil? ? "nil match" : "bad match"
+
+md4 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".match(/(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)/)
+puts md4.length
+puts md4[31]

--- a/test/regexp_match_data.rb.expected
+++ b/test/regexp_match_data.rb.expected
@@ -1,0 +1,8 @@
+hello
+hello world
+hello
+world
+nil capture
+nil match
+32
+a


### PR DESCRIPTION
Fix `String#match` and `Regexp#match` so they return a MatchData-like capture object instead of falling through to unresolved-call emit-0.

Fixes #867.