### PR TITLE
codegen: make unsupported() noreturn to fix SP_COLLECT_ERRORS crashes

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -2059,6 +2059,32 @@ static int program_needs_class_machinery(Compiler *c) {
   return 0;
 }
 
+/* Emit one top-level output unit (a method, constructor, BEGIN/END block, or the
+   top-level body). Outside SP_COLLECT_ERRORS this is just the bare call. In
+   collect mode each unit runs under a setjmp: an `unsupported` gap longjmps back
+   here (instead of exiting), so one run surfaces every unsupported construct --
+   the gap is already printed, this unit's malformed output is discarded, and the
+   driver proceeds to the next unit. `unsupported` re-sets all per-method globals
+   on the next emit_method, so an abandoned unit cannot corrupt the next.
+   On recovery the buffer is rolled back to its length before this unit, so the
+   abandoned unit's partial output is dropped. `body` must be the heap pointer
+   (not an automatic) so a longjmp doesn't leave it indeterminate (C99 7.13.2.1);
+   _saved_len is set before setjmp and so stays determinate across the jump. */
+#define EMIT_COLLECT_UNIT(emit_call)                          \
+  do {                                                        \
+    if (!collect_mode()) { emit_call; }                       \
+    else {                                                    \
+      size_t _saved_len = body->len;                          \
+      if (setjmp(g_unsup_recover) == 0) {                     \
+        g_unsup_armed = 1; emit_call; g_unsup_armed = 0;      \
+      } else {                                                \
+        g_unsup_armed = 0;                                    \
+        body->len = _saved_len;                               \
+        if (body->p) body->p[_saved_len] = '\0';              \
+      }                                                       \
+    }                                                         \
+  } while (0)
+
 char *codegen_program(const NodeTable *nt) {
   Compiler *c = comp_new(nt);
   analyze_program(c);
@@ -2608,12 +2634,12 @@ char *codegen_program(const NodeTable *nt) {
      proc literals they contain accumulate static functions into g_procs /
      g_proc_protos; we splice those in ahead of these bodies, since a proc
      function must be declared before the body that references it. */
-  Buf body; memset(&body, 0, sizeof body);
+  Buf *body = (Buf *)calloc(1, sizeof *body);  /* heap: must survive a collect-mode longjmp (see EMIT_COLLECT_UNIT) */
   for (int i = 0; i < c->nclasses; i++)
     if (!is_builtin_reopen(c->classes[i].name))
-      emit_class_new(c, &c->classes[i], &body);
+      EMIT_COLLECT_UNIT(emit_class_new(c, &c->classes[i], body));
   for (int s = 1; s < c->nscopes; s++) {
-    if (c->scopes[s].yields || !c->scopes[s].reachable || scope_is_shadowed(c, s) || c->scopes[s].is_transplanted_source) continue; emit_method(c, &c->scopes[s], &body);
+    if (c->scopes[s].yields || !c->scopes[s].reachable || scope_is_shadowed(c, s) || c->scopes[s].is_transplanted_source) continue; EMIT_COLLECT_UNIT(emit_method(c, &c->scopes[s], body));
   }
 
   /* Emit END block static functions for atexit registration */
@@ -2630,38 +2656,38 @@ char *codegen_program(const NodeTable *nt) {
         if (!sty || strcmp(sty, "PostExecutionNode")) continue;
         int stmts = nt_ref(c->nt, tbody[k], "statements");
         end_count++;
-        buf_printf(&body, "static void sp_end_fn_%d(void) { SP_GC_SAVE();\n", end_count);
-        emit_stmts(c, stmts, &body, 1);
-        buf_puts(&body, "}\n");
+        buf_printf(body, "static void sp_end_fn_%d(void) { SP_GC_SAVE();\n", end_count);
+        EMIT_COLLECT_UNIT(emit_stmts(c, stmts, body, 1));
+        buf_puts(body, "}\n");
       }
     }
   }
 
-  buf_puts(&body, "int main(int argc,char**argv){\n");
-  buf_puts(&body, "    SP_GC_SAVE();\n");
-  buf_puts(&body, "    sp_re_init();\n");
-  buf_puts(&body, "    { sp_argv.len = argc - 1; sp_argv.data = (const char**)malloc(sizeof(const char*) * (size_t)(argc > 1 ? argc - 1 : 1)); for (int _ai = 0; _ai < argc - 1; _ai++) sp_argv.data[_ai] = sp_str_dup_external(argv[_ai + 1]); }\n");
-  buf_puts(&body, "    sp_program_name = argc > 0 ? argv[0] : \"\";\n");
+  buf_puts(body, "int main(int argc,char**argv){\n");
+  buf_puts(body, "    SP_GC_SAVE();\n");
+  buf_puts(body, "    sp_re_init();\n");
+  buf_puts(body, "    { sp_argv.len = argc - 1; sp_argv.data = (const char**)malloc(sizeof(const char*) * (size_t)(argc > 1 ? argc - 1 : 1)); for (int _ai = 0; _ai < argc - 1; _ai++) sp_argv.data[_ai] = sp_str_dup_external(argv[_ai + 1]); }\n");
+  buf_puts(body, "    sp_program_name = argc > 0 ? argv[0] : \"\";\n");
   /* Enable the backtrace substrate (Exception#backtrace, Kernel#caller) in
      debug builds only: --debug compiles at -O0 with non-inlined methods, so
      the captured frames demangle to Class#method. Optimized/release builds
      leave sp_bt_enabled = 0 (frames inline away), keeping the empty-array
      behavior. */
   if (getenv("SPINEL_DEBUG")) {
-    buf_puts(&body, "    sp_bt_enabled = 1;\n");
-    buf_puts(&body, "    sp_bt_srcfile = ");
-    emit_str_literal(&body, c->nt->source_file ? c->nt->source_file : "source.rb");
-    buf_puts(&body, ";\n");
+    buf_puts(body, "    sp_bt_enabled = 1;\n");
+    buf_puts(body, "    sp_bt_srcfile = ");
+    emit_str_literal(body, c->nt->source_file ? c->nt->source_file : "source.rb");
+    buf_puts(body, ";\n");
   }
   /* Ruby auto-seeds its PRNG at startup, so rand/shuffle/sample vary per
      run. Seed once here; an explicit srand(seed) in user code runs later
      and overrides this for reproducible sequences. */
-  buf_puts(&body, "    srand((unsigned)time(NULL));\n");
+  buf_puts(body, "    srand((unsigned)time(NULL));\n");
   /* Register END blocks (atexit runs LIFO, so they execute in reverse registration order) */
   for (int e = 1; e <= end_count; e++)
-    buf_printf(&body, "    atexit(sp_end_fn_%d);\n", e);
-  emit_scope_decls(c, &c->scopes[0], &body);
-  buf_puts(&body, "\n");
+    buf_printf(body, "    atexit(sp_end_fn_%d);\n", e);
+  emit_scope_decls(c, &c->scopes[0], body);
+  buf_puts(body, "\n");
   /* Hoist BEGIN blocks to run first */
   {
     int top_body = c->scopes[0].body;
@@ -2674,20 +2700,21 @@ char *codegen_program(const NodeTable *nt) {
         const char *sty = nt_type(c->nt, tbody[k]);
         if (!sty || strcmp(sty, "PreExecutionNode")) continue;
         int stmts = nt_ref(c->nt, tbody[k], "statements");
-        emit_stmts(c, stmts, &body, 1);
+        EMIT_COLLECT_UNIT(emit_stmts(c, stmts, body, 1));
       }
     }
   }
-  emit_stmts(c, c->scopes[0].body, &body, 1);
+  EMIT_COLLECT_UNIT(emit_stmts(c, c->scopes[0].body, body, 1));
   if (g_needs_at_exit)
-    buf_puts(&body, "  { mrb_int _ax_args[16] = {0}; for (mrb_int _ax = sp_at_exit_count - 1; _ax >= 0; _ax--) sp_proc_call(sp_at_exit_hooks[_ax], 0, _ax_args); }\n");
-  buf_puts(&body, "  return 0;\n}\n");
+    buf_puts(body, "  { mrb_int _ax_args[16] = {0}; for (mrb_int _ax = sp_at_exit_count - 1; _ax >= 0; _ax--) sp_proc_call(sp_at_exit_hooks[_ax], 0, _ax_args); }\n");
+  buf_puts(body, "  return 0;\n}\n");
 
   emit_regex_section(&b);
   if (g_proc_protos.len) { buf_puts(&b, g_proc_protos.p); buf_puts(&b, "\n"); }
   if (g_procs.len) { buf_puts(&b, g_procs.p); buf_puts(&b, "\n"); }
-  buf_puts(&b, body.p ? body.p : "");
-  free(body.p);
+  buf_puts(&b, body->p ? body->p : "");
+  free(body->p);
+  free(body);
   free(g_procs.p); free(g_proc_protos.p);
   memset(&g_procs, 0, sizeof g_procs);
   memset(&g_proc_protos, 0, sizeof g_proc_protos);

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -17,6 +17,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
+#include <setjmp.h>
 
 /* ---- output buffer ---- */
 
@@ -307,7 +308,15 @@ void emit_local_ref(Compiler *c, int scope_node, const char *name, Buf *b);
 void emit_yblk_ref(Buf *b);
 void emit_tail_lead(Buf *b);
 const char *rename_local(const char *nm);
-void unsupported(Compiler *c, int id, const char *what);
+/* `unsupported` never returns: normal mode exits; SP_COLLECT_ERRORS mode
+   longjmps to the codegen driver's per-unit recovery (see g_unsup_recover)
+   when one is armed, else exits. Marked noreturn so every caller's
+   "this construct is unsupported" guard correctly treats the code after it as
+   unreachable. */
+int collect_mode(void);            /* 1 in SP_COLLECT_ERRORS mode (cached) */
+extern jmp_buf g_unsup_recover;    /* per-unit recovery point, armed by the driver */
+extern int g_unsup_armed;          /* nonzero while a recovery point is live */
+__attribute__((noreturn)) void unsupported(Compiler *c, int id, const char *what);
 int builtin_class_id(const char *name);
 int is_builtin_class_name(const char *n);
 const char *c_type_name(TyKind t);

--- a/src/codegen_util.c
+++ b/src/codegen_util.c
@@ -2,6 +2,17 @@
 
 Buf *g_pre = NULL;
 
+/* SP_COLLECT_ERRORS recovery: in collect mode a codegen gap longjmps back to a
+   per-unit recovery point armed by the output driver (codegen.c), so one run
+   surfaces every unsupported construct instead of aborting on the first. */
+jmp_buf g_unsup_recover;
+int g_unsup_armed = 0;
+int collect_mode(void) {
+  static int collect = -1;
+  if (collect < 0) collect = getenv("SP_COLLECT_ERRORS") ? 1 : 0;
+  return collect;
+}
+
 void buf_putn(Buf *b, const char *s, size_t n) {
   if (b->len + n + 1 > b->cap) {
     size_t nc = b->cap ? b->cap * 2 : 256;
@@ -273,7 +284,7 @@ const char *rename_local(const char *nm) {
     if (strcmp(g_ren_from[i], nm) == 0) return g_ren_to[i];
   return nm;
 }
-void unsupported(Compiler *c, int id, const char *what) {
+__attribute__((noreturn)) void unsupported(Compiler *c, int id, const char *what) {
   const char *ty = nt_type(c->nt, id);
   /* Ruby-map the diagnostic (#1338): a codegen gap reports against the source
      line the parser stamped (the same position the #line machinery uses), so
@@ -303,12 +314,12 @@ void unsupported(Compiler *c, int id, const char *what) {
   else
     fprintf(stderr, "spinel: %sunsupported %s: node %d (%s)\n",
             pos, what, id, ty ? ty : "?");
-  /* SP_COLLECT_ERRORS: don't abort on the first gap -- keep going so one
-     run surfaces every unsupported construct (the emitted C is then
-     malformed and only the stderr list is useful). */
-  static int collect = -1;
-  if (collect < 0) collect = getenv("SP_COLLECT_ERRORS") ? 1 : 0;
-  if (!collect) exit(1);
+  /* SP_COLLECT_ERRORS: don't abort on the first gap -- longjmp back to the
+     driver's per-unit recovery point (when armed) so one run surfaces every
+     unsupported construct, abandoning just this unit's (discarded) output.
+     `unsupported` thus never returns: it exits, or longjmps. */
+  if (collect_mode() && g_unsup_armed) longjmp(g_unsup_recover, 1);
+  exit(1);
 }
 int builtin_class_id(const char *name) {
   if (!name) return 0;


### PR DESCRIPTION
## Problem

`unsupported()` (the codegen "this construct isn't supported yet" reporter) aborts on the first gap, unless `SP_COLLECT_ERRORS` is set — then it *returns* so one run can surface every gap. But the code after each `unsupported()` call assumes it does **not** return: it goes on to dereference a now-NULL `name`/`op` or index an empty `argv`. So collect mode crashed instead of collecting.

This was found by clang's static analyzer (`core.NullDereference`, `unix.cstring.NullArg`, `unix.Malloc`) across `codegen_call.c`, `codegen_expr.c`, `codegen_stmt.c`, `codegen_fold.c` (~15 sites)

## Fix

Make `unsupported()` **never return**: it still `exit`s in normal mode, and in collect mode `longjmp`s to a per-unit recovery point armed by the output driver. Each top-level unit (method, constructor, BEGIN/END block, the top-level body) emits under a fresh `setjmp`; a gap prints, abandons that unit's discarded output, and the driver proceeds to the next unit.

This is safe because `emit_method` re-sets all per-method emission globals at entry, so an abandoned unit can't corrupt the next. Marking `unsupported()` `noreturn` lets the compiler treat every post-`unsupported` path as unreachable — which is also why this clears the analyzer's NULL-deref family structurally rather than site-by-site.

## Why not just add `return;`?

A per-site `return;` is memory-safe at the patched site but fragile: it can leave a caller's invariants half-built and crash later, and every future `unsupported()` call has to remember it. Making the function `noreturn` restores the invariant every caller already assumes, in one place.

## Verification

- `make test`: 949 pass, 0 fail, 0 error
- `make bootstrap`: IR + C fixpoint OK on analyze.rb and codegen.rb (normal-mode output is byte-identical — the recovery wrapper is a no-op outside collect mode)
- Smoke test: a program with unsupported calls in three methods + the top level now prints **one gap per unit (4 total) without crashing**, where normal mode aborts after the first


🤖 Generated with [Claude Code](https://claude.com/claude-code)