### PR TITLE
Support super into an included-module method

### DIFF
--- a/src/analyze_scope.c
+++ b/src/analyze_scope.c
@@ -1568,6 +1568,18 @@ void resolve_parents(Compiler *c) {
   }
 }
 
+/* True if the method scope's body contains a `super` (an explicit-arg SuperNode
+   or a bare ForwardingSuperNode). */
+static int scope_body_has_super(Compiler *c, int scope_idx) {
+  const NodeTable *nt = c->nt;
+  for (int id = 0; id < nt->count; id++) {
+    if (c->nscope[id] != scope_idx) continue;
+    const char *ty = nt_type(nt, id);
+    if (ty && (!strcmp(ty, "SuperNode") || !strcmp(ty, "ForwardingSuperNode"))) return 1;
+  }
+  return 0;
+}
+
 /* Process include calls in a single class body, creating scope copies for each
    included module method. We copy (not mutate) so multiple classes can include
    the same module independently. */
@@ -1598,17 +1610,52 @@ void process_include_body(Compiler *c, int ci, int body_node) {
       for (int ms = 0; ms < snap; ms++) {
         Scope *src = &c->scopes[ms];
         if (src->class_id != mod_id || src->is_cmethod || !src->name) continue;
-        if (comp_method_in_class(c, ci, src->name) >= 0) continue;
+        const char *dst_name = src->name;
+        char inc_shadow[256];
+        int own = comp_method_in_class(c, ci, src->name);
+        if (own >= 0) {
+          /* The class overrides the module method. If the override calls super,
+             the module method is the super target: copy it under a shadow name
+             and chain to it so emit_super reaches it via the prepend-super path.
+             Otherwise the module method is simply shadowed -- nothing to emit. */
+          if (!scope_body_has_super(c, own)) continue;
+          const char *existing = comp_prep_chain_target(c, ci, src->name);
+          snprintf(inc_shadow, sizeof inc_shadow, "__inc_%d_%s",
+                   c->classes[ci].prep_shadow_count++, src->name);
+          if (existing) {
+            /* Another included module already supplies the super target for this
+               method. A later include takes precedence (Ruby MRO: C -> Mlast ->
+               ... -> Mfirst), so retarget the class's super to this module's copy
+               and chain this copy to the previously included one:
+               name -> new_shadow -> earlier_shadow. */
+            char *prev = strdup(existing);  /* stable copy: the slot is freed below */
+            ClassInfo *cif = &c->classes[ci];
+            for (int kk = 0; kk < cif->nprep_chain; kk++)
+              if (!strcmp(cif->prep_from[kk], src->name)) {
+                free(cif->prep_to[kk]);
+                cif->prep_to[kk] = strdup(inc_shadow);
+                break;
+              }
+            comp_prep_chain_add(cif, inc_shadow, prev);
+            free(prev);
+          } else {
+            comp_prep_chain_add(&c->classes[ci], src->name, inc_shadow);
+          }
+          dst_name = inc_shadow;
+        }
         /* Create a new scope sharing the same AST nodes but owned by ci. */
-        Scope *dst = comp_scope_new(c, src->name, src->def_node);
+        Scope *dst = comp_scope_new(c, dst_name, src->def_node);
         int dst_idx = c->nscopes - 1;
         /* comp_scope_new may realloc c->scopes; re-derive src pointer. */
         src = &c->scopes[ms];
-        /* When the target is a built-in class, `self` has a different (scalar)
-           type than the module's object self, so clone the body and re-attribute
-           it to the target -- otherwise the shared SelfNode resolves to the
-           module and e.g. `self.to_s` mis-dispatches. */
-        if (is_builtin_class_name(c->classes[ci].name) && src->body >= 0) {
+        /* Clone the body and re-attribute it to the target when either:
+           (a) the target is a built-in class, where `self` has a different
+           (scalar) type than the module's object self -- otherwise the shared
+           SelfNode resolves to the module and e.g. `self.to_s` mis-dispatches; or
+           (b) the copied method itself calls `super` (a multi-module chain), so
+           its super node resolves to this shadow scope (and thus the class's prep
+           chain) rather than to the source module, where the chain isn't set. */
+        if ((is_builtin_class_name(c->classes[ci].name) || scope_body_has_super(c, ms)) && src->body >= 0) {
           int nb = nt_clone_subtree((NodeTable *)nt, src->body);
           if (nb >= 0) {
             comp_grow_node_arrays(c);

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1724,7 +1724,14 @@ void emit_super(Compiler *c, int id, Buf *b) {
         buf_puts(b, "((void)0)");
       return;
     }
-    unsupported(c, id, "super (no parent method)");
+    /* No superclass method anywhere (parent chain, included-module shadow, and
+       the exception-initialize special case all missed). CRuby raises
+       NoMethodError at runtime, so emit that rather than rejecting at compile
+       time -- the call may sit in a branch that never runs. */
+    const char *scn = class_ruby_name(c, s->class_id);
+    if (!scn) scn = c->classes[s->class_id].name;
+    buf_printf(b, "(sp_raise_cls(\"NoMethodError\", \"super: no superclass method '%s' for an instance of %s\"), %s)",
+               uname, scn, default_value(comp_ntype(c, id)));
     return;
   }
   buf_printf(b, "sp_%s_%s((sp_%s *)%s", c->classes[defcls].name, mc(uname), c->classes[defcls].name, g_self);

--- a/test/super_into_included_module.rb
+++ b/test/super_into_included_module.rb
@@ -1,0 +1,46 @@
+module Greet
+  def hi = "hi"
+  def shout(x) = x.upcase
+end
+
+class C
+  include Greet
+  def hi = "[" + super + "]"          # bare super into the module method
+  def shout(x) = "<" + super + ">"    # forwards x up to the module method
+end
+
+puts C.new.hi
+puts C.new.shout("yo")
+
+# a class that includes the module but does NOT override stays on the normal
+# transplant path (the module method is callable directly)
+class D
+  include Greet
+end
+puts D.new.hi
+
+# multiple modules defining the same method: a later include takes precedence,
+# and super chains through them in MRO order (C -> M2 -> M1)
+module M1
+  def tag = "M1"
+end
+module M2
+  def tag = "M2(" + super + ")"
+end
+class F
+  include M1
+  include M2
+  def tag = "F[" + super + "]"
+end
+puts F.new.tag
+
+# super with no superclass method anywhere raises NoMethodError at runtime
+# (CRuby raises when the method is called, not at definition)
+class E
+  def orphan = super
+end
+begin
+  E.new.orphan
+rescue => e
+  puts "#{e.class}: #{e.message}"
+end

--- a/test/super_into_included_module.rb.expected
+++ b/test/super_into_included_module.rb.expected
@@ -1,0 +1,5 @@
+[hi]
+<YO>
+hi
+F[M2(M1)]
+NoMethodError: super: no superclass method 'orphan' for an instance of E


### PR DESCRIPTION
A class method that overrides an included module's method and calls `super` rejected with `unsupported super (no parent method)`. `include` flattens a module's methods into the class but skips the copy when the class already defines that name, so the module method was unreachable — and the super lookup walks only the superclass chain, finding nothing.

When the class overrides a module method and the override calls `super`, this copies the module method into the class under a shadow name and registers a chain entry, so `emit_super` reaches it through the existing prepend-super path. This keeps `self` as the class type (the body is re-attributed like any transplanted include) and avoids a module-struct cast. The shadow is created only for the super-into-module case (gated on the override actually containing a `super`); classes that include without overriding stay on the normal transplant path.

Multiple modules defining the same method chain in Ruby MRO order: a later `include` takes precedence, so its copy becomes the class's super target and chains to the earlier module's copy (`name -> __inc_N -> __inc_N-1`). A copied method that itself calls `super` has its body re-attributed to the shadow scope, so its `super` resolves through the class's chain rather than back to the source module.

`super` with no superclass method anywhere — not in the parent chain, an included-module shadow, or the exception-`initialize` path — now raises `NoMethodError` at runtime (`super: no superclass method '<m>' for an instance of <Class>`), matching CRuby, rather than rejecting at compile time (the call may sit in a branch that never runs).

Verified: `make test` (976 pass, 0 fail), `make bootstrap` IR + C fixpoint OK for `analyze.rb` and `codegen.rb`, and `test/super_into_included_module.rb` (expected regenerated from CRuby) covers bare `super`, argument-forwarding `super` into the module method, a non-overriding includer, multi-module MRO chaining (`F[M2(M1)]`), and the no-superclass-method runtime `NoMethodError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)