### PR TITLE
Resolve const_get with a literal name

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -2194,6 +2194,16 @@ else {
   if (!strcmp(name, "!")) return TY_BOOL;
   if (!strcmp(name, "respond_to?") && recv >= 0) return TY_BOOL;
   if ((!strcmp(name, "method_defined?") || !strcmp(name, "const_defined?")) && recv >= 0) return TY_BOOL;
+  /* const_get(:K) with a literal name resolves to the constant's type (codegen
+     emits cst_<K>); a literal name that does not resolve raises NameError at
+     runtime, so its value type is poly. A dynamic name is left unresolved. */
+  if (!strcmp(name, "const_get") && recv >= 0 && argc >= 1) {
+    const char *cgt = nt_type(nt, argv[0]);
+    const char *cgn = NULL;
+    if (cgt && !strcmp(cgt, "SymbolNode")) cgn = nt_str(nt, argv[0], "value");
+    else if (cgt && !strcmp(cgt, "StringNode")) cgn = nt_str(nt, argv[0], "content");
+    if (cgn) { LocalVar *cv = comp_const(c, cgn); if (cv && cv->type != TY_UNKNOWN) return cv->type; return TY_POLY; }
+  }
   if (!strcmp(name, "nil?") && recv >= 0 && argc == 0) return TY_BOOL;
   if (!strcmp(name, "object_id") && recv >= 0 && argc == 0) return TY_INT;
   if (!strcmp(name, "between?") && argc == 2 && (rt == TY_STRING || ty_is_numeric(rt))) return TY_BOOL;

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -6960,6 +6960,49 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     return;
   }
 
+  /* Class.const_get(:K) with a literal name: constants live in a flat namespace
+     (cst_<name>), so resolve it like a ConstantRead. A literal name that does not
+     resolve raises NameError at runtime, matching CRuby: "uninitialized constant
+     <Name>" for a valid constant name, "wrong constant name <name>" for one that
+     is not (no leading uppercase). A dynamic name can't be resolved ahead of time
+     and is diagnosed. */
+  if (!strcmp(name, "const_get") && recv >= 0 && argc >= 1) {
+    const char *cg_aty = nt_type(nt, argv[0]);
+    const char *cg_qm = NULL;
+    if (cg_aty && !strcmp(cg_aty, "SymbolNode")) cg_qm = nt_str(nt, argv[0], "value");
+    else if (cg_aty && !strcmp(cg_aty, "StringNode")) cg_qm = nt_str(nt, argv[0], "content");
+    if (cg_qm) {
+      LocalVar *cv = comp_const(c, cg_qm);
+      if (cv && cv->type != TY_UNKNOWN) { buf_printf(b, "cst_%s", cg_qm); return; }
+      /* literal but unresolved: evaluate the receiver for side effects, then raise.
+         CRuby qualifies "uninitialized constant" by a named module receiver
+         (M::Missing) but not by Object/top-level; "wrong constant name" is never
+         qualified. Qualify when the receiver is a constant other than Object. */
+      buf_puts(b, "((void)("); emit_expr(c, recv, b); buf_puts(b, "), sp_raise_cls(\"NameError\", ");
+      if (cg_qm[0] >= 'A' && cg_qm[0] <= 'Z') {
+        /* Qualify by the receiver's full Ruby name when it resolves to a known
+           class/module (M, or nested M::N); a builtin like Object resolves to no
+           user-class index and stays unqualified, matching CRuby. */
+        const char *rcv_ty = nt_type(nt, recv);
+        const char *rcv_nm = (rcv_ty && (!strcmp(rcv_ty, "ConstantReadNode") ||
+                                         !strcmp(rcv_ty, "ConstantPathNode"))) ? nt_str(nt, recv, "name") : NULL;
+        int rcid = rcv_nm ? comp_class_index(c, rcv_nm) : -1;
+        if (rcid >= 0) {
+          const char *qn = class_ruby_name(c, rcid); if (!qn) qn = c->classes[rcid].name;
+          buf_printf(b, "\"uninitialized constant %s::%s\"", qn, cg_qm);
+        } else {
+          buf_printf(b, "\"uninitialized constant %s\"", cg_qm);
+        }
+      } else {
+        buf_printf(b, "\"wrong constant name %s\"", cg_qm);
+      }
+      buf_puts(b, "), sp_box_nil())");
+      return;
+    }
+    unsupported(c, id, "const_get (needs a compile-time-known constant name)");
+    return;
+  }
+
   /* Class.const_defined?(:K): compile-time presence check. Constants are
      recorded in a flat namespace, so this consults the global const and class
      tables rather than the receiver's own constants. */

--- a/test/const_get_literal.rb
+++ b/test/const_get_literal.rb
@@ -1,0 +1,20 @@
+module M
+  X = 7
+  NAME = "spinel"
+  module N
+    Z = 1
+  end
+end
+
+# literal symbol and string names resolve to the constant value
+puts M.const_get(:X)
+puts M.const_get(:NAME)
+puts M.const_get("X")
+
+# a literal but unresolved name raises NameError at runtime, matching CRuby:
+# a valid constant name reports "uninitialized constant", qualified by a named
+# module receiver; a name without a leading uppercase reports "wrong constant name".
+begin; M.const_get(:Missing); rescue => e; puts "#{e.class}: #{e.message}"; end
+begin; M.const_get(:lower); rescue => e; puts "#{e.class}: #{e.message}"; end
+begin; Object.const_get(:Nope); rescue => e; puts "#{e.class}: #{e.message}"; end
+begin; M::N.const_get(:Missing); rescue => e; puts "#{e.class}: #{e.message}"; end

--- a/test/const_get_literal.rb.expected
+++ b/test/const_get_literal.rb.expected
@@ -1,0 +1,7 @@
+7
+spinel
+7
+NameError: uninitialized constant M::Missing
+NameError: wrong constant name lower
+NameError: uninitialized constant Nope
+NameError: uninitialized constant M::N::Missing


### PR DESCRIPTION
`Module.const_get(:K)` was unsupported even for a literal symbol/string name (the gap doc believed the literal case worked — it did not). Constants live in a flat namespace (`cst_<name>`), so a literal name resolves exactly like a `ConstantRead`: emit the constant value, infer the constant's type.

A literal name that does not resolve now raises `NameError` at runtime, matching CRuby rather than rejecting at compile time:

* a valid constant name reports `uninitialized constant <Name>`, qualified by a named module receiver (`M::Missing`) but not by `Object`;
* a name without a leading uppercase reports `wrong constant name <name>`.

The receiver is evaluated for its side effects first. A dynamic (non-literal) name cannot be resolved ahead of time and gets a specific diagnostic.

Verified: `make test` (956 pass, 0 fail), `make bootstrap` IR + C fixpoint OK for `analyze.rb` and `codegen.rb`, and `test/const_get_literal.rb` (expected regenerated from CRuby) covers literal symbol/string names over Integer and String constants, plus the unresolved `uninitialized constant` (qualified and `Object`-unqualified) and `wrong constant name` runtime errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
