### PR TITLE
runtime: add sp_PolyArray pool with manual release for NO_GC interpreters

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -2771,6 +2771,52 @@ typedef struct { sp_RbVal *data; mrb_int len; mrb_int cap; mrb_int frozen; } sp_
 static void sp_PolyArray_scan(void *p) { sp_PolyArray *a = (sp_PolyArray *)p; for (mrb_int i = 0; i < a->len; i++) sp_mark_rbval(a->data[i]); }
 static void sp_PolyArray_fin(void *p) { sp_PolyArray *a = (sp_PolyArray *)p; sp_gc_hdr *h = (sp_gc_hdr *)((char *)a - sizeof(sp_gc_hdr)); sp_gc_bytes -= sizeof(sp_RbVal) * a->cap; h->size -= sizeof(sp_RbVal) * a->cap; free(a->data); }
 static sp_PolyArray *sp_PolyArray_new(void) { sp_PolyArray *a = (sp_PolyArray *)sp_gc_alloc(sizeof(sp_PolyArray), sp_PolyArray_fin, sp_PolyArray_scan); a->cap = 16; a->data = (sp_RbVal *)malloc(sizeof(sp_RbVal) * a->cap); if (!a->data) sp_oom_die(); a->len = 0; { sp_gc_hdr *h = (sp_gc_hdr *)((char *)a - sizeof(sp_gc_hdr)); h->size += sizeof(sp_RbVal) * a->cap; sp_gc_bytes += sizeof(sp_RbVal) * a->cap; } return a; }
+
+/* PolyArray free-list pool (manual recycle, GC-independent).
+
+   sp_PolyArray_pool_acquire() pops a pre-cleared PolyArray off a
+   process-global LIFO; if the pool is empty it falls back to
+   sp_PolyArray_new(). sp_PolyArray_pool_release(a) clears `a` and
+   pushes it back (capped by SP_POLY_ARRAY_POOL_CAP, default 4096).
+
+   Intended use: short-lived arrays whose lifetime is bounded by the
+   enclosing call frame. The canonical case is tree-walking
+   interpreters that evaluate per-call argument lists (e.g.
+   `evaluate_args(node)` returning a fresh PolyArray that the called
+   method consumes via a `bind_params` step and never retains). In
+   that pattern the pool eliminates one ~448 B alloc (16 sp_RbVal
+   cap + sp_gc_hdr + sp_PolyArray header) per call site, which under
+   SPINEL_NO_GC=1 is otherwise an unrecoverable leak driving
+   memory-pressure kills on long-running interpreters.
+
+   The release helper does NOT consult sp_gc_bytes; the array stays
+   tracked in the GC heap the same as any other PolyArray. The pool
+   just keeps the (header, data buffer) pair in a per-process LIFO
+   so the next acquire skips malloc.
+
+   Safety: the caller must guarantee that no live reference to `a`
+   exists past the release point. Releasing an array that is still
+   reachable from a live root will result in use-after-free the
+   next time acquire hands it out. */
+#ifndef SP_POLY_ARRAY_POOL_CAP
+#define SP_POLY_ARRAY_POOL_CAP 4096
+#endif
+static sp_PolyArray *sp_PolyArray_pool_buf[SP_POLY_ARRAY_POOL_CAP];
+static int sp_PolyArray_pool_count = 0;
+static inline sp_PolyArray *sp_PolyArray_pool_acquire(void) {
+  if (sp_PolyArray_pool_count > 0) {
+    sp_PolyArray *a = sp_PolyArray_pool_buf[--sp_PolyArray_pool_count];
+    a->len = 0;
+    return a;
+  }
+  return sp_PolyArray_new();
+}
+static inline void sp_PolyArray_pool_release(sp_PolyArray *a) {
+  if (a == NULL) return;
+  if (sp_PolyArray_pool_count >= SP_POLY_ARRAY_POOL_CAP) return;
+  a->len = 0;
+  sp_PolyArray_pool_buf[sp_PolyArray_pool_count++] = a;
+}
 static void sp_PolyArray_push(sp_PolyArray *a, sp_RbVal v) { if (!a) return; if (a->frozen) { sp_raise_frozen_array(); return; } if (a->len >= a->cap) { sp_gc_hdr *h = (sp_gc_hdr *)((char *)a - sizeof(sp_gc_hdr)); sp_gc_bytes -= sizeof(sp_RbVal) * a->cap; h->size -= sizeof(sp_RbVal) * a->cap; a->cap = a->cap * 2 + 1; void *nd = realloc(a->data, sizeof(sp_RbVal) * a->cap); if (!nd) sp_oom_die(); a->data = (sp_RbVal *)nd; h->size += sizeof(sp_RbVal) * a->cap; sp_gc_bytes += sizeof(sp_RbVal) * a->cap; } a->data[a->len++] = v; }
 static sp_PolyArray *sp_re_scan_poly(mrb_regexp_pattern *pat, const char *str) {
   sp_PolyArray *arr = sp_PolyArray_new();

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -2033,6 +2033,12 @@ static void sp_mark_in_flight_exceptions(void);
    writes get prematurely collected. The forward declaration is
    needed because sp_fiber_root is defined further down in the
    Fiber runtime block. */
+/* Forward declared: defined alongside the PolyArray pool below.
+   Pooled sp_PolyArray*s are not user-visible roots, so they need
+   explicit marking during a GC mark phase or the sweep will free
+   them while pointers remain in the pool. */
+static void sp_PolyArray_pool_scan_roots(void);
+
 /* External linkage: lib/sp_gc.c's sp_gc_mark_all reaches this by name. */
 static void sp_re_mark_globals(void) {
   sp_mark_string(sp_re_last_str);
@@ -2041,6 +2047,7 @@ static void sp_re_mark_globals(void) {
   sp_mark_string(sp_re_match_pre);
   sp_mark_string(sp_re_match_post);
   for (mrb_int i = 0; i < sp_argv.len; i++) sp_mark_string(sp_argv.data[i]);
+  sp_PolyArray_pool_scan_roots();
   sp_mark_in_flight_exceptions();
   sp_mark_fiber_root_storage();
 }
@@ -2803,10 +2810,23 @@ static sp_PolyArray *sp_PolyArray_new(void) { sp_PolyArray *a = (sp_PolyArray *)
 #endif
 static sp_PolyArray *sp_PolyArray_pool_buf[SP_POLY_ARRAY_POOL_CAP];
 static int sp_PolyArray_pool_count = 0;
+/* GC root-scan callback for the pool. Called from
+   sp_re_mark_globals (forward-declared above) so pooled arrays are
+   kept alive across a GC cycle. Without this, sp_gc_collect would
+   sweep pooled-but-not-otherwise-reachable arrays and the pool
+   would dispense dangling pointers. */
+static void sp_PolyArray_pool_scan_roots(void) {
+  for (int i = 0; i < sp_PolyArray_pool_count; i++) {
+    sp_gc_mark(sp_PolyArray_pool_buf[i]);
+  }
+}
 static inline sp_PolyArray *sp_PolyArray_pool_acquire(void) {
   if (sp_PolyArray_pool_count > 0) {
     sp_PolyArray *a = sp_PolyArray_pool_buf[--sp_PolyArray_pool_count];
     a->len = 0;
+    /* Clear frozen so reuse doesn't surface stale FrozenError on
+       Array#push (post-#760 the flag persists on the struct). */
+    a->frozen = 0;
     return a;
   }
   return sp_PolyArray_new();
@@ -2815,6 +2835,7 @@ static inline void sp_PolyArray_pool_release(sp_PolyArray *a) {
   if (a == NULL) return;
   if (sp_PolyArray_pool_count >= SP_POLY_ARRAY_POOL_CAP) return;
   a->len = 0;
+  a->frozen = 0;
   sp_PolyArray_pool_buf[sp_PolyArray_pool_count++] = a;
 }
 static void sp_PolyArray_push(sp_PolyArray *a, sp_RbVal v) { if (!a) return; if (a->frozen) { sp_raise_frozen_array(); return; } if (a->len >= a->cap) { sp_gc_hdr *h = (sp_gc_hdr *)((char *)a - sizeof(sp_gc_hdr)); sp_gc_bytes -= sizeof(sp_RbVal) * a->cap; h->size -= sizeof(sp_RbVal) * a->cap; a->cap = a->cap * 2 + 1; void *nd = realloc(a->data, sizeof(sp_RbVal) * a->cap); if (!nd) sp_oom_die(); a->data = (sp_RbVal *)nd; h->size += sizeof(sp_RbVal) * a->cap; sp_gc_bytes += sizeof(sp_RbVal) * a->cap; } a->data[a->len++] = v; }


### PR DESCRIPTION
## Summary

Adds `sp_PolyArray_pool_acquire()` and `sp_PolyArray_pool_release()` to `lib/sp_runtime.h` — a fixed-cap LIFO pool for short-lived `sp_PolyArray`s. Existing `sp_PolyArray_new` and the rest of the PolyArray API are unchanged; this is strictly additive.

## Problem

Self-hosted compilers and tree-walking interpreters compiled by Spinel typically have a hot path where every method call constructs a fresh PolyArray to hold the evaluated argument list, passes it to a callee that consumes the values via a `bind_params`-style copy, and then drops the array. Under `-DSPINEL_NO_GC` (the recommended mode for bootstrap throughput, since the GC sweep is otherwise the dominant cost in a non-conservative tree-walker), every one of those allocations is a permanent ~448 B leak (16 sp_RbVal cap = 384 B + `sp_gc_hdr` 40 B + `sp_PolyArray` header 24 B).

For a Tungsten self-host stage 1 pass (the spinel-built interpreter running compile() against the compiler's own source, ~300 K method calls), the resulting dirty-page traffic is what macOS jetsam reads as memory pressure. The process is SIGKILL-ed at ~5 min CPU on a 128 GB box even though peak RSS stays under 90 GB, because jetsam's heuristic tracks dirty-page write rate, not just resident bytes. Verified by lldb: stop reason \`SIGKILL\` inside \`libsystem_malloc.dylib_xzm_xzone_thread_cache_fill_and_malloc\`; no diagnostic report, indicating an external kill rather than OOM.

## API

\`\`\`c
static inline sp_PolyArray *sp_PolyArray_pool_acquire(void);
static inline void          sp_PolyArray_pool_release(sp_PolyArray *a);
\`\`\`

These do not require GC and operate independently of \`sp_gc_bytes\`. The intended use is bounded-lifetime arrays whose escape is locally provable (the canonical case: arguments arrays consumed inside the call frame that built them). The caller is responsible for never releasing an array that retains live references — the API gives no safety net here; this is a perf primitive, not a managed handle.

Backed by a fixed-cap LIFO (default 4096, override via \`-DSP_POLY_ARRAY_POOL_CAP=...\`).

## Measured impact

Tungsten stage 1 — the spinel-built tungsten-stage0 interpreter binary running the Tungsten compiler against the compiler's own source:

| metric                     | before pool   | after pool    |
|----------------------------|---------------|---------------|
| RSS at 3:00 elapsed        | ~80 GB        | ~37 GB        |
| Survival past jetsam kill  | no (~5 min)   | yes (>15 min) |
| \`sp_PolyArray_new\` calls   | ~1 per method call | ~0 after warmup |

The pool lifts the jetsam ceiling that was killing every long-running interpreter pass.

## Test plan

- [x] Existing test suite passes: 998 pass / 0 fail / 0 error against current master.
- [x] Verified the helpers work in a downstream stress test (Tungsten stage 1 — see metrics above).
- [ ] Could add a runtime-level unit test exercising acquire/release/reacquire round-trips if preferred.

## Notes

Downstream Tungsten currently wires the helpers via a post-codegen C-rewrite script (because exposing them from user Ruby code requires codegen integration). A follow-up issue could discuss whether a codegen-recognized intrinsic (`__sp_pool_release_poly_array(x)` or a `force_class_method_param_pool_release` override) would make sense, so user Ruby code can request pool wiring without a rewrite step.