### PR TITLE
Root the poly each-loop receiver temp across the loop body

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -41992,6 +41992,16 @@ class Compiler
       idx_tmp = new_temp
       val_tmp = new_temp
       emit("  sp_RbVal " + poly_tmp + " = " + rc + ";")
+ # Root the receiver temp across the loop body. `rc` is frequently a
+ # fresh method-call result (e.g. `@article.comments`) held only in
+ # this temp; the loop body allocates (string append, nested render,
+ # box helpers), so an unrooted PtrArray/heap collection here can be
+ # collected mid-iteration, leaving sp_PtrArray_get to read a freed
+ # slot (observed as a SIGSEGV in sp_obj_cls_id_of on a garbage
+ # pointer under load). The cleanup-attributed root pops at end of
+ # poly_tmp's C scope, which is exactly the loop's extent.
+      @needs_gc = 1
+      emit_gc_root_for_expr(poly_tmp, "poly")
       emit("  if (" + poly_tmp + ".tag == SP_TAG_OBJ) {")
       emit("    mrb_int " + idx_tmp + "_len = 0;")
       emit("    if (" + poly_tmp + ".cls_id == SP_BUILTIN_RANGE) " + idx_tmp + "_len = ((sp_Range *)" + poly_tmp + ".v.p)->last - ((sp_Range *)" + poly_tmp + ".v.p)->first + 1;")

--- a/test/poly_each_receiver_gc_root.rb
+++ b/test/poly_each_receiver_gc_root.rb
@@ -1,0 +1,40 @@
+# The poly (runtime-dispatch) `each` codegen stored the iterated
+# collection in an unrooted temp:
+#
+#     sp_RbVal _t = <receiver>;   // e.g. a method that builds an array
+#     for (...) sp_PtrArray_get((sp_PtrArray *)_t.v.p, i) ...
+#
+# When the receiver is a freshly built heap array referenced only by
+# that temp (the `@article.comments` shape -- a new PtrArray of records)
+# and the loop body allocates, a GC firing mid-iteration freed the
+# unrooted array; the next element fetch then read a dangling pointer,
+# surfacing as a SIGSEGV in sp_obj_cls_id_of under load. The GC.start
+# inside the loop makes that collection deterministic here.
+class Box
+  def initialize(name); @name = name; end
+  def name; @name; end
+  def rename(x); @name = x; end   # self-mutating -> heap, not a value type
+end
+
+class Bag
+  def initialize; @items = []; end
+  def add(b); @items.push(b); end
+
+  # Build a FRESH array on every call; the ternary widens the return
+  # type to poly so `each` takes the runtime-dispatch codegen path.
+  def items
+    fresh = []
+    @items.each { |x| fresh.push(x) }
+    fresh.empty? ? [] : fresh
+  end
+end
+
+bag = Bag.new
+5.times { |i| bag.add(Box.new("item-" + i.to_s)) }
+
+out = []
+bag.items.each do |b|
+  GC.start          # collect mid-iteration; unrooted receiver array freed here
+  out.push(b.name)
+end
+puts out.join(",")

--- a/test/poly_each_receiver_gc_root.rb.expected
+++ b/test/poly_each_receiver_gc_root.rb.expected
@@ -1,0 +1,1 @@
+item-0,item-1,item-2,item-3,item-4


### PR DESCRIPTION
## Problem

The runtime-dispatch (poly) `each` codegen stores the iterated collection in a bare `sp_RbVal` temp without rooting it:

```c
sp_RbVal _t = <receiver>;          // e.g. @article.comments
for (...) { ... sp_PtrArray_get((sp_PtrArray *)_t.v.p, i) ... }
```

When the receiver is a freshly built heap collection referenced **only** by this temp — the common `@article.comments` shape, a new `PtrArray` of records — and the loop body allocates (string append, nested `render`, box helpers), a GC firing mid-iteration collects the unrooted array. The next `sp_PtrArray_get` then reads a freed slot, surfacing as a **SIGSEGV in `sp_obj_cls_id_of`** on a garbage pointer — intermittently, under concurrent load, once the freed block is reused.

Observed in a transpiled Rails blog under load (`/articles/1` rendering `@article.comments`):

```
Program received signal SIGSEGV
0x... in sp_obj_cls_id_of (p=0x85) at sp_runtime.h
#1 ... in sp_Views_Articles_cls_show (...)
```

The concrete-typed each paths are unaffected: their collection is a directly-rooted local/param (e.g. `render @articles` roots `lv_articles`). Only the poly receiver path missed the root.

## Fix

Root the receiver temp right after its declaration. `SP_GC_ROOT_RBVAL` is `cleanup`-attributed, so it pops at the end of the temp's C scope — exactly the loop's extent. Rooting a non-heap `RbVal` is harmless.

## Test

`test/poly_each_receiver_gc_root.rb`: poly `each` over a freshly built array with `GC.start` in the body. Pre-fix the unrooted array is freed after the first element, so subsequent elements read freed slots and the output diverges (`item-0,,,,`); post-fix it matches the CRuby reference. Independently confirmed with AddressSanitizer (pre-fix: `heap-use-after-free in sp_PtrArray_get`; post-fix: clean).

Full suite: **704 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)