### PR TITLE
fix: File::ALT_SEPARATOR returns nil on non-Windows

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -13864,7 +13864,7 @@ class Compiler
             return "(&(\"\\xff\" \"/\")[1])"
           end
           if nname == "ALT_SEPARATOR"
-            return "sp_str_empty"
+            return "((const char*)0)"
           end
           if nname == "PATH_SEPARATOR"
             return "(&(\"\\xff\" \":\")[1])"


### PR DESCRIPTION
CRuby returns nil for File::ALT_SEPARATOR on Linux/macOS since there is no alternate separator. Spinel returned sp_str_empty ("") which made .nil? return false. Return NULL instead, which is the nil representation for the string type.