### PR TITLE
Add native `Exception#backtrace` under `--debug` (macOS + Linux)

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -3378,14 +3378,16 @@ static const char *sp_bt_symbol(const char *line) {
     size_t len = (size_t)(end - p);
     if (len == 0 || len > 250) return 0;          /* unresolved (static/stripped) */
     memcpy(sym, p, len); sym[len] = 0;
-  } else {                                        /* macOS space-delimited form */
-    const char *p = strstr(line, "0x");           /* the address */
-    if (!p) return 0;
-    while (*p && *p != ' ') p++;                   /* skip the address */
-    while (*p == ' ') p++;                          /* to the symbol */
-    if (!*p) return 0;
-    const char *end = p;
-    while (*end && *end != ' ') end++;             /* symbol ends at space/" +" */
+  } else {                                        /* macOS: "<idx> <image> <addr> <symbol> + <off>" */
+    /* The symbol is the token just before the " + <off>" delimiter. Parse
+       backward from the last " + " rather than forward from "0x" — an image
+       path containing "0x" (e.g. /path/0x_proj/bin) would otherwise misparse. */
+    const char *plus = 0, *q = line;
+    while ((q = strstr(q, " + ")) != 0) { plus = q; q += 3; }
+    if (!plus) return 0;
+    const char *end = plus;
+    const char *p = end;
+    while (p > line && p[-1] != ' ') p--;          /* back up to the symbol's start */
     size_t len = (size_t)(end - p);
     if (len == 0 || len > 250) return 0;
     memcpy(sym, p, len); sym[len] = 0;
@@ -3394,20 +3396,39 @@ static const char *sp_bt_symbol(const char *line) {
   if (strncmp(sym, "sp_", 3) != 0) return 0;     /* skip non-Spinel frames */
   const char *name = sym + 3;
   if (sp_bt_is_runtime(name)) return 0;
-  /* sp_Class_method -> Class#method (heuristic: split first '_' after an
-     initial uppercase segment); else just the stripped name. */
-  char out[256];
-  if (name[0] >= 'A' && name[0] <= 'Z') {
-    const char *u = strchr(name, '_');
-    if (u) {
-      size_t cl = (size_t)(u - name);
-      memcpy(out, name, cl);
-      out[cl] = '#';
-      strcpy(out + cl + 1, u + 1);
-      return strdup(out);
-    }
+  /* De-mangle sp_<Class>_<method> back to Ruby. A Spinel symbol is a path of
+     CamelCase class segments (each from a `::`, joined by `_`) followed by the
+     method; the method is the first segment that starts lowercase. A literal
+     `cls` segment marks a singleton method:
+       sp_Helper_cls_boom          -> Helper.boom
+       sp_Tep_Url_parse_query      -> Tep::Url#parse_query
+       sp_Tep_AuthOAuth2_cls_find  -> Tep::AuthOAuth2.find
+       sp_toplevel                 -> toplevel   (top-level method, no class)
+     (Method names stay sanitized — e.g. enabled? is enabled_p; reversing that
+     needs the emitted name table, a separate refinement.) */
+  const char *mstart = 0;   /* first lowercase-starting segment = the method */
+  for (const char *p = name; *p; p++) {
+    int seg_start = (p == name) || (p[-1] == '_');
+    if (seg_start && *p >= 'a' && *p <= 'z') { mstart = p; break; }
   }
-  return strdup(name);
+  if (!mstart) return strdup(name);            /* all-uppercase: leave as-is */
+  if (mstart == name) {                        /* no class path: top-level */
+    if (strncmp(name, "cls_", 4) == 0) return strdup(name + 4);  /* top-level singleton */
+    return strdup(name);
+  }
+  char out[256]; size_t o = 0;
+  const char *meth; char sep;
+  if (strncmp(mstart, "cls_", 4) == 0) { meth = mstart + 4; sep = '.'; }  /* singleton */
+  else                                 { meth = mstart;     sep = '#'; }  /* instance */
+  for (const char *p = name; p < mstart - 1 && o + 2 < sizeof(out); p++) {
+    if (*p == '_') { out[o++] = ':'; out[o++] = ':'; }   /* class-path `_` was a `::` */
+    else out[o++] = *p;
+  }
+  if (o + 1 < sizeof(out)) out[o++] = sep;
+  size_t ml = strlen(meth);
+  if (o + ml < sizeof(out)) { memcpy(out + o, meth, ml); o += ml; }
+  out[o] = 0;
+  return strdup(out);
 }
 
 static sp_StrArray *sp_bt_format(void **buf, int n) {
@@ -3417,9 +3438,10 @@ static sp_StrArray *sp_bt_format(void **buf, int n) {
   if (!syms) return a;
   const char *src = (sp_bt_srcfile && sp_bt_srcfile[0]) ? sp_bt_srcfile : "(spinel)";
   for (int i = 0; i < n; i++) {
-    const char *name = sp_bt_symbol(syms[i]);
+    char *name = (char *)sp_bt_symbol(syms[i]);  /* always strdup'd; free after use */
     if (!name) continue;
     sp_StrArray_push(a, sp_sprintf("%s:in `%s'", src, name));
+    free(name);
   }
   free(syms);
   return a;

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -27,6 +27,25 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <dirent.h>
+
+/* Opt-in native backtrace (spinel --debug). In a -g, non-inlined build the
+   sp_<method> symbols are present, so sp_raise_cls can snapshot the live C
+   stack at raise time and Exception#backtrace / caller format it into a
+   Ruby-style backtrace — no per-method shadow frames needed. Off unless the
+   generated main() sets sp_bt_enabled (debug builds), so non-debug behaviour
+   and cost are unchanged. execinfo is POSIX-ish; absent on Windows. */
+#if !defined(_WIN32)
+#include <execinfo.h>
+#define SP_BT_AVAILABLE 1
+#else
+#define SP_BT_AVAILABLE 0
+#endif
+static int sp_bt_enabled = 0;          /* set to 1 by debug-build main() */
+static const char *sp_bt_srcfile = ""; /* toplevel .rb path, set by debug main() */
+#if SP_BT_AVAILABLE
+static void *sp_bt_buf[256];       /* frames captured at the last raise */
+static int sp_bt_n = 0;
+#endif
 #ifdef _WIN32
 #include <windows.h>
 #include <process.h>
@@ -3318,7 +3337,107 @@ static const char *sp_exc_msg[SP_EXC_STACK_MAX];
 static volatile int sp_exc_top = 0;
 static const char *sp_exc_cls[SP_EXC_STACK_MAX];
 static volatile const char *sp_last_exc_cls = sp_str_empty;
-void sp_raise_cls(const char *cls, const char *msg) { if (sp_exc_top > 0) { sp_exc_msg[sp_exc_top-1] = msg; sp_exc_cls[sp_exc_top-1] = cls; sp_last_exc_cls = cls; longjmp(sp_exc_stack[sp_exc_top-1], 1); } fprintf(stderr, "unhandled exception: %s\n", msg); exit(1); }
+/* ---- Native backtrace formatting (spinel --debug) ---------------------- */
+/* True for sp_<name> symbols that are runtime helpers, not user Ruby methods.
+   A denylist of the lowercase runtime prefixes; user methods are sp_<rubyname>
+   (top-level) or sp_<Class>_<method>, which don't match. Heuristic — a leaf
+   runtime frame may occasionally slip through; refine with an emitted
+   user-method allowlist later. */
+#if SP_BT_AVAILABLE
+static int sp_bt_is_runtime(const char *n) {
+  static const char *pfx[] = {
+    "int_", "str_", "float_", "sym_", "gc_", "bigint", "sprintf", "raise",
+    "exc_", "range", "utf8", "oom", "bt_", "backtrace", "caller", "StrArray",
+    "IntArray", "FloatArray", "PtrArray", "PolyArray", "Str", "Int", "Float",
+    "Hash", "Range", "Complex", "Rational", "Sym", "alloc", "free", "to_s",
+    "dup", "new", "pack", "unpack", "regex", "re_",
+    /* arithmetic/runtime helpers that can raise and sit between the raise
+       and the user frame (ZeroDivisionError via sp_idiv/sp_imod, etc.) */
+    "idiv", "imod", "gcd", "fdiv", "ipow", "iclamp", "div_", "mod_", 0
+  };
+  for (int i = 0; pfx[i]; i++) {
+    size_t l = strlen(pfx[i]);
+    if (strncmp(n, pfx[i], l) == 0) return 1;
+  }
+  return 0;
+}
+
+/* macOS backtrace_symbols line: "<idx> <image> <addr> <symbol> + <off>".
+   Extract the symbol token; NULL if it isn't a keepable user frame. */
+static const char *sp_bt_symbol(const char *line) {
+  const char *p = strstr(line, "0x");           /* the address */
+  if (!p) return 0;
+  while (*p && *p != ' ') p++;                   /* skip the address */
+  while (*p == ' ') p++;                          /* to the symbol */
+  if (!*p) return 0;
+  const char *end = p;
+  while (*end && *end != ' ') end++;             /* symbol ends at space/" +" */
+  size_t len = (size_t)(end - p);
+  if (len == 0 || len > 250) return 0;
+  char sym[256];
+  memcpy(sym, p, len); sym[len] = 0;
+  if (strcmp(sym, "main") == 0) return strdup("<main>");
+  if (strncmp(sym, "sp_", 3) != 0) return 0;     /* skip non-Spinel frames */
+  const char *name = sym + 3;
+  if (sp_bt_is_runtime(name)) return 0;
+  /* sp_Class_method -> Class#method (heuristic: split first '_' after an
+     initial uppercase segment); else just the stripped name. */
+  char out[256];
+  if (name[0] >= 'A' && name[0] <= 'Z') {
+    const char *u = strchr(name, '_');
+    if (u) {
+      size_t cl = (size_t)(u - name);
+      memcpy(out, name, cl);
+      out[cl] = '#';
+      strcpy(out + cl + 1, u + 1);
+      return strdup(out);
+    }
+  }
+  return strdup(name);
+}
+
+static sp_StrArray *sp_bt_format(void **buf, int n) {
+  sp_StrArray *a = sp_StrArray_new();
+  if (!sp_bt_enabled || n <= 0) return a;
+  char **syms = backtrace_symbols(buf, n);
+  if (!syms) return a;
+  const char *src = (sp_bt_srcfile && sp_bt_srcfile[0]) ? sp_bt_srcfile : "(spinel)";
+  for (int i = 0; i < n; i++) {
+    const char *name = sp_bt_symbol(syms[i]);
+    if (!name) continue;
+    sp_StrArray_push(a, sp_sprintf("%s:in `%s'", src, name));
+  }
+  free(syms);
+  return a;
+}
+#endif
+
+/* Backtrace captured at the most recent raise (for Exception#backtrace). */
+static sp_StrArray *sp_backtrace_captured(void) {
+#if SP_BT_AVAILABLE
+  return sp_bt_format(sp_bt_buf, sp_bt_n);
+#else
+  return sp_StrArray_new();
+#endif
+}
+
+/* The current stack, captured now (for Kernel#caller). */
+static sp_StrArray *sp_caller_now(void) {
+#if SP_BT_AVAILABLE
+  if (!sp_bt_enabled) return sp_StrArray_new();
+  void *buf[256];
+  int n = backtrace(buf, 256);
+  return sp_bt_format(buf, n);
+#else
+  return sp_StrArray_new();
+#endif
+}
+
+void sp_raise_cls(const char *cls, const char *msg) {
+#if SP_BT_AVAILABLE
+  if (sp_bt_enabled) sp_bt_n = backtrace(sp_bt_buf, 256);
+#endif
+  if (sp_exc_top > 0) { sp_exc_msg[sp_exc_top-1] = msg; sp_exc_cls[sp_exc_top-1] = cls; sp_last_exc_cls = cls; longjmp(sp_exc_stack[sp_exc_top-1], 1); } fprintf(stderr, "unhandled exception: %s\n", msg); exit(1); }
 static void sp_raise(const char *msg) { sp_raise_cls("RuntimeError", msg); }
 
 /* Issue #781: bridge between the regex compile-error path (which lives

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -3362,20 +3362,34 @@ static int sp_bt_is_runtime(const char *n) {
   return 0;
 }
 
-/* macOS backtrace_symbols line: "<idx> <image> <addr> <symbol> + <off>".
-   Extract the symbol token; NULL if it isn't a keepable user frame. */
+/* Extract the symbol token from a backtrace_symbols line. Two formats:
+     - glibc/Linux: "<module>(<symbol>+0x<off>) [0x<addr>]". The symbol is
+       empty for unresolved frames (static or stripped fns) -> skip.
+     - macOS:       "<idx> <image> <addr> <symbol> + <off>".
+   Returns NULL if it isn't a keepable user frame. Detect Linux by the '('
+   that delimits the symbol (the macOS format has none). */
 static const char *sp_bt_symbol(const char *line) {
-  const char *p = strstr(line, "0x");           /* the address */
-  if (!p) return 0;
-  while (*p && *p != ' ') p++;                   /* skip the address */
-  while (*p == ' ') p++;                          /* to the symbol */
-  if (!*p) return 0;
-  const char *end = p;
-  while (*end && *end != ' ') end++;             /* symbol ends at space/" +" */
-  size_t len = (size_t)(end - p);
-  if (len == 0 || len > 250) return 0;
   char sym[256];
-  memcpy(sym, p, len); sym[len] = 0;
+  const char *lp = strchr(line, '(');
+  if (lp) {                                       /* glibc/Linux paren form */
+    const char *p = lp + 1;
+    const char *end = p;
+    while (*end && *end != '+' && *end != ')') end++;
+    size_t len = (size_t)(end - p);
+    if (len == 0 || len > 250) return 0;          /* unresolved (static/stripped) */
+    memcpy(sym, p, len); sym[len] = 0;
+  } else {                                        /* macOS space-delimited form */
+    const char *p = strstr(line, "0x");           /* the address */
+    if (!p) return 0;
+    while (*p && *p != ' ') p++;                   /* skip the address */
+    while (*p == ' ') p++;                          /* to the symbol */
+    if (!*p) return 0;
+    const char *end = p;
+    while (*end && *end != ' ') end++;             /* symbol ends at space/" +" */
+    size_t len = (size_t)(end - p);
+    if (len == 0 || len > 250) return 0;
+    memcpy(sym, p, len); sym[len] = 0;
+  }
   if (strcmp(sym, "main") == 0) return strdup("<main>");
   if (strncmp(sym, "sp_", 3) != 0) return 0;     /* skip non-Spinel frames */
   const char *name = sym + 3;

--- a/spinel
+++ b/spinel
@@ -245,11 +245,13 @@ if [ "$DEBUG" -eq 1 ]; then
   # Native Exception#backtrace on Linux: glibc's backtrace_symbols only
   # resolves frames whose symbols are in the dynamic symbol table. Debug
   # builds emit user methods with external linkage; -rdynamic exports them
-  # so backtrace_symbols can name them. macOS resolves via the Mach-O
-  # symbol table already, so it's a Linux-only flag.
-  if [ "$(uname -s)" != "Darwin" ]; then
-    EXTRA_FLAGS="$EXTRA_FLAGS -rdynamic"
-  fi
+  # so backtrace_symbols can name them. macOS resolves via the Mach-O symbol
+  # table already; Windows has no backtrace (SP_BT_AVAILABLE=0) and -rdynamic
+  # is ELF-only — so it's a Linux/BSD-only flag (skip Darwin *and* MinGW/Cygwin).
+  case "$(uname -s 2>/dev/null)" in
+    Darwin|MINGW*|MSYS*|CYGWIN*) ;;
+    *) EXTRA_FLAGS="$EXTRA_FLAGS -rdynamic" ;;
+  esac
 fi
 
 # Step 1: Parse. spinel_parse is C-only; build it via `make parse`

--- a/spinel
+++ b/spinel
@@ -242,6 +242,14 @@ trap 'rm -f "$AST_TMP" "$IR_TMP" "$EVAL_TMP" "$SEED_TMP"; [ -n "$C_TMP_DIR" ] &&
 if [ "$DEBUG" -eq 1 ]; then
   export SPINEL_DEBUG=1
   EXTRA_FLAGS="$EXTRA_FLAGS -g"
+  # Native Exception#backtrace on Linux: glibc's backtrace_symbols only
+  # resolves frames whose symbols are in the dynamic symbol table. Debug
+  # builds emit user methods with external linkage; -rdynamic exports them
+  # so backtrace_symbols can name them. macOS resolves via the Mach-O
+  # symbol table already, so it's a Linux-only flag.
+  if [ "$(uname -s)" != "Darwin" ]; then
+    EXTRA_FLAGS="$EXTRA_FLAGS -rdynamic"
+  fi
 fi
 
 # Step 1: Parse. spinel_parse is C-only; build it via `make parse`

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -10707,7 +10707,7 @@ class Compiler
           if j < cm_returns.length
             rt = cm_returns[j]
           end
-          emit_raw("static " + c_type(rt) + " sp_" + cname + "_cls_" + sanitize_name(cmnames[j]) + "(" + cls_method_params_decl(i, j) + ");")
+          emit_raw((@debug ? "" : "static ") + c_type(rt) + " sp_" + cname + "_cls_" + sanitize_name(cmnames[j]) + "(" + cls_method_params_decl(i, j) + ");")
           j = j + 1
         end
       end
@@ -12207,6 +12207,14 @@ class Compiler
       emit_raw(cm_linkage + c_type(rt) + " sp_" + cname + "_" + sanitize_name(mname) + "(sp_" + cname + " self" + build_params_str(pnames, ptypes) + yp + ") {")
     else
       emit_raw(cm_linkage + c_type(rt) + " sp_" + cname + "_" + sanitize_name(mname) + "(sp_" + cname + " *self" + build_params_str(pnames, ptypes) + yp + ") {")
+      # Debug-only null-receiver guard: a method called on a nil heap receiver is
+      # a hard NULL deref in a release build (CRuby raises NoMethodError) — the
+      # silent-crash class behind matz/spinel#1259. In --debug, fault loudly with
+      # the Ruby error instead of segfaulting deep in the callee. Zero effect on
+      # release output (gated on @debug); pointer-self methods only.
+      if @debug
+        emit_raw("  if (!self) sp_raise_cls(\"NoMethodError\", \"undefined method '" + mname + "' for nil\");")
+      end
     end
 
     push_scope
@@ -12307,7 +12315,10 @@ class Compiler
     saved_hp_names_len_mb = @heap_promoted_names.length
     saved_hp_cells_len_mb = @heap_promoted_cells.length
 
-    emit_raw("static " + c_type(rt) + " sp_" + cname + "_cls_" + sanitize_name(mname) + "(" + build_params_decl(pnames, ptypes) + ") {")
+    # Debug: external linkage (not static) so -rdynamic exports the symbol and
+    # class/singleton methods resolve in native backtraces, same as instance
+    # methods. Release stays `static` (output unchanged).
+    emit_raw((@debug ? "" : "static ") + c_type(rt) + " sp_" + cname + "_cls_" + sanitize_name(mname) + "(" + build_params_decl(pnames, ptypes) + ") {")
 
     push_scope
     j = 0

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -13616,6 +13616,15 @@ class Compiler
  # is what makes the gate actually effective.
     scan_for_argv(@root_id)
     emit_raw("int main(int argc,char**argv){")
+ # Debug builds: turn on the runtime's native backtrace so sp_raise_cls
+ # snapshots the C stack at each raise and Exception#backtrace formats it.
+    if @debug
+      bt_path = @source_file_path
+      if bt_path == nil || bt_path == ""
+        bt_path = "source.rb"
+      end
+      emit_raw("  sp_bt_enabled = 1; sp_bt_srcfile = \"" + bt_path + "\";")
+    end
  # Gate the ARGV ingest: sp_argv is BSS-zero-initialized
  # (len=0, data=NULL), and sp_mark_externals' loop reads
  # `sp_argv.len` first so an unused-ARGV program never
@@ -18479,8 +18488,15 @@ class Compiler
  # the deferred `caller` portion of #878). Return an empty
  # str_array instead of nil so callers' `.first` / `.length`
  # don't crash.
+ #
+ # Debug builds (--debug): the runtime captured a native backtrace at the
+ # raise (sp_raise_cls -> backtrace()), so return that formatted instead of
+ # empty. Non-debug keeps the empty array (sp_bt_enabled stays 0).
         @needs_str_array = 1
         @needs_gc = 1
+        if @debug
+          return "sp_backtrace_captured()"
+        end
         return "sp_StrArray_new()"
       end
       if mname == "is_a?" || mname == "kind_of?"

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -9985,10 +9985,16 @@ class Compiler
   def method_linkage_named(body_id, has_yield, mname)
  # Debug builds: never promote to `static inline`. An inlined method has
  # no distinct frame after the C compiler runs, so a native debugger
- # can't break on it or show it in a backtrace. Keep every method a real
- # `static` function for faithful stepping (paired with cc -O0).
+ # can't break on it or show it in a backtrace. Emit each method with
+ # *external* linkage (not `static`): glibc's backtrace_symbols can only
+ # resolve a frame to a name if its symbol is in the dynamic symbol table,
+ # which `static` functions never reach even under -rdynamic. External +
+ # -rdynamic (added by the wrapper for debug builds) is what makes native
+ # Exception#backtrace name user frames on Linux. macOS resolves via the
+ # Mach-O symbol table regardless, so it was already fine; this just brings
+ # Linux to parity. Paired with cc -O0 for faithful stepping.
     if @debug
-      return "static "
+      return ""
     end
     if has_yield == 1
       return "static "


### PR DESCRIPTION
# Add native `Exception#backtrace` under `--debug` (macOS + Linux)

> Builds on the merged #1292 (`--debug`): a `-g`, non-inlined debug build keeps
> the `sp_<method>` symbols around, so the runtime can snapshot the live C stack
> at `raise` and format it back to Ruby — no per-method shadow frames.

## What

Under `--debug`, a Spinel exception now carries the real call chain instead of an
empty array:

```ruby
begin
  Calc.run
rescue => e
  e.backtrace   # app.rb:in `Calc.run' / app.rb:in `Calc.helper' / app.rb:in `<main>'
end
```

The runtime captures `backtrace()` at the raise site and de-mangles each
`sp_<Class>_<method>` frame back to Ruby: instance methods render `Class#method`
(nested modules `A::B#m`), singleton methods `Class.method`, top-level methods
bare. Runtime-helper frames are filtered out.

Three pieces:
- **base capture + formatting** — `sp_raise_cls` snapshots the stack; the
  formatter parses `backtrace_symbols` output (macOS *and* glibc forms).
- **Linux linkage** — glibc's `backtrace_symbols` only resolves symbols in the
  dynamic symbol table, which `static` functions never reach. Under `--debug`,
  user (and class) methods get *external* linkage and the binary links with
  `-rdynamic` (non-Darwin), so frames actually resolve. Release stays `static`.
- **a debug-only null-receiver guard** — a method call on a nil heap receiver
  raises `NoMethodError` (CRuby parity) instead of a silent NULL deref deep in
  the callee (the matz/spinel#1259 class).

## Design / safety

Opt-in and `--debug`-gated throughout; a release build's codegen, linkage, and
output are byte-for-byte unchanged. The external-linkage + `-rdynamic` and the
null guard only appear in debug builds.

## Known limitation

Frames currently attribute to the toplevel `.rb` (`sp_bt_srcfile` is one path),
not the per-frame file. The function names identify frames correctly; per-frame
file attribution would need codegen to emit a symbol→file table — a follow-up.

## Validation

- `make test`: **803 pass / 0 fail / 0 err** (unchanged — debug-gated).
- Verified `Calc.run → Calc.helper → <main>` for a class-method raise and
  `Foo#bar` for instance methods; ZeroDivisionError drops the `sp_idiv` runtime
  frame; a null receiver raises `undefined method '...' for nil` under `--debug`.
