### PR TITLE
Diagnose send/public_send with a runtime method name

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -2264,6 +2264,50 @@ static void scan_prologue_features(Compiler *c) {
     }                                                         \
   } while (0)
 
+/* `send` / `__send__` / `public_send` with a literal symbol/string name is
+   rewritten to a direct call before this point (textually for a receiver form,
+   on the AST for implicit self). A call to one of these that survives therefore
+   has a runtime method name, which AOT cannot dispatch in a closed world --
+   turn the opaque downstream reject (or silent nil-stub) into one actionable
+   diagnostic anchored to the call site. Skipped entirely if the program defines
+   its own method by that name, since then the call resolves normally. */
+static void reject_runtime_send(Compiler *c) {
+  const NodeTable *nt = c->nt;
+  static const char *const names[] = { "send", "__send__", "public_send", NULL };
+  for (int s = 0; s < c->nscopes; s++) {
+    const char *sn = c->scopes[s].name;
+    if (!sn) continue;
+    for (int k = 0; names[k]; k++)
+      if (!strcmp(sn, names[k])) return;  /* user-defined: leave to normal dispatch */
+  }
+  for (int id = 0; id < nt->count; id++) {
+    const char *ty = nt_type(nt, id);
+    if (!ty || strcmp(ty, "CallNode")) continue;
+    const char *nm = nt_str(nt, id, "name");
+    if (!nm) continue;
+    int is_send = 0;
+    for (int k = 0; names[k]; k++) if (!strcmp(nm, names[k])) { is_send = 1; break; }
+    if (!is_send) continue;
+    int args = nt_ref(nt, id, "arguments");
+    if (args < 0) continue;
+    int ac = 0; const int *av = nt_arr(nt, args, "arguments", &ac);
+    if (ac < 1 || !av) continue;
+    const char *a0 = nt_type(nt, av[0]);
+    /* a literal name should have been rewritten already; only a runtime name
+       (a variable, a method result, an interpolated string, ...) reaches here */
+    if (a0 && (!strcmp(a0, "SymbolNode") || !strcmp(a0, "StringNode"))) continue;
+    /* Only diagnose a send that codegen will actually emit. A send in a dead
+       (unreachable) method is pruned before emission, so rejecting it would
+       fail otherwise-valid programs that merely contain an unused method.
+       walk_scope assigns every node — including those inside blocks — the
+       enclosing method's scope, and the emit loop emits a scope's body only
+       when it is reachable; mirror that gate here. */
+    int sc = c->nscope[id];
+    if (sc < 0 || sc >= c->nscopes || !c->scopes[sc].reachable) continue;
+    unsupported(c, id, "send with a runtime method name (AOT needs a compile-time-known name)");
+  }
+}
+
 char *codegen_program(const NodeTable *nt) {
   Compiler *c = comp_new(nt);
   analyze_program(c);
@@ -2301,6 +2345,10 @@ char *codegen_program(const NodeTable *nt) {
     comp_free(c);
     return strdup("");
   }
+
+  /* Reject runtime-name send before any emission so the diagnostic fires
+     regardless of how the call's result is later consumed. */
+  reject_runtime_send(c);
 
   Buf b; memset(&b, 0, sizeof b);
   memset(&g_procs, 0, sizeof g_procs);

--- a/test/send_dead_code.rb
+++ b/test/send_dead_code.rb
@@ -1,0 +1,18 @@
+# A runtime-name send in an unreachable method must NOT abort compilation.
+# Dead code is pruned before codegen, so the send is never emitted; only a
+# send that codegen actually emits is diagnosed. This mirrors a real program
+# that defines a dispatch helper using `send` but never calls it on the
+# compiled entry path.
+class Pad
+  def press(button)
+    "pressed #{button}"
+  end
+
+  # Never called -> dead-code-eliminated. Uses a runtime method name (the
+  # `action` parameter), which would otherwise trigger the diagnostic.
+  def dispatch(action, button)
+    send(action, button)
+  end
+end
+
+puts Pad.new.press(:a)

--- a/test/send_dead_code.rb.expected
+++ b/test/send_dead_code.rb.expected
@@ -1,0 +1,1 @@
+pressed a

--- a/test/send_literal_and_user.rb
+++ b/test/send_literal_and_user.rb
@@ -1,0 +1,28 @@
+# A literal-name send/public_send is rewritten to a direct call, so it keeps
+# working. A class that defines its own `send` is dispatched normally and is
+# never mistaken for Kernel#send (even with a runtime argument), so the
+# runtime-name diagnostic must not fire for it.
+class Calc
+  def double(n)
+    n * 2
+  end
+
+  def label
+    "calc"
+  end
+end
+
+class Mailer
+  def send(msg)
+    "sent: #{msg}"
+  end
+end
+
+c = Calc.new
+puts c.send(:double, 5)        # literal symbol name -> direct call
+puts c.public_send("label")    # literal string name -> direct call
+
+m = Mailer.new
+greeting = "hi"
+puts m.send(greeting)          # user-defined Mailer#send, runtime arg
+puts m.send(greeting + "!")    # still the user method, not Kernel#send

--- a/test/send_literal_and_user.rb.expected
+++ b/test/send_literal_and_user.rb.expected
@@ -1,0 +1,4 @@
+10
+calc
+sent: hi
+sent: hi!


### PR DESCRIPTION
`send` / `public_send` / `__send__` with a **literal** symbol or string name is rewritten to a direct call before codegen (textually for a receiver form, on the AST for implicit self). A call to one of these that survives therefore has a **runtime** method name:

```ruby
def run(o, m)
  o.send(m)        # m is only known at runtime
end
```

A closed-world AOT compiler cannot dispatch that. Previously it fell through to an opaque, misleading reject — `unsupported call`, or even `unsupported puts argument` when the result happened to feed `puts` — or silently degraded to a `nil` stub on a poly receiver.

A pre-emission scan (`reject_runtime_send`, run at the top of `codegen_program` before any emission) flags a residual runtime-name send with a single diagnostic anchored to the call site (`unsupported send with a runtime method name (AOT needs a compile-time-known name)`). Running before emission makes the message independent of how the call's result is later consumed.

The scan is **scoped to sends that codegen will actually emit**. A send in an unreachable (dead-code-eliminated) method is skipped: `walk_scope` assigns every node — including those inside blocks — its enclosing method's scope, and codegen emits a scope's body only when it is reachable, so the scan mirrors that gate via `c->scopes[c->nscope[id]].reachable`. Without this, a program that merely *contains* an unused helper using `send` (e.g. a UI-input dispatch method never called on a headless entry path) would fail to compile even though the call is never emitted.

A program that defines its own method named `send` / `public_send` / `__send__` is exempt from the scan, so a user method by that name still dispatches normally. Literal-name sends are unaffected and continue to lower to direct calls. Deeper name folding (a local or constant bound to a literal symbol) is not attempted: those slots carry no literal value to fold against — out of scope; such names remain a diagnostic.

Verified: `test/send_literal_and_user.rb` (expected regenerated from CRuby) covers literal-symbol `send`, literal-string `public_send`, and a user-defined `#send` invoked with a runtime argument — all lower and run correctly. `test/send_dead_code.rb` covers a runtime-name `send` in a never-called method (the dead-code case the reachability gate fixes). A reachable runtime-name send still prints the specific diagnostic and exits non-zero. `make test` 976 pass, 0 fail; `make optcarrot` `checksum: 59662` / `Optcarrot: OK` (a real program with a `send`-based dispatch helper in a pruned path); `make bootstrap` IR + C fixpoints byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
