### PR TITLE
codegen: anchor sym_json_escape input as string for the self-host build

### DIFF
--- a/spinel_codegen.rb
+++ b/spinel_codegen.rb
@@ -9606,7 +9606,14 @@ class Compiler
 
   def symbol_file_path(fid)
     if fid != nil && fid >= 0 && fid < @file_table.length
-      p = @file_table[fid]
+ # .to_s anchor: under self-host the @file_table element read can
+ # land on poly (the table is filled in compiler_helpers across the
+ # require boundary), which poisons this return — and with it
+ # sym_json_escape's param — to poly with no concrete arm, so the
+ # escape loop emitted 0 and every --emit-symbol-map string field
+ # came out "" from the self-hosted binary (CRuby codegen was
+ # fine). spinel-dev#16.
+      p = @file_table[fid].to_s
       if p != nil && p != ""
         return p
       end
@@ -9617,7 +9624,10 @@ class Compiler
     "source.rb"
   end
 
-  def sym_json_escape(s)
+  def sym_json_escape(s0)
+ # Same self-host anchor as symbol_file_path: keep the escape input
+ # a concrete string even if a caller's arg slot degraded to poly.
+    s = s0.to_s
     out = ""
     i = 0
     while i < s.length


### PR DESCRIPTION
The **self-hosted** `spinel_codegen` binary emitted `--emit-symbol-map` (#1345) with every string field empty:

```json
{"c":"","ruby":"","kind":"imeth","file":"","line":2}
```

CRuby-run codegen was correct, so the bug only showed in shipped toolchains. Mechanism: under self-host inference the `@file_table` element read in `symbol_file_path` lands on poly (the table is filled in `compiler_helpers` across the require boundary), poisoning its return — and through it `sym_json_escape`'s param — to poly with no concrete arm; `s.length`/`s[i]` emit 0 (the build's own `cannot resolve call to 'length' on poly ... (emitting 0)` warnings were the fingerprint) and the escape loop returns "".

Fix: `.to_s` anchors at the table read and the escape input. After it, the self-host build is warning-free at `sym_json_escape` and the binary emits populated fields — including `file`/`line`, which were also casualties (the poisoned table read never yielded the path):

```json
{"c":"sp_Foo_save_p","ruby":"Foo#save?","kind":"imeth","file":"symmap_demo.rb","line":2}
```

Suite 845 pass / 0 fail. Found wiring perf tools to consume the map (OriPekelman/spinel-dev#16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)