### PR TITLE
codegen: GC scan walks full ancestor chain, not just immediate parent (#1050)

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -9976,9 +9976,16 @@ class Compiler
           end
           j = j + 1
         end
- # Also scan parent fields
-        if @cls_parents[i] != ""
-          pi = find_class_idx(@cls_parents[i])
+ # Also scan inherited fields. Walk the FULL ancestor chain, not just
+ # the immediate parent: each class records only its OWN ivars (step 1
+ # skips inherited names so they're marked under the ancestor's type),
+ # so a passthrough parent that introduces no ivars of its own would
+ # otherwise drop a grandparent's ivars from this class's scan -- the
+ # collector then frees objects still reachable through those fields
+ # (issue #1050).
+        anc = @cls_parents[i]
+        while anc != ""
+          pi = find_class_idx(anc)
           if pi >= 0
             pnames = @cls_ivar_names[pi].split(";", -1)
             ptypes = @cls_ivar_types[pi].split(";", -1)
@@ -9991,6 +9998,9 @@ class Compiler
               end
               pj = pj + 1
             end
+            anc = @cls_parents[pi]
+          else
+            anc = ""
           end
         end
         emit_raw("}")

--- a/test/i1050.rb
+++ b/test/i1050.rb
@@ -1,0 +1,41 @@
+# A grandchild's GC scan function must mark ivars introduced two or more
+# levels up the inheritance chain. When a passthrough class (B) sits
+# between the class that introduces an ivar (A) and the leaf (C), the
+# leaf's scan must still walk PAST the empty middle class to mark the
+# grandparent's ivar -- otherwise a GC fired while the instance is live
+# frees the object that ivar holds (use-after-free / lost data). The
+# object is reachable ONLY through the inherited ivar, and GC.start
+# forces the collection that surfaces it (issue #1050).
+class A
+  def payload=(v); @payload = v; end
+  def payload; @payload; end
+end
+
+class B < A   # passthrough: introduces no ivars of its own
+end
+
+class C < B
+  def own=(v); @own = v; end
+  def own; @own; end
+end
+
+def churn(n)
+  i = 0
+  s = ""
+  while i < n
+    s = s + i.to_s + ","
+    i += 1
+  end
+  s.length
+end
+
+obj = C.new
+obj.payload = "secret_" + 42.to_s   # grandparent ivar; only live reference
+obj.own     = "kept_" + 7.to_s      # leaf's own ivar (already scanned)
+
+GC.start
+churn(8000)                          # reuse any freed slot
+GC.start
+
+puts obj.own
+puts obj.payload

--- a/test/i1050.rb.expected
+++ b/test/i1050.rb.expected
@@ -1,0 +1,2 @@
+kept_7
+secret_42


### PR DESCRIPTION
Fixes #1050.

## Problem

A class's generated `_gc_scan` function unioned ivars from the class itself plus
its **immediate** parent's own-ivar list — not the transitive set over all
ancestors. Each class records only its *own* ivars (step 1 deliberately skips
inherited names so they're marked under the ancestor's recorded type). So when a
**passthrough class** that introduces no ivars of its own sits in the chain, a
grandchild leaf **drops the grandparent's ivars** from its scan. Instances are
allocated with the leaf class's scan fn, so those ivars are never marked and the
collector frees objects still reachable through them → use-after-free.

Concretely: `ActionController::Base` introduces `@params`; `ApplicationController`
(direct child) keeps it; `ArticlesController < ApplicationController` drops it.

## Fix

Walk the full ancestor chain via `@cls_parents` instead of stopping at the
immediate parent. Each ivar lives in exactly one ancestor's own-list, so there's
no double-marking, and the existing per-ancestor type handling is preserved.

## Test

`test/i1050.rb` — a 3-level hierarchy (`A` introduces `@payload`, empty
passthrough `B`, leaf `C` with its own `@own`). The grandparent ivar `@payload`
is collected across `GC.start` before the fix (prints empty) and survives after.
Full suite: 650 pass / 0 fail / 0 error.

## Notes / for review

- Found while debugging the roundhouse Rails-blog crash referenced in #1050.
  This fix is **necessary but not sufficient** for that app — there is a separate,
  independent bug (a poly `sp_RbVal` local assigned from a method return is not
  `SP_GC_ROOT`'d) that I'm filing as its own issue.
- The chain walk uses `@cls_parents` (superclass only). If ivars can be introduced
  via included **modules**, those would need handling elsewhere — flagging since
  the cases I can exercise are single inheritance.
