### PR TITLE
Add `spinel --emit-types`: position-keyed inferred types + degrade diagnostics (JSON)

### DIFF
--- a/compiler_helpers.rb
+++ b/compiler_helpers.rb
@@ -468,6 +468,7 @@ class Compiler
     @nd_value.push(0)
     @nd_line.push(0)   # keep the source-map arrays parallel with the rest, so a
     @nd_file.push(0)   # dynamically-allocated node can't drift them out of sync
+    @nd_col.push(0)    # (and the self-host inferencer needs the literal push here)
     @nd_content.push("")
     @nd_flags.push(0)
     @nd_operator.push("")
@@ -532,6 +533,7 @@ class Compiler
     @nd_value = Array.new(n, 0)
     @nd_line = Array.new(n, 0)
     @nd_file = Array.new(n, 0)
+    @nd_col = Array.new(n, 0)
     @nd_content = Array.new(n, "")
     @nd_flags = Array.new(n, 0)
     @nd_operator = Array.new(n, "")
@@ -679,6 +681,10 @@ class Compiler
  # Debug multi-file map: id into the FILE table (0 = toplevel source).
     if field == "node_file"
       @nd_file[nid] = val
+    end
+ # Debug/types export: 0-based source column for hover position keys.
+    if field == "node_col"
+      @nd_col[nid] = val
     end
   end
 

--- a/spinel
+++ b/spinel
@@ -47,6 +47,7 @@ SOURCE=""
 OUTPUT=""
 C_ONLY=0
 EMIT_RBS=0
+EMIT_TYPES=0
 STDOUT_MODE=0
 RUN_MODE=0
 OPT_LEVEL="2"
@@ -122,6 +123,10 @@ $1"
     -c)         C_ONLY=1; shift ;;
     --emit-rbs) # Analyze-only: dump inferred signatures as RBS, no binary.
                 EMIT_RBS=1; shift ;;
+    --emit-types) # Analyze-only: dump per-position inferred types + degrade
+                  # diagnostics as JSON (for the ruby-lsp addon). Needs node
+                  # positions, so it turns on SPINEL_DEBUG below.
+                EMIT_TYPES=1; DEBUG=1; shift ;;
     -S)         STDOUT_MODE=1; shift ;;
     -E)         RUN_MODE=1; shift ;;
     *.rb)
@@ -177,6 +182,22 @@ if [ "$EMIT_RBS" -eq 1 ]; then
   fi
 fi
 
+# --emit-types is likewise analyze-only — reject the binary/C-output modes.
+if [ "$EMIT_TYPES" -eq 1 ]; then
+  if [ "$RUN_MODE" -eq 1 ]; then
+    echo "spinel: --emit-types cannot be combined with -E (run)" >&2
+    exit 2
+  fi
+  if [ "$C_ONLY" -eq 1 ]; then
+    echo "spinel: --emit-types cannot be combined with -c (C source only)" >&2
+    exit 2
+  fi
+  if [ "$STDOUT_MODE" -eq 1 ]; then
+    echo "spinel: --emit-types cannot be combined with -S (stdout)" >&2
+    exit 2
+  fi
+fi
+
 # `-e` mode: write the accumulated inline script to a temp file and
 # treat it as the source. Default output name is `a` since the
 # inline form has no .rb basename to derive from. If both -e and a
@@ -206,6 +227,7 @@ if [ -z "$SOURCE" ]; then
   echo "  -o FILE     Output file" >&2
   echo "  -c          C source only (don't compile)" >&2
   echo "  --emit-rbs  Dump inferred type signatures as RBS (-> app.rbs), no binary" >&2
+  echo "  --emit-types Dump per-position inferred types + degrade diagnostics as JSON" >&2
   echo "  -S          Print C to stdout" >&2
   echo "  -E          Run the compiled binary; leftover args become its ARGV" >&2
   echo "  -O LEVEL    Optimization level (default: 2)" >&2
@@ -289,6 +311,10 @@ if [ "$EMIT_RBS" -eq 1 ]; then
   RBS_OUT="${OUTPUT:-$BASENAME.rbs}"
   export SPINEL_EMIT_RBS="$RBS_OUT"
 fi
+if [ "$EMIT_TYPES" -eq 1 ]; then
+  TYPES_OUT="${OUTPUT:-$BASENAME.types.json}"
+  export SPINEL_EMIT_TYPES="$TYPES_OUT"
+fi
 if [ -x "$ANALYZE_BIN" ]; then
   "$ANALYZE_BIN" "$AST_TMP" "$IR_TMP" $SEED_TMP
 else
@@ -299,9 +325,14 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-# --emit-rbs is analyze-only: the signatures are written, stop before codegen.
+# --emit-rbs / --emit-types are analyze-only: the artifact is written by the
+# analyzer; stop before codegen.
 if [ "$EMIT_RBS" -eq 1 ]; then
   echo "Wrote $RBS_OUT" >&2
+  exit 0
+fi
+if [ "$EMIT_TYPES" -eq 1 ]; then
+  echo "Wrote $TYPES_OUT" >&2
   exit 0
 fi
 

--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -36,6 +36,7 @@ class Compiler
     @nd_value = []
     @nd_line = []
     @nd_file = []
+    @nd_col = []
     @file_table = []
     @nd_content = "".split(",", -1)
     @nd_flags = []
@@ -26542,6 +26543,165 @@ class Compiler
     out
   end
 
+ # ---- Position-keyed type + diagnostics export (for the ruby-lsp addon) ----
+ # Emits JSON: every node with a concrete inferred type, keyed by source
+ # position (1-based line / 0-based col, matching Prism's node.location), plus
+ # a focused list of degrade diagnostics (parameters that widened to the boxed
+ # poly slow path). Positions come from the parser's node_line/node_file/node_col
+ # (the --debug machinery); gated by SPINEL_EMIT_TYPES in main. Hand-rolled JSON
+ # because the self-hosted subset has no stdlib json.
+
+  def json_escape(s)
+    out = ""
+    i = 0
+    while i < s.length
+      c = s[i]
+      if c == "\""
+        out = out + "\\\""
+      elsif c == "\\"
+        out = out + "\\\\"
+      elsif c == "\n"
+        out = out + "\\n"
+      elsif c == "\t"
+        out = out + "\\t"
+      else
+        out = out + c
+      end
+      i = i + 1
+    end
+    out
+  end
+
+  def types_file_path(fid)
+    if fid != nil && fid >= 0 && fid < @file_table.length
+      if @file_table[fid] != nil && @file_table[fid] != ""
+        return @file_table[fid]
+      end
+    end
+    if @source_file_path != nil
+      return @source_file_path
+    end
+    "source.rb"
+  end
+
+ # 1 when a type tag is on the boxed poly slow path (the degrade signal).
+  def is_poly_degraded(t)
+    b = base_type(t)
+    if b == "poly"
+      return 1
+    end
+    if b == "poly_array"
+      return 1
+    end
+    if t.include?("poly_hash")
+      return 1
+    end
+    0
+  end
+
+ # 1 when any param or the return of a signature is on the poly slow path.
+  def method_sig_degraded(ptypes, ret)
+    i = 0
+    while i < ptypes.length
+      if ptypes[i] != "" && is_poly_degraded(ptypes[i]) == 1
+        return 1
+      end
+      i = i + 1
+    end
+    if ret != nil && ret != "" && is_poly_degraded(ret) == 1
+      return 1
+    end
+    0
+  end
+
+ # Return a string of "|<body-node-id>|" tokens for each degraded method of a
+ # class (instance or singleton). Body ids index-align with ptypes (`|`-sep)
+ # and returns (`;`-sep); body sentinel "-2" is the injected builtin, skipped.
+  def degraded_bodies_for_class(ptypes_str, returns_str, bodies_str)
+    out = ""
+    ptall = ptypes_str.split("|", -1)
+    rets = returns_str.split(";", -1)
+    bodies = bodies_str.split(";", -1)
+    j = 0
+    while j < bodies.length
+      if bodies[j] != "" && bodies[j] != "-2"
+        pts = "".split(",", -1)
+        if j < ptall.length
+          pts = ptall[j].split(",", -1)
+        end
+        rr = ""
+        if j < rets.length
+          rr = rets[j]
+        end
+        if method_sig_degraded(pts, rr) == 1
+          out = out + "|" + bodies[j] + "|"
+        end
+      end
+      j = j + 1
+    end
+    out
+  end
+
+  def emit_types_json
+    types_out = ""
+    tn = 0
+    nid = 0
+    while nid < @nd_type.length
+      ty = @nd_inferred_type[nid]
+      ln = @nd_line[nid]
+      if ty != nil && ty != "" && ty != "void" && ln != nil && ln > 0
+        if tn > 0
+          types_out = types_out + ",\n"
+        end
+        types_out = types_out + "    {\"file\":\"" + json_escape(types_file_path(@nd_file[nid])) + "\",\"line\":" + ln.to_s + ",\"col\":" + @nd_col[nid].to_s + ",\"type\":\"" + json_escape(ty) + "\",\"rbs\":\"" + json_escape(type_to_rbs(ty)) + "\"}"
+        tn = tn + 1
+      end
+      nid = nid + 1
+    end
+ # Diagnostics: methods whose signature degraded to the boxed poly slow path
+ # (the same widening the RBS export comments), positioned at the `def`. The
+ # degrade lives in the signature tables, not the per-node cache (which holds
+ # context-specialised concrete types), so we match each DefNode to its method
+ # by body-node id. Low-noise (one per degraded method); the per-node type map
+ # above still lets the editor show concrete types on hover everywhere.
+    degraded = ""
+    mi = 0
+    while mi < @meth_names.length
+      if @meth_names[mi] != "" && mi < @meth_body_ids.length
+        if method_sig_degraded(@meth_param_types[mi].split(",", -1), @meth_return_types[mi]) == 1
+          degraded = degraded + "|" + @meth_body_ids[mi].to_s + "|"
+        end
+      end
+      mi = mi + 1
+    end
+    ci = 0
+    while ci < @cls_names.length
+      degraded = degraded + degraded_bodies_for_class(@cls_meth_ptypes[ci], @cls_meth_returns[ci], @cls_meth_bodies[ci])
+      degraded = degraded + degraded_bodies_for_class(@cls_cmeth_ptypes[ci], @cls_cmeth_returns[ci], @cls_cmeth_bodies[ci])
+      ci = ci + 1
+    end
+
+    diag_out = ""
+    dn = 0
+    nid2 = 0
+    while nid2 < @nd_type.length
+      if @nd_type[nid2] == "DefNode"
+        bid = @nd_body[nid2]
+        ln2 = @nd_line[nid2]
+        if bid != nil && bid >= 0 && ln2 != nil && ln2 > 0 && degraded.include?("|" + bid.to_s + "|")
+          if dn > 0
+            diag_out = diag_out + ",\n"
+          end
+          msg = "Spinel: `" + @nd_name[nid2] + "` has a parameter or return widened to untyped (boxed poly slow path)"
+          diag_out = diag_out + "    {\"file\":\"" + json_escape(types_file_path(@nd_file[nid2])) + "\",\"line\":" + ln2.to_s + ",\"col\":" + @nd_col[nid2].to_s + ",\"severity\":\"warning\",\"message\":\"" + json_escape(msg) + "\"}"
+          dn = dn + 1
+        end
+      end
+      nid2 = nid2 + 1
+    end
+    "{\n  \"types\": [\n" + types_out + "\n  ],\n  \"diagnostics\": [\n" + diag_out + "\n  ]\n}\n"
+  end
+
  # B1 discovery (STALIN.md §11): count slot types that landed on
  # poly / nullable-poly / *_poly_hash / poly_array. Output to
  # stderr after all analyze passes finish, gated by envvar to
@@ -34803,5 +34963,11 @@ compiler.analyze_phase
  # IR is still written so the same run can also feed codegen).
 if ENV["SPINEL_EMIT_RBS"] != nil && ENV["SPINEL_EMIT_RBS"] != ""
   File.write(ENV["SPINEL_EMIT_RBS"], compiler.emit_rbs)
+end
+ # Position-keyed type + diagnostics export (for the ruby-lsp addon). Requires
+ # the parser to have stamped node positions (SPINEL_DEBUG=1, set by the
+ # wrapper's --emit-types mode).
+if ENV["SPINEL_EMIT_TYPES"] != nil && ENV["SPINEL_EMIT_TYPES"] != ""
+  File.write(ENV["SPINEL_EMIT_TYPES"], compiler.emit_types_json)
 end
 File.write(ir_file, compiler.dump_analysis_buf)

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -73,6 +73,7 @@ class Compiler
     @nd_value = []
     @nd_line = []
     @nd_file = []
+    @nd_col = []
     @nd_content = "".split(",", -1)
     @nd_flags = []
     @nd_operator = "".split(",", -1)

--- a/spinel_parse.c
+++ b/spinel_parse.c
@@ -246,9 +246,10 @@ static int flatten(pm_node_t *node) {
      raw value is the line in the concatenated buffer; the map translates it
      back to the original file and line. */
   if (g_emit_line) {
-    int32_t bl = pm_newline_list_line(&g_parser->newline_list,
-                                      node->location.start,
-                                      g_parser->start_line);
+    pm_line_column_t lc = pm_newline_list_line_column(&g_parser->newline_list,
+                                                      node->location.start,
+                                                      g_parser->start_line);
+    int32_t bl = lc.line;
     int orig = bl;
     int fid = 0;
     if (sp_line_map_n > 0 && bl >= 1 && bl <= sp_line_map_n) {
@@ -257,6 +258,9 @@ static int flatten(pm_node_t *node) {
     }
     emit_int(id, "node_line", (long long)orig);
     emit_int(id, "node_file", (long long)fid);
+    /* Column is concatenation-stable (require splicing is line-based), so the
+       buffer column equals the original-file column. 0-based, as Prism gives. */
+    emit_int(id, "node_col", (long long)lc.column);
   }
 
 #define N(type_name) out_add("N %d " type_name, id)


### PR DESCRIPTION
# Add `spinel --emit-types`: position-keyed inferred types + degrade diagnostics (JSON)

> Builds on the now-merged #1292 (`--debug`): the per-node source positions come
> from that PR's parser stamps, and the wrapper turns on `SPINEL_DEBUG` for
> `--emit-types`.

## What

An analyze-only flag that dumps the whole-program inference as position-keyed
JSON:

```sh
spinel app.rb --emit-types            # writes app.types.json, no binary
```

The output is a single object with two arrays:

```json
{
  "types":       [ {"file":"app.rb","line":2,"col":4,"type":"Integer","rbs":"Integer"}, ... ],
  "diagnostics": [ {"file":"app.rb","line":7,"col":2,"severity":"warning","message":"...widened to untyped..."}, ... ]
}
```

`types` is every node with a concrete inferred type, keyed by source position
(1-based line / 0-based col, matching Prism's `node.location`), with both the
internal type and its RBS form. `diagnostics` flags where a value fell to the
boxed `untyped` / poly slow path, positioned at the enclosing `def`.

## Why

This is the machine-readable companion to `--emit-rbs` (#1276). Keyed by source
position, it's what an editor integration consumes directly: a ruby-lsp addon can
show the compiler's inferred type on hover and underline the degrade sites (the
silent-miscompile signal) without re-deriving anything. Same inference, exposed
per-position instead of per-signature.

## Design / safety

- **Opt-in and analyze-only.** Stops before codegen; writes only the JSON. No
  effect on a normal build's output.
- Touches the wrapper (the flag + `SPINEL_EMIT_TYPES` env + analyze-only exit),
  the analyzer (`emit_types_json`), `spinel_parse.c` (emit `node_col` alongside
  the `node_line`/`node_file` from #1292 — Prism's column helper, concatenation-
  stable across require splicing), and a slot to carry the column.

## A note on the schema

The **JSON shape is the least-settled** part of this series — happy to adjust the
keys / structure (e.g. how degrades are represented, whether to nest by file) to
whatever you'd want a stable consumer to depend on. Flagging it so we lock the
shape deliberately rather than by accident.

## Validation

- `make test`: 802 pass / 0 fail / 0 err on current master (unchanged
  — analyze-only and opt-in).
- `spinel app.rb --emit-types` writes a JSON of `{file,line,col,type,rbs}`
  entries + degrade diagnostics.
