### PR TITLE
Poly dispatch: call method_is_void() in the void-arm guards (follow-up to #1469)

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -1526,7 +1526,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
             if (kmi < 0) continue;
             TyKind kr = (TyKind)c->scopes[kmi].ret;
             buf_printf(b, " case %d: ", k);
-            if (unified == TY_POLY && (kr == TY_UNKNOWN || kr == TY_VOID || kr == TY_NIL)) {
+            if (unified == TY_POLY && method_is_void(&c->scopes[kmi])) {
               /* void-return (raises): call then fall through with nil */
               emit_method_cname(c, &c->scopes[kmi], b);
               buf_puts(b, "(");
@@ -1559,7 +1559,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
           buf_printf(b, " default: ");
           {
             TyKind dr = (TyKind)c->scopes[defmi].ret;
-            if (unified == TY_POLY && (dr == TY_UNKNOWN || dr == TY_VOID || dr == TY_NIL)) {
+            if (unified == TY_POLY && method_is_void(&c->scopes[defmi])) {
               emit_method_cname(c, &c->scopes[defmi], b);
               buf_puts(b, "(");
               emit_args_filled(c, defmi, nt_ref(nt, id, "arguments"), "", b);

--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -3120,8 +3120,9 @@ else {
     if (kmi < 0) continue;
     TyKind arm_ret = (TyKind)c->scopes[kmi].ret;
     const char *kfn = mc(c->scopes[kmi].name);
-    if (arm_ret == TY_VOID || arm_ret == TY_NIL || arm_ret == TY_UNKNOWN) {
-      /* void-returning override: call it, assign nil/zero to the result temp */
+    if (method_is_void(&c->scopes[kmi])) {
+      /* override emitted as a void C function (method_is_void: VOID/NIL/UNKNOWN
+         ret, or initialize) -- call it, assign nil/zero to the result temp */
       buf_printf(b, " case %d: sp_%s_%s((sp_%s *)%s", k,
                  c->classes[kd].name, kfn, c->classes[kd].name, selfptr);
       for (int a = 0; a < np; a++) buf_printf(b, ", _t%d", atmp[a]);
@@ -3159,7 +3160,7 @@ else {
   }
   /* default arm uses the base-class (defcls) implementation */
   TyKind def_ret = (TyKind)m->ret;
-  if (def_ret == TY_VOID || def_ret == TY_NIL || def_ret == TY_UNKNOWN) {
+  if (method_is_void(m)) {
     buf_printf(b, " default: sp_%s_%s((sp_%s *)%s",
                c->classes[defcls].name, mc(mname), c->classes[defcls].name, selfptr);
     for (int a = 0; a < np; a++) buf_printf(b, ", _t%d", atmp[a]);


### PR DESCRIPTION
Follow-up to #1469, implementing the change @matz suggested on that PR.

#1469 fixed the four poly-dispatch void-arm guards by making each enumerate the no-value set `{VOID, NIL, UNKNOWN}` explicitly. As noted there, the guards can instead call **`method_is_void(&c->scopes[mi])` directly** — it's `!is_scalar_ret(ret)`, which is true for exactly `{VOID, NIL, UNKNOWN}` (plus `initialize`). So the void arm is now taken **iff the override is emitted as a C `void` function** — the *same* predicate `emit_method_signature` uses to decide `void`. The dispatch and the function declaration can no longer disagree, and a future no-value `TyKind` can't reintroduce the mirror-incompleteness #1469 fixed.

**Four sites** (case + default × both dispatchers):
- `codegen_fold.c` instance self-dispatch — `arm_ret`/`def_ret` enum check → `method_is_void(&c->scopes[kmi])` / `method_is_void(m)`
- `codegen_call.c` class-method dispatch — `kr`/`dr` enum check → `method_is_void(&c->scopes[kmi])` / `method_is_void(&c->scopes[defmi])`

(The `arm_ret`/`kr`/`def_ret`/`dr` locals stay — the value arms still use them for box-fn selection.)

No behavior change for the cases #1469 covered; additionally routes a poly-dispatched void `initialize` through the void arm, consistent with its void emission.

`make test`: **950 pass / 0 fail / 0 error**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)