### PR TITLE
Replace ucontext fibers with a portable asm context switch (OpenBSD)

### DIFF
--- a/lib/sp_fiber.c
+++ b/lib/sp_fiber.c
@@ -7,6 +7,74 @@
 #include <string.h>
 #include <sys/mman.h>
 
+/* OpenBSD requires the stack a coroutine runs on to be MAP_STACK, else the
+   first push faults. Linux defines MAP_STACK as a (currently) no-op; keep it
+   portable. */
+#ifndef MAP_STACK
+#define MAP_STACK 0
+#endif
+
+/* ---- Portable coroutine context switch (replaces swapcontext) ----
+   sp_ctx_swap saves the callee-saved registers onto the *current* stack, stows
+   the resulting stack pointer in *from, loads *to's stack pointer, and pops the
+   callee-saved registers (the very first switch into a coroutine pops the zeroed
+   slots sp_ctx_make laid out and `ret`s into the trampoline). It lives in .text
+   (W^X-safe) and issues no syscall. See sp_fiber_ctx.h for sp_ctx_make and the
+   stack layout it must mirror. */
+#if SP_FIBER_ASM
+#if defined(__APPLE__)
+  #define SP_CTX_SYM "_sp_ctx_swap"
+#else
+  #define SP_CTX_SYM "sp_ctx_swap"
+#endif
+#if defined(__x86_64__)
+__asm__(
+  ".text\n"
+  ".globl " SP_CTX_SYM "\n"
+  SP_CTX_SYM ":\n"
+  "  pushq %rbp\n  pushq %rbx\n  pushq %r12\n  pushq %r13\n  pushq %r14\n  pushq %r15\n"
+  "  movq %rsp, (%rdi)\n"        /* from->sp = rsp                      */
+  "  movq (%rsi), %rsp\n"        /* rsp = to->sp                        */
+  "  popq %r15\n  popq %r14\n  popq %r13\n  popq %r12\n  popq %rbx\n  popq %rbp\n"
+  "  ret\n"
+);
+#elif defined(__aarch64__)
+__asm__(
+  ".text\n"
+  ".globl " SP_CTX_SYM "\n"
+  SP_CTX_SYM ":\n"
+  /* save x19..x30 (12*8) + d8..d15 (8*8) = 160 bytes onto the current stack */
+  "  stp x19, x20, [sp, #-160]!\n"
+  "  stp x21, x22, [sp, #16]\n"
+  "  stp x23, x24, [sp, #32]\n"
+  "  stp x25, x26, [sp, #48]\n"
+  "  stp x27, x28, [sp, #64]\n"
+  "  stp x29, x30, [sp, #80]\n"
+  "  stp d8,  d9,  [sp, #96]\n"
+  "  stp d10, d11, [sp, #112]\n"
+  "  stp d12, d13, [sp, #128]\n"
+  "  stp d14, d15, [sp, #144]\n"
+  "  mov x2, sp\n"
+  "  str x2, [x0]\n"             /* from->sp = sp */
+  "  ldr x2, [x1]\n"            /* sp = to->sp   */
+  "  mov sp, x2\n"
+  "  ldp d14, d15, [sp, #144]\n"
+  "  ldp d12, d13, [sp, #128]\n"
+  "  ldp d10, d11, [sp, #112]\n"
+  "  ldp d8,  d9,  [sp, #96]\n"
+  "  ldp x29, x30, [sp, #80]\n"
+  "  ldp x27, x28, [sp, #64]\n"
+  "  ldp x25, x26, [sp, #48]\n"
+  "  ldp x23, x24, [sp, #32]\n"
+  "  ldp x21, x22, [sp, #16]\n"
+  "  ldp x19, x20, [sp], #160\n"
+  "  ret\n"
+);
+#endif
+#else  /* ucontext fallback */
+void sp_ctx_swap(sp_fiber_ctx *from, sp_fiber_ctx *to) { swapcontext(&from->uc, &to->uc); }
+#endif
+
 /* ---- Reached by name in the generated TU ---- */
 void *sp_gc_alloc(size_t sz, void (*fin)(void *), void (*scn)(void *));
 void sp_raise_cls(const char *cls, const char *msg);
@@ -68,13 +136,13 @@ static void sp_mark_suspended_fibers(void){sp_mark_fiber_roots(&sp_fiber_root);s
 static void sp_fiber_install_gc_hook(void){if(!sp_gc_mark_suspended_fibers_hook)sp_gc_mark_suspended_fibers_hook=sp_mark_suspended_fibers;}
 static void sp_Fiber_fin(void*p){sp_Fiber*f=(sp_Fiber*)p;if(f->stack)munmap(f->stack,SP_FIBER_STACK_SIZE);if(f->saved_roots)free(f->saved_roots);sp_fiber_list_remove(f);}
 static void sp_Fiber_scan(void*p){sp_Fiber*f=(sp_Fiber*)p;if(f->user_data)sp_gc_mark(f->user_data);if(f->storage)sp_gc_mark(f->storage);}
-sp_Fiber*sp_Fiber_new(void(*body)(sp_Fiber*)){sp_Fiber*f=(sp_Fiber*)sp_gc_alloc(sizeof(sp_Fiber),sp_Fiber_fin,sp_Fiber_scan);f->stack=(char*)mmap(NULL,SP_FIBER_STACK_SIZE,PROT_READ|PROT_WRITE,MAP_PRIVATE|MAP_ANONYMOUS,-1,0);if(f->stack==MAP_FAILED){f->stack=NULL;sp_raise_cls("FiberError","failed to allocate fiber stack");}f->state=0;f->transferred=0;f->body=body;f->yielded_value=sp_box_nil();f->resumed_value=sp_box_nil();f->user_data=NULL;f->saved_exc_top=0;f->saved_catch_top=0;f->storage=NULL;f->saved_roots=NULL;f->saved_nroots=0;f->saved_roots_cap=0;f->fiber_next=NULL;f->fiber_prev=NULL;sp_fiber_list_add(f);sp_fiber_install_gc_hook();if(sp_fiber_current&&sp_fiber_current->storage){sp_Fiber*volatile _froot=f;int _pushed=0;if(sp_gc_nroots<SP_GC_STACK_MAX){sp_gc_roots[sp_gc_nroots++]=(void**)&_froot;_pushed=1;}f->storage=sp_FiberStore_dup((sp_FiberStore*)sp_fiber_current->storage);if(_pushed)sp_gc_nroots--;}return f;}
+sp_Fiber*sp_Fiber_new(void(*body)(sp_Fiber*)){sp_Fiber*f=(sp_Fiber*)sp_gc_alloc(sizeof(sp_Fiber),sp_Fiber_fin,sp_Fiber_scan);f->stack=(char*)mmap(NULL,SP_FIBER_STACK_SIZE,PROT_READ|PROT_WRITE,MAP_PRIVATE|MAP_ANONYMOUS|MAP_STACK,-1,0);if(f->stack==MAP_FAILED){f->stack=NULL;sp_raise_cls("FiberError","failed to allocate fiber stack");}f->state=0;f->transferred=0;f->body=body;f->yielded_value=sp_box_nil();f->resumed_value=sp_box_nil();f->user_data=NULL;f->saved_exc_top=0;f->saved_catch_top=0;f->storage=NULL;f->saved_roots=NULL;f->saved_nroots=0;f->saved_roots_cap=0;f->fiber_next=NULL;f->fiber_prev=NULL;sp_fiber_list_add(f);sp_fiber_install_gc_hook();if(sp_fiber_current&&sp_fiber_current->storage){sp_Fiber*volatile _froot=f;int _pushed=0;if(sp_gc_nroots<SP_GC_STACK_MAX){sp_gc_roots[sp_gc_nroots++]=(void**)&_froot;_pushed=1;}f->storage=sp_FiberStore_dup((sp_FiberStore*)sp_fiber_current->storage);if(_pushed)sp_gc_nroots--;}return f;}
 sp_RbVal sp_Fiber_storage_get(sp_Fiber*f,sp_sym k){if(!f->storage)return sp_box_nil();return sp_FiberStore_get((sp_FiberStore*)f->storage,k);}
 void sp_Fiber_storage_set(sp_Fiber*f,sp_sym k,sp_RbVal v){if(!f->storage)f->storage=sp_FiberStore_new();sp_FiberStore_set((sp_FiberStore*)f->storage,k,v);}
-static void sp_fiber_trampoline(void){sp_Fiber*f=sp_fiber_current;f->body(f);f->state=3;if(f->transferred){sp_fiber_current=&sp_fiber_root;setcontext(&sp_fiber_root.ctx);}else{swapcontext(&f->ctx,&f->caller_ctx);}}
-sp_RbVal sp_Fiber_resume(sp_Fiber*f,sp_RbVal val){if(f->state==3){sp_raise_cls("FiberError","attempt to resume a terminated fiber");}f->resumed_value=val;sp_Fiber*prev=sp_fiber_current;sp_fiber_save_roots(prev);sp_fiber_restore_roots(f);sp_fiber_current=f;if(f->state==0){f->state=1;getcontext(&f->ctx);f->ctx.uc_stack.ss_sp=f->stack;f->ctx.uc_stack.ss_size=SP_FIBER_STACK_SIZE;f->ctx.uc_link=&f->caller_ctx;makecontext(&f->ctx,(void(*)(void))sp_fiber_trampoline,0);swapcontext(&f->caller_ctx,&f->ctx);}else{f->state=1;swapcontext(&f->caller_ctx,&f->ctx);}sp_fiber_save_roots(f);sp_fiber_restore_roots(prev);sp_fiber_current=prev;return f->yielded_value;}
-sp_RbVal sp_Fiber_yield(sp_RbVal val){sp_Fiber*f=sp_fiber_current;f->yielded_value=val;f->state=2;swapcontext(&f->ctx,&f->caller_ctx);return f->resumed_value;}
+static void sp_fiber_trampoline(void){sp_Fiber*f=sp_fiber_current;f->body(f);f->state=3;if(f->transferred){sp_fiber_current=&sp_fiber_root;sp_ctx_swap(&f->ctx,&sp_fiber_root.ctx);}else{sp_ctx_swap(&f->ctx,&f->caller_ctx);}}
+sp_RbVal sp_Fiber_resume(sp_Fiber*f,sp_RbVal val){if(f->state==3){sp_raise_cls("FiberError","attempt to resume a terminated fiber");}f->resumed_value=val;sp_Fiber*prev=sp_fiber_current;sp_fiber_save_roots(prev);sp_fiber_restore_roots(f);sp_fiber_current=f;if(f->state==0){f->state=1;sp_ctx_make(&f->ctx,f->stack,SP_FIBER_STACK_SIZE,sp_fiber_trampoline);sp_ctx_swap(&f->caller_ctx,&f->ctx);}else{f->state=1;sp_ctx_swap(&f->caller_ctx,&f->ctx);}sp_fiber_save_roots(f);sp_fiber_restore_roots(prev);sp_fiber_current=prev;return f->yielded_value;}
+sp_RbVal sp_Fiber_yield(sp_RbVal val){sp_Fiber*f=sp_fiber_current;f->yielded_value=val;f->state=2;sp_ctx_swap(&f->ctx,&f->caller_ctx);return f->resumed_value;}
 mrb_bool sp_Fiber_alive(sp_Fiber*f){return f->state!=3;}
-sp_RbVal sp_Fiber_transfer(sp_Fiber*f,sp_RbVal val){f->resumed_value=val;sp_Fiber*prev=sp_fiber_current;sp_fiber_save_roots(prev);sp_fiber_restore_roots(f);sp_fiber_current=f;if(f->state==0){f->state=1;f->transferred=1;getcontext(&f->ctx);f->ctx.uc_stack.ss_sp=f->stack;f->ctx.uc_stack.ss_size=SP_FIBER_STACK_SIZE;f->ctx.uc_link=&prev->ctx;makecontext(&f->ctx,(void(*)(void))sp_fiber_trampoline,0);swapcontext(&prev->ctx,&f->ctx);}else{f->state=1;swapcontext(&prev->ctx,&f->ctx);}sp_fiber_save_roots(f);sp_fiber_restore_roots(prev);sp_fiber_current=prev;return prev->resumed_value;}
+sp_RbVal sp_Fiber_transfer(sp_Fiber*f,sp_RbVal val){f->resumed_value=val;sp_Fiber*prev=sp_fiber_current;sp_fiber_save_roots(prev);sp_fiber_restore_roots(f);sp_fiber_current=f;if(f->state==0){f->state=1;f->transferred=1;sp_ctx_make(&f->ctx,f->stack,SP_FIBER_STACK_SIZE,sp_fiber_trampoline);sp_ctx_swap(&prev->ctx,&f->ctx);}else{f->state=1;sp_ctx_swap(&prev->ctx,&f->ctx);}sp_fiber_save_roots(f);sp_fiber_restore_roots(prev);sp_fiber_current=prev;return prev->resumed_value;}
 
 void sp_mark_fiber_root_storage(void){if(sp_fiber_root.storage)sp_gc_mark(sp_fiber_root.storage);}

--- a/lib/sp_fiber.h
+++ b/lib/sp_fiber.h
@@ -1,19 +1,20 @@
 /* sp_fiber.h -- Fiber runtime surface.
  *
- * The sp_Fiber struct (a cooperative coroutine over POSIX ucontext) is
- * shared between the generated translation unit and lib/sp_fiber.c, which
- * holds the function bodies. `storage` is an opaque pointer to fiber-local
- * variable storage (defined in lib/sp_fiber.c). */
+ * The sp_Fiber struct (a cooperative coroutine) is shared between the generated
+ * translation unit and lib/sp_fiber.c, which holds the function bodies. The
+ * context switch lives in sp_fiber_ctx.h (a portable asm switch on x86_64 /
+ * aarch64, ucontext elsewhere) -- no <ucontext.h> here, so OpenBSD compiles.
+ * `storage` is an opaque pointer to fiber-local variable storage. */
 #ifndef SP_FIBER_H
 #define SP_FIBER_H
 
 #include "sp_gc.h"   /* sp_RbVal */
-#include <ucontext.h>
+#include "sp_fiber_ctx.h"
 
 
 #define SP_FIBER_STACK_SIZE (64*1024)
 
-typedef struct sp_Fiber{ucontext_t ctx;ucontext_t caller_ctx;char*stack;int state;int transferred;sp_RbVal yielded_value;sp_RbVal resumed_value;void(*body)(struct sp_Fiber*);void*user_data;int saved_exc_top;int saved_catch_top;void*storage;void***saved_roots;int saved_nroots;int saved_roots_cap;struct sp_Fiber*fiber_next;struct sp_Fiber*fiber_prev;}sp_Fiber;
+typedef struct sp_Fiber{sp_fiber_ctx ctx;sp_fiber_ctx caller_ctx;char*stack;int state;int transferred;sp_RbVal yielded_value;sp_RbVal resumed_value;void(*body)(struct sp_Fiber*);void*user_data;int saved_exc_top;int saved_catch_top;void*storage;void***saved_roots;int saved_nroots;int saved_roots_cap;struct sp_Fiber*fiber_next;struct sp_Fiber*fiber_prev;}sp_Fiber;
 
 /* The currently-running fiber; the generated TU reads it directly for
    `Fiber.current` and as the implicit receiver of Fiber operations. */

--- a/lib/sp_fiber_ctx.h
+++ b/lib/sp_fiber_ctx.h
@@ -1,0 +1,81 @@
+/* sp_fiber_ctx.h -- portable coroutine context switch for sp_fiber.c.
+ *
+ * Replaces POSIX <ucontext.h> (getcontext/makecontext/swapcontext), which
+ * OpenBSD removed in 5.7 (W^X / ASLR hardening) and which is deprecated on
+ * macOS. On x86_64 and aarch64 we use a tiny cooperative register switch
+ * written as file-scope inline asm (defined in sp_fiber.c): it lands in .text
+ * (W^X-safe, unlike libco's executable data blob), does no syscall (unlike
+ * swapcontext's sigprocmask, so it's faster), and only saves the callee-saved
+ * registers + stack pointer. The "context" is therefore just the saved stack
+ * pointer; all other state lives on the coroutine's own stack. Other
+ * architectures fall back to <ucontext.h>.
+ *
+ *   sp_ctx_swap(from, to)               save the current context into *from,
+ *                                       then switch to *to.
+ *   sp_ctx_make(ctx, base, size, entry) prime a fresh context so the first swap
+ *                                       into it begins executing entry() on the
+ *                                       stack [base, base+size). entry must
+ *                                       never return.
+ */
+#ifndef SP_FIBER_CTX_H
+#define SP_FIBER_CTX_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(__x86_64__) || defined(__aarch64__)
+  #define SP_FIBER_ASM 1
+#else
+  #define SP_FIBER_ASM 0
+#endif
+
+#if SP_FIBER_ASM
+
+/* The whole machine context is the saved stack pointer; the callee-saved
+   registers are pushed onto / popped from the coroutine's own stack by
+   sp_ctx_swap (see the file-scope asm in sp_fiber.c). */
+typedef struct sp_fiber_ctx { void *sp; } sp_fiber_ctx;
+
+static inline void sp_ctx_make(sp_fiber_ctx *ctx, void *base, size_t size,
+                               void (*entry)(void)) {
+  uintptr_t top = ((uintptr_t)base + size) & ~(uintptr_t)15; /* 16B-align the top */
+#if defined(__x86_64__)
+  /* SysV AMD64: entry's first instruction needs rsp%16 == 8 (as if reached by
+     `call`). sp_ctx_swap pops 6 callee-saved regs then `ret`s into the slot
+     just above them: [entry][rbp][rbx][r12][r13][r14][r15<-sp]. */
+  void **s = (void **)(top - 8);
+  *--s = (void *)entry;                  /* `ret` target, at top-16 */
+  for (int i = 0; i < 6; i++) *--s = 0;  /* rbp, rbx, r12, r13, r14, r15 */
+  ctx->sp = s;                           /* top-64 */
+#else /* __aarch64__ */
+  /* Mirror the aarch64 sp_ctx_swap frame: 160 bytes holding x19..x30 (12) then
+     d8..d15 (8). x30 (lr = entry) sits at offset 88 (slot 11). On the first
+     swap the ldp's load zeros + entry into lr and `ret` (br x30) jumps to it. */
+  void **s = (void **)(top - 160);
+  for (int i = 0; i < 20; i++) s[i] = 0;
+  s[11] = (void *)entry;                 /* x30 (lr) */
+  ctx->sp = s;
+#endif
+}
+
+#else  /* portable fallback: POSIX ucontext */
+
+#include <ucontext.h>
+typedef struct sp_fiber_ctx { ucontext_t uc; } sp_fiber_ctx;
+
+static inline void sp_ctx_make(sp_fiber_ctx *ctx, void *base, size_t size,
+                               void (*entry)(void)) {
+  getcontext(&ctx->uc);
+  ctx->uc.uc_stack.ss_sp = base;
+  ctx->uc.uc_stack.ss_size = size;
+  ctx->uc.uc_link = NULL;               /* entry never returns (trampoline switches) */
+  makecontext(&ctx->uc, entry, 0);
+}
+
+#endif
+
+/* Defined as file-scope asm in sp_fiber.c (asm backend) or a swapcontext
+   wrapper (fallback). */
+void sp_ctx_swap(sp_fiber_ctx *from, sp_fiber_ctx *to);
+
+#endif /* SP_FIBER_CTX_H */


### PR DESCRIPTION
Replaces POSIX ucontext (getcontext/makecontext/swapcontext) in the Fiber runtime with a tiny cooperative asm register switch, so Spinel builds and runs on OpenBSD (which removed ucontext in 5.7 for W^X/ASLR hardening; also deprecated on macOS).

**Mechanism**: the machine context is just the saved stack pointer; `sp_ctx_swap` saves callee-saved registers onto the coroutine's own stack and switches sp, `sp_ctx_make` lays out a fresh stack so the first swap `ret`s into the trampoline. File-scope inline asm for x86_64 + aarch64 (lands in .text — W^X-safe, no syscall, so faster than swapcontext's sigprocmask); other arches fall back to ucontext. No `<ucontext.h>` on the asm path. Fiber stacks mmap'd MAP_STACK where available (OpenBSD requires it).

**Validation**:
- x86_64 (local): optcarrot **checksum 59662** (PPU is a Fiber-heavy coroutine) at **fps 721** (slightly faster than the swapcontext build), all fiber/thread tests under `SPINEL_GC_STRESS`, full gate green.
- **aarch64: this PR runs to validate it on the macOS arm64 CI runner** (couldn't test locally).

`Fiber#transfer` to the root fiber was already a pre-existing segfault on the ucontext code; unchanged here.

This PR exists specifically so CI exercises the aarch64 asm before it reaches master.