### PR TITLE
Fix String#match/match? with position argument

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -1951,6 +1951,18 @@ static mrb_bool sp_re_match_p_at(mrb_regexp_pattern *pat, const char *str, mrb_i
   int caps[2];
   return re_exec(pat, str, slen, (mrb_int)pos, caps, 2) > 0;
 }
+/* String#match?(/re/, pos) — pos is a codepoint index (CRuby semantics),
+   unlike Regexp#match?(str, pos) which uses byte offset. Convert the
+   codepoint index to a byte offset before dispatching to re_exec. */
+static mrb_bool sp_str_re_match_p_at(mrb_regexp_pattern *pat, const char *str, mrb_int cpos) {
+  mrb_int cl = sp_str_length(str);
+  if (cpos < 0) cpos += cl;
+  if (cpos < 0 || cpos > cl) return FALSE;
+  size_t boff = sp_utf8_byte_offset(str, cpos);
+  int64_t slen = (int64_t)strlen(str);
+  int caps[2];
+  return re_exec(pat, str, slen, (mrb_int)boff, caps, 2) > 0;
+}
 
 /* Issue #855: expand `\1`..`\9` / `\&` / `\0` backreferences in
    the replacement string against the current caps[] array. `\\`
@@ -2564,6 +2576,29 @@ static sp_MatchData *sp_re_matchdata(mrb_regexp_pattern *pat, const char *str) {
   int64_t slen = (int64_t)strlen(str);
   int caps[64];
   int n = re_exec(pat, str, slen, 0, caps, 64);
+  if (n <= 0 || caps[0] < 0) {
+    for (int i = 0; i < 10; i++) sp_re_captures[i] = NULL;
+    sp_re_last_str = NULL; sp_re_match_str = NULL;
+    sp_re_match_pre = NULL; sp_re_match_post = NULL;
+    return NULL;
+  }
+  int pairs = (n > 64 ? 64 : n) / 2;
+  sp_re_set_captures(str, caps, pairs);
+  sp_MatchData *m = (sp_MatchData *)sp_gc_alloc(sizeof(sp_MatchData), NULL, sp_MatchData_scan);
+  m->source = str;
+  m->ncap = pairs;
+  for (int i = 0; i < pairs * 2; i++) m->caps[i] = caps[i];
+  return m;
+}
+/* String#match(/re/, pos) — pos is a codepoint index (CRuby semantics). */
+static sp_MatchData *sp_re_matchdata_at(mrb_regexp_pattern *pat, const char *str, mrb_int cpos) {
+  mrb_int cl = sp_str_length(str);
+  if (cpos < 0) cpos += cl;
+  if (cpos < 0 || cpos > cl) return NULL;
+  size_t boff = sp_utf8_byte_offset(str, cpos);
+  int64_t slen = (int64_t)strlen(str);
+  int caps[64];
+  int n = re_exec(pat, str, slen, (mrb_int)boff, caps, 64);
   if (n <= 0 || caps[0] < 0) {
     for (int i = 0; i < 10; i++) sp_re_captures[i] = NULL;
     sp_re_last_str = NULL; sp_re_match_str = NULL;

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -21066,6 +21066,9 @@ class Compiler
           if rpat_m != ""
             @needs_rb_value = 1
             @needs_gc = 1
+            if argl_m.length >= 2
+              return "sp_re_matchdata_at(" + rpat_m + ", " + rc + ", " + compile_expr_as_int(argl_m[1]) + ")"
+            end
             return "sp_re_matchdata(" + rpat_m + ", " + rc + ")"
           end
         end
@@ -21078,6 +21081,9 @@ class Compiler
         if argl.length > 0
           rpat = regex_pat_c_expr(argl[0])
           if rpat != ""
+            if argl.length >= 2
+              return "sp_str_re_match_p_at(" + rpat + ", " + rc + ", " + compile_expr_as_int(argl[1]) + ")"
+            end
             return "sp_re_match_p(" + rpat + ", " + rc + ")"
           end
         end

--- a/test/str_match_position.rb
+++ b/test/str_match_position.rb
@@ -1,0 +1,15 @@
+# String#match and String#match? with position argument
+# The position is a codepoint index (not byte offset) that limits
+# where the regex search starts.
+
+# match? with position
+puts "hello".match?(/h/, 1)
+puts "hello".match?(/e/, 1)
+puts "hello".match?(/o/, -1)
+puts "hello".match?(/h/, 0)
+puts "hello".match?(/z/, 0)
+
+# match with position
+r = "hello".match(/h/, 1); puts r == nil ? "nil" : r[0]
+r = "hello".match(/e/, 1); puts r == nil ? "nil" : r[0]
+r = "hello".match(/o/, -1); puts r == nil ? "nil" : r[0]

--- a/test/str_match_position.rb.expected
+++ b/test/str_match_position.rb.expected
@@ -1,0 +1,8 @@
+false
+true
+true
+true
+false
+nil
+e
+o


### PR DESCRIPTION
String#match?(/h/, 1) returned true instead of false because the position argument was silently dropped. Unlike Regexp#match?(str, pos) which uses a byte offset, String#match?(/re/, pos) takes a codepoint index (CRuby semantics). Add sp_str_re_match_p_at and sp_re_matchdata_at runtime helpers that convert the codepoint index to a byte offset via sp_utf8_byte_offset before dispatching to re_exec, and route the codegen to them when a second argument is present.