### PR TITLE
Add --emit-symbol-map: export emitted-symbol → Ruby-name map (#1334)

### DIFF
--- a/spinel
+++ b/spinel
@@ -48,6 +48,7 @@ OUTPUT=""
 C_ONLY=0
 EMIT_RBS=0
 EMIT_TYPES=0
+EMIT_SYMBOL_MAP=0
 STDOUT_MODE=0
 RUN_MODE=0
 OPT_LEVEL="2"
@@ -127,6 +128,10 @@ $1"
                   # diagnostics as JSON (for the ruby-lsp addon). Needs node
                   # positions, so it turns on SPINEL_DEBUG below.
                 EMIT_TYPES=1; DEBUG=1; shift ;;
+    --emit-symbol-map) # Dump emitted-symbol -> Ruby-name map as JSON (#1334).
+                  # Runs codegen (the mangling lives there) but writes no
+                  # binary. DEBUG on so node positions (file/line) are stamped.
+                EMIT_SYMBOL_MAP=1; DEBUG=1; shift ;;
     -S)         STDOUT_MODE=1; shift ;;
     -E)         RUN_MODE=1; shift ;;
     *.rb)
@@ -343,6 +348,28 @@ if [ "$EMIT_RBS" -eq 1 ]; then
 fi
 if [ "$EMIT_TYPES" -eq 1 ]; then
   echo "Wrote $TYPES_OUT" >&2
+  exit 0
+fi
+
+# --emit-symbol-map needs codegen (the C name-mangling lives there) but emits
+# no binary: run codegen with SPINEL_EMIT_SYMBOL_MAP set, route the C output
+# to a temp, and stop.
+if [ "$EMIT_SYMBOL_MAP" -eq 1 ]; then
+  SYM_OUT="${OUTPUT:-$BASENAME.symbols.json}"
+  export SPINEL_EMIT_SYMBOL_MAP="$SYM_OUT"
+  SYM_C_TMP="$(mktemp /tmp/spinel_symc.XXXXXX)"
+  if [ -x "$CODEGEN_BIN" ]; then
+    "$CODEGEN_BIN" "$AST_TMP" "$IR_TMP" "$SYM_C_TMP"
+  else
+    ruby "$CODEGEN_RB" "$AST_TMP" "$IR_TMP" "$SYM_C_TMP"
+  fi
+  cg_rc=$?
+  rm -f "$SYM_C_TMP"
+  if [ $cg_rc -ne 0 ]; then
+    echo "spinel: codegen failed" >&2
+    exit 1
+  fi
+  echo "Wrote $SYM_OUT" >&2
   exit 0
 fi
 

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -8759,6 +8759,138 @@ class Compiler
  # refines. Identical fingerprints between successive iterations means a
  # fixed point has been reached and further iterations are wasted work.
 
+ # Symbol-map export (#1334). Serialize the emitted C-symbol -> Ruby-name
+ # mapping as JSON, gated by SPINEL_EMIT_SYMBOL_MAP. Built here in codegen
+ # -- where the C name-mangling (`sanitize_name`, the `sp_<Class>_<m>`
+ # shape) actually lives -- so the map cannot drift from what is emitted,
+ # the way an out-of-process re-implementation (or an analyze-side rebuild)
+ # would. The METHOD name is exact (the original Ruby name, including
+ # `?`/`!`/operators that `sanitize_name` collapses one-way and the runtime
+ # `sp_bt_symbol` cannot reverse). The class path demangles `_` -> `::`
+ # like `sp_bt_symbol`, so a class with a literal underscore in a namespace
+ # is reported with `::` (a documented limitation shared with the runtime
+ # demangler; recovering it exactly would need the source constant path).
+ # Sibling export to `--emit-rbs` (#1276) / `--emit-types` (#1298).
+  def emit_symbol_map_json
+ # `{-1 => -1}` seed pins this to int_int_hash (an empty `{}` infers as
+ # str_int_hash in the self-hosted build, and the int node-id keys would
+ # then be passed to sp_StrIntHash_set as `const char *` and crash). -1 is
+ # never a real (body) node id. Same pattern as @cls_meth_idx_cache.
+    body_pos = {-1 => -1}
+    pn = 0
+    while pn < @nd_type.length
+      if @nd_type[pn] == "DefNode"
+        pbid = @nd_body[pn]
+        if pbid != nil && pbid >= 0
+          body_pos[pbid] = pn
+        end
+      end
+      pn = pn + 1
+    end
+    out = ""
+    n = 0
+    mi = 0
+    while mi < @meth_names.length
+      mn = @meth_names[mi]
+      if mn != nil && mn != ""
+        tbid = mi < @meth_body_ids.length ? @meth_body_ids[mi] : -1
+        out = symbol_map_row(out, n, "sp_" + sanitize_name(mn), mn, "toplevel", tbid, body_pos)
+        n = n + 1
+      end
+      mi = mi + 1
+    end
+    ci = 0
+    while ci < @cls_names.length
+      cn = @cls_names[ci]
+      if cn != nil && cn != ""
+        rcls = sym_class_ruby_name(cn)
+        inames = @cls_meth_names[ci].split(";", -1)
+        ibodies = @cls_meth_bodies[ci].split(";", -1)
+        j = 0
+        while j < inames.length
+          if inames[j] != ""
+            ibid = j < ibodies.length ? ibodies[j].to_i : -1
+            out = symbol_map_row(out, n, "sp_" + cn + "_" + sanitize_name(inames[j]), rcls + "#" + inames[j], "imeth", ibid, body_pos)
+            n = n + 1
+          end
+          j = j + 1
+        end
+        snames = @cls_cmeth_names[ci].split(";", -1)
+        sbodies = @cls_cmeth_bodies[ci].split(";", -1)
+        k = 0
+        while k < snames.length
+          if snames[k] != ""
+            sbid = k < sbodies.length ? sbodies[k].to_i : -1
+            out = symbol_map_row(out, n, "sp_" + cn + "_cls_" + sanitize_name(snames[k]), rcls + "." + snames[k], "cmeth", sbid, body_pos)
+            n = n + 1
+          end
+          k = k + 1
+        end
+      end
+      ci = ci + 1
+    end
+    "{\n  \"symbols\": [\n" + out + "\n  ]\n}\n"
+  end
+
+  def symbol_map_row(out, n, c_sym, ruby, kind, bid, body_pos)
+    pos = ",\"file\":null,\"line\":null"
+    if bid != nil && bid >= 0 && body_pos.key?(bid)
+      dn = body_pos[bid]
+      ln = @nd_line[dn]
+      if ln != nil && ln > 0
+        pos = ",\"file\":\"" + sym_json_escape(symbol_file_path(@nd_file[dn])) + "\",\"line\":" + ln.to_s
+      end
+    end
+    row = "    {\"c\":\"" + sym_json_escape(c_sym) + "\",\"ruby\":\"" + sym_json_escape(ruby) + "\",\"kind\":\"" + kind + "\"" + pos + "}"
+    if n > 0
+      return out + ",\n" + row
+    end
+    out + row
+  end
+
+ # C class name (`Tep_Url`) -> Ruby (`Tep::Url`). Lossy for a class with a
+ # literal underscore in a namespace; same assumption as sp_bt_symbol.
+  def sym_class_ruby_name(cn)
+    out = ""
+    i = 0
+    while i < cn.length
+      if cn[i] == "_"
+        out = out + "::"
+      else
+        out = out + cn[i]
+      end
+      i = i + 1
+    end
+    out
+  end
+
+  def symbol_file_path(fid)
+    if fid != nil && fid >= 0 && fid < @file_table.length
+      p = @file_table[fid]
+      if p != nil && p != ""
+        return p
+      end
+    end
+    if @source_file_path != nil && @source_file_path != ""
+      return @source_file_path
+    end
+    "source.rb"
+  end
+
+  def sym_json_escape(s)
+    out = ""
+    i = 0
+    while i < s.length
+      c = s[i]
+      if c == "\"" || c == "\\"
+        out = out + "\\" + c
+      else
+        out = out + c
+      end
+      i = i + 1
+    end
+    out
+  end
 
   def generate_code
  # Mirror analyze's pre-pass: rewrite constant-aliased `class CONST`
@@ -51957,6 +52089,12 @@ compiler.load_analysis_buf(File.read(ir_file))
 # absent from this file by design.
 compiler.generate_code
 result = compiler.build_output
+ # Symbol-map export (#1334): when SPINEL_EMIT_SYMBOL_MAP names a path, dump
+ # the emitted-symbol -> Ruby-name map there. generate_code has run, so the
+ # method/class tables and node positions are populated.
+if ENV["SPINEL_EMIT_SYMBOL_MAP"] != nil && ENV["SPINEL_EMIT_SYMBOL_MAP"] != ""
+  File.write(ENV["SPINEL_EMIT_SYMBOL_MAP"], compiler.emit_symbol_map_json)
+end
 if out_file != nil
   File.write(out_file, result)
 else


### PR DESCRIPTION
Implements the #1334 RFC: an opt-in `--emit-symbol-map` exporting the compiler's emitted-C-symbol → Ruby-name map as JSON, so out-of-process tools (profilers/tracers, value-bisectors) don't re-implement the name mangling. Sibling export to `--emit-rbs` (#1276) / `--emit-types` (#1298).

## What

```
spinel app.rb --emit-symbol-map -o app.symbols.json
```
```json
{ "symbols": [
  { "c": "sp_Tep_Url_save_p", "ruby": "Tep::Url#save?", "kind": "imeth", "file": "app.rb", "line": 4 },
  { "c": "sp_Tep_Url__cmp",   "ruby": "Tep::Url#<=>",   "kind": "imeth", "file": "app.rb", "line": 5 },
  { "c": "sp_Tep_Url__aref",  "ruby": "Tep::Url#[]",    "kind": "imeth", "file": "app.rb", "line": 6 },
  { "c": "sp_Article_cls_all","ruby": "Article.all",    "kind": "cmeth", "file": "app.rb", "line": 12 }
] }
```

## Why this shape

- **More accurate than runtime demangling.** `sanitize_name` is many-to-one and irreversible (`save?`→`save_p`, `<=>`→`_cmp`, `[]`→`_aref`, `==`→`_eq_eq`); the runtime `sp_bt_symbol` (#1300) documents it cannot reverse these. The map records the *forward* direction (the original Ruby name), so predicate / bang / operator methods are exact.
- **Generated in codegen, not reconstructed.** The mangling (`sanitize_name`, the `sp_<Class>_<m>` shape) lives in codegen; `emit_symbol_map_json` builds the map there, so it can't drift from what is emitted — the RFC's point for out-of-process tools, kept true internally.

## Scope / notes

- `kind`: `imeth` / `cmeth` / `toplevel`. Runtime symbols (`sp_gc_alloc`) are out of scope — a tool treats any `sp_` symbol absent from the map as runtime.
- Synthetic/builtin methods (e.g. `Method#initialize`) come through with `file`/`line` null.
- Class path demangles `_`→`::` (same assumption as `sp_bt_symbol`); a class with a literal underscore in a namespace is the one shared lossy case (exact recovery would need the source constant path).
- Output-neutral: gated by `SPINEL_EMIT_SYMBOL_MAP`; release builds unchanged. The flag runs codegen (the mangling lives there) but emits no binary.

## Verification

`make gate` green (844 tests / 57 benchmarks / optcarrot checksum 59662 / self-host fixpoint). Verified `--emit-symbol-map` on the rebuilt **self-hosted** binary, not just MRI — the map's `body_pos` is int-keyed, so it needs the `{-1 => -1}` int_int_hash seed (same pattern as `@cls_meth_idx_cache`) to avoid a `str_int_hash` mismatch in the self-host build.

A golden-file test (mirroring `rbs-test`) is a sensible follow-up; held off to match `--emit-types`, which ships without one.

Refs #1334