### PR TITLE
Add `spinel --debug` / `-g`: #line-mapped builds for native-debugger stepping

### DIFF
--- a/compiler_helpers.rb
+++ b/compiler_helpers.rb
@@ -466,6 +466,8 @@ class Compiler
     @nd_type.push("")
     @nd_name.push("")
     @nd_value.push(0)
+    @nd_line.push(0)   # keep the source-map arrays parallel with the rest, so a
+    @nd_file.push(0)   # dynamically-allocated node can't drift them out of sync
     @nd_content.push("")
     @nd_flags.push(0)
     @nd_operator.push("")
@@ -529,6 +531,7 @@ class Compiler
     @nd_name = Array.new(n, "")
     @nd_value = Array.new(n, 0)
     @nd_line = Array.new(n, 0)
+    @nd_file = Array.new(n, 0)
     @nd_content = Array.new(n, "")
     @nd_flags = Array.new(n, 0)
     @nd_operator = Array.new(n, "")
@@ -673,6 +676,21 @@ class Compiler
     if field == "node_line"
       @nd_line[nid] = val
     end
+ # Debug multi-file map: id into the FILE table (0 = toplevel source).
+    if field == "node_file"
+      @nd_file[nid] = val
+    end
+  end
+
+ # Debug multi-file map: record a FILE <id> <path> table entry emitted by
+ # the parser. Grown on demand so ids can arrive in any order.
+  def set_file_entry(id, path)
+    @file_table ||= []   # self-contained: the analyze/codegen consumers init it,
+                         # but don't rely on that from this shared helper
+    while @file_table.length <= id
+      @file_table.push("")
+    end
+    @file_table[id] = path
   end
 
   def set_ref_field(nid, field, ref_id)

--- a/compiler_helpers.rb
+++ b/compiler_helpers.rb
@@ -528,6 +528,7 @@ class Compiler
     @nd_type = Array.new(n, "")
     @nd_name = Array.new(n, "")
     @nd_value = Array.new(n, 0)
+    @nd_line = Array.new(n, 0)
     @nd_content = Array.new(n, "")
     @nd_flags = Array.new(n, 0)
     @nd_operator = Array.new(n, "")
@@ -664,6 +665,13 @@ class Compiler
  # UnsupportedNode carries the source line so codegen can cite
  # location in the compile error.
       @nd_value[nid] = val
+    end
+ # Debug builds only (SPINEL_DEBUG=1): the parser stamps every node
+ # with its 1-based source line in a dedicated slot so codegen can
+ # emit `#line` directives. Kept separate from @nd_value, which is
+ # overloaded for integer/float literal values, numbered-param max, etc.
+    if field == "node_line"
+      @nd_line[nid] = val
     end
   end
 

--- a/node_table_loader.rb
+++ b/node_table_loader.rb
@@ -32,6 +32,14 @@ class NodeTableLoader
               @table.set_source_file_path(unescape_str(parts[1]))
             end
           end
+ # Debug multi-file map (FILE <id> <escaped-path>): records which
+ # original file each node's `node_file` id refers to, so codegen can
+ # emit `#line N "file"` across require_relative-inlined sources.
+          if parts.first == "FILE"
+            if parts.length >= 3
+              @table.set_file_entry(parts[1].to_i, unescape_str(parts[2]))
+            end
+          end
           if parts.first == "N"
             nid = parts[1].to_i
             if nid > max_id

--- a/spinel
+++ b/spinel
@@ -18,6 +18,9 @@
 #              first .rb file ends spinel-flag parsing, and the rest
 #              of the command line becomes the binary's ARGV.
 #   -O LEVEL   Optimization level for cc (default: 2)
+#   --debug    Debug build: #line directives + non-inlined methods + -g -O0,
+#              so gdb/lldb step through the original .rb source
+#   -g         Add debug info + #line without forcing -O0
 #   --cc=CMD   C compiler command (default: cc)
 #   -e STR     Inline Ruby source (repeatable; multiple -e join with \n)
 
@@ -49,6 +52,7 @@ RUN_MODE=0
 OPT_LEVEL="2"
 CC_CMD="cc"
 EXTRA_FLAGS=""
+DEBUG=0
 C_TMP=""
 C_TMP_DIR=""
 RUN_TMP_DIR=""
@@ -98,6 +102,14 @@ while [ $# -gt 0 ]; do
                 ;;
     -o)         shift; OUTPUT="$1"; shift ;;
     -O)         shift; OPT_LEVEL="$1"; shift ;;
+    --debug)    # Debug build: native-debugger stepping through Ruby.
+                # Emits #line directives + keeps methods non-inlined
+                # (SPINEL_DEBUG=1), forces -O0 and adds -g.
+                DEBUG=1; OPT_LEVEL="0"; shift ;;
+    -g)         # Debug info + #line, but leave -O as-is (a -g build at
+                # the default -O2 gives lossy DWARF; use --debug for
+                # faithful stepping).
+                DEBUG=1; shift ;;
     -e)         shift
                 if [ "$EVAL_USED" -eq 0 ]; then
                   EVAL_SCRIPT="$1"
@@ -197,6 +209,9 @@ if [ -z "$SOURCE" ]; then
   echo "  -S          Print C to stdout" >&2
   echo "  -E          Run the compiled binary; leftover args become its ARGV" >&2
   echo "  -O LEVEL    Optimization level (default: 2)" >&2
+  echo "  --debug     Debug build: step through the .rb in gdb/lldb" >&2
+  echo "              (emits #line, keeps methods non-inlined, -g -O0)" >&2
+  echo "  -g          Add debug info + #line without forcing -O0" >&2
   echo "  --cc=CMD    C compiler (default: cc)" >&2
   echo "  -e STR      Inline Ruby source (repeatable; joined with newlines)" >&2
   echo "  --rbs DIR   Seed analyzer with RBS signatures from DIR (advisory)" >&2
@@ -220,6 +235,14 @@ fi
 AST_TMP="$(mktemp /tmp/spinel_ast.XXXXXX)"
 IR_TMP="$(mktemp /tmp/spinel_ir.XXXXXX)"
 trap 'rm -f "$AST_TMP" "$IR_TMP" "$EVAL_TMP" "$SEED_TMP"; [ -n "$C_TMP_DIR" ] && rm -rf "$C_TMP_DIR"; [ -n "$RUN_TMP_DIR" ] && rm -rf "$RUN_TMP_DIR"' EXIT
+
+# Debug mode signal, read by the parser (per-node line stamps) and the
+# codegen (#line emission + non-inlined methods). Must be exported
+# before the parse step below since spinel_parse reads it at init.
+if [ "$DEBUG" -eq 1 ]; then
+  export SPINEL_DEBUG=1
+  EXTRA_FLAGS="$EXTRA_FLAGS -g"
+fi
 
 # Step 1: Parse. spinel_parse is C-only; build it via `make parse`
 # (or `make all`) before invoking spinel.

--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -34,6 +34,9 @@ class Compiler
     @nd_type = "".split(",", -1)
     @nd_name = "".split(",", -1)
     @nd_value = []
+    @nd_line = []
+    @nd_file = []
+    @file_table = []
     @nd_content = "".split(",", -1)
     @nd_flags = []
     @nd_operator = "".split(",", -1)

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -61,6 +61,10 @@ class Compiler
  # original Ruby. Off by default -> output byte-for-byte unchanged.
     @debug = (ENV["SPINEL_DEBUG"] == "1")
     @last_line_emitted = 0
+    @last_file_emitted = ""
+ # Debug multi-file map: FILE table (id -> path) populated from the AST's
+ # FILE records. Empty in single-file or non-debug builds.
+    @file_table = []
 
  # ---- AST node storage (parallel arrays by node ID) ----
  # Use "".split(",", -1) for StrArray init (v1 infers StrArray from split)
@@ -68,6 +72,7 @@ class Compiler
     @nd_name = "".split(",", -1)
     @nd_value = []
     @nd_line = []
+    @nd_file = []
     @nd_content = "".split(",", -1)
     @nd_flags = []
     @nd_operator = "".split(",", -1)
@@ -3256,17 +3261,26 @@ class Compiler
     if ln <= 0
       return
     end
-    if ln == @last_line_emitted
+ # Resolve the node's original file via the multi-file map (FILE table);
+ # fall back to the toplevel source path for single-file / id-0 nodes.
+    path = ""
+    fid = @nd_file[nid]
+    if fid != nil && fid >= 0 && fid < @file_table.length
+      path = @file_table[fid]
+    end
+    if path == nil || path == ""
+      path = @source_file_path
+    end
+    if path == nil || path == ""
+      path = "source.rb"
+    end
+ # Suppress only a consecutive duplicate of the *same* (line, file): across
+ # a file boundary the same line number must still re-emit.
+    if ln == @last_line_emitted && path == @last_file_emitted
       return
     end
     @last_line_emitted = ln
-    path = @source_file_path
-    if path == nil
-      path = "source.rb"
-    end
-    if path == ""
-      path = "source.rb"
-    end
+    @last_file_emitted = path
     @out_lines.push("#line " + ln.to_s + " \"" + path + "\"")
   end
 

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -55,11 +55,19 @@ class Compiler
  # the cache is up-to-date and the override stays off.
     @int_overflow_mode = ENV["SPINEL_INT_OVERFLOW"] || "raise"
 
+ # Debug builds (`spinel --debug` / `-g`, which export SPINEL_DEBUG=1):
+ # emit `#line N "src.rb"` before each statement and keep every method a
+ # real (non-inlined) frame, so a native debugger steps through the
+ # original Ruby. Off by default -> output byte-for-byte unchanged.
+    @debug = (ENV["SPINEL_DEBUG"] == "1")
+    @last_line_emitted = 0
+
  # ---- AST node storage (parallel arrays by node ID) ----
  # Use "".split(",", -1) for StrArray init (v1 infers StrArray from split)
     @nd_type = "".split(",", -1)
     @nd_name = "".split(",", -1)
     @nd_value = []
+    @nd_line = []
     @nd_content = "".split(",", -1)
     @nd_flags = []
     @nd_operator = "".split(",", -1)
@@ -3226,6 +3234,40 @@ class Compiler
 
   def emit_raw(s)
     @out_lines.push(s)
+  end
+
+ # Debug builds: emit a C `#line N "src.rb"` directive (column 0) so the
+ # C toolchain's DWARF maps generated code back to the original Ruby
+ # source. No-op unless @debug. `node_line` is stamped per-node by the
+ # parser under SPINEL_DEBUG (a dedicated slot, never the overloaded
+ # @nd_value). Consecutive duplicates are suppressed so a multi-line
+ # statement doesn't reset to the same line repeatedly.
+  def emit_line_directive(nid)
+    if @debug == false
+      return
+    end
+    if nid < 0
+      return
+    end
+    ln = @nd_line[nid]
+    if ln == nil
+      return
+    end
+    if ln <= 0
+      return
+    end
+    if ln == @last_line_emitted
+      return
+    end
+    @last_line_emitted = ln
+    path = @source_file_path
+    if path == nil
+      path = "source.rb"
+    end
+    if path == ""
+      path = "source.rb"
+    end
+    @out_lines.push("#line " + ln.to_s + " \"" + path + "\"")
   end
 
 
@@ -9918,6 +9960,13 @@ class Compiler
  # no yield, and not self-recursive are considered inlineable.
 
   def method_linkage_named(body_id, has_yield, mname)
+ # Debug builds: never promote to `static inline`. An inlined method has
+ # no distinct frame after the C compiler runs, so a native debugger
+ # can't break on it or show it in a backtrace. Keep every method a real
+ # `static` function for faithful stepping (paired with cc -O0).
+    if @debug
+      return "static "
+    end
     if has_yield == 1
       return "static "
     end
@@ -34914,6 +34963,7 @@ class Compiler
     if nid < 0
       return
     end
+    emit_line_directive(nid)
     t = @nd_type[nid]
     if t == "UnsupportedNode"
  # Imaginary / Rational now have proper nodes (#840 #841). Any
@@ -49358,6 +49408,12 @@ class Compiler
       i = i + 1
     end
     last = stmts.last
+ # Debug builds: the method's tail (implicit-return) expression is
+ # compiled through the specialized paths below, not compile_stmt, so
+ # stamp its source line here too — otherwise it would inherit the
+ # previous statement's #line and only map correctly by C/Ruby line
+ # coincidence.
+    emit_line_directive(last)
     if @nd_type[last] == "ReturnNode"
       compile_return_stmt(last)
       return

--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -71,6 +71,13 @@ static char *g_source_file_escaped = NULL;  /* escape_str(g_source_file), set on
    `node_line` field so codegen can place C `#line` directives. Off by
    default so the AST text format (and golden tests) are unchanged. */
 static int g_emit_line = 0;
+/* Debug multi-file source map, populated by sp_build_line_map() before
+   flatten() runs and read in flatten() to attribute each node to its
+   original file/line. Declared here because flatten() precedes the
+   require-resolution machinery that defines the builder. */
+static int *sp_line_file = NULL;  /* buffer line (1-based) -> file id */
+static int *sp_line_orig = NULL;  /* buffer line (1-based) -> original line */
+static int sp_line_map_n = 0;
 
 static char *cstr(pm_constant_id_t id) {
   if (id == 0) return strdup("");
@@ -232,15 +239,24 @@ static int flatten(pm_node_t *node) {
   int id = node_counter++;
   pm_node_type_t t = PM_NODE_TYPE(node);
 
-  /* Debug builds only: stamp every node with its 1-based source line so
-     codegen can emit `#line` directives. Same newline-list lookup the
-     __LINE__ / UnsupportedNode cases already use; written to a dedicated
-     `node_line` field (NOT the overloaded `value`/`start_line` slot). */
+  /* Debug builds only: stamp every node with its source line — and, when a
+     multi-file map was built, its original file — so codegen can emit
+     `#line N "file"` directives. Written to dedicated `node_line` /
+     `node_file` fields (NOT the overloaded `value`/`start_line` slot). The
+     raw value is the line in the concatenated buffer; the map translates it
+     back to the original file and line. */
   if (g_emit_line) {
-    int32_t node_line = pm_newline_list_line(&g_parser->newline_list,
-                                             node->location.start,
-                                             g_parser->start_line);
-    emit_int(id, "node_line", (long long)node_line);
+    int32_t bl = pm_newline_list_line(&g_parser->newline_list,
+                                      node->location.start,
+                                      g_parser->start_line);
+    int orig = bl;
+    int fid = 0;
+    if (sp_line_map_n > 0 && bl >= 1 && bl <= sp_line_map_n) {
+      orig = sp_line_orig[bl];
+      fid = sp_line_file[bl];
+    }
+    emit_int(id, "node_line", (long long)orig);
+    emit_int(id, "node_file", (long long)fid);
   }
 
 #define N(type_name) out_add("N %d " type_name, id)
@@ -1489,6 +1505,108 @@ static void sp_includes_free(void) {
   sp_included_cap = 0;
 }
 
+/* ---- Debug multi-file source map (g_emit_line only) -------------------
+   require/require_relative are resolved by *textual* splicing into one
+   buffer, so a node's Prism line is a line in that concatenated buffer and
+   the original file boundaries are lost. For --debug we recover them: each
+   spliced file's content is wrapped in PUSH/POP marker *comments* (Prism
+   ignores comments, so the AST is unchanged), and a single pass over the
+   final buffer reconstructs, per buffer line, which file and original line
+   it came from. The stack accounting needs no original-line bookkeeping at
+   splice time: a PUSH consumes the parent's (replaced) require line, then
+   content lines count within the child's own coordinates until POP. */
+#define SP_PUSH_PREFIX "#<SPINEL_PUSH>"
+#define SP_POP_PREFIX "#<SPINEL_POP>"
+
+static char **sp_file_table = NULL;  /* id -> path */
+static int sp_file_count = 0, sp_file_cap = 0;
+
+static int sp_intern_file(const char *path) {
+  for (int i = 0; i < sp_file_count; i++)
+    if (strcmp(sp_file_table[i], path) == 0) return i;
+  if (sp_file_count >= sp_file_cap) {
+    int nc = sp_file_cap == 0 ? 8 : sp_file_cap * 2;
+    char **np = (char **)realloc(sp_file_table, sizeof(char *) * nc);
+    if (!np) { fprintf(stderr, "spinel_parse: out of memory\n"); exit(1); }
+    sp_file_table = np; sp_file_cap = nc;
+  }
+  char *dup_path = strdup(path);
+  if (!dup_path) { fprintf(stderr, "spinel_parse: out of memory\n"); exit(1); }
+  sp_file_table[sp_file_count] = dup_path;
+  return sp_file_count++;
+}
+
+/* In debug mode, wrap an included file's (already-resolved) content with
+   PUSH <path> / POP marker lines. Takes ownership of `content`; returns it
+   unchanged when not in debug mode. */
+static char *sp_wrap_included(char *content, const char *path) {
+  if (!g_emit_line) return content;
+  size_t clen = strlen(content);
+  int need_nl = (clen > 0 && content[clen - 1] != '\n') ? 1 : 0;
+  size_t total = strlen(SP_PUSH_PREFIX) + strlen(path) + 1 + clen + need_nl
+               + strlen(SP_POP_PREFIX) + 1 + 1;
+  char *w = malloc(total + 8);
+  if (!w) { fprintf(stderr, "spinel_parse: out of memory\n"); exit(1); }
+  size_t o = (size_t)sprintf(w, SP_PUSH_PREFIX "%s\n", path);
+  memcpy(w + o, content, clen); o += clen;
+  if (need_nl) w[o++] = '\n';
+  o += (size_t)sprintf(w + o, SP_POP_PREFIX "\n");
+  w[o] = '\0';
+  free(content);
+  return w;
+}
+
+/* Reconstruct the line map from the final spliced buffer. toplevel is the
+   path of the outermost file (interned as the initial frame). */
+static void sp_build_line_map(const char *src, const char *toplevel) {
+  size_t nlines = 1;
+  for (const char *p = src; *p; p++) if (*p == '\n') nlines++;
+  sp_line_map_n = (int)nlines;
+  sp_line_file = (int *)calloc(nlines + 2, sizeof(int));
+  sp_line_orig = (int *)calloc(nlines + 2, sizeof(int));
+
+  int *stk_file = (int *)malloc(sizeof(int) * (nlines + 2));
+  int *stk_next = (int *)malloc(sizeof(int) * (nlines + 2));
+  if (!sp_line_file || !sp_line_orig || !stk_file || !stk_next) {
+    fprintf(stderr, "spinel_parse: out of memory\n"); exit(1);
+  }
+  int sp = 0;
+  stk_file[sp] = sp_intern_file(toplevel);
+  stk_next[sp] = 1;
+
+  int bl = 1;
+  const char *line = src;
+  while (1) {
+    const char *eol = strchr(line, '\n');
+    size_t len = eol ? (size_t)(eol - line) : strlen(line);
+    if (strncmp(line, SP_PUSH_PREFIX, strlen(SP_PUSH_PREFIX)) == 0) {
+      /* The replaced require occupied one parent line: consume it. */
+      if (sp >= 0) stk_next[sp] += 1;
+      char pathbuf[1024];
+      size_t plen = len - strlen(SP_PUSH_PREFIX);
+      if (plen >= sizeof(pathbuf)) plen = sizeof(pathbuf) - 1;
+      memcpy(pathbuf, line + strlen(SP_PUSH_PREFIX), plen);
+      pathbuf[plen] = '\0';
+      sp++;
+      stk_file[sp] = sp_intern_file(pathbuf);
+      stk_next[sp] = 1;
+      /* marker line maps to nothing meaningful */
+    } else if (strncmp(line, SP_POP_PREFIX, strlen(SP_POP_PREFIX)) == 0) {
+      if (sp > 0) sp--;
+    } else {
+      sp_line_file[bl] = stk_file[sp];
+      sp_line_orig[bl] = stk_next[sp];
+      stk_next[sp] += 1;
+    }
+    bl++;
+    if (!eol) break;
+    line = eol + 1;
+    if (*line == '\0') break;
+  }
+  free(stk_file);
+  free(stk_next);
+}
+
 /* Simple require_relative resolver: replace lines matching
    require_relative "path" with the file content. Files that have
    already been included once are silently skipped on subsequent
@@ -1574,6 +1692,10 @@ static char *resolve_requires(const char *source, const char *source_path) {
       }
       free(canonical);
     }
+
+    /* Debug: wrap with PUSH/POP markers so the line map can attribute this
+       file's nodes to the right source. No-op outside --debug. */
+    content = sp_wrap_included(content, full_path);
 
     /* Replace the line */
     size_t line_len = (line_end - pos) + ((*line_end == '\n') ? 1 : 0);
@@ -1691,6 +1813,10 @@ static char *resolve_plain_requires(char *source, const char *exe_path) {
         content = resolved;
       }
     }
+
+    /* Debug: marker-wrap so plain-require'd lib content doesn't corrupt the
+       line map's accounting for code after the require. No-op without --debug. */
+    content = sp_wrap_included(content, lib_path);
 
     /* Replace only the `require "name"` statement itself, not the whole
        line, so `require "x"; code` keeps `code`. Consume trailing
@@ -1882,11 +2008,41 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+  /* Set the debug flag before resolving requires so the resolvers insert the
+     PUSH/POP markers used to rebuild the multi-file source map. */
+  {
+    const char *dbg = getenv("SPINEL_DEBUG");
+    g_emit_line = (dbg != NULL && dbg[0] == '1' && dbg[1] == '\0') ? 1 : 0;
+  }
+
   /* Resolve require_relative and plain require */
   char *resolved = resolve_requires(source, source_file);
   free(source);
   source = resolve_plain_requires(resolved, argv[0]);
+
+  /* Debug: build the buffer-line -> (file, original line) map from the
+     marker-annotated buffer *before* syntax-sugar rewriting (which could
+     touch a marker line's text). Sugar preserves line count, so the map
+     stays aligned with the parsed node lines; if that ever fails to hold,
+     disable the map rather than emit wrong attributions. */
+  char *premap = NULL;
+  if (g_emit_line) {
+    premap = strdup(source);
+    if (!premap) { fprintf(stderr, "spinel_parse: out of memory\n"); exit(1); }
+  }
   source = rewrite_syntax_sugar(source);
+  if (g_emit_line) {
+    size_t la = 1, lb = 1;
+    for (const char *p = premap; *p; p++) if (*p == '\n') la++;
+    for (const char *p = source; *p; p++) if (*p == '\n') lb++;
+    if (la == lb) {
+      sp_build_line_map(premap, source_file);
+    } else {
+      fprintf(stderr, "spinel_parse: --debug multi-file map disabled "
+                      "(syntax-sugar changed line count)\n");
+    }
+    free(premap);
+  }
 
   size_t source_len = strlen(source);
 
@@ -1913,10 +2069,6 @@ int main(int argc, char **argv) {
   g_parser = &parser;
   g_source_file = source_file;
   g_source_file_escaped = escape_str((const uint8_t *)g_source_file, strlen(g_source_file));
-  {
-    const char *dbg = getenv("SPINEL_DEBUG");
-    g_emit_line = (dbg != NULL && dbg[0] == '1' && dbg[1] == '\0') ? 1 : 0;
-  }
 
   /* Flatten AST to text */
   lines = NULL;
@@ -1954,6 +2106,13 @@ int main(int argc, char **argv) {
      even when the source contains no `__FILE__` reference. The
      loader stashes it in @source_file_path. */
   fprintf(out, "SOURCE_FILE %s\n", g_source_file_escaped);
+  /* Debug multi-file map: emit the id -> path table so codegen can resolve
+     each node's `node_file` id to a path for its `#line` directive. */
+  for (int i = 0; i < sp_file_count; i++) {
+    char *esc = escape_str((const uint8_t *)sp_file_table[i], strlen(sp_file_table[i]));
+    fprintf(out, "FILE %d %s\n", i, esc);
+    free(esc);
+  }
   for (size_t i = 0; i < line_count; i++) {
     fprintf(out, "%s\n", lines[i]);
     free(lines[i]);

--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -67,6 +67,10 @@ static void out_add(const char *fmt, ...) {
 static const pm_parser_t *g_parser;
 static const char *g_source_file = "";
 static char *g_source_file_escaped = NULL;  /* escape_str(g_source_file), set once at init */
+/* Debug builds: when SPINEL_DEBUG=1, flatten() emits a per-node
+   `node_line` field so codegen can place C `#line` directives. Off by
+   default so the AST text format (and golden tests) are unchanged. */
+static int g_emit_line = 0;
 
 static char *cstr(pm_constant_id_t id) {
   if (id == 0) return strdup("");
@@ -227,6 +231,17 @@ static int flatten(pm_node_t *node) {
 
   int id = node_counter++;
   pm_node_type_t t = PM_NODE_TYPE(node);
+
+  /* Debug builds only: stamp every node with its 1-based source line so
+     codegen can emit `#line` directives. Same newline-list lookup the
+     __LINE__ / UnsupportedNode cases already use; written to a dedicated
+     `node_line` field (NOT the overloaded `value`/`start_line` slot). */
+  if (g_emit_line) {
+    int32_t node_line = pm_newline_list_line(&g_parser->newline_list,
+                                             node->location.start,
+                                             g_parser->start_line);
+    emit_int(id, "node_line", (long long)node_line);
+  }
 
 #define N(type_name) out_add("N %d " type_name, id)
 #define S(field, val) do { char *_e = (val); emit_str(id, field, _e); free(_e); } while(0)
@@ -1898,6 +1913,10 @@ int main(int argc, char **argv) {
   g_parser = &parser;
   g_source_file = source_file;
   g_source_file_escaped = escape_str((const uint8_t *)g_source_file, strlen(g_source_file));
+  {
+    const char *dbg = getenv("SPINEL_DEBUG");
+    g_emit_line = (dbg != NULL && dbg[0] == '1' && dbg[1] == '\0') ? 1 : 0;
+  }
 
   /* Flatten AST to text */
   lines = NULL;


### PR DESCRIPTION
# Add `spinel --debug` / `-g`: `#line`-mapped builds for native-debugger stepping

## What

A debug build mode that makes a Spinel binary steppable in gdb/lldb against the
**original Ruby source**:

```sh
spinel app.rb --debug      # #line directives + non-inlined methods + -g -O0
spinel app.rb -g           # add #line + -g at the current -O
gdb ./app                  # break app.rb:42 ; step ; bt   -> Ruby lines
```

The codegen emits `#line <rubyline> "<rubyfile>"` directives mapping the
generated C back to the `.rb`, keeps methods non-inlined (so each Ruby method is
a real C frame), and the wrapper adds `-g -O0`. Multi-file: the `#line` map
follows `require_relative`'d sources, so stepping crosses file boundaries.

## Why

Today a compiled Spinel program is a black box to native tooling — a crash or a
breakpoint lands in generated C with no path back to the Ruby the developer
wrote. With `#line`, the line table points at the `.rb`, so breakpoints by
`app.rb:line`, single-stepping, and `bt` all speak Ruby. It's also the
foundation the inference-position export (`--emit-types`) and native
`Exception#backtrace` build on.

## Design / safety

- **Opt-in.** Without `--debug`/`-g`, codegen and the binary are byte-for-byte
  unchanged. `--debug` forces `-O0` and non-inlined methods for faithful
  stepping; `-g` is the lighter "add line info at the current `-O`" variant.
- The parser stamps each node with its `(file, line)`; codegen emits the
  matching `#line` directives and suppresses inlining under debug.

## Known limitation (please read)

`#line` directives perturb the C compiler's **DWARF variable-location** info: a
debugger then reads a function's **locals** from the wrong stack slot (their
zero-init) when that function has a GC-rooted (heap) local. **Source-line
stepping and the line table are correct** — breakpoints, stepping, and `bt` work;
only *local-value inspection* (`p lv_x`) is unreliable in heap-local functions.

This reproduces **cross-toolchain** (clang/lldb on macOS and gcc/gdb on Linux),
so it reads as a fundamental `#line`-vs-DWARF interaction rather than a one-compiler
bug. It's disclosed up front because it's load-bearing: a value-differential
tool we built around this sidesteps it by tracing a `#line`-free build and mapping
C lines back via the directives. Happy to discuss whether to narrow it (e.g.
emit `#line` only at statement boundaries, or gate per-function) in review.

## Validation

- `make test`: **787 pass / 0 fail / 0 err** (unchanged — debug is opt-in).
- A `--debug` build carries `#line app.rb:<n>` directives; gdb/lldb break on
  `.rb` lines and `bt` shows Ruby frames.

First of the debug-surface series; `--emit-types` (position-keyed inferred types)
and native `Exception#backtrace` build directly on this.
