### PR TITLE
Poly dispatch: void-arm guards must cover the full no-value set {VOID,NIL,UNKNOWN}

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -1526,7 +1526,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
             if (kmi < 0) continue;
             TyKind kr = (TyKind)c->scopes[kmi].ret;
             buf_printf(b, " case %d: ", k);
-            if (unified == TY_POLY && (kr == TY_UNKNOWN || kr == TY_VOID)) {
+            if (unified == TY_POLY && (kr == TY_UNKNOWN || kr == TY_VOID || kr == TY_NIL)) {
               /* void-return (raises): call then fall through with nil */
               emit_method_cname(c, &c->scopes[kmi], b);
               buf_puts(b, "(");
@@ -1559,7 +1559,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
           buf_printf(b, " default: ");
           {
             TyKind dr = (TyKind)c->scopes[defmi].ret;
-            if (unified == TY_POLY && (dr == TY_UNKNOWN || dr == TY_VOID)) {
+            if (unified == TY_POLY && (dr == TY_UNKNOWN || dr == TY_VOID || dr == TY_NIL)) {
               emit_method_cname(c, &c->scopes[defmi], b);
               buf_puts(b, "(");
               emit_args_filled(c, defmi, nt_ref(nt, id, "arguments"), "", b);

--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -3120,7 +3120,7 @@ else {
     if (kmi < 0) continue;
     TyKind arm_ret = (TyKind)c->scopes[kmi].ret;
     const char *kfn = mc(c->scopes[kmi].name);
-    if (arm_ret == TY_VOID || arm_ret == TY_NIL) {
+    if (arm_ret == TY_VOID || arm_ret == TY_NIL || arm_ret == TY_UNKNOWN) {
       /* void-returning override: call it, assign nil/zero to the result temp */
       buf_printf(b, " case %d: sp_%s_%s((sp_%s *)%s", k,
                  c->classes[kd].name, kfn, c->classes[kd].name, selfptr);
@@ -3159,7 +3159,7 @@ else {
   }
   /* default arm uses the base-class (defcls) implementation */
   TyKind def_ret = (TyKind)m->ret;
-  if (def_ret == TY_VOID || def_ret == TY_NIL) {
+  if (def_ret == TY_VOID || def_ret == TY_NIL || def_ret == TY_UNKNOWN) {
     buf_printf(b, " default: sp_%s_%s((sp_%s *)%s",
                c->classes[defcls].name, mc(mname), c->classes[defcls].name, selfptr);
     for (int a = 0; a < np; a++) buf_printf(b, ", _t%d", atmp[a]);


### PR DESCRIPTION
## Symptom

`spinel app.rb -o app` fails C compilation with `invalid use of void expression`, pointing at a poly-dispatched call to a `void`-returning method — but **only on some build machines**, passing on others at the *same* commit.

Minimal trigger (real-blog `has_many :comments, dependent: :destroy`):
```ruby
def before_destroy
  comments.each { |c| c.destroy }   # value is the receiver in Ruby; unused here
end
```
On the affected build this emits, in `ActiveRecord::Base#destroy`'s dispatch:
```c
case <Article>: { _t = sp_box_int(sp_Article_before_destroy((sp_Article *)self)); }
```
— boxing the result of a function that is declared `void`.

## Root cause

Both poly-receiver dispatchers split between the **void arm** (call the override as a statement, assign a default to the result temp) and the **value arm** (box the call's return) based on the arm's stored return `TyKind`. Each tested only a *subset* of the "no usable value" types, and the two were **mirror-incomplete**:

| dispatcher | void-arm guard tested | missing |
|---|---|---|
| `codegen_fold.c` (instance self-dispatch) | `VOID`, `NIL` | `UNKNOWN` |
| `codegen_call.c` (class-method dispatch) | `UNKNOWN`, `VOID` | `NIL` |

A method whose `ret` is *any* of `VOID`/`NIL`/`UNKNOWN` is emitted `void` — that's exactly `method_is_void`, i.e. `!is_scalar_ret(ret)`. When such a method's `ret` is the one type the local guard omits, the dispatch falls through to the value arm and emits `_t = <void call>` / `sp_box_int(<void call>)` → invalid C.

## Why it's environment-dependent

The inferred `ret` of `comments.each { |c| c.destroy }` is **layout-sensitive**: `TY_NIL` on some builds, `TY_UNKNOWN` on others. This is **not UB** — `valgrind --track-origins` and a `-fsanitize=undefined` build are both completely clean, and it reproduces identically at `-O0`. It's a well-defined but allocation-order-dependent inference result. The function is emitted `void` regardless; on builds where `ret` landed `TY_UNKNOWN`, `codegen_fold.c`'s case arm (which omitted `UNKNOWN`) took the value arm and produced `sp_box_int(<void call>)`, failing the AOT compile on those machines only.

(The underlying inference nondeterminism — *why* `ret` is `UNKNOWN` vs `NIL` — is a separate, deeper item. But the dispatch should be robust to it regardless: an `UNKNOWN`/`void` method's result must never be boxed.)

## Fix

Make all four arms (case + default, both dispatchers) test the full no-value set `{VOID, NIL, UNKNOWN}`. Each is a one-token addition that closes a real latent `box(<void call>)` hole, and it makes the two dispatchers consistent.

## Verification

- `make test`: **950 pass / 0 fail / 0 error**.
- The real-blog AOT compile that failed (`before_destroy` → `sp_box_int(<void call>)`) now compiles on the machine where it reproduced 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
