### PR TITLE
spinel-doctor: add an `inference` leg (methods widened to untyped)

### DIFF
--- a/tools/doctor.rb
+++ b/tools/doctor.rb
@@ -7,6 +7,7 @@
 #   build       compile to a binary; report compile / codegen / C-build failure
 #   unsupported codegen gaps that degrade to a stub (stderr "unsupported ...")
 #   unresolved  calls that silently degrade to nil/0 (SPINEL_WARN_UNRESOLVED)
+#   inference   methods spinel widened to untyped (the boxed poly slow path)
 #   requires    non-relative `require`s spinel treats as native / no-op
 #   behavior    (opt) compiled output vs CRuby; needs `ruby` on PATH
 
@@ -63,7 +64,7 @@ def main
       quiet = true
     elsif a == "-h" || a == "--help"
       puts "usage: spinel-doctor [--only a,b] [--skip a,b] [--behavior] [--quiet] app.rb"
-      puts "  legs: build unsupported unresolved requires behavior"
+      puts "  legs: build unsupported unresolved inference requires behavior"
       exit(0)
     else
       src = a
@@ -89,6 +90,24 @@ def main
   end
   if leg_on("unresolved", only, skip)
     errs = errs + report("unresolved", "warn", grep_kind(diag, "warning: unresolved"), quiet)
+  end
+
+  if leg_on("inference", only, skip)
+    # Methods whose signature spinel widened to `untyped` -- the boxed poly
+    # slow path. Each such site is a "# spinel: widened to untyped (slow path)"
+    # comment in --emit-rbs. Not a defect (the program is correct), so it is
+    # info severity and does not affect the exit code; it surfaces where
+    # inference could not pin a concrete type (a perf cost, and sometimes the
+    # first sign of a latent type gap worth a closer look).
+    rbs = tmp_path("doctor", src, ".rbs")
+    sh(sp + " " + src + " --emit-rbs -o " + rbs)
+    widened = []
+    if File.exist?(rbs)
+      File.read(rbs).split("\n").each { |l|
+        widened.push(l.strip) if l.include?("# spinel: widened")
+      }
+    end
+    report("inference", "info", widened, quiet)
   end
 
   if leg_on("requires", only, skip)


### PR DESCRIPTION
Adds a sixth leg to `spinel-doctor`: **inference** — methods whose signature spinel widened to `untyped`, i.e. the boxed poly slow path.

### Why
A widened method is correct but runs the slow path, and is often the first visible sign that inference couldn't pin a concrete type (sometimes the leading edge of a latent type gap). `--emit-rbs` already marks each such site with `# spinel: widened to untyped (slow path)`; today you have to run `--emit-rbs` separately and read the RBS to find them. This folds that signal into the one health report.

### Behavior
- **info severity** — does not affect the exit code (a widened program is still correct), matching the `requires` leg. It surfaces a perf/precision signal, not a defect.
- Reuses the existing `--emit-rbs` path — **no new compiler surface**.
- `--only inference` / `--skip inference` work like the other legs; listed in `--help` and the header.

### Example
```
$ spinel-doctor --only inference box.rb
spinel-doctor: box.rb
[info] inference (2)
         def initialize: (untyped) -> untyped # spinel: widened to untyped (slow path)
         def get: () -> untyped # spinel: widened to untyped (slow path)

spinel-doctor: clean
```
A program with no widening reports `[ok] inference`.

Stays within the spinel subset (compiles clean via `spinel tools/doctor.rb`). Verified on master `f3bb9af9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)