### PR TITLE
Keep nullable int struct members unboxed

### DIFF
--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -10736,8 +10736,9 @@ class Compiler
  # Same base, one nullable: keep / adopt the nullable form
  # rather than collapsing to poly. `@x = "hi"` (string) +
  # `@x = some_string_or_nil` (string?) is one storage shape
- # — `const char *` with NULL as the nil sentinel.
-            elsif base_type(old) == base_type(new_type) && is_nullable_pointer_type(old) == 1
+ # — `const char *` with NULL as the nil sentinel. Scalar int?
+ # follows the same merge rule with SP_INT_NIL as its sentinel.
+            elsif base_type(old) == base_type(new_type) && (is_nullable_pointer_type(old) == 1 || is_scalar_nullable_type(old) == 1)
               if is_nullable_type(new_type) == 1 && is_nullable_type(old) == 0
                 types[k] = new_type
                 @cls_ivar_types[ci] = types.join(";")
@@ -13656,6 +13657,11 @@ class Compiler
       end
     end
     if at == "int"
+ # A literal int call-site is compatible with an existing int?
+ # slot; keep the sentinel-capable storage instead of widening.
+      if is_scalar_nullable_type(old_pt) == 1
+        return old_pt
+      end
  # Numeric compat: int + float is safe in both directions.
       if old_pt == "float"
         return "float"
@@ -16690,6 +16696,22 @@ class Compiler
     end
   end
 
+  def synthetic_struct_class?(ci)
+    if ci < 0 || ci >= @cls_meth_names.length
+      return 0
+    end
+    names = @cls_meth_names[ci].split(";", -1)
+    bodies = @cls_meth_bodies[ci].split(";", -1)
+    k = 0
+    while k < names.length && k < bodies.length
+      if names[k] == "initialize" && bodies[k] == "-2"
+        return 1
+      end
+      k = k + 1
+    end
+    0
+  end
+
  # Post-pass for #634 shape A. An optional param with an explicit
  # `= nil` default whose call sites then widen its type to a
  # Post-pass for #634 shape B. An ivar exposed by attr_reader /
@@ -16749,8 +16771,12 @@ class Compiler
               assigned = ivar_assigned_in_init_chain?(ci, iname)
               obs = cls_ivar_observed_types_for(ci, iname)
               if assigned == 0 && obs == ""
-                types[k] = "poly"
-                @needs_rb_value = 1
+                if pt == "int" && synthetic_struct_class?(ci) == 1
+                  types[k] = "int?"
+                else
+                  types[k] = "poly"
+                  @needs_rb_value = 1
+                end
                 changed_c = 1
               end
           end

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -30916,6 +30916,8 @@ class Compiler
       if found == 0
         if pt == "poly"
           result = result + "sp_box_nil()"
+        elsif is_scalar_nullable_type(pt) == 1
+          result = result + c_default_val(pt)
         else
           result = result + "0"
         end
@@ -31603,6 +31605,8 @@ class Compiler
           else
             if k < ptypes.length && ptypes[k] == "poly"
               result = result + "sp_box_nil()"
+            elsif k < ptypes.length && is_scalar_nullable_type(ptypes[k]) == 1
+              result = result + c_default_val(ptypes[k])
             else
               result = result + "0"
             end
@@ -31610,6 +31614,8 @@ class Compiler
         else
           if k < ptypes.length && ptypes[k] == "poly"
             result = result + "sp_box_nil()"
+          elsif k < ptypes.length && is_scalar_nullable_type(ptypes[k]) == 1
+            result = result + c_default_val(ptypes[k])
           else
             result = result + "0"
           end

--- a/test/struct_int_member_unboxed.rb
+++ b/test/struct_int_member_unboxed.rb
@@ -1,0 +1,14 @@
+Rec = Struct.new(:id, :name)
+
+full = Rec.new(1, "alice")
+puts full.id
+puts full.name
+
+empty = Rec.new
+puts empty.id.nil?
+puts empty.name.nil?
+
+empty.id = 7
+empty.name = "bob"
+puts empty.id
+puts empty.name

--- a/test/struct_int_member_unboxed.rb.expected
+++ b/test/struct_int_member_unboxed.rb.expected
@@ -1,0 +1,6 @@
+1
+alice
+true
+true
+7
+bob


### PR DESCRIPTION
## Summary

Keep indefinite-init integer members of synthetic Struct/Data classes as `int?` instead of widening them to `poly`, so they emit as native `mrb_int` fields with `SP_INT_NIL` for nil.

## Root cause

The struct member could briefly become `int?`, but later constructor argument inference saw `Rec.new(1, ...)`, treated the literal integer as incompatible with the existing nullable int slot, widened the constructor ptype to `poly`, and copied that back to the ivar type.

## Scope

This is limited to synthetic Struct/Data classes, indefinite-init integer members, and the existing scalar-nullable `int?` representation. Other scalar types still widen to `poly`.

## Validation

- `LC_ALL=en_US.UTF-8 make`
- targeted regression and canaries:
  - `struct_int_member_unboxed` PASS
  - `bundle_classd_49` PASS
  - `param_body_hash_inference` PASS
- `LC_ALL=en_US.UTF-8 make bootstrap`
  - `analyze.rb: IR fixpoint OK`
  - `analyze.rb: C fixpoint OK`
  - `codegen.rb: IR fixpoint OK`
  - `codegen.rb: C fixpoint OK`
- `LC_ALL=en_US.UTF-8 make REF_RUBY="mise x ruby@3.4.9 -- ruby" test`
  - `668 pass, 0 fail, 0 error`
