### PR TITLE
README: add spinel-dev and spinelgems to the community ecosystem list

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,19 @@ Adjacent ecosystem (community-built, not part of this repo):
 - [rubocop_spinel](https://github.com/gurgeous/rubocop_spinel) —
   a RuboCop custom cop that flags Ruby code Spinel doesn't yet
   support.
+- [spinel-dev](https://github.com/OriPekelman/spinel-dev) —
+  developer-experience tooling that surfaces what the compiler
+  already knows: `spinel doctor` (a one-shot risk report —
+  unresolved calls, widened slots, inference↔codegen
+  disagreements, C-build failures), a differential
+  CRuby-vs-Spinel value-bisector for silent miscompiles, a
+  delta-debugging minimal-repro reducer, an inferred-types
+  ruby-lsp addon, and flamegraph-based perf analysis.
+- [spinelgems](https://github.com/OriPekelman/spinelgems) —
+  a gem-compatibility survey and differential-verification
+  harness that determines which RubyGems compile and run
+  correctly under Spinel, with bundler-spinel for vendoring
+  pinned dependencies.
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -584,7 +584,11 @@ Adjacent ecosystem (community-built, not part of this repo):
   disagreements, C-build failures), a differential
   CRuby-vs-Spinel value-bisector for silent miscompiles, a
   delta-debugging minimal-repro reducer, an inferred-types
-  ruby-lsp addon, and flamegraph-based perf analysis.
+  ruby-lsp addon, and flamegraph-based perf analysis. Plus a
+  migration toolset for keeping real projects building against a
+  fast-moving compiler — a capability/layout probe, a two-compiler
+  parity check, a multi-file repro reducer, and a commit-bisector —
+  which has driven several minimal reproducers and fixes upstream.
 - [spinelgems](https://github.com/OriPekelman/spinelgems) —
   a gem-compatibility survey and differential-verification
   harness that determines which RubyGems compile and run


### PR DESCRIPTION
Adds two community-built developer-experience projects to the "Adjacent ecosystem" list, next to `rubocop_spinel` — they may be useful to others doing Spinel development:

- **[spinel-dev](https://github.com/OriPekelman/spinel-dev)** — tooling that surfaces what the compiler already knows: `spinel doctor` (a one-shot risk report — unresolved calls, widened slots, inference↔codegen disagreements, C-build failures), a differential CRuby-vs-Spinel value-bisector for silent miscompiles, a delta-debugging minimal-repro reducer, an inferred-types ruby-lsp addon, and flamegraph-based perf analysis. (Several of its substrate flags — `--emit-rbs`, `--emit-types`, `--debug`, native backtrace — already merged here.)
- **[spinelgems](https://github.com/OriPekelman/spinelgems)** — a gem-compatibility survey and differential-verification harness (which RubyGems compile and run correctly under Spinel), with bundler-spinel for vendoring pinned dependencies.

Docs-only; one hunk in `README.md`. Format matches the existing `rubocop_spinel` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)