### PR TITLE
Extend implicit holder specialization to pointer-array payloads

### DIFF
--- a/spinel_analyze.rb
+++ b/spinel_analyze.rb
@@ -10488,15 +10488,38 @@ class Compiler
     end
   end
 
-  def implicit_new_site_has_obj_arg?(nid)
+  def implicit_new_holder_specialization_payload_type(t)
+    bt = base_type(t)
+    if is_ptr_array_type(bt) == 1
+      return bt
+    end
+    if is_obj_type(bt) == 1 && is_array_type(bt) == 0
+      return bt
+    end
+    ""
+  end
+
+  def implicit_new_site_has_specialization_payload?(nid)
     arg_types = implicit_new_site_arg_types(nid)
     k = 0
     while k < arg_types.length
-      bt = base_type(arg_types[k])
-      if is_obj_type(bt) == 1 && is_array_type(bt) == 0
+      if implicit_new_holder_specialization_payload_type(arg_types[k]) != ""
         return 1
       end
       k = k + 1
+    end
+    0
+  end
+
+  def implicit_holder_payload_self_ref?(cname, payload_type)
+    bt = base_type(payload_type)
+    if is_ptr_array_type(bt) == 1
+      bt = elem_type_of_array(bt)
+    end
+    if is_obj_type(bt) == 1
+      if bt[4, bt.length - 4] == cname
+        return 1
+      end
     end
     0
   end
@@ -10508,18 +10531,18 @@ class Compiler
  # rewritten call site passes the specialized type, so the generated C does not
  # type-check (and the recursive method dispatch resolves to an undeclared
  # base-class function). Specialization buys nothing measurable here, so skip
- # the whole class when any of its construction sites takes its own type as an
- # object argument.
-  def implicit_class_has_self_obj_holder_site?(cname, site_ids, site_classes)
+ # the whole class when any of its construction sites takes its own type as a
+ # specialization payload.
+  def implicit_class_has_self_payload_holder_site?(cname, site_ids, site_classes)
     k = 0
     while k < site_ids.length
       if site_classes[k] == cname
         arg_types = implicit_new_site_arg_types(site_ids[k])
         j = 0
         while j < arg_types.length
-          bt = base_type(arg_types[j])
-          if is_obj_type(bt) == 1 && is_array_type(bt) == 0
-            if bt[4, bt.length - 4] == cname
+          payload_type = implicit_new_holder_specialization_payload_type(arg_types[j])
+          if payload_type != ""
+            if implicit_holder_payload_self_ref?(cname, payload_type) == 1
               return 1
             end
           end
@@ -10531,14 +10554,14 @@ class Compiler
     0
   end
 
-  def implicit_new_site_obj_signature_key(cname, nid)
+  def implicit_new_site_payload_signature_key(cname, nid)
     arg_types = implicit_new_site_arg_types(nid)
     key = cname + "|" + arg_types.length.to_s
     k = 0
     while k < arg_types.length
-      bt = base_type(arg_types[k])
-      if is_obj_type(bt) == 1 && is_array_type(bt) == 0
-        key = key + "|" + k.to_s + ":" + bt
+      payload_type = implicit_new_holder_specialization_payload_type(arg_types[k])
+      if payload_type != ""
+        key = key + "|" + k.to_s + ":" + payload_type
       end
       k = k + 1
     end
@@ -10796,7 +10819,7 @@ class Compiler
     while ci < original_class_count
       cname = @cls_names[ci]
       if count_implicit_new_sites_for_class(site_classes, cname) >= 2
-        holder_self_ref = implicit_class_has_self_obj_holder_site?(cname, site_ids, site_classes)
+        holder_self_ref = implicit_class_has_self_payload_holder_site?(cname, site_ids, site_classes)
         k = 0
         while k < site_ids.length
           if site_classes[k] == cname
@@ -10804,14 +10827,14 @@ class Compiler
             holder_site = 0
             if implicit_specializable_class?(ci) == 1 && implicit_new_site_arg_count(site_ids[k]) == 0 && implicit_candidate_class_escaped?(escaping_classes, cname) == 0
               specialize_site = 1
-            elsif implicit_holder_specializable_class?(ci) == 1 && holder_self_ref == 0 && implicit_new_site_arg_count(site_ids[k]) > 0 && implicit_new_site_has_obj_arg?(site_ids[k]) == 1
+            elsif implicit_holder_specializable_class?(ci) == 1 && holder_self_ref == 0 && implicit_new_site_arg_count(site_ids[k]) > 0 && implicit_new_site_has_specialization_payload?(site_ids[k]) == 1
               specialize_site = 1
               holder_site = 1
             end
             if specialize_site == 1
               spec_name = cname + "__implicit_" + site_ids[k].to_s
               if holder_site == 1
-                signature_key = implicit_new_site_obj_signature_key(cname, site_ids[k])
+                signature_key = implicit_new_site_payload_signature_key(cname, site_ids[k])
                 existing_spec = implicit_new_signature_class(signature_key)
                 if existing_spec != ""
                   spec_name = existing_spec

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -3418,6 +3418,10 @@ class Compiler
         end
       end
     end
+    spec_expr_t = implicit_specialized_expr_type(nid)
+    if spec_expr_t != ""
+      return spec_expr_t
+    end
  # Sibling-scope narrow override: when the active narrow stack
  # narrows `x` to `obj_<C>` and this CallNode is `x.attr` where
  # `attr` is an attr_reader on `C`, the cached type (filled by

--- a/test/implicit_alloc_site_holder_ptr_array_records.rb
+++ b/test/implicit_alloc_site_holder_ptr_array_records.rb
@@ -1,0 +1,39 @@
+RowA = Struct.new(:id, :name)
+RowB = Struct.new(:id, :label)
+require "json"
+
+class Holder
+  attributes :record, :records
+
+  def initialize(record, records)
+    @record = record
+    @records = records
+  end
+
+  def record_json
+    JSON.generate(@record)
+  end
+
+  def first_record_json
+    JSON.generate(@records[0])
+  end
+end
+
+def first_name(result)
+  result.records[0].name
+end
+
+def first_label(result)
+  result.records[0].label
+end
+
+holder_a = Holder.new(RowA.new(0, "empty-a"), [RowA.new(1, "alpha")])
+holder_b = Holder.new(RowB.new(0, "empty-b"), [RowB.new(2, "beta")])
+
+puts first_name(holder_a)
+puts first_label(holder_b)
+puts holder_a.records.length + holder_b.records.length
+puts holder_a.record_json
+puts holder_b.record_json
+puts holder_a.first_record_json
+puts holder_b.first_record_json

--- a/test/implicit_alloc_site_holder_ptr_array_records.rb.expected
+++ b/test/implicit_alloc_site_holder_ptr_array_records.rb.expected
@@ -1,0 +1,7 @@
+alpha
+beta
+2
+{"id":0,"name":"empty-a"}
+{"id":0,"label":"empty-b"}
+{"id":1,"name":"alpha"}
+{"id":2,"label":"beta"}


### PR DESCRIPTION
## Summary

This extends the holder specialization added in #1299 to constructor payloads that are concrete object pointer arrays.

The supported constructor payload shapes are now:

- direct object payloads, such as `obj_Row`
- concrete object pointer arrays, such as `obj_Row_ptr_array`

It also fixes shared method-body typing so expressions like `@record` and `@records[index]` are resolved from the active synthetic holder class before codegen consults shared node caches.

## Why

A holder class can be allocated at multiple closed-world sites with different record payloads. The existing holder specialization handled direct object payloads, but concrete record arrays did not participate in the allocation-site signature key.

That left shared holder methods vulnerable to stale cached expression types when the same AST node was emitted for multiple synthetic classes. The active synthetic holder class should determine the expression type.

## Changes

- Classify constructor arguments through one specialization-payload helper.
- Include concrete object pointer arrays in holder allocation-site signature keys.
- Keep direct object payloads on the same classifier path.
- Extend the self-reference guard to pointer-array payloads.
- Resolve active-specialization expression types before shared codegen node caches.
- Add a regression covering direct record payloads and concrete record-array payloads across two holder allocation sites.

## Test

Added:

```txt
test/implicit_alloc_site_holder_ptr_array_records.rb
```

Validation:

```txt
make -C .vendor/spinel LTO=0 codegen
make -C .vendor/spinel LTO=0 REF_RUBY='mise exec ruby -- ruby -EUTF-8' retest
```

Full retest summary:

```txt
RBS extractor tests: 13 pass
Analyze-fail tests: 3 pass
Tests: 823 pass, 0 fail, 0 error
```
