### PR TITLE
Fix String#split(" ") to use whitespace-split mode

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -21128,6 +21128,11 @@ class Compiler
           if @nd_type[a[0]] == "NilNode"
             return "sp_str_split_ws(" + rc + ")"
           end
+ # CRuby special case: split(" ") is whitespace-split mode (strips
+ # leading whitespace, collapses consecutive), not literal " " split.
+          if @nd_type[a[0]] == "StringNode" && @nd_content[a[0]] == " "
+            return "sp_str_split_ws(" + rc + ")"
+          end
  # Two-arg split(sep, limit) -- positive limit caps the result at
  # that many elements with the last one holding the unsplit
  # remainder. Issue #619 puzzle 2.

--- a/test/str_split_space_whitespace.rb
+++ b/test/str_split_space_whitespace.rb
@@ -1,0 +1,10 @@
+# String#split(" ") is whitespace-split mode (CRuby special case)
+# Strips leading whitespace, collapses consecutive whitespace.
+
+# split(" ") is whitespace mode
+puts "  hello  world  ".split(" ").inspect
+puts "a  b".split(" ").inspect
+# no-arg split is also whitespace mode
+puts "  hello  world  ".split.inspect
+# split(",") is literal mode (preserves empty fields)
+puts "a,,b".split(",").inspect

--- a/test/str_split_space_whitespace.rb.expected
+++ b/test/str_split_space_whitespace.rb.expected
@@ -1,0 +1,4 @@
+["hello", "world"]
+["a", "b"]
+["hello", "world"]
+["a", "", "b"]


### PR DESCRIPTION
"a  b".split(" ") returned ["a", "", "b"] (literal space splitting) instead of ["a", "b"]. CRuby treats a single-space separator as whitespace-split mode — same as no-arg split — which strips leading whitespace and collapses consecutive whitespace. Route literal " " to sp_str_split_ws in the codegen, matching the existing nil-arg and no-arg paths.