### PR TITLE
File.expand_path: record the normalized length, not the reserved capacity

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -5440,6 +5440,12 @@ else {
     p = q;
   }
   out[olen] = 0;
+  /* The result was sized to the pre-normalized rawlen+1 (a safe capacity
+     bound), but normalization can shrink it, so the actual content is olen
+     bytes. Record olen as the length; otherwise the string carries trailing
+     NUL/garbage bytes past the path (e.g. File.expand_path("x") returns a
+     string whose byte length includes a stray "\0"). */
+  sp_str_set_len(out, olen);
   return out;
 }
 


### PR DESCRIPTION
### Problem

`File.expand_path` returns a string whose byte length is one (or more) too large: it includes trailing NUL byte(s) past the real path.

```ruby
p File.expand_path("foo").length      # => one more than the visible path
p File.expand_path("foo").bytes.last  # => 0   (a stray NUL; should be the last real char)
```

Expected (matches CRuby): the result is exactly the path, with no trailing NUL, and `.length` is the visible length.

### Cause

`sp_file_expand_path` (in `lib/sp_runtime.h`) sizes the result with `sp_str_alloc(rawlen + 1)` — a safe upper bound on capacity — then writes the normalized path (`olen` bytes) into it:

```c
size_t rawlen = strlen(raw);
char *out = sp_str_alloc(rawlen + 1);   // records length = rawlen + 1
...                                     // writes olen bytes (normalization can shrink it)
out[olen] = 0;
return out;                             // string length still rawlen + 1 -> trailing NUL(s)
```

Path normalization (collapsing `.` / `..` / `//`, adding the single leading `/`) can produce fewer bytes than the pre-normalized `raw`, but the string's recorded length was left at the reserved `rawlen + 1`.

### Fix

Record the actual written length (`olen`) before returning. The `rawlen + 1` allocation stays as the capacity bound; only the recorded length is corrected:

```c
out[olen] = 0;
sp_str_set_len(out, olen);
return out;
```

### Verification

```
File.expand_path(".../tailwind.css").length   84 -> 83   (trailing NUL gone)
File.expand_path("a/../b")                     normalizes correctly, no trailing bytes
File.expand_path("/x/y")                       unchanged
```

One line plus a comment; no change to the content of any valid path's result, only its length and trailing bytes.
