### PR TITLE
fix(ci): pre-start sccache server and raise startup timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,19 @@ jobs:
       # the compile step is in sccache's cacheable pattern.
       CC: sccache ${{ matrix.cc }}
       SCCACHE_GHA_ENABLED: "true"
+      # Room for the slow GHA-backed server startup (default ~10s); keep it
+      # alive across steps. See the pre-start step below.
+      SCCACHE_STARTUP_TIMEOUT: "30"
+      SCCACHE_IDLE_TIMEOUT: "0"
     steps:
       - uses: actions/checkout@v6
 
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@v0.0.10
+
+      # Start the server once here so `make -j` clients don't race to start it.
+      - name: Pre-start sccache server
+        run: sccache --start-server
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
CI intermittently fails the `ubuntu/gcc` and `macos/clang` jobs with:

```
sccache: error: Timed out waiting for server startup. Maybe the remote service is unreachable?
make: *** [build/prism/node.o] Error 2
```

`ubuntu/clang` passes on the same commit and the code builds + tests fine
locally, so it's a transient CI-infra flake, not a code bug.

## Root cause

The sccache *client* gives up waiting for the sccache *server* to become ready.
Two compounding factors:
1. With `SCCACHE_GHA_ENABLED`, the server contacts GitHub's Actions Cache
   service at startup — slow during the cache-service brownouts (hence the
   "remote service unreachable" hint).
2. `make -j$(nproc)` launches many `sccache <cc>` clients at once (the vendored
   prism objects), all racing to auto-start the single server. The default ~10s
   `SCCACHE_STARTUP_TIMEOUT` under that race is exceeded — the failure landing on
   one of the first parallel compiles (`build/prism/node.o`) is the signature.
   (See mozilla/sccache https://github.com/mozilla/sccache/issues/1153 and
   https://github.com/mozilla/sccache/issues/317.)

## Change

`.github/workflows/ci.yml`:
- Add a `Pre-start sccache server` step (`sccache --start-server`) right after
  the sccache-action setup, so the one slow GHA-backed startup happens serially,
  up front — the parallel `make -j` compiles then just connect to a running
  server.
- `SCCACHE_STARTUP_TIMEOUT: "30"` — room for the GHA-backed startup (default ~10s).
- `SCCACHE_IDLE_TIMEOUT: "0"` — keep the server alive across all steps.

Caching behaviour is unchanged; the trailing `sccache --show-stats` step still
reports hits.