### PR TITLE
Flatten nested interpolated-string parts

### DIFF
--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -1,9 +1,36 @@
 #include "codegen_internal.h"
 
+/* Adjacent string literals joined by `\`-continuation (or `+`-folded at parse
+   time) produce an InterpolatedStringNode whose own parts are themselves
+   InterpolatedStringNodes. Flatten the part tree into one list of leaf parts
+   (StringNode / EmbeddedStatementsNode) so the format/arg assembly below sees a
+   single flat sequence and emits one sp_sprintf call. */
+static void interp_flatten(const NodeTable *nt, int id, int **out, int *n, int *cap) {
+  int pn = 0;
+  const int *parts = nt_arr(nt, id, "parts", &pn);
+  for (int k = 0; k < pn; k++) {
+    int pid = parts[k];
+    const char *pty = nt_type(nt, pid);
+    if (pty && !strcmp(pty, "InterpolatedStringNode")) {
+      interp_flatten(nt, pid, out, n, cap);
+      continue;
+    }
+    if (*n >= *cap) {
+      int ncap = *cap ? *cap * 2 : 8;
+      int *grown = realloc(*out, (size_t)ncap * sizeof(int));
+      if (!grown) { fprintf(stderr, "spinel: out of memory\n"); exit(1); }
+      *out = grown; *cap = ncap;
+    }
+    (*out)[(*n)++] = pid;
+  }
+}
+
 void emit_interp(Compiler *c, int id, Buf *b) {
   const NodeTable *nt = c->nt;
   int n = 0;
-  const int *parts = nt_arr(nt, id, "parts", &n);
+  int *flat = NULL, fcap = 0;
+  interp_flatten(nt, id, &flat, &n, &fcap);
+  const int *parts = flat;
   Buf fmt; memset(&fmt, 0, sizeof fmt);
   Buf argbuf; memset(&argbuf, 0, sizeof argbuf);
   Buf decls; memset(&decls, 0, sizeof decls);  /* rooted %s-arg temp decls */
@@ -121,10 +148,10 @@ void emit_interp(Compiler *c, int id, Buf *b) {
         /* a bare empty array literal interpolates as "[]" */
         int en = 0; nt_arr(nt, expr, "elements", &en);
         if (en == 0) { buf_puts(&fmt, "%s"); buf_puts(&conv, "\"[]\""); }
-        else { free(fmt.p); free(argbuf.p); free(decls.p); free(conv.p); unsupported(c, pid, "interpolation value"); }
+        else { free(fmt.p); free(argbuf.p); free(decls.p); free(conv.p); free(flat); unsupported(c, pid, "interpolation value"); }
       }
       else {
-        free(fmt.p); free(argbuf.p); free(decls.p); free(conv.p);
+        free(fmt.p); free(argbuf.p); free(decls.p); free(conv.p); free(flat);
         unsupported(c, pid, "interpolation value");
       }
       #undef EMIT_IV
@@ -145,7 +172,7 @@ else {
       nargs++;
     }
     else {
-      free(fmt.p); free(argbuf.p);
+      free(fmt.p); free(argbuf.p); free(flat);
       unsupported(c, pid, "interpolation part");
     }
   }
@@ -169,7 +196,7 @@ else {
     buf_printf(b, "({ %ssp_sprintf(\"%s\"%s); })",
                decls.p, fmt.p ? fmt.p : "", argbuf.p ? argbuf.p : "");
   }
-  free(fmt.p); free(argbuf.p); free(decls.p);
+  free(fmt.p); free(argbuf.p); free(decls.p); free(flat);
 }
 
 /* ---- expression ---- */

--- a/test/interp_adjacent_concat.rb
+++ b/test/interp_adjacent_concat.rb
@@ -1,0 +1,23 @@
+# adjacent string literals joined by backslash-continuation, each with its own
+# interpolation -- parses to nested InterpolatedStringNodes
+def svg(px, inner)
+  "<a width='#{px}' " \
+  "height='#{px}'>#{inner}</a>"
+end
+
+# three-way adjacency mixing plain and interpolated parts
+def three(a, b)
+  "[" \
+  "#{a}-#{b}" \
+  "]"
+end
+
+# adjacency where one fragment is a plain literal (no interpolation)
+def tail(n)
+  "n=#{n}" \
+  " done"
+end
+
+puts svg(16, "x")
+puts three("L", "R")
+puts tail(7)

--- a/test/interp_adjacent_concat.rb.expected
+++ b/test/interp_adjacent_concat.rb.expected
@@ -1,0 +1,3 @@
+<a width='16' height='16'>x</a>
+[L-R]
+n=7 done


### PR DESCRIPTION
Adjacent string literals joined by `\`-continuation, each carrying its own interpolation, parse to an `InterpolatedStringNode` whose parts are themselves `InterpolatedStringNode`s. `emit_interp` only handled `StringNode` / `EmbeddedStatementsNode` parts and rejected a nested interpolated part with `unsupported interpolation part`.

This pre-flattens the part tree into a single list of leaf parts before the format/arg assembly, so the whole adjacency emits one `sp_sprintf` call. The assembly loop is unchanged; only the part list it walks is flattened.

Verified: `make test` (956 pass, 0 fail), `make bootstrap` IR + C fixpoint OK for `analyze.rb` and `codegen.rb`, and the new `test/interp_adjacent_concat.rb` (expected regenerated from CRuby) passes across three adjacency shapes. Generated C confirms one flattened `sp_sprintf("<a width='%lld' height='%lld'>%s</a>", ...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
