### PR TITLE
fix: defined?() returns nil for never-written globals

### DIFF
--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -581,6 +581,7 @@ class Compiler
  # Global variables ($x)
     @gvar_names = "".split(",", -1)
     @gvar_types = "".split(",", -1)
+    @gvar_written = []
 
  # Poly tracking: functions with params called with different types
     @poly_funcs = "".split(",", -1)
@@ -20652,8 +20653,9 @@ class Compiler
         if not_in(gname, @gvar_names) == 1
           @gvar_names.push(gname)
           @gvar_types.push(gt)
+          @gvar_written.push(1)
         else
- # Check type consistency
+ # Check type consistency + mark written
           gi = 0
           while gi < @gvar_names.length
             if @gvar_names[gi] == gname
@@ -20661,6 +20663,7 @@ class Compiler
                 $stderr.puts "Error: global variable " + gname + " type mismatch: " + @gvar_types[gi] + " vs " + gt
                 exit(1)
               end
+              @gvar_written[gi] = 1
             end
             gi = gi + 1
           end
@@ -20681,8 +20684,10 @@ class Compiler
  # against an mrb_int and fail to compile.
           if gname == "$PROGRAM_NAME" || gname == "$0"
             @gvar_types.push("string")
+            @gvar_written.push(1)
           else
             @gvar_types.push("int")
+            @gvar_written.push(0)
           end
         end
       end
@@ -29669,6 +29674,7 @@ class Compiler
     buf = ir_emit_sa(buf, "@cvar_init_values", @cvar_init_values)
     buf = ir_emit_sa(buf, "@gvar_names", @gvar_names)
     buf = ir_emit_sa(buf, "@gvar_types", @gvar_types)
+    buf = ir_emit_ia(buf, "@gvar_written", @gvar_written)
 
  # Modules
     buf = ir_emit_sa(buf, "@module_names", @module_names)

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -587,6 +587,7 @@ class Compiler
  # Global variables ($x)
     @gvar_names = "".split(",", -1)
     @gvar_types = "".split(",", -1)
+    @gvar_written = []
 
  # Poly tracking: functions with params called with different types
     @poly_funcs = "".split(",", -1)
@@ -14014,10 +14015,19 @@ class Compiler
         return "((const char*)0)"
       end
       if it_d == "GlobalVariableReadNode"
- # CRuby returns "global-variable" whether the gvar has been
- # assigned or not (gvars read as nil when unset, but the name
- # itself is always "defined" syntactically).
-        return "\"global-variable\""
+        gname_d = @nd_name[inner_d]
+        gi_d = 0
+        while gi_d < @gvar_names.length
+          if @gvar_names[gi_d] == gname_d
+            if @gvar_written[gi_d] == 1
+              return "\"global-variable\""
+            end
+            gi_d = @gvar_names.length
+          else
+            gi_d = gi_d + 1
+          end
+        end
+        return "((const char*)0)"
       end
       if it_d == "CallNode" && @nd_receiver[inner_d] < 0
         mname_d = @nd_name[inner_d]
@@ -45228,6 +45238,8 @@ class Compiler
       @pre_execution_blocks = val
     elsif name == "@post_execution_blocks"
       @post_execution_blocks = val
+    elsif name == "@gvar_written"
+      @gvar_written = val
     end
   end
 

--- a/test/defined_globals_methods.rb
+++ b/test/defined_globals_methods.rb
@@ -1,6 +1,7 @@
 # defined? on globals and methods. Methods already returned
 # "method"; globals were returning "expression". CRuby returns
-# "global-variable" for $x whether set or not.
+# "global-variable" for assigned $x but nil for never-assigned
+# globals (the name alone is not "defined" if never written).
 $g = 1
 puts defined?($g)
 puts defined?($unset_gvar)

--- a/test/defined_globals_methods.rb.expected
+++ b/test/defined_globals_methods.rb.expected
@@ -1,5 +1,5 @@
 global-variable
-global-variable
+
 method
 local-variable
 true


### PR DESCRIPTION
CRuby returns nil for defined?() when  has never been assigned, but Spinel always returned "global-variable" since the analyzer registered every gvar read (including bare references in defined? checks) into @gvar_names with no write tracking.

Add @gvar_written flag array that records whether each global variable has a write node in the program. The analyzer sets the flag on write and exports it through the IR; the codegen's defined? handler checks it before returning "global-variable".