### PR TITLE
codegen: emit $stdout/$stderr.puts/print as one expression (valid in value position)

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -7935,14 +7935,22 @@ else {
       const char *fd = is_err ? "stderr" : "stdout";
       if (!strcmp(name, "puts") || !strcmp(name, "print")) {
         int want_nl = !strcmp(name, "puts");
+        /* Emit a SINGLE C expression, joining the pieces with the comma
+           operator (not ';'). $stderr.puts/print can appear in value/return
+           position, where the surrounding emitter wraps this as
+           `(<here>, sp_box_nil())`; a ';' produced invalid C
+           (`(fputs(..); fputc(..), sp_box_nil())`). The comma operator also
+           gives the missing separator between multiple args. */
+        int emitted = 0;
         for (int k = 0; k < argc; k++) {
+          if (emitted++) buf_puts(b, ", ");
           TyKind at = comp_ntype(c, argv[k]);
           if (at == TY_STRING) { buf_printf(b, "fputs("); emit_expr(c, argv[k], b); buf_printf(b, ", %s)", fd); }
           else if (at == TY_INT) { buf_printf(b, "fprintf(%s, \"%%lld\", (long long)(", fd); emit_expr(c, argv[k], b); buf_puts(b, "))"); }
           else { buf_printf(b, "fputs(sp_poly_to_s("); emit_expr(c, argv[k], b); buf_printf(b, "), %s)", fd); }
-          if (want_nl && k == argc - 1) buf_printf(b, "; fputc('\\n', %s)", fd);
         }
-        if (argc == 0 && want_nl) buf_printf(b, "fputc('\\n', %s)", fd);
+        if (want_nl) { if (emitted++) buf_puts(b, ", "); buf_printf(b, "fputc('\\n', %s)", fd); }
+        if (!emitted) buf_puts(b, "(void)0");  /* e.g. bare `$stdout.print` */
         return;
       }
       if (!strcmp(name, "flush")) { buf_printf(b, "fflush(%s)", fd); return; }

--- a/test/stdout_puts_value_position.rb
+++ b/test/stdout_puts_value_position.rb
@@ -1,0 +1,26 @@
+# $stdout/$stderr.puts/print in a value/return position must emit a single C
+# expression. The lowering joined fputs(...) and the trailing fputc('\n', ...)
+# with a ';', producing a statement sequence — fine in statement position, but
+# when the call lands in value position the emitter wraps it as
+# `(<here>, sp_box_nil())`, yielding the invalid `(fputs(..); fputc(..), nil)`
+# ("expected ')' before ';'"). It must be a comma-operator expression instead.
+#
+# Trigger: an if/else whose other branch yields a boxed value (the File.open
+# block) forces the $stdout.puts branch into a returned-value position — the
+# exact shape from tep's Logger#log. (Uses $stdout so output is captured.)
+class Out
+  def initialize(p)
+    @p = p
+  end
+  def write(line)
+    if @p.length > 0
+      File.open(@p, "a") { |f| f.puts(line) }
+    else
+      $stdout.puts(line)
+    end
+  end
+end
+
+Out.new("").write("hello")
+$stdout.print("done")
+$stdout.puts("")

--- a/test/stdout_puts_value_position.rb.expected
+++ b/test/stdout_puts_value_position.rb.expected
@@ -1,0 +1,2 @@
+hello
+done


### PR DESCRIPTION
## The bug

The `$stdout`/`$stderr` `puts`/`print` lowering in `src/codegen_call.c` joins the per-arg `fputs(...)` and the trailing `fputc('\n', fd)` with a **`;`** — a statement sequence. That's fine in statement position, but the call can land in **value/return position** (e.g. the `else` arm of an `if/else` whose other arm yields a boxed value), where the surrounding emitter wraps it as `(<lowering>, sp_box_nil())`. The `;` then makes invalid C:

```c
return (fputs(lv_line, stderr); fputc('\n', stderr), sp_box_nil());
//                            ^ error: expected ')' before ';'
//        error: incompatible types when returning 'int' but 'sp_RbVal' was expected
```

### Minimal repro (`test/stdout_puts_value_position.rb`, included)

```ruby
class Out
  def initialize(p) ; @p = p ; end
  def write(line)
    if @p.length > 0
      File.open(@p, "a") { |f| f.puts(line) }   # boxed-value branch...
    else
      $stdout.puts(line)                         # ...forces this into value position
    end
  end
end
Out.new("").write("hello")
$stdout.print("done")
$stdout.puts("")
```

Each piece alone (bare `$stdout.puts`, the `File.open` block, the `if/else` of two plain `puts`) compiles; the bug needs `puts`/`print` in a value position where the result type is boxed. Surfaced on [tep](https://github.com/OriPekelman/tep)'s `Logger#log`, which blocked compiling a real downstream app's server.

## The fix

Emit a **single comma-operator expression** — join the args and the trailing-newline `fputc` with `,` instead of `;`. Valid in both statement and value position, and it also supplies the arg separator that was previously missing between multiple `puts` args (`fputs(a, fd)fputs(b, fd)` → `fputs(a, fd), fputs(b, fd)`). A bare `$stdout.print` (no args) emits `(void)0`.

## Verification

- New test fails pre-fix with the exact `expected ')' before ';'` + `int` vs `sp_RbVal` errors; passes after.
- Full suite: **849 pass / 0 fail / 0 error** (aarch64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)