### PR TITLE
Install sp_types.h in make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -677,6 +677,7 @@ install: all
 	install -m 644 spinel_codegen.rb     $(SPNLDIR)/
 	install -m 644 lib/libspinel_rt.a    $(SPNLDIR)/lib/
 	install -m 644 lib/sp_runtime.h      $(SPNLDIR)/lib/
+	install -m 644 lib/sp_types.h        $(SPNLDIR)/lib/
 	install -m 644 lib/sp_core.h         $(SPNLDIR)/lib/
 	install -m 644 lib/sp_time.h         $(SPNLDIR)/lib/
 	install -m 644 lib/sp_net.h          $(SPNLDIR)/lib/


### PR DESCRIPTION
sp_runtime.h includes sp_types.h, but the install target did not copy it. This caused C compilation to fail for any Spinel-compiled program using FFI after a fresh `make install`.