### PR TITLE
fix(math): raise Math::DomainError on out-of-domain Math.* input

### DIFF
--- a/lib/sp_core.c
+++ b/lib/sp_core.c
@@ -255,8 +255,11 @@ mrb_int sp_powmod(mrb_int base,mrb_int exp,mrb_int mod){if(mod==0)sp_raise_cls("
 mrb_int sp_ceildiv(mrb_int a,mrb_int b){if(b==0)sp_raise_cls("ZeroDivisionError","divided by 0");if(b==-1)return -a;mrb_int q=a/b;if(a%b!=0&&((a^b)>=0))q++;return q;}
 mrb_int sp_int_clamp(mrb_int v,mrb_int lo,mrb_int hi){return v<lo?lo:v>hi?hi:v;}
 /* Integer square root via Newton's method -- exact for the full
-   mrb_int range. Negative input returns 0 (no exception path). */
-mrb_int sp_int_sqrt(mrb_int n){if(n<0)return 0;if(n<2)return n;mrb_int x=n,y=(x+1)/2;while(y<x){x=y;y=(x+n/x)/2;}return x;}
+   mrb_int range. CRuby raises Math::DomainError on negative input
+   (flattened runtime name "Math_DomainError"). The seed is n/2, not
+   (n+1)/2: at n == MRB_INT_MAX the latter overflows (signed UB), and
+   n/2 is a valid Newton seed for all n >= 2. */
+mrb_int sp_int_sqrt(mrb_int n){if(n<0)sp_raise_cls("Math_DomainError","Numerical argument is out of domain - \"isqrt\"");if(n<2)return n;mrb_int x=n,y=n/2;while(y<x){x=y;y=(x+n/x)/2;}return x;}
 /* Integer#round/ceil/floor/truncate at 10^(-ndigits). Pure integer
    arithmetic (no double precision loss above 2^53). 10^p fits mrb_int
    only for p<=18; p>=19 collapses to 0. Round-up multiply is overflow-

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -246,6 +246,26 @@ const char *sp_sprintf(const char *fmt, ...);
 /* system()/backtick ($?) support now lives in libspinel_rt.a (lib/sp_system.c). */
 #include "sp_system.h"
 
+/* Math.* wrappers that raise Math::DomainError on out-of-domain input, per
+   CRuby. The runtime exception name is the flattened "Math_DomainError"
+   (the codegen maps a `rescue Math::DomainError` path to that form, matching
+   the StringScanner::Error -> StringScanner_Error precedent). Only the
+   domain-restricted methods get wrappers; cos/sin/tan/atan/sinh/cosh/tanh/
+   asinh/exp/cbrt/erf/erfc/atan2/hypot accept all reals and call libc
+   directly from codegen. log(0) is -Infinity in CRuby (no raise); only a
+   negative argument raises. atanh's endpoints (|x| == 1) yield ±Infinity and
+   do NOT raise in CRuby -- only |x| > 1 is out of domain. CRuby's Math.*
+   message names the function WITHOUT quotes (e.g. `... out of domain - sqrt`),
+   unlike Integer.sqrt which quotes "isqrt". */
+static inline mrb_float sp_math_sqrt(mrb_float x){if(x<0.0)sp_raise_cls("Math_DomainError","Numerical argument is out of domain - sqrt");return sqrt(x);}
+static inline mrb_float sp_math_log(mrb_float x){if(x<0.0)sp_raise_cls("Math_DomainError","Numerical argument is out of domain - log");return log(x);}
+static inline mrb_float sp_math_log2(mrb_float x){if(x<0.0)sp_raise_cls("Math_DomainError","Numerical argument is out of domain - log2");return log2(x);}
+static inline mrb_float sp_math_log10(mrb_float x){if(x<0.0)sp_raise_cls("Math_DomainError","Numerical argument is out of domain - log10");return log10(x);}
+static inline mrb_float sp_math_acos(mrb_float x){if(x<-1.0||x>1.0)sp_raise_cls("Math_DomainError","Numerical argument is out of domain - acos");return acos(x);}
+static inline mrb_float sp_math_asin(mrb_float x){if(x<-1.0||x>1.0)sp_raise_cls("Math_DomainError","Numerical argument is out of domain - asin");return asin(x);}
+static inline mrb_float sp_math_acosh(mrb_float x){if(x<1.0)sp_raise_cls("Math_DomainError","Numerical argument is out of domain - acosh");return acosh(x);}
+static inline mrb_float sp_math_atanh(mrb_float x){if(x<-1.0||x>1.0)sp_raise_cls("Math_DomainError","Numerical argument is out of domain - atanh");return atanh(x);}
+
 static sp_Range sp_range_new(mrb_int f,mrb_int l,mrb_int e){sp_Range r;r.first=f;r.last=l;r.excl=e;return r;}
 static mrb_bool sp_range_eq(sp_Range a,sp_Range b){return a.first==b.first&&a.last==b.last&&a.excl==b.excl;}
 /* `Range#include?`/`#cover?` on the boxed (SP_TAG_OBJ cls_id
@@ -4677,6 +4697,7 @@ static mrb_int sp_exc_is_a(volatile sp_Exception *ve, const char *cn) {
     {"NotImplementedError",   "StandardError"},
     {"StopIteration",         "IndexError"},
     {"FloatDomainError",      "RangeError"},
+    {"Math_DomainError",      "StandardError"},
     {"FrozenError",           "RuntimeError"},
     {"EncodingError",         "StandardError"},
     {"LoadError",             "StandardError"},
@@ -4735,6 +4756,7 @@ static int sp_exc_cls_matches(const char *raised, const char *target) {
     {"NotImplementedError",  "StandardError"},
     {"StopIteration",        "IndexError"},
     {"FloatDomainError",     "RangeError"},
+    {"Math_DomainError",     "StandardError"},
     {"FrozenError",          "RuntimeError"},
     {"EncodingError",        "StandardError"},
     {"LoadError",            "StandardError"},

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1040,8 +1040,8 @@ int is_exc_name(const char *n) {
     "TypeError", "NameError", "NoMethodError", "IndexError",
     "KeyError", "RangeError", "IOError", "EOFError",
     "ZeroDivisionError", "NotImplementedError", "StopIteration",
-    "FloatDomainError", "FrozenError", "EncodingError", "LoadError",
-    "RegexpError", "StringScanner_Error", "FiberError", NULL
+    "FloatDomainError", "Math_DomainError", "FrozenError", "EncodingError",
+    "LoadError", "RegexpError", "StringScanner_Error", "FiberError", NULL
   };
   for (int i = 0; EX[i]; i++) if (!strcmp(n, EX[i])) return 1;
   return 0;

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -2543,21 +2543,24 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
   if (recv >= 0 && nt_type(nt, recv) && !strcmp(nt_type(nt, recv), "ConstantReadNode") &&
       nt_str(nt, recv, "name") && !strcmp(nt_str(nt, recv, "name"), "Math")) {
     /* 1-arg functions */
+    /* Domain-restricted functions route through sp_math_* wrappers that
+       raise Math::DomainError on out-of-domain input (CRuby parity); the
+       rest call libc directly (all reals are in domain). */
     const char *cfn = NULL;
     if      (!strcmp(name, "sin"))   cfn = "sin";
     else if (!strcmp(name, "cos"))   cfn = "cos";
     else if (!strcmp(name, "tan"))   cfn = "tan";
-    else if (!strcmp(name, "asin"))  cfn = "asin";
-    else if (!strcmp(name, "acos"))  cfn = "acos";
+    else if (!strcmp(name, "asin"))  cfn = "sp_math_asin";
+    else if (!strcmp(name, "acos"))  cfn = "sp_math_acos";
     else if (!strcmp(name, "atan"))  cfn = "atan";
     else if (!strcmp(name, "sinh"))  cfn = "sinh";
     else if (!strcmp(name, "cosh"))  cfn = "cosh";
     else if (!strcmp(name, "tanh"))  cfn = "tanh";
     else if (!strcmp(name, "asinh")) cfn = "asinh";
-    else if (!strcmp(name, "acosh")) cfn = "acosh";
-    else if (!strcmp(name, "atanh")) cfn = "atanh";
+    else if (!strcmp(name, "acosh")) cfn = "sp_math_acosh";
+    else if (!strcmp(name, "atanh")) cfn = "sp_math_atanh";
     else if (!strcmp(name, "exp"))   cfn = "exp";
-    else if (!strcmp(name, "sqrt"))  cfn = "sqrt";
+    else if (!strcmp(name, "sqrt"))  cfn = "sp_math_sqrt";
     else if (!strcmp(name, "cbrt"))  cfn = "cbrt";
     else if (!strcmp(name, "erf"))   cfn = "erf";
     else if (!strcmp(name, "erfc"))  cfn = "erfc";
@@ -2573,7 +2576,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     if (!strcmp(name, "log") && (argc == 1 || argc == 2)) {
       TyKind a0t = comp_ntype(c, argv[0]);
       if (argc == 1) {
-        buf_puts(b, "log(");
+        buf_puts(b, "sp_math_log(");
         if (a0t == TY_INT) buf_puts(b, "(double)");
         emit_expr(c, argv[0], b);
         buf_puts(b, ")");
@@ -2589,21 +2592,21 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
         buf_printf(g_pre, "double _t%d = ", t1);
         if (a1t == TY_INT) buf_puts(g_pre, "(double)");
         emit_expr(c, argv[1], g_pre); buf_puts(g_pre, ";\n");
-        buf_printf(b, "(log(_t%d) / log(_t%d))", t0, t1);
+        buf_printf(b, "(sp_math_log(_t%d) / sp_math_log(_t%d))", t0, t1);
       }
       return;
     }
     /* Math.log2(x), Math.log10(x) */
     if (!strcmp(name, "log2") && argc == 1) {
       TyKind a0t = comp_ntype(c, argv[0]);
-      buf_puts(b, "log2(");
+      buf_puts(b, "sp_math_log2(");
       if (a0t == TY_INT) buf_puts(b, "(double)");
       emit_expr(c, argv[0], b); buf_puts(b, ")");
       return;
     }
     if (!strcmp(name, "log10") && argc == 1) {
       TyKind a0t = comp_ntype(c, argv[0]);
-      buf_puts(b, "log10(");
+      buf_puts(b, "sp_math_log10(");
       if (a0t == TY_INT) buf_puts(b, "(double)");
       emit_expr(c, argv[0], b); buf_puts(b, ")");
       return;

--- a/test/math_domain_error.rb
+++ b/test/math_domain_error.rb
@@ -1,0 +1,115 @@
+# Math.* methods raise Math::DomainError on out-of-domain input,
+# matching CRuby semantics. Previously spinel called bare libc
+# sqrt(-1.0) etc. which returns NaN silently. Math::DomainError is
+# now in the known-exception list and the ancestry walker wires it
+# as < StandardError < Exception, so the natural CRuby idiom works:
+#
+#   x = Math.sqrt(input) rescue 0.0
+#   begin Math.log(x); rescue Math::DomainError => e; ...; end
+#
+# Methods with restricted domains (sqrt, log, log2, log10, acos,
+# asin, acosh, atanh, plus Integer.sqrt) get sp_math_* wrappers.
+# Unrestricted methods (cos, sin, tan, atan, sinh, cosh, tanh,
+# asinh, exp, atan2, hypot) call libc directly — no overhead.
+
+# Sanity: in-domain values still work and produce expected output.
+puts Math.sqrt(4.0)
+puts Math.sqrt(2.0).round(4)
+puts Math.acos(1.0)
+puts Math.asin(0.0)
+puts Math.log(1.0)
+
+# sqrt(negative) → Math::DomainError
+begin
+  Math.sqrt(-1.0)
+  puts "no raise"
+rescue Math::DomainError => e
+  puts "sqrt: #{e}"
+end
+
+# log(negative)
+begin
+  Math.log(-1.0)
+  puts "no raise"
+rescue Math::DomainError => e
+  puts "log: #{e}"
+end
+
+# log2 / log10
+begin
+  Math.log2(-1.0)
+rescue Math::DomainError => e
+  puts "log2: #{e}"
+end
+begin
+  Math.log10(-1.0)
+rescue Math::DomainError => e
+  puts "log10: #{e}"
+end
+
+# acos / asin out of [-1, 1]
+begin
+  Math.acos(2.0)
+rescue Math::DomainError => e
+  puts "acos: #{e}"
+end
+begin
+  Math.asin(-2.0)
+rescue Math::DomainError => e
+  puts "asin: #{e}"
+end
+
+# acosh requires x >= 1
+begin
+  Math.acosh(0.5)
+rescue Math::DomainError => e
+  puts "acosh: #{e}"
+end
+
+# atanh raises for |x| > 1; the endpoints ±1 yield ±Infinity (no raise in CRuby)
+begin
+  Math.atanh(2.0)
+rescue Math::DomainError => e
+  puts "atanh: #{e}"
+end
+
+# Integer.sqrt of negative
+begin
+  Integer.sqrt(-4)
+rescue Math::DomainError => e
+  puts "isqrt: #{e}"
+end
+
+# Hierarchy: Math::DomainError < StandardError < Exception
+begin
+  Math.sqrt(-1.0)
+rescue StandardError => e
+  puts "as Std: caught"
+end
+begin
+  Math.sqrt(-1.0)
+rescue Exception => e
+  puts "as Exc: caught"
+end
+
+# Bare rescue catches it
+begin
+  Math.sqrt(-1.0)
+rescue => e
+  puts "bare-rescue: #{e}"
+end
+
+# Unrestricted methods don't raise — return NaN/Infinity per IEEE 754
+puts Math.cos(0.0)
+puts Math.exp(1.0).round(4)
+
+# 2-arg Math.log(x, base): a valid base computes log_base(x); a NEGATIVE base
+# raises (log of a negative). Per CRuby a base of 0.0 or 1.0 does NOT raise
+# (it yields -0.0 / NaN), so only the negative-base domain error is asserted.
+puts Math.log(8.0, 2.0)
+begin
+  Math.log(2.0, -1.0)
+  puts "no raise"
+rescue Math::DomainError => e
+  puts "log neg base: #{e}"
+end

--- a/test/math_domain_error.rb.expected
+++ b/test/math_domain_error.rb.expected
@@ -1,0 +1,21 @@
+2.0
+1.4142
+0.0
+0.0
+0.0
+sqrt: Numerical argument is out of domain - sqrt
+log: Numerical argument is out of domain - log
+log2: Numerical argument is out of domain - log2
+log10: Numerical argument is out of domain - log10
+acos: Numerical argument is out of domain - acos
+asin: Numerical argument is out of domain - asin
+acosh: Numerical argument is out of domain - acosh
+atanh: Numerical argument is out of domain - atanh
+isqrt: Numerical argument is out of domain - "isqrt"
+as Std: caught
+as Exc: caught
+bare-rescue: Numerical argument is out of domain - sqrt
+1.0
+2.7183
+3.0
+log neg base: Numerical argument is out of domain - log


### PR DESCRIPTION
## What

`Math.sqrt`/`log`/`log2`/`log10`/`acos`/`asin`/`acosh`/`atanh` and `Integer.sqrt` now raise `Math::DomainError` on out-of-domain input, matching CRuby. Previously spinel called bare libc `sqrt(-1.0)` etc. (silent NaN) and `sp_int_sqrt(-4)` returned `0`, so the idiom `x = Math.sqrt(v) rescue 0.0` never fired.

## How

- **`lib/sp_runtime.h`**: new `static inline` `sp_math_*` wrappers that guard each function's domain (`sqrt`/`log`: `x >= 0`; `acos`/`asin`: `|x| <= 1`; `acosh`: `x >= 1`; `atanh`: `|x| < 1`) and raise with CRuby's `Numerical argument is out of domain - "<name>"` message. `log(0)` stays `-Infinity` (no raise); only negative raises.
- **`lib/sp_core.c`**: `sp_int_sqrt` raises on negative input instead of returning `0`.
- **`src/codegen_call.c`**: route the domain-restricted `Math.*` dispatch (including both legs of the 2-arg `Math.log(x, base)` and `log2`/`log10`) through the wrappers; unrestricted methods (`cos`/`sin`/`tan`/`atan`/`sinh`/`cosh`/`tanh`/`asinh`/`exp`/`cbrt`/`erf`/`erfc`/`atan2`/`hypot`) still call libc directly.
- **`lib/sp_runtime.h` + `src/codegen.c`**: wire the flattened runtime name `Math_DomainError` into both exception-hierarchy tables (`< StandardError < Exception`) and `is_exc_name`, following the `StringScanner::Error` → `StringScanner_Error` precedent, so `rescue Math::DomainError` (and `rescue StandardError` / `rescue Exception` / bare `rescue`) all match.

## Tests

`test/math_domain_error.rb` covers each wrapped function raising, in-domain values still computing, the hierarchy (`StandardError`/`Exception`/bare rescue), and that unrestricted methods (`cos`, `exp`) don't raise.

## Verification

- `make test` → 864 pass, 0 fail (no regressions).
- `make bootstrap` → analyze/codegen IR + C fixpoints all OK (byte-stable; the change adds inline functions the legacy codegen never emits and does not alter emitted C text).