### PR TITLE
Dispatch implicit-self calls with covariant object return types (fixes #1277)

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -19141,9 +19141,15 @@ class Compiler
                 # suppresses dispatch entirely (matz/spinel#1277).
                 base_bt = base_type(base_rt)
                 cand_bt = base_type(cand_rt)
-                if is_obj_type(base_bt) == 1 && is_obj_type(cand_bt) == 1 &&
-                   cls_is_descendant(find_class_idx(cand_bt[4, cand_bt.length - 4]),
-                                     find_class_idx(base_bt[4, base_bt.length - 4])) == 1
+                covariant = 0
+                if is_obj_type(base_bt) == 1 && is_obj_type(cand_bt) == 1
+                  # Strip the "obj_" prefix (codebase idiom) to name the
+                  # classes, then test the subtype relationship.
+                  base_cls = find_class_idx(base_bt[4, base_bt.length - 4])
+                  cand_cls = find_class_idx(cand_bt[4, cand_bt.length - 4])
+                  covariant = cls_is_descendant(cand_cls, base_cls)
+                end
+                if covariant == 1
                   ol = ol + 1
                 else
                   rt_ok = 0
@@ -19174,11 +19180,17 @@ class Compiler
                 cand_name = @cls_names[cand_owner2]
                 cand_recv = "(sp_" + cand_name + " *)" + self_expr
                 cand_call = "sp_" + cand_name + "_" + sanitize_name(mname) + "(" + cand_recv + build_call_tail(ca, bp, yargs) + ")"
-                # Upcast the override result to the base return C type:
-                # with a covariant object return the arm's call yields a
-                # subtype pointer (sp_Sub *) while tmp is the base type
-                # (sp_Base *). A no-op when the types already match.
-                emit("    case " + cand_cid.to_s + "LL: " + tmp + " = (" + rt_c + ")" + cand_call + "; break;")
+                # Upcast covariant object returns to the base C type: the
+                # arm's call yields a subtype pointer (sp_Sub *) while tmp is
+                # the base type (sp_Base *). Only emit the cast when the C
+                # types actually differ, so an exact-match arm keeps full
+                # compiler diagnostics (matz/spinel#1277).
+                cand_arm_rt = cls_method_return(cand_owner2, mname)
+                arm_val = cand_call
+                if c_type(cand_arm_rt) != rt_c
+                  arm_val = "(" + rt_c + ")" + cand_call
+                end
+                emit("    case " + cand_cid.to_s + "LL: " + tmp + " = " + arm_val + "; break;")
                 ol2 = ol2 + 1
               end
               emit("    default: " + tmp + " = " + default_call + "; break;")

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -19131,8 +19131,24 @@ class Compiler
               cand_owner = p[1].to_i
               cand_rt = cls_method_return(cand_owner, mname)
               if c_type(cand_rt) != base_rt_c
-                rt_ok = 0
-                ol = ovr_list.length
+                # Covariant object return: the override returns a proper
+                # subtype of the base's declared return (e.g. an RBS base
+                # `() -> Base` with a subclass `() -> Sub`, or `self`-
+                # returning per-model primitives). The C types differ
+                # (sp_Sub* vs sp_Base*) but the dispatch is still valid —
+                # the switch arm upcasts the result to the base C type.
+                # Without this, an RBS signature on the base method
+                # suppresses dispatch entirely (matz/spinel#1277).
+                base_bt = base_type(base_rt)
+                cand_bt = base_type(cand_rt)
+                if is_obj_type(base_bt) == 1 && is_obj_type(cand_bt) == 1 &&
+                   cls_is_descendant(find_class_idx(cand_bt[4, cand_bt.length - 4]),
+                                     find_class_idx(base_bt[4, base_bt.length - 4])) == 1
+                  ol = ol + 1
+                else
+                  rt_ok = 0
+                  ol = ovr_list.length
+                end
               else
                 ol = ol + 1
               end
@@ -19158,7 +19174,11 @@ class Compiler
                 cand_name = @cls_names[cand_owner2]
                 cand_recv = "(sp_" + cand_name + " *)" + self_expr
                 cand_call = "sp_" + cand_name + "_" + sanitize_name(mname) + "(" + cand_recv + build_call_tail(ca, bp, yargs) + ")"
-                emit("    case " + cand_cid.to_s + "LL: " + tmp + " = " + cand_call + "; break;")
+                # Upcast the override result to the base return C type:
+                # with a covariant object return the arm's call yields a
+                # subtype pointer (sp_Sub *) while tmp is the base type
+                # (sp_Base *). A no-op when the types already match.
+                emit("    case " + cand_cid.to_s + "LL: " + tmp + " = (" + rt_c + ")" + cand_call + "; break;")
                 ol2 = ol2 + 1
               end
               emit("    default: " + tmp + " = " + default_call + "; break;")


### PR DESCRIPTION
Fixes #1277.

## Problem

An implicit-self call to an overridable method, made inside an **inherited base-class instance method**, is compiled as a static call to the **base** implementation (no virtual dispatch) when the override has a **covariant return type** — i.e. it returns a subtype of the base method's declared return. The subclass override silently never runs.

This surfaces when an RBS signature pins the base method's return to the base class (`def m: () -> Base`) while the subclass override returns the concrete subclass (`() -> Sub`). Without `--rbs`, inference unifies the return types so the bug is hidden; the RBS signature *regresses* otherwise-working dispatch.

## Root cause

In `compile_no_recv_call_expr`, the `cls_id`-switch dispatch for an implicit-self call is gated on every override's return **C type** being exactly equal to the base's:

```ruby
if c_type(cand_rt) != base_rt_c
  rt_ok = 0          # → no switch → static call to the base (empty) impl
```

A covariant object return makes `c_type(cand_rt)` (`sp_Sub *`) differ from `base_rt_c` (`sp_Base *`), so `rt_ok` goes to 0 and the polymorphic switch is suppressed. (A scalar-returning override such as `() -> Integer` on both sides matches, which is why e.g. `Integer`-returning primitives still dispatch correctly — only covariant *object* returns regress.)

## Fix

Accept a covariant object return — the override's class is a descendant of the base's declared return class — and upcast the override's result to the base C type in the switch arm (a no-op when the types already match). Reuses the existing `cls_is_descendant` / `find_class_idx` / `is_obj_type` helpers; ~15 lines in one function. Non-covariant mismatches (e.g. `Integer` vs `String`) still correctly suppress the switch.

## Minimal repro

`r.rb`:
```ruby
class Base
  def initialize; @title = "old"; end
  def title; @title; end
  def refresh; end                 # overridable primitive, empty on Base
  def reload; refresh; self; end   # inherited; bare implicit-self call
end
class Sub < Base
  def refresh; @title = "new"; self; end
end
s = Sub.new
s.reload
puts s.title                       # expect "new"
```

`sig/r.rbs` (the entire trigger is one line):
```rbs
class Base
  def refresh: () -> Base
end
```

```
$ ruby r.rb
new
$ spinel r.rb -o a && ./a              # no RBS
new
$ spinel --rbs sig r.rb -o b && ./b    # with RBS
old    # before this PR — Sub#refresh never ran
new    # after this PR
```

Generated `Base#reload`, before vs after:
```c
// before: static bind to the empty base impl
sp_Base_refresh(self);

// after: correct dispatch, override result upcast to the base type
switch (self->cls_id) {
  case 48LL: _t1 = (sp_Base *)sp_Sub_refresh((sp_Sub *)self); break;
  default:   _t1 = sp_Base_refresh(self); break;
}
```

## Validation

- `make test`: **776 pass, 0 fail, 0 error** (+ 13 RBS-extractor tests).
- The patched compiler self-compiles (bootstrap) cleanly.

## Note on a regression test

The standard `test/*.rb` harness invokes `spinel_analyze` without an RBS seed, and this bug only manifests with `--rbs` (plain inference unifies the return types and hides it), so it doesn't fit the existing per-test harness. The repro above is self-contained; happy to add it under whatever RBS-seeded end-to-end test mechanism you'd prefer.
