### PR TITLE
Fix String#squeeze with charset argument

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -1461,6 +1461,10 @@ static const char*sp_str_delete(const char*s,const char*chars){if(!s)return sp_s
    `bytes` / `length` consult the header (not strlen), so callers
    would see the alloc size and trailing NULs. */
 static const char*sp_str_squeeze(const char*s){if(!s)return sp_str_empty;size_t bl=strlen(s);char*r=sp_str_alloc_raw(bl+1);size_t n=0;uint32_t prev=0xFFFFFFFFu;const char*p=s;while(*p){uint32_t cp;int cn=sp_utf8_decode(p,&cp);if(cp!=prev){memcpy(r+n,p,cn);n+=cn;prev=cp;}p+=cn;}r[n]=0;sp_str_set_len(r,n);return r;}
+/* String#squeeze(chars) — only squeeze chars listed in the charset
+   (same charset syntax as tr: a-z, ^x, etc.). Consecutive runs of
+   non-listed chars pass through untouched. */
+static const char*sp_str_squeeze_chars(const char*s,const char*cs){if(!s)return sp_str_empty;if(!cs||!*cs)return sp_str_squeeze(s);int negate=0;const char*csp=cs;if(*csp=='^'){negate=1;csp++;}size_t fn;uint32_t*fcps=sp_utf8_decode_charset(csp,&fn);size_t bl=strlen(s);char*r=sp_str_alloc_raw(bl+1);size_t n=0;uint32_t prev=0xFFFFFFFFu;const char*p=s;while(*p){uint32_t cp;int cn=sp_utf8_decode(p,&cp);int in_set=0;for(size_t j=0;j<fn;j++)if(fcps[j]==cp){in_set=1;break;}if(negate)in_set=!in_set;if(!in_set){memcpy(r+n,p,cn);n+=cn;prev=0xFFFFFFFFu;}else if(cp!=prev){memcpy(r+n,p,cn);n+=cn;prev=cp;}p+=cn;}r[n]=0;sp_str_set_len(r,n);free(fcps);return r;}
 
 /* Forward decl from sp_crypto.h (libspinel_rt.a). Used by
    sp_str_crypt below to provide a deterministic crypt-like

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -21519,6 +21519,12 @@ class Compiler
       return "sp_str_scrub(" + rc + ", " + rep_sc + ")"
     end
     if mname == "squeeze"
+      if @nd_arguments[nid] >= 0
+        ap_sq = get_args(@nd_arguments[nid])
+        if ap_sq.length > 0
+          return "sp_str_squeeze_chars(" + rc + ", " + compile_expr(ap_sq[0]) + ")"
+        end
+      end
       return "sp_str_squeeze(" + rc + ")"
     end
     if mname == "size"

--- a/test/str_squeeze_arg.rb
+++ b/test/str_squeeze_arg.rb
@@ -1,0 +1,16 @@
+# String#squeeze with charset argument
+# The argument restricts which characters get squeezed.
+# "a" squeezes only 'a', "^a" squeezes everything except 'a'.
+
+# no-arg squeeze (all consecutive)
+puts "aaabbbccc".squeeze.inspect
+# single char
+puts "aaabbbccc".squeeze("a").inspect
+# multiple chars
+puts "aaabbbccc".squeeze("ab").inspect
+# range
+puts "aaabbbccc".squeeze("a-c").inspect
+# negated set
+puts "aaabbbccc".squeeze("^a").inspect
+# no change case
+puts "abc".squeeze("a").inspect

--- a/test/str_squeeze_arg.rb.expected
+++ b/test/str_squeeze_arg.rb.expected
@@ -1,0 +1,6 @@
+"abc"
+"abbbccc"
+"abccc"
+"abc"
+"aaabc"
+"abc"


### PR DESCRIPTION
squeeze("a") was silently dropping the argument and squeezing all consecutive characters (same as the no-arg form). Add sp_str_squeeze_chars runtime helper that checks each character against the charset before deciding to squeeze, with ^-negation support (squeeze("^a") squeezes everything except 'a'). Route codegen to the new helper when an argument is present.