### PR TITLE
runtime,regexp: annotate noreturn on sp_raise_cls / compile_error decls

### DIFF
--- a/lib/regexp/re_compile.c
+++ b/lib/regexp/re_compile.c
@@ -44,7 +44,7 @@ void sp_re_set_error_handler(void (*fn)(const char *msg)) {
   sp_re_error_handler = fn;
 }
 
-static void
+static __attribute__((noreturn)) void
 compile_error(re_compiler *c, const char *msg)
 {
   if (c->stripped) free(c->stripped);

--- a/lib/sp_bigint.c
+++ b/lib/sp_bigint.c
@@ -16,7 +16,7 @@
 
 /* Defined in sp_runtime.h (linked into the final program); forward-declared
    here so the bigint object can raise without pulling in the whole header. */
-extern void sp_raise_cls(const char *cls, const char *msg);
+extern __attribute__((noreturn)) void sp_raise_cls(const char *cls, const char *msg);
 
 #define DIG_SIZE (MPZ_DIG_SIZE)
 #define DIG_BASE (1ULL << DIG_SIZE)

--- a/lib/sp_core.c
+++ b/lib/sp_core.c
@@ -19,7 +19,7 @@ typedef double  mrb_float;
 
 /* Defined in the generated translation unit (sp_runtime.h); referenced
    here and resolved at link time. */
-void sp_raise_cls(const char *cls, const char *msg);
+__attribute__((noreturn)) void sp_raise_cls(const char *cls, const char *msg);
 const char *sp_sprintf(const char *fmt, ...);
 
 /* CRuby's `String#to_i` accepts a leading sign, then digits with

--- a/lib/sp_fiber.c
+++ b/lib/sp_fiber.c
@@ -77,7 +77,7 @@ void sp_ctx_swap(sp_fiber_ctx *from, sp_fiber_ctx *to) { swapcontext(&from->uc, 
 
 /* ---- Reached by name in the generated TU ---- */
 void *sp_gc_alloc(size_t sz, void (*fin)(void *), void (*scn)(void *));
-void sp_raise_cls(const char *cls, const char *msg);
+SP_NORETURN void sp_raise_cls(const char *cls, const char *msg);
 
 static inline sp_RbVal sp_box_nil(void) { sp_RbVal r; r.tag = SP_TAG_NIL; r.cls_id = 0; r.v.i = 0; return r; }
 static void sp_raise(const char *msg) { sp_raise_cls("RuntimeError", msg); }

--- a/lib/sp_io.c
+++ b/lib/sp_io.c
@@ -18,7 +18,7 @@
 
 /* Provided by the generated TU / libspinel_rt.a. */
 extern void *sp_gc_alloc(size_t sz, void (*fin)(void *), void (*scn)(void *));
-extern void sp_raise_cls(const char *cls, const char *msg);
+extern SP_NORETURN void sp_raise_cls(const char *cls, const char *msg);
 
 static void sp_File_fin(void *p) { sp_File *f = (sp_File *)p; if (f->fp) { fclose(f->fp); f->fp = NULL; } }
 static void sp_File_scan(void *p) { sp_File *f = (sp_File *)p; if (f->path) sp_mark_string(f->path); if (f->mode) sp_mark_string(f->mode); }

--- a/lib/sp_strscan.c
+++ b/lib/sp_strscan.c
@@ -35,7 +35,7 @@ extern const char *sp_ext_str_empty(void);
 extern size_t sp_ext_str_byte_len(const char *s);
 extern void *sp_ext_gc_alloc(size_t sz, void (*fin)(void *), void (*scan)(void *));
 extern void  sp_ext_mark_string(const char *s);
-extern void  sp_raise_cls(const char *cls, const char *msg);
+extern __attribute__((noreturn)) void sp_raise_cls(const char *cls, const char *msg);
 
 /* The scanner struct lives in spinel's GC heap. `source` /
    `matched` are GC-tracked strings; the scan function below


### PR DESCRIPTION
Found while triaging clang static-analyzer reports.

**Context:** `sp_raise_cls` is declared `SP_NORETURN` in `sp_runtime.h`, but the standalone runtime translation units (`sp_core`, `sp_bigint`, `sp_fiber`, `sp_io`, `sp_strscan`) forward-declare it without the attribute, and `re_compile`'s `compile_error` — which always `exit`s — lacked it too.

**Why it matters:** without the noreturn contract, the static analyzer assumes execution continues past a raise, manufacturing false null-dereference and divide-by-zero reports (7 cleared by this change). The annotation also lets the compiler optimize and flag genuinely-dead code after a raise.

**Fix:** annotate the forward declarations — `SP_NORETURN` where `sp_types.h` is in scope, `__attribute__((noreturn))` otherwise. No runtime behavior change.

**Verification:** the 7 analyzer findings clear and `make test` is green (949 pass, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)