### PR TITLE
runtime: GC-root the accumulator in poly-hash #inspect

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -3232,7 +3232,7 @@ static sp_StrPolyHash*sp_StrPolyHash_merge(sp_StrPolyHash*a,sp_StrPolyHash*b){sp
 static sp_StrPolyHash*sp_StrPolyHash_dup(sp_StrPolyHash*h){sp_StrPolyHash*r=sp_StrPolyHash_new();r->default_v=h->default_v;for(mrb_int i=0;i<h->len;i++)sp_StrPolyHash_set(r,h->order[i],sp_StrPolyHash_get(h,h->order[i]));return r;}
 static mrb_bool sp_StrPolyHash_eq(sp_StrPolyHash*a,sp_StrPolyHash*b){if(!a||!b)return a==b;if(a->len!=b->len)return FALSE;for(mrb_int i=0;i<a->len;i++){const char*k=a->order[i];if(!sp_StrPolyHash_has_key(b,k))return FALSE;if(!sp_poly_eq(sp_StrPolyHash_get(a,k),sp_StrPolyHash_get(b,k)))return FALSE;}return TRUE;}
 /* Issue #851: inspect for str_poly_hash. */
-static const char*sp_StrPolyHash_inspect(sp_StrPolyHash*h){sp_String*s=sp_String_new("{");if(h){for(mrb_int i=0;i<h->len;i++){if(i>0)sp_String_append(s,", ");sp_String_append(s,sp_str_inspect(h->order[i]));sp_String_append(s,"=>");sp_String_append(s,sp_poly_inspect(sp_StrPolyHash_get(h,h->order[i])));}}sp_String_append(s,"}");return s->data;}
+static const char*sp_StrPolyHash_inspect(sp_StrPolyHash*h){sp_String*s=sp_String_new("{");SP_GC_ROOT(s);if(h){for(mrb_int i=0;i<h->len;i++){if(i>0)sp_String_append(s,", ");sp_String_append(s,sp_str_inspect(h->order[i]));sp_String_append(s,"=>");sp_String_append(s,sp_poly_inspect(sp_StrPolyHash_get(h,h->order[i])));}}sp_String_append(s,"}");return s->data;}
 /* Convert a narrower StrStrHash to a StrPolyHash. Needed when the
    analyzer widens an LV slot to sp_StrPolyHash* (e.g. later poly-value
    writes) but the initial RHS is a sibling narrower hash variant —
@@ -3263,7 +3263,7 @@ static sp_SymPolyHash*sp_SymPolyHash_dup(sp_SymPolyHash*h){sp_SymPolyHash*r=sp_S
 static mrb_bool sp_SymPolyHash_eq(sp_SymPolyHash*a,sp_SymPolyHash*b){if(!a||!b)return a==b;if(a->len!=b->len)return FALSE;for(mrb_int i=0;i<a->len;i++){sp_sym k=a->order[i];if(!sp_SymPolyHash_has_key(b,k))return FALSE;if(!sp_poly_eq(sp_SymPolyHash_get(a,k),sp_SymPolyHash_get(b,k)))return FALSE;}return TRUE;}
 /* Hash#inspect for sym_poly_hash. CRuby 4.0 renders symbol keys
    in shorthand: `{a: 1, b: "x"}` rather than `{:a=>1, :b=>"x"}`. */
-static const char*sp_SymPolyHash_inspect(sp_SymPolyHash*h){if(!h){char*r=sp_str_alloc_raw(3);r[0]='{';r[1]='}';r[2]=0;sp_str_set_len(r,2);return r;}sp_String*s=sp_String_new("{");for(mrb_int i=0;i<h->len;i++){if(i>0)sp_String_append(s,", ");sp_String_append(s,sp_sym_to_s(h->order[i]));sp_String_append(s,": ");sp_String_append(s,sp_poly_inspect(sp_SymPolyHash_get(h,h->order[i])));}sp_String_append(s,"}");return s->data;}
+static const char*sp_SymPolyHash_inspect(sp_SymPolyHash*h){if(!h){char*r=sp_str_alloc_raw(3);r[0]='{';r[1]='}';r[2]=0;sp_str_set_len(r,2);return r;}sp_String*s=sp_String_new("{");SP_GC_ROOT(s);for(mrb_int i=0;i<h->len;i++){if(i>0)sp_String_append(s,", ");sp_String_append(s,sp_sym_to_s(h->order[i]));sp_String_append(s,": ");sp_String_append(s,sp_poly_inspect(sp_SymPolyHash_get(h,h->order[i])));}sp_String_append(s,"}");return s->data;}
 
 /* PolyPolyHash: heterogeneous keys + values (both sp_RbVal). For
    primitives the hash/eql is tag-based (value equality); for OBJ tag

--- a/test/hash_inspect_poly_gc.rb
+++ b/test/hash_inspect_poly_gc.rb
@@ -1,0 +1,22 @@
+# Hash#inspect on poly-valued hashes (sym_poly / str_poly) with large,
+# heterogeneous values. Exercises the accumulator-string append loop in
+# sp_SymPolyHash_inspect / sp_StrPolyHash_inspect at scale — the helpers
+# that root their accumulator string with SP_GC_ROOT for GC-safety. The
+# existing test/hash_inspect_poly.rb only covers 3-entry hashes; this adds
+# a multi-hundred-KB value to keep the full result intact under heavy
+# allocation. Assert exact length plus the head/tail so a truncation or
+# mis-format anywhere in the body is caught.
+
+big = "z" * 300000
+h = { a: big, b: 1, c: 2.5, d: :sym, e: "tail" }
+s = h.inspect
+puts s.length
+puts s.start_with?("{a: \"zzz")
+puts s.end_with?(", b: 1, c: 2.5, d: :sym, e: \"tail\"}")
+
+bigs = "y" * 300000
+g = { "a" => bigs, "b" => 1, "c" => :s }
+t = g.inspect
+puts t.length
+puts t.start_with?("{\"a\"=>\"yyy")
+puts t.end_with?(", \"b\"=>1, \"c\"=>:s}")

--- a/test/hash_inspect_poly_gc.rb.expected
+++ b/test/hash_inspect_poly_gc.rb.expected
@@ -1,0 +1,6 @@
+300041
+true
+true
+300026
+true
+true


### PR DESCRIPTION
`sp_SymPolyHash_inspect` and `sp_StrPolyHash_inspect` build their result by appending into an accumulator `sp_String *s` in a loop, but — unlike the sibling inspect helpers — they never root `s`. If a garbage collection fires while the loop is mid-flight (an allocation inside `sp_poly_inspect` / `sp_String_append` crossing the GC threshold), the accumulator is unreachable from any root and can be reclaimed out from under the remaining appends.

Adds `SP_GC_ROOT(s)` to both helpers, bringing them in line with the other inspect helpers that already root their accumulator. 2-line change in `lib/sp_runtime.h`.

The inspect *output* itself is unchanged and already correct on master (`{a: 1}` / `{"a"=>1}` shorthand), covered by `test/hash_inspect_poly.rb` for small hashes. This PR adds `test/hash_inspect_poly_gc.rb`, which inspects sym_poly and str_poly hashes carrying multi-hundred-KB heterogeneous values and asserts the exact length plus head/tail — extending coverage of the accumulator append loop beyond the existing 3-entry cases.

**Verification:** `make test` → all green (new test included); `make bootstrap` → 4-way fixpoint holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
