### PR TITLE
fix: backticks update $? from the command's exit status

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -3853,6 +3853,10 @@ static const char *sp_backtick(const char *cmd) {
   size_t n = fread(buf, 1, 4095, p);
   buf[n] = 0;
   int status = pclose(p);
+#ifdef _WIN32
+  /* MinGW pclose returns the child exit code, not a POSIX wait status. */
+  if (status >= 0) status <<= 8;
+#endif
   sp_last_status = status;
   return buf;
 }

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -3842,7 +3842,7 @@ static sp_Time sp_file_mtime(const char *path) {
 #endif
 #endif
 }
-static const char *sp_backtick(const char *cmd) { FILE *p = popen(cmd, "r"); if (!p) return sp_str_empty; char *buf = sp_str_alloc_raw(4096); size_t n = fread(buf, 1, 4095, p); buf[n] = 0; pclose(p); return buf; }
+static const char *sp_backtick(const char *cmd) { fflush(NULL); FILE *p = popen(cmd, "r"); if (!p) { sp_last_status = -1; return sp_str_empty; } char *buf = sp_str_alloc_raw(4096); size_t n = fread(buf, 1, 4095, p); buf[n] = 0; sp_last_status = pclose(p); return buf; }
 static const char *sp_file_basename(const char *path) {
   const char *s = strrchr(path, '/');
   const char *base = s ? s + 1 : path;

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -3853,9 +3853,6 @@ static const char *sp_backtick(const char *cmd) {
   size_t n = fread(buf, 1, 4095, p);
   buf[n] = 0;
   int status = pclose(p);
-#ifdef _WIN32
-  if (status >= 0) status <<= 8;
-#endif
   sp_last_status = status;
   return buf;
 }

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -3842,7 +3842,23 @@ static sp_Time sp_file_mtime(const char *path) {
 #endif
 #endif
 }
-static const char *sp_backtick(const char *cmd) { fflush(NULL); FILE *p = popen(cmd, "r"); if (!p) { sp_last_status = -1; return sp_str_empty; } char *buf = sp_str_alloc_raw(4096); size_t n = fread(buf, 1, 4095, p); buf[n] = 0; sp_last_status = pclose(p); return buf; }
+static const char *sp_backtick(const char *cmd) {
+  fflush(NULL);
+  FILE *p = popen(cmd, "r");
+  if (!p) {
+    sp_last_status = -1;
+    return sp_str_empty;
+  }
+  char *buf = sp_str_alloc_raw(4096);
+  size_t n = fread(buf, 1, 4095, p);
+  buf[n] = 0;
+  int status = pclose(p);
+#ifdef _WIN32
+  if (status >= 0) status <<= 8;
+#endif
+  sp_last_status = status;
+  return buf;
+}
 static const char *sp_file_basename(const char *path) {
   const char *s = strrchr(path, '/');
   const char *base = s ? s + 1 : path;

--- a/lib/sp_system.h
+++ b/lib/sp_system.h
@@ -1,6 +1,6 @@
 /* sp_system.h -- system()/backtick support in libspinel_rt.a.
  *
- * `sp_last_status` backs Ruby's `$?` (the exit status of the last
+ * `sp_last_status` backs Ruby's `$?` (the wait status of the last
  * `system` / backtick). `sp_system_args` runs argv[0] with the rest as
  * arguments (the multi-arg `system(...)` form), setting `sp_last_status`
  * and returning whether the child exited 0. The bool result is declared

--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -9879,9 +9879,6 @@ class Compiler
     emit_raw("typedef struct{mrb_int first;mrb_int last;mrb_int excl;}sp_Range;")
     emit_raw("static sp_Range sp_range_new(mrb_int f,mrb_int l,mrb_int e){sp_Range r;r.first=f;r.last=l;r.excl=e;return r;}")
     emit_raw("static mrb_bool sp_range_eq(sp_Range a,sp_Range b){return a.first==b.first&&a.last==b.last&&a.excl==b.excl;}")
-    if @needs_system == 1
-      emit_raw("static int sp_last_status = 0;")
-    end
     emit_raw("")
   end
 

--- a/test/backtick_status.rb
+++ b/test/backtick_status.rb
@@ -1,6 +1,8 @@
-# Backticks update $? from the command's exit status.
+# Backticks update $? from the command status.
 
 `false`
 puts($? == 0)
 `true`
 puts($? == 0)
+`ruby -e "exit 42"`
+puts($? == 42 * 256)

--- a/test/backtick_status.rb
+++ b/test/backtick_status.rb
@@ -1,0 +1,6 @@
+# Backticks update $? from the command's exit status.
+
+`false`
+puts($? == 0)
+`true`
+puts($? == 0)

--- a/test/backtick_status.rb.expected
+++ b/test/backtick_status.rb.expected
@@ -1,0 +1,2 @@
+false
+true

--- a/test/backtick_status.rb.expected
+++ b/test/backtick_status.rb.expected
@@ -1,2 +1,3 @@
 false
 true
+true


### PR DESCRIPTION
## Problem

Backticks previously returned command output but discarded the child
process status from `pclose`, so `$?` stayed at the previous/default
status after a failing command.

Generated C also emitted a duplicate `static sp_last_status` instead of
using the runtime status symbol from `lib/sp_system.c`.

## Reproduce

Save this as `/tmp/spinel_backtick_status.rb`:

```ruby
`false`
puts($? == 0)
`true`
puts($? == 0)
`ruby -e "exit 42"`
puts($? == 42 * 256)
```

## Before/After

Before this change, Spinel reported success after the failing command:

```text
true
true
```

CRuby and fixed Spinel report:

```text
false
true
true
```

## Solution

- `sp_backtick` now records the `pclose` wait status in `sp_last_status`.
- Codegen no longer emits a duplicate `static sp_last_status`; generated
  C uses the single runtime status symbol from `lib/sp_system.c`.
- Adds `test/backtick_status.rb` to pin `` `false` `` / `` `true` ``
  status behavior and a numeric wait-status check against CRuby.

## Verification

- `ruby /tmp/spinel_backtick_status.rb` -> `false`, `true`, `true`
- `./spinel /tmp/spinel_backtick_status.rb -o /tmp/spinel_backtick_status && /tmp/spinel_backtick_status` -> `false`, `true`, `true`
- `make test` -> 846 pass, 0 fail, 0 error
- `make bootstrap` -> analyzer/codegen IR and C fixpoints OK
