### PR TITLE
Dispatch unresolved object calls to method_missing

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -38,10 +38,14 @@ void compute_reachable(Compiler *c) {
     }
   }
 
-  /* Names that may be invoked implicitly (no explicit CallNode): keep live. */
+  /* Names that may be invoked implicitly (no explicit CallNode): keep live.
+     method_missing is reached only through the fallback dispatch the codegen
+     synthesizes, never a direct call, so it must be seeded here or the
+     reachability BFS would prune it. */
   static const char *const implicit[] = {
     "to_s", "inspect", "==", "<=>", "eql?", "hash", "each", "coerce",
-    "to_str", "to_ary", "to_a", "to_i", "to_int", "to_h", "to_proc", "call", NULL };
+    "to_str", "to_ary", "to_a", "to_i", "to_int", "to_h", "to_proc", "call",
+    "method_missing", NULL };
 
   /* BFS queue (scope indices). */
   int *queue = malloc((size_t)c->nscopes * sizeof(int));
@@ -2012,6 +2016,22 @@ void analyze_program(Compiler *c) {
                        !strcmp(snm, "ir_emit_str") ? TY_STRING :
                        !strcmp(snm, "ir_emit_sa")  ? TY_STR_ARRAY : TY_INT_ARRAY;
     sc->ret = TY_STRING;  /* each returns the accumulated buf (a string) */
+  }
+  /* Seed method_missing's signature. It is reached only through the synthesized
+     fallback dispatch (no AST call site), so the param backstop below can't bind
+     it: name is the called method's Symbol and args is the rest poly-array.
+     Unseeded it keeps TY_UNKNOWN params and gets pruned. */
+  for (int s = 0; s < c->nscopes; s++) {
+    Scope *sc = &c->scopes[s];
+    if (sc->class_id < 0 || !sc->name) continue;
+    if (!strcmp(sc->name, "method_missing") && sc->nparams >= 1 && sc->pnames) {
+      LocalVar *pn = scope_local(sc, sc->pnames[0]);
+      if (pn && pn->type == TY_UNKNOWN) pn->type = TY_SYMBOL;
+      if (sc->rest_idx >= 0 && sc->rest_idx < sc->nparams) {
+        LocalVar *pr = scope_local(sc, sc->pnames[sc->rest_idx]);
+        if (pr && pr->type == TY_UNKNOWN) pr->type = TY_POLY_ARRAY;
+      }
+    }
   }
   for (int it = 0; it < 8; it++) { if (!infer_param_types(c)) break; }
 

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -2398,6 +2398,23 @@ else {
     }
   }
 
+  /* method_missing fallback: an otherwise-unresolved call on a concrete object
+     whose class chain defines method_missing routes there at codegen time, so
+     the call's static type is method_missing's return type. Placed last so all
+     builtin / reopened-class resolution wins first (CRuby only reaches
+     method_missing when nothing else handles the call). Skip value objects to
+     match codegen, which only routes pointer-backed receivers here. */
+  if (recv >= 0 && ty_is_object(rt) && !comp_ty_value_obj(c, rt)) {
+    int mm = comp_method_in_chain(c, ty_object_class(rt), "method_missing", NULL);
+    if (mm >= 0) {
+      /* Register the called name as a symbol now (analyze runs before the symbol
+         table is emitted) so codegen can pass it to method_missing; interning it
+         during codegen would land after the table is finalized. */
+      if (name) comp_sym_intern(c, name);
+      return (TyKind)c->scopes[mm].ret;
+    }
+  }
+
   return TY_UNKNOWN;
 }
 

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -3311,6 +3311,81 @@ static int emit_poly_call(Compiler *c, int id, Buf *b) {
   return 0;
 }
 
+/* Route an otherwise-unresolved call on a concrete (non-value) object to
+   <Class>#method_missing(name, *args): the symbol of the called method becomes
+   the first argument and the call's own arguments are packed into the rest
+   array. Returns 1 if emitted, 0 if the method_missing shape isn't one we can
+   lower (caller then falls through to the unsupported diagnostic). Only the
+   canonical (name) and (name, *args) shapes with a usable scalar return are
+   handled; a descendant override of method_missing would mis-dispatch under a
+   direct call, so those bail too. */
+static int emit_method_missing(Compiler *c, int id, int recv, TyKind grt,
+                               int mm, int defcls, Buf *b) {
+  const NodeTable *nt = c->nt;
+  Scope *m = &c->scopes[mm];
+  if (m->nparams < 1) return 0;
+  /* (name) or (name, *args): the rest, if present, must be the second param. */
+  int has_rest = m->rest_idx >= 0;
+  if (has_rest ? (m->nparams != 2 || m->rest_idx != 1) : (m->nparams != 1)) return 0;
+  TyKind ret = (TyKind)m->ret;
+  if (!is_scalar_ret(ret) || ret == TY_UNKNOWN) return 0;
+
+  /* A descendant class with its own method_missing can't be reached by a
+     direct call to the chain-resolved one; refuse rather than mis-dispatch. */
+  int cid = ty_object_class(grt);
+  for (int k = 0; k < c->nclasses; k++) {
+    int is_desc = 0;
+    for (int p = c->classes[k].parent; p >= 0; p = c->classes[p].parent)
+      if (p == cid) { is_desc = 1; break; }
+    if (is_desc && comp_method_in_class(c, k, "method_missing") >= 0) return 0;
+  }
+
+  int args = nt_ref(nt, id, "arguments");
+  int argc = 0;
+  const int *argv = args >= 0 ? nt_arr(nt, args, "arguments", &argc) : NULL;
+  if (!has_rest && argc != 0) return 0;   /* no slot for the extra args */
+  /* a splat/kwargs call shape isn't packed here */
+  for (int k = 0; k < argc; k++) {
+    const char *aty = nt_type(nt, argv[k]);
+    if (aty && (!strcmp(aty, "SplatNode") || !strcmp(aty, "KeywordHashNode"))) return 0;
+  }
+
+  /* method name -> symbol, boxed to match method_missing's first param type. */
+  const char *mname = nt_str(nt, id, "name");
+  int sid = comp_sym_intern(c, mname);
+  LocalVar *p0 = scope_local(m, m->pnames[0]);
+  TyKind p0ty = (p0 && p0->type != TY_UNKNOWN) ? p0->type : TY_POLY;
+  if (p0ty != TY_SYMBOL && p0ty != TY_POLY) return 0;
+
+  if (has_rest) {
+    /* Build the rest array first and keep it GC-rooted for the WHOLE call: a
+       statement expression that only spanned the array would pop the root at its
+       `})`, before the call runs, leaving _mm collectable while the receiver/args
+       evaluate (and possibly allocate) -- a use-after-free. */
+    buf_puts(b, "({ sp_PolyArray *_mm = sp_PolyArray_new(); SP_GC_ROOT(_mm); ");
+    for (int k = 0; k < argc; k++) {
+      buf_puts(b, "sp_PolyArray_push(_mm, "); emit_boxed(c, argv[k], b); buf_puts(b, "); ");
+    }
+    emit_method_cname(c, m, b);
+    buf_printf(b, "((sp_%s *)(", c->classes[defcls].name);
+    emit_expr(c, recv, b);
+    buf_puts(b, "), ");
+    if (p0ty == TY_SYMBOL) buf_printf(b, "(sp_sym)%d", sid);
+    else buf_printf(b, "sp_box_sym((sp_sym)%d)", sid);
+    buf_puts(b, ", _mm); })");
+  } else {
+    buf_puts(b, "(");
+    emit_method_cname(c, m, b);
+    buf_printf(b, "((sp_%s *)(", c->classes[defcls].name);
+    emit_expr(c, recv, b);
+    buf_puts(b, "), ");
+    if (p0ty == TY_SYMBOL) buf_printf(b, "(sp_sym)%d", sid);
+    else buf_printf(b, "sp_box_sym((sp_sym)%d)", sid);
+    buf_puts(b, "))");
+  }
+  return 1;
+}
+
 void emit_call(Compiler *c, int id, Buf *b) {
   const NodeTable *nt = c->nt;
   /* `require` / `require_relative` is a compile-time directive: top-level ones
@@ -9103,6 +9178,13 @@ else {
       }
       buf_puts(b, (is_scalar_ret(ret) && ret != TY_UNKNOWN) ? default_value(ret) : "sp_box_nil()");
       return;
+    }
+    /* method_missing fallback for a concrete (non-value) object whose class
+       chain defines it -- the genuine NoMethodError-routing case. */
+    if (ty_is_object(grt) && !comp_ty_value_obj(c, grt)) {
+      int defcls = -1;
+      int mm = comp_method_in_chain(c, ty_object_class(grt), "method_missing", &defcls);
+      if (mm >= 0 && emit_method_missing(c, id, recv, grt, mm, defcls, b)) return;
     }
   }
   unsupported(c, id, "call");

--- a/test/method_missing_basic.rb
+++ b/test/method_missing_basic.rb
@@ -1,0 +1,35 @@
+# method_missing fallback dispatch: an unresolved call on an object whose class
+# chain defines method_missing routes there, receiving the method name as a
+# Symbol and the call's arguments as a rest array. Real methods and universal
+# builtins still take precedence.
+class Proxy
+  def initialize(label)
+    @label = label
+  end
+
+  def real_method
+    "real"
+  end
+
+  def method_missing(name, *args)
+    "#{@label}:#{name}/#{args.length}"
+  end
+end
+
+p = Proxy.new("px")
+puts p.real_method            # real method wins
+puts p.anything               # -> method_missing, no args
+puts p.greet("a", "b")        # -> method_missing, two args
+puts p.class.name             # universal builtin wins (not method_missing)
+
+# inherited method_missing through the superclass chain
+class Sub < Proxy
+end
+s = Sub.new("sub")
+puts s.whatever(1)
+
+# method_missing return value used in an expression context
+def describe(o)
+  o.mystery.upcase
+end
+puts describe(Proxy.new("z"))

--- a/test/method_missing_basic.rb.expected
+++ b/test/method_missing_basic.rb.expected
@@ -1,0 +1,6 @@
+real
+px:anything/0
+px:greet/2
+Proxy
+sub:whatever/1
+Z:MYSTERY/0


### PR DESCRIPTION
An unresolved call on a concrete user-object receiver was a hard compile error, even when the receiver's class chain defined `method_missing`. CRuby routes such calls to `method_missing` (called name as a `Symbol`, remaining args as a rest array); spinel now does the same when the shape is statically lowerable.

Routing sits at the very end of both call inference and call codegen, after every builtin / reopened-class / universal-method path, so `method_missing` only fires when nothing else resolves the call — matching CRuby's lookup order. A real method and universal builtins (`.class`, `.freeze`, …) still win.

```ruby
class Proxy
  def initialize(label) = (@label = label)
  def method_missing(name, *args) = "#{@label}:#{name}/#{args.length}"
end
p = Proxy.new("px")
puts p.anything        # px:anything/0
puts p.greet("a","b")  # px:greet/2
```

Inference returns `method_missing`'s declared return type for the call. Codegen emits a direct call to the chain-resolved `method_missing`, casting the receiver to the defining class and packing the call args into a fresh poly array. Because `method_missing` has no AST call site, it would be pruned as having unbound params; its signature is seeded (`name`→`Symbol`, rest→poly array) and it is kept reachable. Symbol interning of the called name happens during analysis, before the symbol-name table is finalized.

Only the canonical `(name)` and `(name, *args)` shapes with a usable scalar return are lowered; a descendant override of `method_missing`, a value-type receiver, or a splat/keyword call shape falls through to the existing diagnostic rather than risk a mis-dispatch. The general unresolved-call diagnostic is intentionally left in place for receivers without `method_missing` (it catches real inference failures rather than masking them as runtime `NoMethodError`). `respond_to_missing?` wiring into `respond_to?` is a follow-up.

Verified: `test/method_missing_basic.rb` (expected regenerated from CRuby) covers real-method precedence, no-arg / multi-arg dispatch, inheritance through the superclass chain, builtin precedence, and a non-literal (method-param) receiver. `make test` 976 pass, 0 fail; `make bootstrap` analyze + codegen IR and C fixpoints byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
