### PR TITLE
Diagnose dynamic method_defined? intent

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -6864,6 +6864,16 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     }
   }
 
+  /* The fully dynamic form (class held in a variable, or a non-literal method
+     name) cannot be answered ahead of time: there is no runtime reflection
+     table, and builtin classes have no enumerable method set. Emit a specific
+     diagnostic rather than a generic unsupported-call node dump. Covers both an
+     explicit receiver and an implicit-self call (recv < 0). */
+  if (!strcmp(name, "method_defined?")) {
+    unsupported(c, id, "method_defined? (needs a compile-time-known class and literal method name)");
+    return;
+  }
+
   /* Class.const_defined?(:K): compile-time presence check. Constants are
      recorded in a flat namespace, so this consults the global const and class
      tables rather than the receiver's own constants. */


### PR DESCRIPTION
`method_defined?` is answered at compile time when the receiver is a class constant and the name is a literal symbol/string — this already works (`test/method_defined.rb`). The fully dynamic form, where the class is held in a variable or the method name is a runtime value (e.g. `def has?(k, m) = k.method_defined?(m)`), cannot be answered ahead of time: there is no runtime reflection table, and builtin classes such as `String` have no enumerable method set. It previously fell through to the generic `unsupported call (method_defined?)` node dump.

This emits a specific diagnostic naming the requirement (a compile-time-known class and literal method name), so the limitation is actionable rather than opaque. The successful compile-time path is unchanged.

Note on testing: the C compiler's reject diagnostics have no automated harness (`make test` is PASS-based; `test/analyze_fail` exercises the legacy Ruby analyzer, not `bin/spinel`). Verified manually that the dynamic form now prints the specific message and the constant form (`test/method_defined.rb`) still compiles. `make test` (956 pass, 0 fail) and `make bootstrap` IR + C fixpoint OK for `analyze.rb` and `codegen.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
