### PR TITLE
analyze: don't let a guessed (int-receiver) dispatch collapse a concrete setter param to poly

### DIFF
--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -16184,7 +16184,22 @@ class Compiler
                     while kk_fwd_c < arg_count_fwd
                       at_fwd_c = infer_type(arg_ids_fwd[kk_fwd_c])
                       if kk_fwd_c < ptypes_fwd_c.length
-                        ptypes_fwd_c[kk_fwd_c] = unify_call_types(ptypes_fwd_c[kk_fwd_c], at_fwd_c, arg_ids_fwd[kk_fwd_c])
+                        prev_fwd_c = ptypes_fwd_c[kk_fwd_c]
+                        unified_fwd_c = unify_call_types(prev_fwd_c, at_fwd_c, arg_ids_fwd[kk_fwd_c])
+ # The receiver type is unresolved ("int"), so this dispatch
+ # target is a GUESS -- every user class defining mname at this
+ # arity is walked, not just the real receiver's class. Lifting an
+ # int-default param to a concrete type is the intended
+ # fallback-signature fix; but letting a guessed target COLLAPSE an
+ # already-concrete param to "poly" contaminates unrelated
+ # same-named setters program-wide (a String-only `Row#body=`
+ # widened to poly because an unrelated `Response#body=` site passes
+ # a poly value through the same as-yet-int-typed local). The real
+ # target's obj-/poly-receiver branches above still unify precisely
+ # once the receiver type resolves. spinel-dev#8.
+                        if prev_fwd_c == "int" || unified_fwd_c != "poly"
+                          ptypes_fwd_c[kk_fwd_c] = unified_fwd_c
+                        end
                       end
                       kk_fwd_c = kk_fwd_c + 1
                     end


### PR DESCRIPTION
## Problem

The forward-ref dispatch widening in `scan_new_calls` fires when a call's receiver is still statically `int` (an as-yet-unresolved ivar/local read whose true class hasn't propagated through the fixpoint) and `mname` belongs to a user class. It walks **every** user class defining `mname` at the call's arity and unifies that class's param types with the call-site args, so the `int`→class fallback dispatch's C signatures match the values the fallback passes (the existing `#545`-style protection).

For **setters this over-widens into unrelated classes.** Every `x=` writer has arity 1, so the arity filter is effectively no filter. A single `recv.body = <poly>` call site whose `recv` hasn't resolved yet unifies `body=`'s param across *every* class defining `body=` — including classes that only ever store a `String`. `unify_call_types(string, <poly>)` collapses to `poly`, and the setter body `@x = value` carries that poly into the ivar. The contamination is sticky (poly never narrows back), so it survives even after `recv` later resolves to its real, single class.

### Concrete repro

The [roundhouse](https://rubys.github.io/roundhouse/) Rails blog (self-building: `curl -O https://rubys.github.io/roundhouse/browse/spinel.tgz`):

```ruby
# app/models/article_row.rb — @body is ONLY ever assigned a String
class ArticleRow
  def body=(value); @body = value; end
  def self.from_raw(row)
    instance = ArticleRow.new
    instance.body = (row["body"]).to_s   # String
    # ...
  end
end
```

`spinel main.rb --emit-rbs` infers `ArticleRow#body: () -> untyped`, while `title`/`created_at` (identical shape, but no same-named poly setter elsewhere in the program) stay `String`. The contamination comes from `main.rb`'s `res.body = controller.body` — `res` is a dispatch param typed `Tep::Response` only later in the fixpoint, so at the time `infer_main_call_types` runs it's still `int`, and the forward-ref branch fans `body=`'s poly arg out to every `body=` class.

## Fix

In this branch only — where the receiver class is a **guess**, not resolved — lift an `int`-default param as before (the fallback-signature protection), but don't apply a unification that would **collapse an already-concrete param to `poly`**. The real receiver's obj-/poly-receiver branches (which know the class, or narrow via `observed_class_ids_for_recv`) still unify precisely once the type resolves.

```ruby
prev_fwd_c = ptypes_fwd_c[kk_fwd_c]
unified_fwd_c = unify_call_types(prev_fwd_c, at_fwd_c, arg_ids_fwd[kk_fwd_c])
if prev_fwd_c == "int" || unified_fwd_c != "poly"
  ptypes_fwd_c[kk_fwd_c] = unified_fwd_c
end
```

## Result — correctly selective

- `ArticleRow#body`, `CommentRow#body` (pure `.to_s`, only-String): `untyped` → **`String`** ✓
- `Article#body` (does `self.body = row["body"]` with no `.to_s` — a genuine `str_poly_hash` untyped read): correctly **stays** `untyped` ✓
- `Tep::Response#body` (a real poly slot): correctly **stays** `untyped` ✓

It removes only the false contamination, preserving every genuinely-poly slot.

## Validation

- Self-host bootstrap converges (`make all`).
- Full suite: **831 pass, 0 fail, 0 error** (+ 13 RBS extractor tests).
- Pre-existing self-compile warnings unchanged (verified against baseline).

Found via the inference-disagreement tooling discussed in OriPekelman/spinel-dev#8 / #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)