### PR TITLE
Validate clamp bounds against NaN and min>max

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -1423,6 +1423,24 @@ static const char*sp_float_to_s(mrb_float f){
   out[o]=0;sp_str_set_len(out,(size_t)o);return out;
 }
 #define sp_float_inspect sp_float_to_s
+
+/* Bound-checked clamp. The arithmetic lives in the compiled-once leaf
+   helpers (sp_core.c); the validation rides here because it needs the
+   error-message machinery (sp_sprintf) and Ruby float inspect, neither of
+   which the decoupled sp_core.c TU links against. CRuby's Comparable#clamp
+   compares min<=>max first (so a NaN bound names max), then self against
+   each bound (so a NaN receiver names min); a non-NaN min>max is the
+   ordinary ArgumentError. */
+static inline mrb_int sp_int_clamp_ck(mrb_int v,mrb_int lo,mrb_int hi){
+  if(lo>hi)sp_raise_cls("ArgumentError","min argument must be less than or equal to max argument");
+  return sp_int_clamp(v,lo,hi);
+}
+static inline mrb_float sp_float_clamp_ck(mrb_float v,mrb_float lo,mrb_float hi){
+  if(lo!=lo||hi!=hi)sp_raise_cls("ArgumentError",sp_sprintf("comparison of Float with %s failed",sp_float_to_s(hi)));
+  if(lo>hi)sp_raise_cls("ArgumentError","min argument must be less than or equal to max argument");
+  if(v!=v)sp_raise_cls("ArgumentError",sp_sprintf("comparison of Float with %s failed",sp_float_to_s(lo)));
+  return sp_float_clamp(v,lo,hi);
+}
 /* String#inspect: wrap in double quotes and escape \, ", \n, \t, \r,
    plus any non-printable byte as \xNN. Output is always ASCII-safe. */
 static const char*sp_str_inspect(const char*s){if(!s){char*r=sp_str_alloc_raw(4);r[0]='n';r[1]='i';r[2]='l';r[3]=0;return r;}size_t sl=sp_str_byte_len(s);size_t cap=sl*4+3;char*r=sp_str_alloc_raw(cap);size_t o=0;r[o++]='"';for(size_t i=0;i<sl;i++){unsigned char c=(unsigned char)s[i];if(c=='\\'||c=='"'){r[o++]='\\';r[o++]=c;}else if(c=='\n'){r[o++]='\\';r[o++]='n';}else if(c=='\t'){r[o++]='\\';r[o++]='t';}else if(c=='\r'){r[o++]='\\';r[o++]='r';}else if(c<0x20||c==0x7f){snprintf(r+o,5,"\\x%02X",c);o+=4;}else{r[o++]=(char)c;}}r[o++]='"';r[o]=0;sp_str_set_len(r,o);return r;}

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -2369,11 +2369,11 @@ static int emit_scalar_call(Compiler *c, int id, Buf *b) {
         buf_printf(b, "; sp_IntArray *_t%d = sp_IntArray_new(); sp_IntArray_push(_t%d, sp_gcd(%s, _t%d));"
                       " sp_IntArray_push(_t%d, sp_lcm(%s, _t%d)); _t%d; })", o, o, r, ta, o, r, ta, o);
       }
-      else if (!strcmp(name, "clamp") && argc == 2) { buf_printf(b, "sp_int_clamp(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ", "); emit_expr(c, argv[1], b); buf_puts(b, ")"); }
+      else if (!strcmp(name, "clamp") && argc == 2) { buf_printf(b, "sp_int_clamp_ck(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ", "); emit_expr(c, argv[1], b); buf_puts(b, ")"); }
       else if (!strcmp(name, "clamp") && argc == 1 && nt_type(c->nt, argv[0]) && !strcmp(nt_type(c->nt, argv[0]), "RangeNode")) {
         int rn = argv[0]; int tcr = ++g_tmp;
         buf_printf(b, "({ sp_Range _t%d = ", tcr); emit_expr(c, argv[0], b);
-        buf_printf(b, "; sp_int_clamp(%s, _t%d.first, _t%d.last - _t%d.excl); })", r, tcr, tcr, tcr);
+        buf_printf(b, "; sp_int_clamp_ck(%s, _t%d.first, _t%d.last - _t%d.excl); })", r, tcr, tcr, tcr);
         (void)rn;
       }
       else if (!strcmp(name, "digits") && argc == 0) buf_printf(b, "sp_int_digits(%s, 10)", r);
@@ -2456,7 +2456,7 @@ static int emit_scalar_call(Compiler *c, int id, Buf *b) {
          Mirrors the inference condition in analyze_infer.c. */
       else if (!strcmp(name, "clamp") && argc == 2 &&
                comp_ntype(c, argv[0]) == TY_FLOAT && comp_ntype(c, argv[1]) == TY_FLOAT) {
-        buf_printf(b, "sp_float_clamp(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ", "); emit_expr(c, argv[1], b); buf_puts(b, ")");
+        buf_printf(b, "sp_float_clamp_ck(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ", "); emit_expr(c, argv[1], b); buf_puts(b, ")");
       }
       else if (!strcmp(name, "coerce") && argc == 1) {
         TyKind a0 = comp_ntype(c, argv[0]);

--- a/test/clamp_bounds.rb
+++ b/test/clamp_bounds.rb
@@ -1,0 +1,35 @@
+# clamp must raise ArgumentError when the minimum bound exceeds the maximum,
+# and Float#clamp must also raise when any operand is NaN (comparisons with
+# NaN are undefined). Receiver and bounds are routed through method params so
+# the runtime helpers are exercised, not a compile-time fold.
+def show_i(label, x, lo, hi)
+  print label, ": "
+  p x.clamp(lo, hi)
+rescue => e
+  puts "#{e.class}: #{e.message}"
+end
+
+def show_ir(label, x)
+  print label, ": "
+  p x.clamp(10..2)
+rescue => e
+  puts "#{e.class}: #{e.message}"
+end
+
+def show_f(label, x, lo, hi)
+  print label, ": "
+  p x.clamp(lo, hi)
+rescue => e
+  puts "#{e.class}: #{e.message}"
+end
+
+nan = 0.0 / 0.0
+
+show_i("int ok", 5, 1, 9)
+show_i("int min>max", 5, 10, 2)
+show_ir("int range bad", 5)
+show_f("float ok", 5.0, 1.5, 3.5)
+show_f("float min>max", 5.0, 2.0, 1.0)
+show_f("float recv nan", nan, 1.0, 2.0)
+show_f("float lo nan", 1.5, nan, 2.0)
+show_f("float hi nan", 1.5, 1.0, nan)

--- a/test/clamp_bounds.rb.expected
+++ b/test/clamp_bounds.rb.expected
@@ -1,0 +1,8 @@
+int ok: 5
+int min>max: ArgumentError: min argument must be less than or equal to max argument
+int range bad: ArgumentError: min argument must be less than or equal to max argument
+float ok: 3.5
+float min>max: ArgumentError: min argument must be less than or equal to max argument
+float recv nan: ArgumentError: comparison of Float with 1.0 failed
+float lo nan: ArgumentError: comparison of Float with 2.0 failed
+float hi nan: ArgumentError: comparison of Float with NaN failed


### PR DESCRIPTION
Follow-up to the merged `Float#clamp` support (https://github.com/matz/spinel/pull/1480). `clamp` previously returned a silently-wrong value when the minimum bound exceeded the maximum, and `Float#clamp` did the same when any operand was `NaN`. CRuby raises `ArgumentError` in both situations. This makes the runtime match CRuby's exact error classes and messages.

The arithmetic stays in the compiled-once leaf helpers (`sp_int_clamp`/`sp_float_clamp` in `lib/sp_core.c`); the validation rides in thin `static inline` wrappers `sp_int_clamp_ck`/`sp_float_clamp_ck` in `lib/sp_runtime.h`, where the error-message machinery (`sp_sprintf`) and Ruby float inspect (`sp_float_to_s`) are in scope — neither links against the decoupled `sp_core.c` translation unit. Codegen emits the `_ck` wrappers from the integer (2-arg and Range form) and float clamp branches.

The message order mirrors `Comparable#clamp`: it compares `min <=> max` first (so a `NaN` bound names `max`), then the receiver against each bound (so a `NaN` receiver names `min`); a non-`NaN` `min > max` is the ordinary `ArgumentError`.

```c
static inline mrb_float sp_float_clamp_ck(mrb_float v, mrb_float lo, mrb_float hi) {
  if (lo != lo || hi != hi) sp_raise_cls("ArgumentError", sp_sprintf("comparison of Float with %s failed", sp_float_to_s(hi)));
  if (lo > hi)              sp_raise_cls("ArgumentError", "min argument must be less than or equal to max argument");
  if (v != v)               sp_raise_cls("ArgumentError", sp_sprintf("comparison of Float with %s failed", sp_float_to_s(lo)));
  return sp_float_clamp(v, lo, hi);
}
```

Verified: `test/clamp_bounds.rb` routes the receiver and bounds through method parameters so the runtime helpers are exercised rather than constant-folded (the generated C calls `sp_int_clamp_ck`/`sp_float_clamp_ck`); `.expected` was regenerated from CRuby and covers `min > max` for int and float, the int Range form, and receiver/min/max `NaN`. `make test` 976 pass, 0 fail; `make bootstrap` `analyze.rb` and `codegen.rb` IR + C fixpoints byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
