### PR TITLE
Seed empty-hash parameters from index-or-write usage

### DIFF
--- a/src/analyze_pass.c
+++ b/src/analyze_pass.c
@@ -1442,7 +1442,37 @@ int infer_hash_params(Compiler *c) {
   };
   for (int id = 0; id < nt->count; id++) {
     const char *ty = nt_type(nt, id);
-    if (!ty || strcmp(ty, "CallNode")) continue;
+    if (!ty) continue;
+    /* Index-or-write on an unknown param hash (h[k] ||= v / &&= / op=): infer the
+       variant from the key + value types, mirroring the []= case below. These are
+       not CallNodes, so the CallNode path never reaches them; without this a hash
+       passed in empty (`{}` infers TY_UNKNOWN) stays unresolved and the method's
+       return type degrades to poly, which the caller then rejects. */
+    if (!strcmp(ty, "IndexOrWriteNode") || !strcmp(ty, "IndexAndWriteNode") ||
+        !strcmp(ty, "IndexOperatorWriteNode")) {
+      int wrecv = nt_ref(nt, id, "receiver");
+      if (wrecv < 0) continue;
+      const char *wrty = nt_type(nt, wrecv);
+      if (!wrty || strcmp(wrty, "LocalVariableReadNode")) continue;
+      const char *wrnm = nt_str(nt, wrecv, "name");
+      if (!wrnm) continue;
+      Scope *ws = comp_scope_of(c, id);
+      LocalVar *wlv = scope_local(ws, wrnm);
+      if (!wlv || !wlv->is_param || wlv->type != TY_UNKNOWN) continue;
+      int wargs = nt_ref(nt, id, "arguments");
+      int wan = 0; const int *wargv = wargs >= 0 ? nt_arr(nt, wargs, "arguments", &wan) : NULL;
+      if (wan < 1) continue;
+      TyKind wkt = infer_type(c, wargv[0]);
+      TyKind wvt = infer_type(c, nt_ref(nt, id, "value"));
+      TyKind wwant = TY_UNKNOWN;
+      if (wkt == TY_STRING) wwant = (wvt == TY_STRING) ? TY_STR_STR_HASH : TY_STR_POLY_HASH;
+      else if (wkt == TY_SYMBOL) wwant = TY_SYM_POLY_HASH;
+      else if (wkt == TY_INT) wwant = TY_POLY_POLY_HASH;
+      if (wwant == TY_UNKNOWN) continue;
+      wlv->type = wwant; changed = 1;
+      continue;
+    }
+    if (strcmp(ty, "CallNode")) continue;
     const char *name = nt_str(nt, id, "name");
     if (!name) continue;
     int recv = nt_ref(nt, id, "receiver");

--- a/test/index_or_write_empty_hash.rb
+++ b/test/index_or_write_empty_hash.rb
@@ -1,0 +1,29 @@
+# h[k] ||= v / &&= / op= on a hash parameter passed in empty ({} infers as an
+# unresolved element type): the index-or-write usage now seeds the parameter's
+# hash variant from the key and value types, so the method's return type
+# resolves instead of degrading to poly.
+def fill(h, k)
+  h[k] ||= "default"
+  h[k]
+end
+puts fill({}, "name")
+puts fill({ "name" => "set" }, "name")   # existing key: ||= keeps it
+
+def tally(h, k)
+  h[k] ||= 0
+  h[k] += 1
+  h[k]
+end
+puts tally({}, "x")
+
+def memo(h, k)
+  h[k] &&= "present"
+  h[k].inspect
+end
+puts memo({}, "y")                       # &&= on a missing key stays nil
+
+def symfill(h, k)
+  h[k] ||= "sym"
+  h[k]
+end
+puts symfill({}, :a)                     # symbol-keyed hash

--- a/test/index_or_write_empty_hash.rb.expected
+++ b/test/index_or_write_empty_hash.rb.expected
@@ -1,0 +1,5 @@
+default
+set
+1
+nil
+sym


### PR DESCRIPTION
`h[k] ||= v` (and `&&=` / `op=`) on a hash parameter passed in empty was rejected:

```ruby
def fill(h, k)
  h[k] ||= "default"
  h[k]
end
puts fill({}, "name")   # CRuby: default ; spinel (before): reject
```

An empty `{}` literal infers as `TY_UNKNOWN`. The parameter was never seeded because the index-or-write nodes are not `CallNode`s, so `infer_hash_params` — which already seeds unknown params from `[]` / `fetch` / `[]=` usage — never saw them. The method's return type then degraded to poly and the caller rejected the call.

`infer_hash_params` now also inspects `IndexOrWriteNode` / `IndexAndWriteNode` / `IndexOperatorWriteNode` on an unknown hash parameter and infers the hash variant from the key and value types, exactly as the existing `[]=` case does. It runs inside the post-fixpoint re-inference loop, so the seeded parameter type propagates and the method's return type resolves. Typed-hash fast paths and already-resolved params are untouched (the seeding only fires for `is_param && TY_UNKNOWN`).

Verified: `test/index_or_write_empty_hash.rb` (expected regenerated from CRuby) covers empty-hash `||=`, existing-key `||=`, `||=` + `+=` tally, `&&=` on a missing key, and a symbol-keyed hash. `make test` 956 pass, 0 fail; `make bootstrap` analyze + codegen IR and C fixpoints byte-identical (this touches an inference pass, so the fixpoint is the key gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
