### PR TITLE
rbs_extract: map heterogeneous unions to poly instead of dropping the seed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ NODE_TABLE_LOADER_STAMP := build/stamps/node_table_loader.rb.stamp
 COMPILER_HELPERS_STAMP := build/stamps/compiler_helpers.rb.stamp
 PARSE_STAMP   := build/stamps/spinel_parse.c.stamp
 
-.PHONY: all parse bootstrap codegen rbs_extract test retest fast-test clean-test-results regen-expected bench optcarrot clean install uninstall deps FORCE
+.PHONY: all parse bootstrap codegen rbs_extract rbs-test regen-rbs-expected test retest fast-test clean-test-results regen-expected bench optcarrot clean install uninstall deps FORCE
 
 # `make all` includes spinel_rbs_extract when vendor/rbs has been
 # fetched (via `make deps`). Without vendor/rbs the extractor is
@@ -441,8 +441,9 @@ endif
 TEST_TARGETS := $(patsubst test/%.rb,build/test-results/%.ok,$(TESTS))
 
 # `make test` is incremental via mtime tracking on .ok files;
-# `make retest` wipes them for a forced rerun.
-test: $(TEST_TARGETS)
+# `make retest` wipes them for a forced rerun. The rbs-test prereq
+# golden-checks the RBS extractor (cheap, runs every invocation).
+test: rbs-test $(TEST_TARGETS)
 	@if [ -z "$(TIMEOUT_BIN)" ]; then echo "Note: no 'timeout' command found; running without time limits."; fi
 	@if [ -t 1 ]; then printf '\n'; fi
 	@pass=$$(grep -l '^PASS' build/test-results/*.ok 2>/dev/null | wc -l); \
@@ -466,6 +467,46 @@ retest: clean-test-results
 
 fast-test: clean-test-results
 	@$(MAKE) --no-print-directory test OPT=-O0 LTO=0
+
+# ---- RBS extractor golden tests ----
+# spinel_rbs_extract is a pure text transform (*.rbs -> seed lines on
+# stdout), so it golden-tests cleanly without Ruby at test time. Each
+# test/rbs/<name>.rbs has a committed test/rbs/<name>.seed.expected;
+# `rbs-test` diffs live output against it. Regenerate after intentional
+# extractor changes with `make regen-rbs-expected` and commit the diff.
+# Skips (rather than fails) when vendor/rbs hasn't been fetched, so a
+# `make deps`-less checkout can still run the rest of `make test`.
+RBS_TEST_SRCS := $(sort $(wildcard test/rbs/*.rbs))
+
+ifeq ($(wildcard $(RBS_INC)/rbs/parser.h),)
+rbs-test:
+	@echo "rbs-test: skipped (vendor/rbs not fetched; run 'make deps')"
+regen-rbs-expected:
+	@echo "regen-rbs-expected: skipped (vendor/rbs not fetched; run 'make deps')"
+else
+rbs-test: spinel_rbs_extract$(EXE)
+	@fail=0; n=0; \
+	for f in $(RBS_TEST_SRCS); do \
+	  n=$$((n+1)); \
+	  exp="$${f%.rbs}.seed.expected"; \
+	  if [ ! -f "$$exp" ]; then echo "rbs-test: MISSING golden $$exp"; fail=1; continue; fi; \
+	  d=$$(./spinel_rbs_extract$(EXE) "$$f" 2>/dev/null | diff -u "$$exp" - 2>&1); \
+	  if [ -z "$$d" ]; then \
+	    if [ -t 1 ]; then printf .; fi; \
+	  else \
+	    echo; echo "rbs-test FAIL: $$f"; echo "$$d"; fail=1; \
+	  fi; \
+	done; \
+	if [ -t 1 ]; then printf '\n'; fi; \
+	if [ $$fail -ne 0 ]; then echo "RBS extractor tests: FAIL"; exit 1; fi; \
+	echo "RBS extractor tests: $$n pass"
+
+regen-rbs-expected: spinel_rbs_extract$(EXE)
+	@for f in $(RBS_TEST_SRCS); do \
+	  ./spinel_rbs_extract$(EXE) "$$f" > "$${f%.rbs}.seed.expected"; \
+	  echo "regen: $${f%.rbs}.seed.expected"; \
+	done
+endif
 
 # The .ok target is the test's stamp; mtime tracking gives per-test
 # caching for free. Order-only spinel_parse$(EXE) / spinel_analyze$(EXE)

--- a/spinel_rbs_extract.c
+++ b/spinel_rbs_extract.c
@@ -431,26 +431,46 @@ static bool map_type(rbs_parser_t *p, rbs_node_t *node,
             return true;
         }
         case RBS_TYPES_UNION: {
-            /* Only support `T | nil` shape (equivalent to T?). Any
-             * other union → out-of-subset, skip. */
+            /* `T | nil` (the nilable shape) maps to `T?`. Every other
+             * union has no single concrete C representation, so it
+             * maps to poly (sp_RbVal, the tagged union) -- the same
+             * target `untyped` uses. This boxes the value correctly.
+             *
+             * Previously any non-`T | nil` union returned false, which
+             * dropped the *entire* method seed (the caller bails on a
+             * false return type), letting inference collapse e.g.
+             * {int, string} to a single C type and mis-compile
+             * heterogeneous returns (matz/spinel#1255). Mapping to poly
+             * is the faithful choice: spinel's only representation for
+             * "one of several incompatible types" is the tagged union.
+             *
+             * This touches only the RBS-seed layer. The self-host build
+             * ships no `.rbs`, so the inference-level unify_return_type
+             * heuristic (load-bearing for stage-2) is unaffected. */
             rbs_types_union_t *u = (rbs_types_union_t *) node;
-            if (u->types == NULL || u->types->length != 2) return false;
-            rbs_node_t *a = u->types->head->node;
-            rbs_node_t *b = u->types->head->next->node;
-            rbs_node_t *t = NULL;
-            if (a->type == RBS_TYPES_BASES_NIL) t = b;
-            else if (b->type == RBS_TYPES_BASES_NIL) t = a;
-            if (t == NULL) return false;
-            sbuf_t inner;
-            sbuf_init(&inner);
-            if (!map_type(p, t, enclosing_scope, &inner)) { sbuf_free(&inner); return false; }
-            if (inner.len > 0 && inner.buf[inner.len - 1] == '?') {
-                sbuf_set(out, inner.buf, inner.len);
-            } else {
-                sbuf_set(out, inner.buf, inner.len);
-                sbuf_append_cstr(out, "?");
+            if (u->types != NULL && u->types->length == 2) {
+                rbs_node_t *a = u->types->head->node;
+                rbs_node_t *b = u->types->head->next->node;
+                rbs_node_t *t = NULL;
+                if (a->type == RBS_TYPES_BASES_NIL) t = b;
+                else if (b->type == RBS_TYPES_BASES_NIL) t = a;
+                if (t != NULL) {
+                    sbuf_t inner;
+                    sbuf_init(&inner);
+                    if (map_type(p, t, enclosing_scope, &inner)) {
+                        sbuf_set(out, inner.buf, inner.len);
+                        if (inner.len == 0 || inner.buf[inner.len - 1] != '?') {
+                            sbuf_append_cstr(out, "?");
+                        }
+                        sbuf_free(&inner);
+                        return true;
+                    }
+                    /* `T | nil` where T is itself out-of-subset →
+                     * fall through to poly below. */
+                    sbuf_free(&inner);
+                }
             }
-            sbuf_free(&inner);
+            sbuf_set(out, "poly", 4);
             return true;
         }
         default:

--- a/test/rbs/README.md
+++ b/test/rbs/README.md
@@ -1,0 +1,45 @@
+# RBS extractor golden tests
+
+Golden tests for `spinel_rbs_extract` — the tool that reads `*.rbs`
+files and emits the line-oriented seed format `spinel_analyze` consumes
+under `spinel --rbs DIR`. See `docs/RBS-EXTRACT.md` for the supported
+subset and `experiments/rbs/` for an end-to-end seeding spike.
+
+The extractor is a pure, deterministic text transform (`*.rbs` in →
+seed lines on stdout) and a compiled C binary, so it golden-tests
+cleanly with **no Ruby at test time** — unlike the compile-and-run
+fixtures under `test/`. This layer is also where RBS regressions are
+actually visible: seeds are advisory, so most extractor bugs produce
+identical *program* output and slip past the `test/*.rb` suite.
+
+## Layout
+
+Each case is one input/golden pair:
+
+- `<name>.rbs` — input RBS source
+- `<name>.seed.expected` — committed expected seed output
+
+`make rbs-test` runs `spinel_rbs_extract <name>.rbs` for every case and
+diffs stdout against the golden. It is a prerequisite of `make test`,
+and skips gracefully when `vendor/rbs` has not been fetched.
+
+## Adding or updating a case
+
+1. Add (or edit) `<name>.rbs`.
+2. `make regen-rbs-expected` to (re)generate every `.seed.expected`.
+3. **Read the diff** — the goldens encode intended behavior, so confirm
+   the change is what you meant before committing both files.
+
+## Coverage
+
+Single-file fixtures cover the documented subset: the scalar type
+vocabulary, nominal types, `Array[T]` / `Hash[K,V]` tag selection,
+nullable (`T?` / `T | nil`), heterogeneous-union → `poly`, member kinds
+(`meth` / `cmeth` / `self?.` / `attr_*` / `@ivar`), unqualified
+parent-scope resolution, first-overload-wins, and the signature- and
+type-level shapes that drop a method wholesale.
+
+Multi-file cross-file resolution (issue #658) is not covered here:
+output ordering across files depends on `readdir`, which isn't portable
+enough for a stable golden. The single-file `unqualified.rbs` exercises
+the parent-scope fallback deterministically.

--- a/test/rbs/arrays.rbs
+++ b/test/rbs/arrays.rbs
@@ -1,0 +1,10 @@
+# Array[T] maps to a per-element-type array tag; element types outside
+# the int/float/string/symbol/nominal set fall back to poly_array.
+class Arrays
+  def i: (Array[Integer]) -> Array[Integer]
+  def f: (Array[Float]) -> Array[Float]
+  def s: (Array[String]) -> Array[String]
+  def y: (Array[Symbol]) -> Array[Symbol]
+  def o: (Array[Foo]) -> Array[Foo]
+  def p: (Array[bool]) -> Array[bool]
+end

--- a/test/rbs/arrays.seed.expected
+++ b/test/rbs/arrays.seed.expected
@@ -1,0 +1,7 @@
+class Arrays
+meth i int_array int_array
+meth f float_array float_array
+meth s str_array str_array
+meth y sym_array sym_array
+meth o obj_Foo_ptr_array obj_Foo_ptr_array
+meth p poly_array poly_array

--- a/test/rbs/dropped_members.rbs
+++ b/test/rbs/dropped_members.rbs
@@ -1,0 +1,13 @@
+# Member kinds that are not modeled: mixins (include/extend/prepend),
+# visibility (public/private), alias, and `@@cvar` class-variable
+# declarations. `kept` confirms emission resumes after them.
+class DroppedMembers
+  include Enumerable
+  extend Forwardable
+  prepend Helper
+  public
+  private
+  alias foo bar
+  @@count: Integer
+  def kept: (Integer) -> Integer
+end

--- a/test/rbs/dropped_members.seed.expected
+++ b/test/rbs/dropped_members.seed.expected
@@ -1,0 +1,2 @@
+class DroppedMembers
+meth kept int int

--- a/test/rbs/dropped_sigs.rbs
+++ b/test/rbs/dropped_sigs.rbs
@@ -1,0 +1,14 @@
+# Method signature shapes that take the whole method out of subset:
+# anything other than plain required positional params. `kept` confirms
+# emission resumes after each dropped method.
+#
+# (Keyword and block params are handled separately and are intentionally
+# NOT exercised here -- see the PR description.)
+class DroppedSigs
+  def opt: (?String) -> void
+  def rest: (*Integer) -> void
+  def trailing: (Integer, ?String, Integer) -> void
+  def restkw: (**Integer) -> void
+  def generic: [X] (X) -> X
+  def kept: (Integer) -> Integer
+end

--- a/test/rbs/dropped_sigs.seed.expected
+++ b/test/rbs/dropped_sigs.seed.expected
@@ -1,0 +1,2 @@
+class DroppedSigs
+meth kept int int

--- a/test/rbs/dropped_types.rbs
+++ b/test/rbs/dropped_types.rbs
@@ -1,0 +1,14 @@
+# Type-level shapes with no spinel tag. Any one of these in a required
+# positional (or as the return) drops the whole method. `kept` confirms
+# emission resumes. Note: `untyped` is NOT here -- it maps to poly.
+class DroppedTypes
+  def a: (self) -> void
+  def b: (instance) -> void
+  def c: (_Each) -> void
+  def d: (Integer & String) -> void
+  def e: (:sym) -> void
+  def f: (Integer, String) -> [Integer, String]
+  def g: ({ name: String }) -> void
+  def h: (^(Integer) -> void) -> void
+  def kept: (Integer) -> Integer
+end

--- a/test/rbs/dropped_types.seed.expected
+++ b/test/rbs/dropped_types.seed.expected
@@ -1,0 +1,2 @@
+class DroppedTypes
+meth kept int int

--- a/test/rbs/hashes.rbs
+++ b/test/rbs/hashes.rbs
@@ -1,0 +1,11 @@
+# Hash[K, V] is supported only when K is String or Symbol. The value
+# type collapses to int / string / poly. A non-String/Symbol key takes
+# the whole signature out of subset (see dropped_types.rbs).
+class Hashes
+  def si: (Hash[String, Integer]) -> Hash[String, Integer]
+  def ss: (Hash[String, String]) -> Hash[String, String]
+  def sp: (Hash[String, Float]) -> Hash[String, Float]
+  def yi: (Hash[Symbol, Integer]) -> Hash[Symbol, Integer]
+  def ys: (Hash[Symbol, String]) -> Hash[Symbol, String]
+  def yp: (Hash[Symbol, Float]) -> Hash[Symbol, Float]
+end

--- a/test/rbs/hashes.seed.expected
+++ b/test/rbs/hashes.seed.expected
@@ -1,0 +1,7 @@
+class Hashes
+meth si str_int_hash str_int_hash
+meth ss str_str_hash str_str_hash
+meth sp str_poly_hash str_poly_hash
+meth yi sym_int_hash sym_int_hash
+meth ys sym_str_hash sym_str_hash
+meth yp sym_poly_hash sym_poly_hash

--- a/test/rbs/ivars.rbs
+++ b/test/rbs/ivars.rbs
@@ -1,0 +1,8 @@
+# All four ivar sources emit an `ivar` line: attr_accessor / attr_reader
+# / attr_writer and a bare `@name: Type` instance-variable declaration.
+class Ivars
+  attr_accessor acc: String
+  attr_reader rd: Integer
+  attr_writer wr: Symbol
+  @direct: Float
+end

--- a/test/rbs/ivars.seed.expected
+++ b/test/rbs/ivars.seed.expected
@@ -1,0 +1,5 @@
+class Ivars
+ivar acc string
+ivar rd int
+ivar wr symbol
+ivar @direct float

--- a/test/rbs/members.rbs
+++ b/test/rbs/members.rbs
@@ -1,0 +1,7 @@
+# Member kinds: instance method (meth), singleton method (cmeth via
+# `def self.`), and `def self?.` which emits BOTH a meth and a cmeth.
+class Members
+  def inst: (Integer) -> String
+  def self.cls: (Integer) -> String
+  def self?.both: (Integer) -> String
+end

--- a/test/rbs/members.seed.expected
+++ b/test/rbs/members.seed.expected
@@ -1,0 +1,5 @@
+class Members
+meth inst string int
+cmeth cls string int
+meth both string int
+cmeth both string int

--- a/test/rbs/nominal.rbs
+++ b/test/rbs/nominal.rbs
@@ -1,0 +1,7 @@
+# Nominal class types map to obj_<QualifiedName>, with `::` flattened
+# to `_`. No symbol table is consulted; the mapping is purely
+# structural.
+class Holder
+  def a: (Foo) -> Foo
+  def b: (Foo::Bar) -> Foo::Bar
+end

--- a/test/rbs/nominal.seed.expected
+++ b/test/rbs/nominal.seed.expected
@@ -1,0 +1,3 @@
+class Holder
+meth a obj_Foo obj_Foo
+meth b obj_Foo_Bar obj_Foo_Bar

--- a/test/rbs/nullable.rbs
+++ b/test/rbs/nullable.rbs
@@ -1,0 +1,8 @@
+# `T?` and the two-arm `T | nil` / `nil | T` unions both reduce to the
+# nilable tag `<T>?`. Doubled nullability and `nil?` are normalized.
+class Nullable
+  def a: (String?) -> Integer?
+  def b: (String | nil) -> (nil | Integer)
+  def c: (Foo?) -> Foo?
+  def d: (Array[String]?) -> Array[Integer]?
+end

--- a/test/rbs/nullable.seed.expected
+++ b/test/rbs/nullable.seed.expected
@@ -1,0 +1,5 @@
+class Nullable
+meth a int? string?
+meth b int? string?
+meth c obj_Foo? obj_Foo?
+meth d int_array? str_array?

--- a/test/rbs/overloads.rbs
+++ b/test/rbs/overloads.rbs
@@ -1,0 +1,13 @@
+# Only the first overload is considered. `first_ok`'s first overload is
+# in-subset, so it is emitted (the String overload is ignored).
+# `first_bad`'s first overload is a proc type (out of subset), so the
+# whole method is dropped even though a later overload is in-subset.
+class Overloads
+  def first_ok: (Integer) -> Integer
+              | (String) -> String
+
+  def first_bad: (^(Integer) -> void) -> void
+               | (Integer) -> Integer
+
+  def kept: (Integer) -> Integer
+end

--- a/test/rbs/overloads.seed.expected
+++ b/test/rbs/overloads.seed.expected
@@ -1,0 +1,3 @@
+class Overloads
+meth first_ok int int
+meth kept int int

--- a/test/rbs/scalars.rbs
+++ b/test/rbs/scalars.rbs
@@ -1,0 +1,12 @@
+# Scalar type vocabulary: every primitive RBS type that reduces to a
+# single spinel tag, plus the return-only `void`.
+class Scalars
+  def i: (Integer) -> Integer
+  def f: (Float) -> Float
+  def s: (String) -> String
+  def y: (Symbol) -> Symbol
+  def b: (bool) -> bool
+  def t: (TrueClass) -> FalseClass
+  def n: (NilClass) -> nil
+  def v: () -> void
+end

--- a/test/rbs/scalars.seed.expected
+++ b/test/rbs/scalars.seed.expected
@@ -1,0 +1,9 @@
+class Scalars
+meth i int int
+meth f float float
+meth s string string
+meth y symbol symbol
+meth b bool bool
+meth t bool bool
+meth n nil nil
+meth v nil -

--- a/test/rbs/union_poly.rbs
+++ b/test/rbs/union_poly.rbs
@@ -1,0 +1,9 @@
+# Heterogeneous unions (anything other than the two-arm `T | nil`
+# nilable shape) have no single concrete C representation, so they map
+# to the bare `poly` tag (sp_RbVal, the tagged union) rather than
+# dropping the whole seed. Regression guard for matz/spinel#1255.
+class Unions
+  def two: (Integer | String) -> (Integer | String)
+  def three: (Integer | String | Symbol) -> void
+  def with_nil: (Integer | String | nil) -> void
+end

--- a/test/rbs/union_poly.seed.expected
+++ b/test/rbs/union_poly.seed.expected
@@ -1,0 +1,4 @@
+class Unions
+meth two poly poly
+meth three nil poly
+meth with_nil nil poly

--- a/test/rbs/unqualified.rbs
+++ b/test/rbs/unqualified.rbs
@@ -1,0 +1,13 @@
+# Unqualified type resolution: inside `module Geo; class Point`, a bare
+# `Base` resolves to obj_Geo_Base via single-level parent fallback, and
+# `Point` resolves to obj_Geo_Point. The enclosing class name is
+# flattened to Geo_Point.
+module Geo
+  class Base
+  end
+
+  class Point
+    def base: () -> Base
+    def twin: (Point) -> Point
+  end
+end

--- a/test/rbs/unqualified.seed.expected
+++ b/test/rbs/unqualified.seed.expected
@@ -1,0 +1,4 @@
+class Geo
+class Geo_Point
+meth base obj_Geo_Base -
+meth twin obj_Geo_Point obj_Geo_Point


### PR DESCRIPTION
## Summary

Fixes the RBS-annotation path for #1255. `map_type`'s `RBS_TYPES_UNION` arm only accepted the `T | nil` shape (→ `T?`); **every other union returned `false`**. Because a `false` return type makes `emit_method` bail, the *entire* method seed was dropped — not just the return slot. With no seed, the analyzer infers freely and `unify_return_type` collapses e.g. `{int, string}` to a single concrete C type, producing the `incompatible integer to pointer conversion` error from the issue's `Rec#[]` repro.

This maps any non-`T | nil` union to **`poly`** (`sp_RbVal`, the tagged union) — the same target `untyped` already uses. It's the faithful choice: spinel's only representation for "one of several incompatible types" *is* the tagged union, so boxing is correct, and the seed now survives extraction instead of silently vanishing.

- `T | nil` → `T?` (precision preserved, unchanged)
- `T | nil` where `T` is itself out-of-subset → falls through to `poly`
- any other union (`Integer | String`, 3+ members, etc.) → `poly`

## Relationship to the `unify_return_type` work scoped in #1255

This is deliberately a **different layer** from the inference-level fix you scoped as "larger, separate work." That fix is blocked because `unify_return_type` (which treats `int` as an unresolved-default) is load-bearing for self-hosting — widening inferred `{int, string}` to poly breaks the stage-2 `sp_StrArray_push` sites.

The RBS-seed extractor has no such constraint: **the self-host build ships no `.rbs` files**, so `spinel_rbs_extract` never runs on the compiler's own source and stage-2 inference is untouched. This change only affects code that *explicitly* annotates a heterogeneous union in RBS — exactly the `-> untyped`-equivalent the issue recommends as the workaround, now working for the precise union form (`-> (Integer | String)`) too. So a consumer (e.g. roundhouse) can emit the *correct, precise* union — good for Steep/TypeProf/humans — and spinel does the representation-collapse at consumption time, where it belongs.

## Verification

Against the issue's own repro:

```ruby
# rec.rb
class Rec
  def initialize; @id = 7; @name = "hi"; end
  def [](field)
    case field
    when :id then @id
    when :name then @name
    end
  end
end
r = Rec.new
puts r[:id]; puts r[:name]
```
```rbs
# sig/rec.rbs
class Rec
  def []: (Symbol field) -> (Integer | String)
end
```

Before: `spinel --rbs sig rec.rb` → `incompatible integer to pointer conversion`.
After: compiles and runs (`7` / `hi`); `spinel_rbs_extract sig` emits `meth [] poly symbol`. A sibling `def maybe: () -> (Integer | nil)` still emits `meth maybe int? -`, confirming the `T?` path is unchanged.

## Tests

No automated test is included: the RBS→seed extractor currently has no in-suite test harness — the standard `test/*.rb` runner never passes `--rbs` (no `.rbs` fixtures under `test/`), and `experiments/rbs/` is a manual spike with a hand-written seed. Establishing an extractor test mechanism felt out of scope for this one-arm fix; happy to add one (e.g. a harness step that diffs `spinel_rbs_extract` output against an expected seed) if you'd like it as part of this PR.