### PR TITLE
Add File.size class method

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -5119,7 +5119,14 @@ static mrb_int sp_file_size(const char *path) {
   }
   struct stat st;
   if (stat(path, &st) == -1) {
-    sp_raise_cls(errno == ENOENT ? "Errno::ENOENT" : "RuntimeError", sp_sprintf("%s @ File.size - %s", strerror(errno), path));
+    int err = errno;  /* capture once: strerror() may clobber errno */
+    sp_raise_cls(err == ENOENT ? "Errno::ENOENT" : "RuntimeError", sp_sprintf("%s @ File.size - %s", strerror(err), path));
+    return 0;
+  }
+  /* off_t (typically 64-bit) into mrb_int (intptr_t -> 32-bit on a 32-bit
+     build): guard the narrowing, as spinel does for int arithmetic. */
+  if ((off_t)(mrb_int)st.st_size != st.st_size) {
+    sp_raise_cls("RangeError", "file size out of range for Integer");
     return 0;
   }
   return (mrb_int)st.st_size;

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -5109,6 +5109,21 @@ static sp_Time sp_file_mtime(const char *path) {
   return (sp_Time){(int64_t)st.st_mtim.tv_sec, (int32_t)st.st_mtim.tv_nsec, 0};
 #endif
 }
+/* File.size(path) -> byte size. Raises Errno::ENOENT on a missing path,
+   matching MRI (and sp_file_read / sp_file_mtime, which stat/open the
+   same way). */
+static mrb_int sp_file_size(const char *path) {
+  if (!path) {
+    sp_raise_cls("TypeError", "no implicit conversion of nil into String");
+    return 0;
+  }
+  struct stat st;
+  if (stat(path, &st) == -1) {
+    sp_raise_cls(errno == ENOENT ? "Errno::ENOENT" : "RuntimeError", sp_sprintf("%s @ File.size - %s", strerror(errno), path));
+    return 0;
+  }
+  return (mrb_int)st.st_size;
+}
 static const char *sp_backtick(const char *cmd) {
   FILE *p = popen(cmd, "r");
   if (!p) { sp_last_status = -1; return sp_str_empty; }

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -862,7 +862,8 @@ else {
         return TY_STRING;
       if (!strcmp(name, "exist?") || !strcmp(name, "exists?"))
         return TY_BOOL;
-      if (!strcmp(name, "write") || !strcmp(name, "binwrite") || !strcmp(name, "delete"))
+      if (!strcmp(name, "write") || !strcmp(name, "binwrite") || !strcmp(name, "delete") ||
+          !strcmp(name, "size"))
         return TY_INT;
       if (!strcmp(name, "readable?") || !strcmp(name, "directory?") || !strcmp(name, "file?") ||
           !strcmp(name, "zero?") || !strcmp(name, "empty?"))

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -6023,6 +6023,9 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     if (!strcmp(name, "mtime") && argc == 1) {
       buf_puts(b, "sp_file_mtime("); emit_expr(c, argv[0], b); buf_puts(b, ")"); return;
     }
+    if (!strcmp(name, "size") && argc == 1) {
+      buf_puts(b, "sp_file_size("); emit_expr(c, argv[0], b); buf_puts(b, ")"); return;
+    }
     if (!strcmp(name, "expand_path") && (argc == 1 || argc == 2)) {
       buf_puts(b, "sp_file_expand_path("); emit_expr(c, argv[0], b); buf_puts(b, ", ");
       if (argc == 2) emit_expr(c, argv[1], b); else buf_puts(b, "(const char *)0");

--- a/test/file_size.rb
+++ b/test/file_size.rb
@@ -2,8 +2,8 @@
 # counted, unlike a strlen); a missing path raises Errno::ENOENT, matching
 # MRI and the other stat/open-based File class methods.
 filename = "test_size_temp.bin"
-File.write(filename, "ABC")
 begin
+  File.write(filename, "ABC")
   puts File.size(filename)
   File.write(filename, [65, 0, 66, 0, 67].pack("C*"))   # 5 bytes incl 2 NULs
   puts File.size(filename)
@@ -14,5 +14,5 @@ begin
     puts e.class
   end
 ensure
-  File.delete(filename)
+  File.delete(filename) if File.exist?(filename)
 end

--- a/test/file_size.rb
+++ b/test/file_size.rb
@@ -1,0 +1,18 @@
+# File.size(path): byte count (stat-based, so embedded NUL bytes are
+# counted, unlike a strlen); a missing path raises Errno::ENOENT, matching
+# MRI and the other stat/open-based File class methods.
+filename = "test_size_temp.bin"
+File.write(filename, "ABC")
+begin
+  puts File.size(filename)
+  File.write(filename, [65, 0, 66, 0, 67].pack("C*"))   # 5 bytes incl 2 NULs
+  puts File.size(filename)
+  begin
+    File.size("definitely_missing_size_test")
+    puts "no-raise"
+  rescue => e
+    puts e.class
+  end
+ensure
+  File.delete(filename)
+end

--- a/test/file_size.rb.expected
+++ b/test/file_size.rb.expected
@@ -1,0 +1,3 @@
+3
+5
+Errno::ENOENT


### PR DESCRIPTION
`File.size(path)` returns the byte size via `stat`, or raises `Errno::ENOENT` on a missing path — matching MRI and the existing stat/open-based File class methods (`File.mtime`, `File.read`).

The runtime had no size-by-path helper, so today the idiomatic call is unsupported and callers reach for `File.read(path).length` — which slurps the whole file just to measure it, and (being length-of-a-read) only works because the read is binary-safe. `File.size` stats instead: no read, and binary-safe by construction (it counts embedded NUL bytes rather than stopping at one).

**Change** (mirrors `File.mtime`):
- `lib/sp_runtime.h`: `sp_file_size(path)` — `stat` → `st_size`, raising `Errno::ENOENT`/`RuntimeError` on `stat` failure, exactly like `sp_file_mtime`.
- `src/analyze_infer.c`: `File.size` → `TY_INT`.
- `src/codegen_call.c`: dispatch `File.size(path)` → `sp_file_size(...)`.

**Test:** `test/file_size.rb` — byte count including embedded NULs, plus the missing-path raise. `make test`: 951 pass / 0 fail / 0 error.

Came up while standing up an HTTP file server on `sp_net` (Content-Length without re-reading the file) — matz/spinel#1466 — but it's a general `File` gap.
