### PR TITLE
Diagnose eval of a runtime string

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -3448,6 +3448,17 @@ void emit_call(Compiler *c, int id, Buf *b) {
     buf_puts(b, ")");
     return;
   }
+  /* eval(string) / Kernel.eval(string): compiling an arbitrary runtime string is
+     a hard AOT boundary, not a missing feature. Emit an intentional diagnostic.
+     (The instance_eval/class_eval/module_eval block forms are handled separately
+     and are unaffected -- those carry a literal block, not a string.) */
+  if (!strcmp(name, "eval") && argc >= 1 &&
+      (recv < 0 || (nt_type(nt, recv) &&
+                    (!strcmp(nt_type(nt, recv), "ConstantReadNode") || !strcmp(nt_type(nt, recv), "ConstantPathNode")) &&
+                    nt_str(nt, recv, "name") && !strcmp(nt_str(nt, recv, "name"), "Kernel")))) {
+    unsupported(c, id, "eval of a runtime string is not supported by AOT compilation (define the code statically)");
+    return;
+  }
   if (recv < 0 && !strcmp(name, "loop") && argc == 0) {
     int blk = nt_ref(nt, id, "block");
     if (blk >= 0) {


### PR DESCRIPTION
Compiling an arbitrary runtime string via `eval("...")` or `Kernel.eval("...")` is a hard AOT boundary, not a missing feature. These previously fell through to a generic unsupported-call node dump. This emits an intentional diagnostic — "eval of a runtime string is not supported by AOT compilation (define the code statically)" — for the common forms (`x = eval(s)`, bare `eval(s)`).

The `instance_eval` / `class_eval` / `module_eval` block forms carry a literal block, not a string, and are handled separately — unaffected (verified a block-form `instance_eval { ... }` still compiles).

A direct `puts eval(s)` still rejects one level up at the puts-argument check (a narrow case); the assignment and statement forms, which are the common ones, get the specific message.

The C compiler's reject diagnostics have no in-suite PASS harness (`make test` is PASS-based; `test/analyze_fail` exercises the legacy analyzer, not `bin/spinel`), so this is verified manually. `make test` (976 pass, 0 fail) and `make bootstrap` IR + C fixpoint OK for `analyze.rb` and `codegen.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
