### PR TITLE
fix(analyze,codegen): dispatch Proc introspection methods

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -3440,10 +3440,14 @@ static sp_PtrArray *sp_PtrArray_slice_bang(sp_PtrArray *a, mrb_int from, mrb_int
   return r;
 }
 
-typedef struct sp_Proc { void *fn; void *cap; void (*cap_scan)(void *); } sp_Proc;
+typedef struct sp_Proc { void *fn; void *cap; void (*cap_scan)(void *); mrb_int arity; mrb_bool lambda_p; mrb_int param_count; const sp_sym *param_kinds; const sp_sym *param_names; } sp_Proc;
 static void sp_Proc_scan(void *p) { sp_Proc *pr = (sp_Proc *)p; if (pr->cap && pr->cap_scan) pr->cap_scan(pr->cap); }
-static sp_Proc *sp_proc_new(void *fn, void *cap, void (*cap_scan)(void *)) { sp_Proc *p = (sp_Proc *)sp_gc_alloc(sizeof(sp_Proc), NULL, sp_Proc_scan); p->fn = fn; p->cap = cap; p->cap_scan = cap_scan; return p; }
+static sp_Proc *sp_proc_new_meta(void *fn, void *cap, void (*cap_scan)(void *), mrb_int arity, mrb_bool lambda_p, mrb_int param_count, const sp_sym *param_kinds, const sp_sym *param_names) { sp_Proc *p = (sp_Proc *)sp_gc_alloc(sizeof(sp_Proc), NULL, sp_Proc_scan); p->fn = fn; p->cap = cap; p->cap_scan = cap_scan; p->arity = arity; p->lambda_p = lambda_p; p->param_count = param_count; p->param_kinds = param_kinds; p->param_names = param_names; return p; }
+static sp_Proc *sp_proc_new(void *fn, void *cap, void (*cap_scan)(void *)) { return sp_proc_new_meta(fn, cap, cap_scan, 0, FALSE, 0, NULL, NULL); }
+static mrb_int sp_proc_arity(sp_Proc *p) { return p ? p->arity : 0; }
+static mrb_bool sp_proc_lambda_p(sp_Proc *p) { return p ? p->lambda_p : FALSE; }
 static mrb_int sp_proc_call(sp_Proc *p, mrb_int *args) { return (p && p->fn) ? ((mrb_int (*)(void *, mrb_int *))p->fn)(p->cap, args) : 0; }
+static sp_PolyArray *sp_proc_parameters(sp_Proc *p) { sp_PolyArray *r = sp_PolyArray_new(); if (!p || p->param_count <= 0 || !p->param_kinds) return r; SP_GC_ROOT(r); for (mrb_int i = 0; i < p->param_count; i++) { sp_PolyArray *pair = sp_PolyArray_new(); sp_PolyArray_push(pair, sp_box_sym(p->param_kinds[i])); if (p->param_names && p->param_names[i] >= 0) sp_PolyArray_push(pair, sp_box_sym(p->param_names[i])); sp_PolyArray_push(r, sp_box_poly_array(pair)); } return r; }
 
 /* ---- StringIO runtime ---- */
 typedef struct { char *buf; int64_t len; int64_t cap; int64_t pos; int64_t lineno; int closed; } sp_StringIO;

--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -3367,6 +3367,9 @@ class Compiler
     if mname == "proc"
       return "proc"
     end
+    if mname == "lambda"
+      return "proc"
+    end
     if mname == "new"
       if recv >= 0
         rcname = constructor_class_name(recv)
@@ -6274,6 +6277,17 @@ class Compiler
  # Method call on poly
     if recv >= 0
       rt = infer_type(recv)
+      if rt == "proc"
+        if mname == "arity"
+          return "int"
+        end
+        if mname == "lambda?"
+          return "bool"
+        end
+        if mname == "parameters"
+          return "poly_array"
+        end
+      end
  # Complex value-type methods.
       if rt == "complex"
         if mname == "real" || mname == "imaginary" || mname == "imag"
@@ -24514,6 +24528,64 @@ class Compiler
 
  # Symbol-keyed hash with string values.
 
+  def collect_sym_name_into(local, name)
+    if name != "" && not_in(name, local) == 1
+      local.push(name)
+    end
+  end
+
+  def collect_proc_param_sym_names(local, blk, lambda_flag)
+    if blk < 0
+      return
+    end
+    params = @nd_parameters[blk]
+    if params < 0
+      return
+    end
+    kind_req = lambda_flag == 1 ? "req" : "opt"
+    collect_sym_name_into(local, kind_req)
+    if @nd_type[params] == "NumberedParametersNode"
+      k_np = 0
+      while k_np < @nd_value[params]
+        collect_sym_name_into(local, "_" + (k_np + 1).to_s)
+        k_np = k_np + 1
+      end
+      return
+    end
+    inner = @nd_parameters[params]
+    if inner < 0
+      return
+    end
+    reqs = parse_id_list(@nd_requireds[inner])
+    k = 0
+    while k < reqs.length
+      collect_sym_name_into(local, @nd_name[reqs[k]])
+      k = k + 1
+    end
+    opts = parse_id_list(@nd_optionals[inner])
+    if opts.length > 0
+      collect_sym_name_into(local, "opt")
+    end
+    k = 0
+    while k < opts.length
+      collect_sym_name_into(local, @nd_name[opts[k]])
+      k = k + 1
+    end
+    rest = @nd_rest[inner]
+    if rest >= 0 && @nd_type[rest] == "RestParameterNode"
+      collect_sym_name_into(local, "rest")
+      collect_sym_name_into(local, @nd_name[rest])
+    end
+    posts = parse_id_list(@nd_posts[inner])
+    k = 0
+    while k < posts.length
+      if @nd_type[posts[k]] == "RequiredParameterNode"
+        collect_sym_name_into(local, @nd_name[posts[k]])
+      end
+      k = k + 1
+    end
+  end
+
  # Symbol type Phase 2, Step 1: collect all SymbolNode content strings
  # into @sym_names as a separate pass (dedup, stable order).
   def collect_sym_names
@@ -24526,9 +24598,10 @@ class Compiler
       t = @nd_type[i]
       if t == "SymbolNode"
         sname = @nd_content[i]
-        if not_in(sname, local) == 1
-          local.push(sname)
-        end
+        collect_sym_name_into(local, sname)
+      end
+      if t == "BlockNode"
+        collect_proc_param_sym_names(local, i, 0)
       end
  # Also collect "literal".to_sym / .intern receivers so the
  # static-intern optimization can resolve them to SPS_ constants.
@@ -24538,8 +24611,18 @@ class Compiler
           r = @nd_receiver[i]
           if r >= 0 && @nd_type[r] == "StringNode"
             lname = @nd_content[r]
-            if not_in(lname, local) == 1
-              local.push(lname)
+            collect_sym_name_into(local, lname)
+          end
+        end
+        if mn == "proc" || mn == "lambda"
+          collect_proc_param_sym_names(local, @nd_block[i], mn == "lambda" ? 1 : 0)
+        end
+        if mn == "new"
+          r_proc_sym = @nd_receiver[i]
+          if r_proc_sym >= 0 && (@nd_type[r_proc_sym] == "ConstantReadNode" || @nd_type[r_proc_sym] == "ConstantPathNode")
+            cn_proc_sym = @nd_name[r_proc_sym]
+            if cn_proc_sym == "Proc" || cn_proc_sym == "Lambda"
+              collect_proc_param_sym_names(local, @nd_block[i], cn_proc_sym == "Lambda" ? 1 : 0)
             end
           end
         end

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -3249,6 +3249,9 @@ class Compiler
           return "obj_" + implicit
         end
       end
+      if @nd_receiver[nid] < 0 && (@nd_name[nid] == "proc" || @nd_name[nid] == "lambda")
+        return "proc"
+      end
  # Bare class-method call inside a class-method body (`def
  # self.last; all[-1]; end` — both `all` and `last` are cmeths
  # on the same class hierarchy). analyze skips the cache for
@@ -3278,6 +3281,18 @@ class Compiler
  # outer `.to_s` emit `sp_int_to_s(...)` instead of the bool
  # ternary `(... ? "true" : "false")`.
       cmp_mname = @nd_name[nid]
+      cmp_recv_proc = @nd_receiver[nid]
+      if cmp_recv_proc >= 0 && infer_type(cmp_recv_proc) == "proc"
+        if cmp_mname == "arity"
+          return "int"
+        end
+        if cmp_mname == "lambda?"
+          return "bool"
+        end
+        if cmp_mname == "parameters"
+          return "poly_array"
+        end
+      end
       if cmp_mname == "block_given?"
         cmp_recv = @nd_receiver[nid]
         if cmp_recv < 0 || (cmp_recv >= 0 && @nd_type[cmp_recv] == "SelfNode")
@@ -16446,6 +16461,20 @@ class Compiler
       end
     end
 
+ # Proc introspection.
+    if recv_type == "proc"
+      if mname == "arity"
+        return "sp_proc_arity(" + rc + ")"
+      end
+      if mname == "lambda?"
+        return "sp_proc_lambda_p(" + rc + ")"
+      end
+      if mname == "parameters"
+        @needs_rb_value = 1
+        return "sp_proc_parameters(" + rc + ")"
+      end
+    end
+
  # Wrap in a statement expression so receivers like `Time.now`
  # (which expand to a clock_gettime call) are evaluated exactly once
  # even when to_f references the value twice.
@@ -17128,6 +17157,12 @@ class Compiler
       if @nd_block[nid] >= 0
         return compile_proc_literal(nid)
       end
+    end
+    if mname == "lambda"
+      if @nd_block[nid] >= 0
+        return compile_proc_literal(nid, "", 1)
+      end
+      return "sp_proc_new_meta(NULL, NULL, NULL, 0, TRUE, 0, NULL, NULL)"
     end
     if mname == "method"
       args_id = @nd_arguments[nid]
@@ -36067,9 +36102,12 @@ class Compiler
     s
   end
 
-  def compile_proc_literal(nid, blk_param_types = "")
+  def compile_proc_literal(nid, blk_param_types = "", lambda_flag = 0)
     blk = @nd_block[nid]
     if blk < 0
+      if lambda_flag == 1
+        return "sp_proc_new_meta(NULL, NULL, NULL, 0, TRUE, 0, NULL, NULL)"
+      end
       return "sp_proc_new(NULL, NULL, NULL)"
     end
  # Collect every block param name. Single-param blocks fall through
@@ -36091,6 +36129,7 @@ class Compiler
     fname = "_sp_proc_fn_" + pid.to_s
     cap_name = "_proc_cap_" + pid.to_s
     cap_scan_name = "_proc_cap_scan_" + pid.to_s
+    meta_args = proc_metadata_args(nid, pid, lambda_flag)
     bbody = @nd_body[blk]
 
  # Detect captures (free variables that resolve in outer scope).
@@ -36332,7 +36371,7 @@ class Compiler
         emit("  " + cap_ptr + "->" + vn + " = " + cell + ";")
         k = k + 1
       end
-      return "sp_proc_new(" + fname + ", " + cap_ptr + ", " + cap_scan_name + ")"
+      return "sp_proc_new_meta(" + fname + ", " + cap_ptr + ", " + cap_scan_name + ", " + meta_args + ")"
     end
 
  # No captures: file-scope function with unused cap arg, sp_proc_new
@@ -36348,7 +36387,7 @@ class Compiler
     @lambda_funcs << "  return "
     @lambda_funcs << bexpr
     @lambda_funcs << ";\n}\n"
-    return "sp_proc_new(" + fname + ", NULL, NULL)"
+    return "sp_proc_new_meta(" + fname + ", NULL, NULL, " + meta_args + ")"
   end
 
   def compile_bracket_assign(nid)
@@ -38049,6 +38088,102 @@ class Compiler
       return @nd_name[reqs[idx]]
     end
     ""
+  end
+
+  def proc_metadata_args(nid, pid, lambda_flag)
+    kinds = "".split(",", -1)
+    names = "".split(",", -1)
+    arity = 0
+    blk = @nd_block[nid]
+    if blk >= 0
+      params = @nd_parameters[blk]
+      if params >= 0
+        req_kind = lambda_flag == 1 ? "req" : "opt"
+        if @nd_type[params] == "NumberedParametersNode"
+          n = @nd_value[params]
+          arity = n
+          k_np = 0
+          while k_np < n
+            kinds.push(req_kind)
+            names.push("_" + (k_np + 1).to_s)
+            k_np = k_np + 1
+          end
+        else
+          inner = @nd_parameters[params]
+          if inner >= 0
+            reqs = parse_id_list(@nd_requireds[inner])
+            opts = parse_id_list(@nd_optionals[inner])
+            posts = parse_id_list(@nd_posts[inner])
+            min_required = reqs.length + posts.length
+            k = 0
+            while k < reqs.length
+              kinds.push(req_kind)
+              names.push(@nd_name[reqs[k]])
+              k = k + 1
+            end
+            k = 0
+            while k < opts.length
+              kinds.push("opt")
+              names.push(@nd_name[opts[k]])
+              k = k + 1
+            end
+            rest = @nd_rest[inner]
+            has_rest = 0
+            if rest >= 0 && @nd_type[rest] == "RestParameterNode"
+              has_rest = 1
+              kinds.push("rest")
+              names.push(@nd_name[rest])
+            end
+            k = 0
+            while k < posts.length
+              if @nd_type[posts[k]] == "RequiredParameterNode"
+                kinds.push(req_kind)
+                names.push(@nd_name[posts[k]])
+              end
+              k = k + 1
+            end
+            arity = min_required
+            if has_rest == 1 || (lambda_flag == 1 && opts.length > 0)
+              arity = -(min_required + 1)
+            end
+          end
+        end
+      end
+    end
+    lambda_c = lambda_flag == 1 ? "TRUE" : "FALSE"
+    if kinds.length == 0
+      return arity.to_s + ", " + lambda_c + ", 0, NULL, NULL"
+    end
+    kinds_name = "_sp_proc_param_kinds_" + pid.to_s
+    names_name = "_sp_proc_param_names_" + pid.to_s
+    kind_vals = ""
+    name_vals = ""
+    k = 0
+    while k < kinds.length
+      if k > 0
+        kind_vals = kind_vals + ", "
+        name_vals = name_vals + ", "
+      end
+      kind_vals = kind_vals + compile_symbol_literal(kinds[k])
+      pname = names[k]
+      if pname == ""
+        name_vals = name_vals + "((sp_sym)-1)"
+      else
+        name_vals = name_vals + compile_symbol_literal(pname)
+      end
+      k = k + 1
+    end
+    @lambda_funcs << "static const sp_sym "
+    @lambda_funcs << kinds_name
+    @lambda_funcs << "[] = {"
+    @lambda_funcs << kind_vals
+    @lambda_funcs << "};\n"
+    @lambda_funcs << "static const sp_sym "
+    @lambda_funcs << names_name
+    @lambda_funcs << "[] = {"
+    @lambda_funcs << name_vals
+    @lambda_funcs << "};\n"
+    arity.to_s + ", " + lambda_c + ", " + kinds.length.to_s + ", " + kinds_name + ", " + names_name
   end
 
   def compile_each_slice_block(nid)

--- a/test/proc_introspection.rb
+++ b/test/proc_introspection.rb
@@ -1,0 +1,11 @@
+# Issue #861: Proc#arity, #lambda?, and #parameters dispatch.
+
+p = Proc.new { |a, b| }
+puts p.arity
+puts p.lambda?
+puts p.parameters.inspect
+
+l = lambda { |a, b| }
+puts l.arity
+puts l.lambda?
+puts l.parameters.inspect

--- a/test/proc_introspection.rb.expected
+++ b/test/proc_introspection.rb.expected
@@ -1,0 +1,6 @@
+2
+false
+[[:opt, :a], [:opt, :b]]
+2
+true
+[[:req, :a], [:req, :b]]


### PR DESCRIPTION
Fix `Proc#arity`, `Proc#lambda?`, and `Proc#parameters` so they return Proc metadata instead of falling through to unresolved-call emit-0.

Fixes #861.