### PR TITLE
Lower instance_variable_get/set on a literal name

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -1123,6 +1123,21 @@ else {
     if (!strcmp(name, "is_a?") || !strcmp(name, "kind_of?") || !strcmp(name, "instance_of?") ||
         !strcmp(name, "respond_to?") || !strcmp(name, "==") || !strcmp(name, "!=") ||
         !strcmp(name, "nil?") || !strcmp(name, "equal?") || !strcmp(name, "frozen?")) return TY_BOOL;
+    /* instance_variable_get(:@x) yields @x's declared type; instance_variable_set
+       yields the field type too (C `lvalue = v` evaluates to the lvalue). The
+       codegen lowers both to a direct iv_ field access on the known layout. */
+    if ((!strcmp(name, "instance_variable_get") || !strcmp(name, "instance_variable_set")) && argc >= 1) {
+      const char *a0ty = nt_type(nt, argv[0]);
+      if (a0ty && (!strcmp(a0ty, "SymbolNode") || !strcmp(a0ty, "StringNode"))) {
+        const char *sym = !strcmp(a0ty, "SymbolNode")
+                            ? nt_str(nt, argv[0], "value") : nt_str(nt, argv[0], "content");
+        /* A name in the layout yields its declared type; an undefined-but-valid
+           `@`-name reads as nil and a bad name (no `@`) raises NameError -- both poly. */
+        int iv = (sym && sym[0] == '@') ? comp_ivar_index(cls, sym) : -1;
+        if (iv >= 0) return cls->ivar_types[iv];
+        return TY_POLY;
+      }
+    }
     /* attr reader (resolve alias so `alias v access_token` returns @access_token type) */
     { int rdcls = -1;
       if (comp_reader_in_chain(c, cid, name, &rdcls)) {

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -2679,6 +2679,74 @@ static int emit_object_call(Compiler *c, int id, Buf *b) {
                  ret_ty == TY_RANGE ? "(sp_Range){0}" : default_value(ret_ty));
       return 1;
     }
+    /* instance_variable_get(:@x) / instance_variable_set(:@x, v) with a literal
+       symbol or string name. A name present in the known layout lowers to a
+       direct field read/write. An undefined-but-valid `@`-name reads as nil
+       (get), matching CRuby; a name without a leading `@` raises NameError at
+       runtime, also matching CRuby. A dynamic name -- or instance_variable_set
+       to a valid name absent from the fixed object layout (no field to write) --
+       cannot be represented and is diagnosed. */
+    if ((!strcmp(name, "instance_variable_get") || !strcmp(name, "instance_variable_set")) &&
+        argc >= 1 && nt_type(nt, argv[0]) &&
+        (!strcmp(nt_type(nt, argv[0]), "SymbolNode") || !strcmp(nt_type(nt, argv[0]), "StringNode"))) {
+      const char *a0ty = nt_type(nt, argv[0]);
+      const char *sym = !strcmp(a0ty, "SymbolNode")
+                          ? nt_str(nt, argv[0], "value") : nt_str(nt, argv[0], "content");
+      int is_set = !strcmp(name, "instance_variable_set");
+      /* Arity is statically known: get takes just the name, set the name and a
+         value. A wrong count is a clear diagnostic rather than falling through to
+         the misleading by-value-receiver message below. */
+      if (is_set && argc != 2) { unsupported(c, id, "instance_variable_set takes exactly 2 arguments"); return 1; }
+      if (!is_set && argc != 1) { unsupported(c, id, "instance_variable_get takes exactly 1 argument"); return 1; }
+      int is_val = comp_ty_value_obj(c, rt);
+      const char *rty = nt_type(nt, recv);
+      int recv_lvalue = rty && (!strcmp(rty, "LocalVariableReadNode") ||
+                                !strcmp(rty, "InstanceVariableReadNode") || !strcmp(rty, "SelfNode"));
+      /* A name without a leading `@` is never a valid ivar name: raise NameError
+         at runtime (evaluating the receiver first for its side effects). */
+      if (!sym || sym[0] != '@') {
+        if (recv >= 0) { buf_puts(b, "(("); emit_expr(c, recv, b); buf_puts(b, "), "); }
+        else buf_puts(b, "(");
+        buf_printf(b, "sp_raise_cls(\"NameError\", \"'%s' is not allowed as an instance variable name\"), sp_box_nil())",
+                   sym ? sym : "");
+        return 1;
+      }
+      int mi = -1;
+      for (int i = 0; i < c->classes[cid].nivars; i++)
+        if (!strcmp(c->classes[cid].ivars[i], sym)) { mi = i; break; }
+      if (mi >= 0) {
+        /* A value object is passed by value, so a field write only sticks when
+           the receiver is an lvalue (a local / ivar / self); a pointer object
+           can be mutated through any reference. */
+        if (is_set && is_val && !recv_lvalue) {
+          unsupported(c, id, "instance_variable_set on a by-value object requires an lvalue receiver");
+          return 1;
+        }
+        TyKind mt = c->classes[cid].ivar_types[mi];
+        const char *acc = is_val ? "." : "->";
+        if (is_set) {
+          buf_puts(b, "(("); emit_expr(c, recv, b);
+          buf_printf(b, ")%siv_%s = ", acc, sym + 1);
+          if (mt == TY_POLY) emit_boxed(c, argv[1], b); else emit_expr(c, argv[1], b);
+          buf_puts(b, ")");
+        }
+        else {
+          buf_puts(b, "("); emit_expr(c, recv, b);
+          buf_printf(b, ")%siv_%s", acc, sym + 1);
+        }
+        return 1;
+      }
+      /* A valid `@`-name not in the layout: get reads as nil (CRuby returns nil
+         for an unset ivar); set has no field to write under the fixed layout. */
+      if (is_set) {
+        unsupported(c, id, "instance_variable_set to an ivar absent from the fixed object layout");
+        return 1;
+      }
+      if (recv >= 0) { buf_puts(b, "(("); emit_expr(c, recv, b); buf_puts(b, "), sp_box_nil())"); }
+      else buf_puts(b, "sp_box_nil()");
+      return 1;
+    }
+
     /* attr reader -> field access (recv).iv_x */
     if (comp_reader_in_chain(c, cid, name, NULL)) {
       const char *rn2 = comp_resolve_alias(c, cid, name);

--- a/test/ivar_get_set_literal.rb
+++ b/test/ivar_get_set_literal.rb
@@ -1,0 +1,35 @@
+class Box
+  def initialize
+    @v = 0
+    @name = "box"
+  end
+  def v = @v
+end
+
+# receiver via a method param exercises a non-folded object receiver
+def setget(b)
+  b.instance_variable_set(:@v, 99)
+  b.instance_variable_get(:@v)
+end
+
+b = Box.new
+b.instance_variable_set(:@v, 42)
+puts b.instance_variable_get(:@v)
+puts b.v
+puts setget(Box.new)
+
+# instance_variable_set evaluates to the assigned value
+x = b.instance_variable_set(:@v, 7)
+puts x
+puts b.v
+
+# a String name resolves the same as a symbol
+puts b.instance_variable_get("@name")
+
+# an undefined but valid @-name reads as nil (CRuby returns nil for an unset ivar)
+p b.instance_variable_get(:@missing)
+
+# a name without a leading @ raises NameError at runtime
+begin; b.instance_variable_get(:x); rescue => e; puts "#{e.class}: #{e.message}"; end
+begin; b.instance_variable_set(:y, 1); rescue => e; puts "#{e.class}: #{e.message}"; end
+begin; b.instance_variable_get("z"); rescue => e; puts "#{e.class}: #{e.message}"; end

--- a/test/ivar_get_set_literal.rb.expected
+++ b/test/ivar_get_set_literal.rb.expected
@@ -1,0 +1,10 @@
+42
+42
+99
+7
+7
+box
+nil
+NameError: 'x' is not allowed as an instance variable name
+NameError: 'y' is not allowed as an instance variable name
+NameError: 'z' is not allowed as an instance variable name


### PR DESCRIPTION
`instance_variable_get(:@x)` and `instance_variable_set(:@x, v)` were unsupported. With a literal symbol or string naming an ivar present in the class's known layout, this lowers them to a direct field access — get reads the `iv_x` field; set assigns it and (per C `lvalue = v`) evaluates to the field, matching the value Ruby returns. A value-object receiver (passed by value) is mutated only when it is an lvalue (a local / ivar / self); a pointer object can be mutated through any reference. Inference returns the ivar's declared type.

The remaining cases match CRuby rather than being rejected:

* an undefined but valid `@`-name reads as `nil` for `get`, since CRuby returns nil for an unset ivar (the receiver is still evaluated for its side effects);
* a `String` argument (`"@x"`) resolves the same as a symbol;
* a name without a leading `@` (`:x` / `"x"`) raises `NameError: '<name>' is not allowed as an instance variable name` at runtime.

A dynamic (non-literal) name — or `instance_variable_set` to a valid name absent from the fixed object layout, which has no field to write — cannot be represented and is diagnosed.

Verified: `make test` (956 pass, 0 fail), `make bootstrap` IR + C fixpoint OK for `analyze.rb` and `codegen.rb`, and `test/ivar_get_set_literal.rb` (expected regenerated from CRuby) covers get/set in the layout, a method-param receiver, `set`'s return value, a String name, the undefined-ivar `nil`, and the bad-name `NameError` for both `get` and `set`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
