### PR TITLE
Support define_singleton_method with a literal name

### DIFF
--- a/src/analyze_scope.c
+++ b/src/analyze_scope.c
@@ -653,7 +653,24 @@ void walk_scope(Compiler *c, int id, int scope_idx, int class_id) {
        function (class_id stays -1), matching `def`. */
     const char *dm_cn = nt_str(c->nt, id, "name");
     int dm_recv = nt_ref(c->nt, id, "receiver");
-    if (dm_cn && !strcmp(dm_cn, "define_method") && dm_recv < 0) {
+    int dm_is_dm  = dm_cn && !strcmp(dm_cn, "define_method") && dm_recv < 0;
+    int dm_is_dsm = dm_cn && !strcmp(dm_cn, "define_singleton_method");
+    /* define_singleton_method registers a class method on the resolved target:
+       a class constant receiver, `self` in a class body, or no receiver (the
+       enclosing class). An arbitrary-instance singleton has no compile-time
+       class, so it is not registered (the later call rejects). */
+    int dm_cmethod = 0, dm_cls = class_id, dm_ok = dm_is_dm;
+    if (dm_is_dsm) {
+      dm_cmethod = 1;
+      const char *dsm_rty = dm_recv >= 0 ? nt_type(c->nt, dm_recv) : NULL;
+      if (dm_recv < 0) dm_cls = class_id;
+      else if (dsm_rty && (!strcmp(dsm_rty, "ConstantReadNode") || !strcmp(dsm_rty, "ConstantPathNode")))
+        dm_cls = comp_class_index(c, nt_str(c->nt, dm_recv, "name"));
+      else if (dsm_rty && !strcmp(dsm_rty, "SelfNode")) dm_cls = class_id;
+      else dm_cls = -1;
+      dm_ok = dm_cls >= 0;
+    }
+    if (dm_ok) {
       int dm_args = nt_ref(c->nt, id, "arguments");
       int dm_na = 0;
       const int *dm_argv = dm_args >= 0 ? nt_arr(c->nt, dm_args, "arguments", &dm_na) : NULL;
@@ -669,7 +686,8 @@ void walk_scope(Compiler *c, int id, int scope_idx, int class_id) {
           Scope *dm_s = comp_scope_new(c, dm_mname, id);
           int dm_new_idx = c->nscopes - 1;
           dm_s->body = nt_ref(c->nt, dm_blk, "body");
-          dm_s->class_id = class_id;
+          dm_s->class_id = dm_cls;
+          dm_s->is_cmethod = dm_cmethod;
           /* the block's params are the defined method's params (e.g. the
              `&:to_s`-rewritten `{ |_spx| _spx.to_s }`'s _spx). */
           int dm_pn = nt_ref(c->nt, dm_blk, "parameters");

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -2250,6 +2250,18 @@ void emit_stmt_inner(Compiler *c, int id, Buf *b, int indent) {
   if (!strcmp(ty, "CallNode")) {
     const char *cnm = nt_str(nt, id, "name");
     if (cnm && !strcmp(cnm, "define_method") && nt_ref(nt, id, "receiver") < 0) return;
+    /* define_singleton_method on a supported target (no receiver, `self`, or a
+       class-constant / namespaced-class receiver) is resolved into a class-method
+       scope at analyze time, so the call emits no runtime code. Mirror exactly the
+       receivers analyze registers; an arbitrary-instance receiver is NOT no-op'd
+       here -- it falls through to the normal unresolved-call reject at this site. */
+    if (cnm && !strcmp(cnm, "define_singleton_method")) {
+      int dsm_recv = nt_ref(nt, id, "receiver");
+      if (dsm_recv < 0) return;
+      const char *dsm_rty = nt_type(nt, dsm_recv);
+      if (dsm_rty && (!strcmp(dsm_rty, "SelfNode") || !strcmp(dsm_rty, "ConstantReadNode") ||
+                      !strcmp(dsm_rty, "ConstantPathNode"))) return;
+    }
     /* `class_eval/module_eval { defs }` reopen: the block's def/define_method
        were registered as the target's methods at analyze time and are emitted
        separately; the call itself is a no-op at runtime. g_class_body_id resolves

--- a/test/define_singleton_method_literal.rb
+++ b/test/define_singleton_method_literal.rb
@@ -1,0 +1,19 @@
+class C
+  define_singleton_method(:hello) { "hi" }                 # no receiver: the enclosing class
+  self.define_singleton_method(:hello_self) { "hi self" }  # self receiver
+end
+
+C.define_singleton_method(:world) { "earth" }              # class-constant receiver
+C.define_singleton_method(:double) { |x| x * 2 }           # parameterized
+
+module M
+  class D
+  end
+end
+M::D.define_singleton_method(:nested) { "nested" }         # namespaced (ConstantPath) receiver
+
+puts C.hello
+puts C.hello_self
+puts C.world
+puts C.double(21)
+puts M::D.nested

--- a/test/define_singleton_method_literal.rb.expected
+++ b/test/define_singleton_method_literal.rb.expected
@@ -1,0 +1,5 @@
+hi
+hi self
+earth
+42
+nested


### PR DESCRIPTION
`define_singleton_method(:name) { ... }` was unsupported. This extends the existing `define_method` registration to handle it: the block body is registered as a class-method scope on the resolved target — a class-constant receiver (`C.define_singleton_method(...)`), `self` in a class body, or no receiver (the enclosing class). The call itself emits no runtime code, exactly like `define_method`.

A singleton method on an arbitrary instance (`obj.define_singleton_method`) has no compile-time class and no per-instance method storage, so it is left unregistered and the later call rejects loudly, rather than being silently dropped — that case is out of scope.

Verified: `make test` (956 pass, 0 fail), `make bootstrap` IR + C fixpoint OK for `analyze.rb` and `codegen.rb`, and `test/define_singleton_method_literal.rb` (expected regenerated from CRuby) covers in-body and class-constant receivers plus a parameterized singleton method (`C.double(21) => 42`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
