### PR TITLE
runtime: raise Errno::ENOENT on File.read/write/binread open failure

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -3774,7 +3774,14 @@ static const char *sp_file_read(const char *path) {
     sp_raise_cls("Errno::EISDIR", sp_sprintf("Is a directory @ io_fread - %s", path));
   }
   FILE *f = fopen(path, "r");
-  if (!f) return &("\xff" "")[1];
+  /* CRuby contract: a failed open raises (Errno::ENOENT for a missing
+     path), it does not yield "". The silent empty string let a missing
+     input flow deep into programs until something dereferenced garbage
+     (no-output SIGSEGV far from the one-line cause). spinel-dev#17;
+     same raise shape as File.mtime below. */
+  if (!f) {
+    sp_raise_cls(errno == ENOENT ? "Errno::ENOENT" : "RuntimeError", sp_sprintf("%s @ rb_sysopen - %s", strerror(errno), path));
+  }
   fseek(f, 0, SEEK_END);
   long sz = ftell(f);
   fseek(f, 0, SEEK_SET);
@@ -3793,10 +3800,14 @@ static void sp_file_write(const char *path, const char *data) {
     sp_raise_cls("Errno::EISDIR", sp_sprintf("Is a directory @ rb_sysopen - %s", path));
   }
   FILE *f = fopen(path, "wb");
-  if (f) {
-    fwrite(data, 1, sp_str_byte_len(data), f);
-    fclose(f);
+  /* Same contract as sp_file_read: a failed open raises (ENOENT for a
+     missing directory component, EACCES for permissions), it does not
+     silently drop the write. spinel-dev#17. */
+  if (!f) {
+    sp_raise_cls(errno == ENOENT ? "Errno::ENOENT" : (errno == EACCES ? "Errno::EACCES" : "RuntimeError"), sp_sprintf("%s @ rb_sysopen - %s", strerror(errno), path));
   }
+  fwrite(data, 1, sp_str_byte_len(data), f);
+  fclose(f);
 }
 static mrb_bool sp_file_exist(const char *path) { FILE *f = fopen(path, "r"); if (f) { fclose(f); return TRUE; } return FALSE; }
 static void sp_file_delete(const char *path) { remove(path); }
@@ -4065,7 +4076,11 @@ static sp_IntArray *sp_file_binread_bytes(const char *path) {
   }
   FILE *f = fopen(path, "rb");
   sp_IntArray *a = sp_IntArray_new();
-  if (!f) return a;
+  /* CRuby raises on a failed binread open too — an empty byte array is
+     the same silent-"" trap as sp_file_read. spinel-dev#17. */
+  if (!f) {
+    sp_raise_cls(errno == ENOENT ? "Errno::ENOENT" : "RuntimeError", sp_sprintf("%s @ rb_sysopen - %s", strerror(errno), path));
+  }
   fseek(f, 0, SEEK_END);
   long sz = ftell(f);
   fseek(f, 0, SEEK_SET);

--- a/test/file_read_missing_raises.rb
+++ b/test/file_read_missing_raises.rb
@@ -1,0 +1,28 @@
+# spinel-dev#17. File.read on a missing path silently returned "" (and
+# File.write to an un-openable path silently dropped the write; binread
+# returned an empty byte array) instead of raising Errno::ENOENT like
+# CRuby. The bogus "" flowed deep into programs until something
+# dereferenced garbage — a no-output SIGSEGV far from the one-line
+# cause. Now all three raise on open failure, with the strerror text
+# and the rb_sysopen-style location CRuby uses.
+
+# Success path stays a success path.
+File.write("spinel_dev17_roundtrip.txt", "hello")
+puts File.read("spinel_dev17_roundtrip.txt").length
+File.delete("spinel_dev17_roundtrip.txt")
+
+begin
+  File.read("definitely_missing_spinel_dev17.txt")
+  puts "no raise"
+rescue => e
+  puts "read raised"
+  puts(e.message.include?("No such file or directory") ? "enoent" : e.message)
+end
+
+begin
+  File.write("no_such_dir_spinel_dev17/x.txt", "d")
+  puts "no raise"
+rescue => e
+  puts "write raised"
+  puts(e.message.include?("No such file or directory") ? "enoent" : e.message)
+end

--- a/test/file_read_missing_raises.rb.expected
+++ b/test/file_read_missing_raises.rb.expected
@@ -1,0 +1,5 @@
+5
+read raised
+enoent
+write raised
+enoent


### PR DESCRIPTION
`File.read` on a missing path silently returned `""` (CRuby: raises `Errno::ENOENT` at the call site). `File.write` to an un-openable path silently dropped the write; `File.binread` returned an empty byte array.

The silent empty value is close to the worst debugging experience for a one-line user error: it flows deep into the program until something dereferences garbage — in the wild this surfaced as a zero-output SIGSEGV (exit 139) in an ML data pipeline whose only actual problem was a missing fixture file (OriPekelman/spinel-dev#17).

Fix: raise on a failed `fopen` in all three entry points, using the exact shape `File.mtime` already uses — `Errno::ENOENT` (or `EACCES` / `RuntimeError` per errno) with the `strerror` text and the `rb_sysopen`-style location CRuby prints. `Errno::EISDIR` guards and success paths unchanged; `File.exist?` keeps probing with fopen.

Suite 846 pass / 0 fail (845 + a regression test covering the raise on read and write plus the surviving round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)