### PR TITLE
Fix #1417: match RBS seeds for module-nested classes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,8 +342,8 @@ rbs-seed-test: $(SPINEL) spinel_rbs_extract$(EXE)
 	$(SPINEL) test/rbs-seed/nested_ivar.rb --rbs test/rbs-seed/sig \
 	  -c --no-line-map -o "$$tmp/out.c" 2>/dev/null; \
 	ok=1; \
-	grep -q 'const char \* iv_label' "$$tmp/out.c" || ok=0; \
-	if grep -q 'sp_RbVal iv_label' "$$tmp/out.c"; then ok=0; fi; \
+	grep -Eq 'const char[[:space:]]+\*[[:space:]]*iv_label' "$$tmp/out.c" || ok=0; \
+	if grep -Eq 'sp_RbVal[[:space:]]+iv_label' "$$tmp/out.c"; then ok=0; fi; \
 	$(CC) -fsyntax-only -Ilib "$$tmp/out.c" 2>/dev/null || ok=0; \
 	rm -rf "$$tmp"; \
 	if [ $$ok -eq 1 ]; then echo "rbs-seed-test: pass"; \

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ RBS_SRC      = $(wildcard $(RBS_DIR)/src/*.c) $(wildcard $(RBS_DIR)/src/util/*.c
 RBS_OBJ      = $(patsubst $(RBS_DIR)/src/%.c,build/rbs/%.o,$(RBS_SRC))
 RBS_LIB      = build/librbs.a
 
-.PHONY: all parse legacy bootstrap codegen regexp rbs_extract rbs-test \
+.PHONY: all parse legacy bootstrap codegen regexp rbs_extract rbs-test rbs-seed-test \
         analyze-fail-test test test-run clean-test-results regen-rbs-expected \
         regen-expected bench optcarrot gate check gate-legs gate-test gate-bench \
         gate-optcarrot clean install uninstall deps
@@ -270,9 +270,10 @@ test:
 	+@$(MAKE) --no-print-directory test-run
 
 # The actual run. rbs-test golden-checks the RBS extractor (cheap, C-only).
-# analyze-fail (legacy-analyzer diagnostics) lives in legacy/ now and runs
-# as part of `make gate`, not the hot `make test` loop.
-test-run: rbs-test $(TEST_TARGETS)
+# rbs-seed-test checks the seeds actually reach the analyzer (incl. nested
+# classes, #1417). analyze-fail (legacy-analyzer diagnostics) lives in legacy/
+# now and runs as part of `make gate`, not the hot `make test` loop.
+test-run: rbs-test rbs-seed-test $(TEST_TARGETS)
 	@if [ -z "$(TIMEOUT_BIN)" ]; then echo "Note: no 'timeout' command found; running without time limits."; fi
 	@if [ -t 1 ]; then printf '\n'; fi
 	@pass=$$(grep -l '^PASS' build/test-results/*.ok 2>/dev/null | wc -l); \
@@ -322,6 +323,31 @@ regen-rbs-expected: spinel_rbs_extract$(EXE)
 	  ./spinel_rbs_extract$(EXE) "$$f" > "$${f%.rbs}.seed.expected"; \
 	  echo "regen: $${f%.rbs}.seed.expected"; \
 	done
+endif
+
+# End-to-end --rbs seeding check (#1417). The extractor emits a module-nested
+# class under its qualified name (`Outer_Box`), but the compiler's class table
+# stores the leaf name (`Box`) + enclosing_class. seed_class_index must match
+# the two so the seed reaches the class. The fixture's `@label` is declared
+# `String?` but only ever assigned nil, so inference alone leaves it poly --
+# only an applied seed pins it to a `const char *` field. The extractor must sit
+# beside $(SPINEL) (main.c looks for it as a sibling), so copy it there first.
+ifeq ($(wildcard $(RBS_INC)/rbs/parser.h),)
+rbs-seed-test:
+	@echo "rbs-seed-test: skipped (vendor/rbs not fetched; run 'make deps')"
+else
+rbs-seed-test: $(SPINEL) spinel_rbs_extract$(EXE)
+	@cp -f spinel_rbs_extract$(EXE) $(dir $(SPINEL))spinel_rbs_extract$(EXE)
+	@tmp=$$(mktemp -d /tmp/spinel-rbsseed.XXXXXX); \
+	$(SPINEL) test/rbs-seed/nested_ivar.rb --rbs test/rbs-seed/sig \
+	  -c --no-line-map -o "$$tmp/out.c" 2>/dev/null; \
+	ok=1; \
+	grep -q 'const char \* iv_label' "$$tmp/out.c" || ok=0; \
+	if grep -q 'sp_RbVal iv_label' "$$tmp/out.c"; then ok=0; fi; \
+	$(CC) -fsyntax-only -Ilib "$$tmp/out.c" 2>/dev/null || ok=0; \
+	rm -rf "$$tmp"; \
+	if [ $$ok -eq 1 ]; then echo "rbs-seed-test: pass"; \
+	else echo "rbs-seed-test: FAIL (#1417: module-nested-class seed not applied)"; exit 1; fi
 endif
 
 # Analyze-fail fixtures test the legacy analyzer's rejection diagnostics;

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -985,7 +985,8 @@ static void class_qualified_name(Compiler *c, int ci, char *out, size_t cap) {
     if (j && j + 1 < cap) out[j++] = '_';
     for (const char *p = nm; *p && j + 1 < cap; p++) out[j++] = *p;
   }
-  out[j < cap ? j : (cap ? cap - 1 : 0)] = '\0';
+  /* The loop only advances j while j + 1 < cap, so j < cap here. */
+  if (cap) out[j] = '\0';
 }
 
 /* Class index for a seed `class` line, normalizing `::` to the `_` form used

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -967,6 +967,27 @@ static TyKind parse_seed_type(Compiler *c, const char *tok) {
   return TY_UNKNOWN;
 }
 
+/* Build ci's fully-qualified name as `Outer_Inner_Leaf` -- the module path
+   joined with `_`, matching the form spinel_rbs_extract emits for a seed
+   `class` line. The compiler's class table stores only the leaf name (e.g.
+   `Flash`) plus an enclosing_class link, so a qualified seed name needs this
+   to match. */
+static void class_qualified_name(Compiler *c, int ci, char *out, size_t cap) {
+  int chain[64];
+  int n = 0;
+  for (int x = ci; x >= 0 && n < (int)(sizeof chain / sizeof chain[0]);
+       x = c->classes[x].enclosing_class)
+    chain[n++] = x;
+  size_t j = 0;
+  for (int i = n - 1; i >= 0; i--) {
+    const char *nm = c->classes[chain[i]].name;
+    if (!nm) continue;
+    if (j && j + 1 < cap) out[j++] = '_';
+    for (const char *p = nm; *p && j + 1 < cap; p++) out[j++] = *p;
+  }
+  out[j < cap ? j : (cap ? cap - 1 : 0)] = '\0';
+}
+
 /* Class index for a seed `class` line, normalizing `::` to the `_` form used
    in the compiler's class table. -1 if no such user class. */
 static int seed_class_index(Compiler *c, const char *name) {
@@ -977,7 +998,18 @@ static int seed_class_index(Compiler *c, const char *name) {
     else buf[j++] = *p++;
   }
   buf[j] = '\0';
-  return comp_class_index(c, buf);
+  int direct = comp_class_index(c, buf);
+  if (direct >= 0) return direct;
+  /* A module-nested class (`module M; class C`) is stored under its leaf name
+     `C` with enclosing_class = M, but the extractor emits the qualified
+     `M_C`. Match against each class's reconstructed qualified name so the
+     seed's ivar/method types are not silently dropped. */
+  for (int i = 0; i < c->nclasses; i++) {
+    char qn[256];
+    class_qualified_name(c, i, qn, sizeof qn);
+    if (!strcmp(qn, buf)) return i;
+  }
+  return -1;
 }
 
 static Scope *find_method_scope(Compiler *c, int class_id, const char *name, int is_cmethod) {

--- a/test/rbs-seed/nested_ivar.rb
+++ b/test/rbs-seed/nested_ivar.rb
@@ -1,0 +1,22 @@
+# Regression for #1417. An RBS `--rbs` seed for a *module-nested* class must
+# reach the class. `Outer::Box#@label` is declared `String?`, but the body only
+# ever assigns nil, so inference alone leaves the ivar poly (`sp_RbVal`). Only
+# the seed pins it to a `String` (`const char *`) field.
+#
+# The extractor emits the seed under the qualified name `Outer_Box`, but the
+# compiler stores the class under its leaf name `Box` (+ enclosing_class). Before
+# the fix, seed_class_index matched by exact name only, so the qualified seed
+# name found nothing and every module-nested class's ivar/method seeds were
+# silently dropped -- here, `@label` stayed poly instead of pinning to a string.
+module Outer
+  class Box
+    def initialize
+      @label = nil
+    end
+    def label
+      @label
+    end
+  end
+end
+
+p Outer::Box.new.label.nil?

--- a/test/rbs-seed/sig/nested_ivar.rbs
+++ b/test/rbs-seed/sig/nested_ivar.rbs
@@ -1,0 +1,7 @@
+module Outer
+  class Box
+    @label: String?
+    def initialize: () -> void
+    def label: () -> String?
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #1417. The reported symptom — a `String?` ivar passed as `sp_RbVal` into a `Hash[String, String]` (`StrStrHash`, `const char *`) setter — is the visible end of a broader root cause: **RBS seeds for every module-nested class are silently dropped.**

### Root cause

The extractor emits a seed `class` line under the fully-qualified name (`ActionDispatch_Flash`, `ActionView_ViewHelpers`, `Views_Articles`), but the compiler's class table stores a nested class under its **leaf** name (`Flash`) plus an `enclosing_class` link. `seed_class_index` matched by exact name only, so the qualified seed name resolved to −1 and the whole seed block was discarded. Measured against the published blog archive: **39 of 77 seed classes failed to resolve — every module-nested one.**

For `ActionDispatch::Flash`, `@notice: String?` is therefore never pinned; inference widens it to poly (assigned from the untyped `[]=` value param and the `each` block var), and `to_h`'s `StrStrHash` store gets an `sp_RbVal`:

```
error: passing 'sp_RbVal' to parameter of incompatible type 'const char *'
```

### Fix

Reconstruct each class's qualified name from the `enclosing_class` chain (`Outer_Inner_Leaf`) and match the seed name against it when the direct lookup misses. Top-level classes still resolve via the direct lookup first (unaffected).

### Test

The suite otherwise never exercises `--rbs`, so this adds an end-to-end `rbs-seed-test` (wired into `make test`): a module-nested class whose `String?` ivar is only ever assigned nil — inference alone leaves it poly, so only an applied seed pins it to a `const char *` field. The target also copies `spinel_rbs_extract` beside `build/spinel`, which `main.c` requires as a sibling — without it, local `--rbs` is a silent no-op (likely why this went unnoticed locally). The test fails before this change and passes after.

Full suite: **886 pass, 0 fail** (+13 RBS extractor tests, +`rbs-seed-test`).

### Scope note

This is the root-cause fix for #1417's ivar case. Applying the ~39 previously-dropped seed sets also **surfaces three pre-existing latent mismatches** the bug had been masking — same family, at return/param boundaries (a poly value flowing into an RBS-pinned narrower type):

- `ActionView::ViewHelpers.content_for_get` / `get_slot` — RBS `-> String?`/`String`, body returns poly (`SymPolyHash#[]`/nil)
- `Views::Articles.article_json(article)` — RBS param `Article`, called with a poly array element

These need a poly→pinned-type coercion at the boundary (the issue's "suggested direction #2") and are left as separate follow-ups so this PR stays scoped to the seed-matching root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)