### PR TITLE
Handle all concrete types in condition position

### DIFF
--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -695,12 +695,20 @@ void emit_cond(Compiler *c, int id, Buf *b) {
   /* a value-type object is never a NULL pointer -- it is always truthy */
   if (comp_ty_value_obj(c, t)) { buf_puts(b, "(("); emit_expr(c, id, b); buf_puts(b, "), 1)"); return; }
   if (t == TY_STRING || ty_is_array(t) || ty_is_hash(t) || ty_is_object(t) ||
-      t == TY_PROC || t == TY_STRINGIO || t == TY_STRINGSCANNER || t == TY_MATCHDATA || t == TY_EXCEPTION) {
+      t == TY_PROC || t == TY_STRINGIO || t == TY_STRINGSCANNER || t == TY_MATCHDATA || t == TY_EXCEPTION ||
+      t == TY_BIGINT || t == TY_REGEX || t == TY_CURRY || t == TY_FIBER || t == TY_RANDOM ||
+      t == TY_METHOD || t == TY_IO || t == TY_ARGF) {
     buf_puts(b, "(("); emit_expr(c, id, b); buf_puts(b, ") != 0)"); return;
   }
   if (t == TY_INT)   { buf_puts(b, "(("); emit_expr(c, id, b); buf_puts(b, ") != SP_INT_NIL)"); return; }
   if (t == TY_FLOAT) { buf_puts(b, "(!sp_float_is_nil("); emit_expr(c, id, b); buf_puts(b, "))"); return; }
   if (t == TY_SYMBOL) { buf_puts(b, "(("); emit_expr(c, id, b); buf_puts(b, "), 1)"); return; }
+  /* Always-truthy concrete value types: a Range / Class / Complex / Rational /
+     Time value is never nil or false, so it is truthy in condition position.
+     Evaluate it for side effects and yield 1. */
+  if (t == TY_RANGE || t == TY_CLASS || t == TY_COMPLEX || t == TY_RATIONAL || t == TY_TIME) {
+    buf_puts(b, "(("); emit_expr(c, id, b); buf_puts(b, "), 1)"); return;
+  }
   if (t != TY_BOOL) unsupported(c, id, "condition (non-bool)");
   emit_expr(c, id, b);
 }

--- a/test/cond_poly_truthy.rb
+++ b/test/cond_poly_truthy.rb
@@ -1,0 +1,34 @@
+# a Range value is always truthy in condition position
+def range_truthy(r) = r ? "yes" : "no"
+puts range_truthy(1..3)
+
+c = (1..5)
+puts "range kept" if c
+
+# a Class value is always truthy
+def class_truthy(k) = k ? "has class" : "no class"
+puts class_truthy(String)
+
+# guard pattern: collect when the (truthy) value is present
+out = []
+val = (1..2)
+out << "kept" if val
+p out
+
+# other always-truthy concrete types in condition position. Each value flows
+# through a monomorphic helper param so it keeps its concrete static type (and
+# is not constant-folded), exercising the per-type truthiness branches.
+def time_truthy(t) = t ? "yes" : "no"
+puts time_truthy(Time.at(0))            # value type (sp_Time)
+
+def regex_truthy(re) = re ? "yes" : "no"
+puts regex_truthy(/x/)                  # pointer type (mrb_regexp_pattern *)
+
+def method_truthy(m) = m ? "yes" : "no"
+puts method_truthy(method(:range_truthy))  # pointer type (sp_BoundMethod *)
+
+def random_truthy(r) = r ? "yes" : "no"
+puts random_truthy(Random.new(42))      # pointer type (sp_Random *)
+
+def curry_truthy(p) = p ? "yes" : "no"
+puts curry_truthy(->(a, b) { a + b }.curry)  # pointer type (sp_Curry *)

--- a/test/cond_poly_truthy.rb.expected
+++ b/test/cond_poly_truthy.rb.expected
@@ -1,0 +1,9 @@
+yes
+range kept
+has class
+["kept"]
+yes
+yes
+yes
+yes
+yes


### PR DESCRIPTION
`emit_cond` rejected several concrete types with `unsupported condition (non-bool)` even though each is always truthy (or truthy when present) in Ruby. The function already handled strings, arrays, hashes, objects, procs, a few pointer-backed builtins, and the int/float/symbol scalars — but a number of equally-concrete types fell through to the reject. (The gap doc framed this as "poly/object" conditions; objects and poly were in fact already handled — the residual triggers reduced to value types like `r = (1..3); ... if r` and pointer-backed builtins.)

**Always-truthy value types** — `Range`, `Class`, `Complex`, `Rational`, `Time` (each `sp_X` by value, never nil or false): evaluate for side effects and yield `1`, the same shape already used for symbols and value objects.

**Pointer-backed builtins** — arbitrary-precision integers, `Regexp`, a curried proc, `Fiber`, `Random`, `Method`, `IO`, `ARGF`: added to the existing non-NULL check, matching how strings and procs are already treated (a non-NULL pointer is truthy, a NULL one — the nil sentinel — is falsy). A mutable string buffer needs no entry: `comp_ntype` normalizes it to a plain string before this dispatch, so the string case already covers it.

`TY_UNKNOWN` still rejects, since an unresolved type cannot be emitted safely.

Verified: `make test` (956 pass, 0 fail), `make bootstrap` IR + C fixpoint OK for `analyze.rb` and `codegen.rb`, and `test/cond_poly_truthy.rb` (expected regenerated from CRuby) routes `Time`/`Regexp`/`Method`/`Random`/curried-proc values through monomorphic params to exercise the per-type branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)