### PR TITLE
Compare objects without a custom == by object identity

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -7801,6 +7801,23 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       buf_printf(b, " %s NULL)", eq ? "==" : "!=");
       return;
     }
+    /* object == object with no user-defined == or <=>: Object#== identity.
+       Pointer-backed objects compare by address -- faithful to CRuby, where two
+       distinct instances are never == and an instance is == only to itself. A
+       value-type object has no stable identity (it is copied by value), so
+       identity is unrepresentable; rather than silently diverge (structural
+       equality would say true where CRuby says false) we refuse and ask for an
+       explicit ==. */
+    if (recv >= 0 && ty_is_object(rt) && ty_is_object(a0)) {
+      if (comp_ty_value_obj(c, rt) || comp_ty_value_obj(c, a0))
+        unsupported(c, id, "equality on a value-type object without a user-defined == (define == for comparison)");
+      buf_puts(b, "((void *)(");
+      emit_expr(c, recv, b);
+      buf_printf(b, ") %s (void *)(", eq ? "==" : "!=");
+      emit_expr(c, argv[0], b);
+      buf_puts(b, "))");
+      return;
+    }
     unsupported(c, id, "equality");
   }
 

--- a/test/object_identity_eq.rb
+++ b/test/object_identity_eq.rb
@@ -1,0 +1,30 @@
+# Object#== with no user-defined == is identity comparison: an instance is
+# equal only to itself, and two distinct instances are never equal. Receivers
+# go through method params so the compare hits the runtime object path (and so
+# the class stays pointer-backed rather than a by-value type).
+class Widget
+  def initialize(n)
+    @n = n
+  end
+
+  def n
+    @n
+  end
+end
+
+def same?(a, b)
+  a == b
+end
+
+def diff?(a, b)
+  a != b
+end
+
+w = Widget.new(1)
+x = Widget.new(1)
+
+puts same?(w, w)   # same object -> true
+puts same?(w, x)   # distinct objects, same contents -> false (identity)
+puts diff?(w, x)   # true
+puts diff?(w, w)   # false
+puts(w.n == x.n)   # ivar values compared, not identity -> true

--- a/test/object_identity_eq.rb.expected
+++ b/test/object_identity_eq.rb.expected
@@ -1,0 +1,5 @@
+true
+false
+true
+false
+true


### PR DESCRIPTION
Comparing two user objects with `==` / `!=` where the class chain defines neither `==` nor `<=>` was rejected at the equality gate and aborted compilation:

```ruby
class Widget
  def initialize(n) = @n = n
end

def same?(a, b) = a == b

w = Widget.new(1)
x = Widget.new(1)
same?(w, w)   # CRuby: true  ; spinel (before): reject
same?(w, x)   # CRuby: false ; spinel (before): reject
```

CRuby's fallback for a class with no own `==` is `Object#==`, which is object identity: an instance is equal only to itself, and two distinct instances are never equal.

A new case at the tail of the equality emitter (after the object-vs-nil identity case, before the reject) handles object-vs-object with no user `==` / `<=>`. Pointer-backed objects lower to a pointer comparison — `((void *)a == (void *)b)` (or `!=`), reproducing CRuby identity exactly. Value-type objects are copied by value and have no stable identity, so identity is unrepresentable; structural equality would silently disagree with CRuby (which reports not-equal for distinct instances), so the gate rejects them with an actionable message asking for an explicit `==` (which already dispatches when defined).

This is strictly additive: cases that compiled before are unchanged (a user-defined `==` / `<=>` still dispatches via the existing paths); only the previously-rejected identity case now lowers.

Verified: `test/object_identity_eq.rb` (expected regenerated from CRuby) covers same-instance and distinct-instance `==` / `!=` routed through method params (forcing the runtime object path and keeping the class pointer-backed), plus an ivar-value compare; generated C confirmed to emit the pointer comparison. `make test` 956 pass, 0 fail; `make bootstrap` analyze + codegen IR and C fixpoints byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
