### PR TITLE
Eager-materialize enum_for(:each) / to_enum into an array

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -256,7 +256,9 @@ else {
   }
   if (mi < 0) return 0;
   Scope *m = &c->scopes[mi];
-  if (!m->blk_param || !m->blk_param[0] || m->yields || m->is_lowered_yield) return 0;
+  /* A lowered yielding method also receives its block as a real proc, so a
+     block passed to it is lifted and captures enclosing locals like any other. */
+  if (!m->blk_param || !m->blk_param[0] || m->yields) return 0;
   /* instance_eval/exec trampolines splice their block at the call site rather
      than lifting it to a proc, so they are not lifted-block captures. */
   if (m->class_id >= 0 && !m->is_cmethod && m->name &&
@@ -1320,6 +1322,130 @@ static int reset_locked_iter_block_params(Compiler *c) {
   return n;
 }
 
+/* Is `id` a `recv.enum_for` / `recv.to_enum` call that materializes the
+   receiver's `#each` (no args, or a single literal `:each`), with no block?
+   These are the forms we lower to an eager `#each`-into-array helper. */
+static int is_enum_for_each(const Compiler *c, int id) {
+  const NodeTable *nt = c->nt;
+  const char *nm = nt_str(nt, id, "name");
+  if (!nm || (strcmp(nm, "enum_for") && strcmp(nm, "to_enum"))) return 0;
+  if (nt_ref(nt, id, "receiver") < 0) return 0;       /* need a receiver to drive */
+  if (nt_ref(nt, id, "block") >= 0) return 0;         /* a size block is unsupported */
+  int args = nt_ref(nt, id, "arguments");
+  int ac = 0; const int *av = args >= 0 ? nt_arr(nt, args, "arguments", &ac) : NULL;
+  if (ac == 0) return 1;                               /* enum_for defaults to :each */
+  if (ac != 1 || !av) return 0;
+  if (!nt_type(nt, av[0]) || strcmp(nt_type(nt, av[0]), "SymbolNode")) return 0;
+  const char *s = nt_str(nt, av[0], "value");
+  return s && !strcmp(s, "each");
+}
+
+/* Rewrite every `recv.enum_for(:each)` / `recv.to_enum` into a call to the
+   synthesized `recv.__enum_to_a`, which materializes `#each` into an array.
+   Purely syntactic (no receiver type needed); the per-class helper is
+   synthesized separately and pruned by reachability when unused. */
+static void rewrite_enum_for_each(Compiler *c) {
+  NodeTable *nt = (NodeTable *)c->nt;
+  /* snapshot the count: synthesis below appends nodes, which must not be rescanned */
+  int count = nt->count;
+  for (int id = 0; id < count; id++) {
+    if (!nt_type(nt, id) || strcmp(nt_type(nt, id), "CallNode")) continue;
+    if (!is_enum_for_each(c, id)) continue;
+    int empty = nt_new_node(nt, "ArgumentsNode");
+    nt_node_set_arr(nt, empty, "arguments", NULL, 0);
+    nt_node_set_str(nt, id, "name", "__enum_to_a");
+    nt_node_set_ref(nt, id, "arguments", empty);
+    comp_grow_node_arrays(c);
+    c->nscope[empty] = c->nscope[id];
+  }
+}
+
+/* Synthesize, on every class that defines an instance `#each` that yields, a
+   helper method
+
+       def __enum_to_a
+         __enum_acc = []
+         each { |__enum_e| __enum_acc << __enum_e }
+         __enum_acc
+       end
+
+   so an `enum_for(:each)` rewritten to `__enum_to_a` materializes the receiver
+   eagerly into an array (then map/select/to_a/... use the array path). The
+   helper is a normal method whose body is inferred and emitted by the usual
+   machinery; when `#each` is force-lowered the inlined `each { }` becomes a
+   real call passing the block as a proc. Unused helpers are pruned by
+   reachability, so this is inert for programs that never call enum_for/to_enum
+   (the self-host compiler included). */
+static void synth_enum_to_a(Compiler *c) {
+  NodeTable *nt = (NodeTable *)c->nt;
+  if (c->nscopes == 0) return;
+  /* collect target classes first (synthesis below grows c->scopes). At most one
+     entry per scope, so pre-size both arrays to nscopes and avoid per-item growth. */
+  int *cls = malloc(sizeof(int) * (size_t)c->nscopes);
+  int *eachdef = malloc(sizeof(int) * (size_t)c->nscopes);
+  if (!cls || !eachdef) { fprintf(stderr, "spinel: out of memory\n"); exit(1); }
+  int ncls = 0;
+  for (int s = 0; s < c->nscopes; s++) {
+    Scope *m = &c->scopes[s];
+    if (!m->name || m->is_cmethod || m->class_id < 0) continue;
+    if (strcmp(m->name, "each") || !m->yields) continue;
+    if (comp_method_in_class(c, m->class_id, "__enum_to_a") >= 0) continue;
+    int dup = 0;
+    for (int k = 0; k < ncls; k++) if (cls[k] == m->class_id) { dup = 1; break; }
+    if (dup) continue;
+    cls[ncls] = m->class_id; eachdef[ncls] = m->def_node; ncls++;
+  }
+  for (int k = 0; k < ncls; k++) {
+    int arr = nt_new_node(nt, "ArrayNode");
+    nt_node_set_arr(nt, arr, "elements", NULL, 0);
+    int accw = nt_new_node(nt, "LocalVariableWriteNode");
+    nt_node_set_str(nt, accw, "name", "__enum_acc");
+    nt_node_set_ref(nt, accw, "value", arr);
+    int ep = nt_new_node(nt, "RequiredParameterNode");
+    nt_node_set_str(nt, ep, "name", "__enum_e");
+    int params = nt_new_node(nt, "ParametersNode");
+    nt_node_set_arr(nt, params, "requireds", &ep, 1);
+    int bparams = nt_new_node(nt, "BlockParametersNode");
+    nt_node_set_ref(nt, bparams, "parameters", params);
+    int accr1 = nt_new_node(nt, "LocalVariableReadNode");
+    nt_node_set_str(nt, accr1, "name", "__enum_acc");
+    int eread = nt_new_node(nt, "LocalVariableReadNode");
+    nt_node_set_str(nt, eread, "name", "__enum_e");
+    int pushargs = nt_new_node(nt, "ArgumentsNode");
+    nt_node_set_arr(nt, pushargs, "arguments", &eread, 1);
+    int push = nt_new_node(nt, "CallNode");
+    nt_node_set_str(nt, push, "name", "<<");
+    nt_node_set_ref(nt, push, "receiver", accr1);
+    nt_node_set_ref(nt, push, "arguments", pushargs);
+    int blkbody = nt_new_node(nt, "StatementsNode");
+    nt_node_set_arr(nt, blkbody, "body", &push, 1);
+    int blk = nt_new_node(nt, "BlockNode");
+    nt_node_set_ref(nt, blk, "parameters", bparams);
+    nt_node_set_ref(nt, blk, "body", blkbody);
+    int eachcall = nt_new_node(nt, "CallNode");
+    nt_node_set_str(nt, eachcall, "name", "each");
+    nt_node_set_ref(nt, eachcall, "block", blk);
+    int accr2 = nt_new_node(nt, "LocalVariableReadNode");
+    nt_node_set_str(nt, accr2, "name", "__enum_acc");
+    int body = nt_new_node(nt, "StatementsNode");
+    int stmts[3] = { accw, eachcall, accr2 };
+    nt_node_set_arr(nt, body, "body", stmts, 3);
+
+    Scope *ms = comp_scope_new(c, "__enum_to_a", eachdef[k]);
+    ms->class_id = cls[k];
+    ms->body = body;
+    int ms_idx = c->nscopes - 1;
+    /* register_locals already ran (before synthesis), so intern this scope's
+       locals here; types are filled in by the inference fixpoint that follows. */
+    scope_local_intern(ms, "__enum_acc");
+    LocalVar *ev = scope_local_intern(ms, "__enum_e");
+    if (ev) ev->is_block_param = 1;
+    comp_grow_node_arrays(c);
+    walk_scope(c, body, ms_idx, cls[k]);
+  }
+  free(cls); free(eachdef);
+}
+
 void analyze_program(Compiler *c) {
   /* scope 0 = top level */
   Scope *top = comp_scope_new(c, NULL, -1);
@@ -1424,6 +1550,13 @@ void analyze_program(Compiler *c) {
       if (self_or_none && nm && !strcmp(nm, "block_given?")) comp_scope_of(c, id)->yields = 1;
     }
   }
+
+  /* Eager Enumerable-via-#each: rewrite `enum_for(:each)`/`to_enum` to a
+     synthesized per-class `__enum_to_a` helper that materializes #each into an
+     array. Done before the inference fixpoint so the helper's body is typed,
+     and before reachability so the helper is kept only when actually called. */
+  rewrite_enum_for_each(c);
+  synth_enum_to_a(c);
 
   /* `&block` + block.call: a method whose block parameter never escapes
      (every read is a `.call` receiver or a `&block` forward) is inlined at
@@ -1837,6 +1970,32 @@ void analyze_program(Compiler *c) {
   /* Promote loop-multiplication variables to bigint */
   detect_bigint_loop_vars(c);
   propagate_bigint_cascade(c);
+
+  /* Force-lower `#each` for any class whose synthesized `__enum_to_a` helper is
+     actually called (an `enum_for`/`to_enum` survived the rewrite). The helper
+     drives `#each` with a collector block; the real (lowered) function form
+     passes that block as a proc. Done BEFORE mark_proc_captures so the
+     collector block lifts and its `__enum_acc` accumulator gets a heap cell. */
+  for (int id = 0; id < c->nt->count; id++) {
+    const char *ty = nt_type(c->nt, id);
+    if (!ty || strcmp(ty, "CallNode")) continue;
+    const char *nm = nt_str(c->nt, id, "name");
+    if (!nm || strcmp(nm, "__enum_to_a")) continue;
+    int recv = nt_ref(c->nt, id, "receiver");
+    if (recv < 0) continue;
+    TyKind rt = infer_type(c, recv);
+    if (!ty_is_object(rt)) continue;
+    int ec = comp_method_in_chain(c, ty_object_class(rt), "each", NULL);
+    if (ec < 0) continue;
+    Scope *m = &c->scopes[ec];
+    if (m->blk_param || !m->yields) continue;   /* already lowered, or no yielding each */
+    m->is_lowered_yield = 1;
+    m->yields = 0;
+    m->ret = TY_INT;
+    m->blk_param = strdup("__yblk__");
+    LocalVar *yblk = scope_local_intern(m, "__yblk__");
+    if (yblk) { yblk->type = TY_PROC; yblk->is_param = 1; yblk->is_cell = 1; }
+  }
 
   /* mark locals captured by escaping procs (they need heap cells) */
   mark_proc_captures(c);

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -3347,6 +3347,55 @@ int diagnose_eval_call(Compiler *c, int id) {
   return 1;
 }
 
+/* Emit the `<argc>, (mrb_int[16]){...}` argument tail of an sp_proc_call.
+   A TY_POLY argument does not fit the mrb_int slot, so it is published to the
+   _sp_proc_poly_args side-channel (with a 0 placeholder in the slot) and a
+   heap-pointer argument is laundered through (mrb_int)(uintptr_t). Shared by
+   the <proc>.call path and the lowered-yield emission. */
+void emit_proc_call_args(Compiler *c, int argc, const int *argv, Buf *b) {
+  int nargs = argc < 16 ? argc : 16;  /* proc-call ABI caps args at mrb_int[16] */
+  int any_poly = 0;
+  for (int k = 0; k < nargs; k++) if (comp_ntype(c, argv[k]) == TY_POLY) { any_poly = 1; break; }
+  buf_printf(b, "%d, ", argc);
+  if (any_poly) {
+    if (!g_needs_proc_poly_argslot) {
+      g_needs_proc_poly_argslot = 1;
+      buf_puts(&g_proc_protos, "static sp_RbVal _sp_proc_poly_args[16];\n");
+    }
+    int atmp[16];
+    for (int k = 0; k < nargs; k++) {
+      TyKind at = comp_ntype(c, argv[k]);
+      atmp[k] = ++g_tmp;
+      Buf vb; memset(&vb, 0, sizeof vb); emit_expr(c, argv[k], &vb);
+      emit_indent(g_pre, g_indent);
+      if (at == TY_POLY) buf_printf(g_pre, "sp_RbVal _t%d = %s;\n", atmp[k], vb.p ? vb.p : "");
+      else if (proc_slot_is_ptr(at)) buf_printf(g_pre, "mrb_int _t%d = (mrb_int)(uintptr_t)(%s);\n", atmp[k], vb.p ? vb.p : "");
+      else buf_printf(g_pre, "mrb_int _t%d = %s;\n", atmp[k], vb.p ? vb.p : "");
+      free(vb.p);
+    }
+    for (int k = 0; k < nargs; k++) if (comp_ntype(c, argv[k]) == TY_POLY) {
+      emit_indent(g_pre, g_indent); buf_printf(g_pre, "_sp_proc_poly_args[%d] = _t%d;\n", k, atmp[k]);
+    }
+    buf_puts(b, "(mrb_int[16]){");
+    for (int k = 0; k < nargs; k++) {
+      if (k) buf_puts(b, ", ");
+      if (comp_ntype(c, argv[k]) == TY_POLY) buf_puts(b, "0");
+      else buf_printf(b, "_t%d", atmp[k]);
+    }
+    buf_puts(b, "})");
+  }
+  else {
+    buf_puts(b, "(mrb_int[16]){");
+    for (int k = 0; k < nargs; k++) {
+      if (k) buf_puts(b, ", ");
+      if (proc_slot_is_ptr(comp_ntype(c, argv[k]))) { buf_puts(b, "(mrb_int)(uintptr_t)("); emit_expr(c, argv[k], b); buf_puts(b, ")"); }
+      else emit_expr(c, argv[k], b);
+    }
+    if (nargs == 0) buf_puts(b, "0");  /* C99: no empty initializer list */
+    buf_puts(b, "})");
+  }
+}
+
 void emit_call(Compiler *c, int id, Buf *b) {
   const NodeTable *nt = c->nt;
   /* `require` / `require_relative` is a compile-time directive: top-level ones
@@ -3957,52 +4006,8 @@ void emit_call(Compiler *c, int id, Buf *b) {
     if (unbox_poly || unbox_float) buf_puts(b, "((void)");
     buf_puts(b, "sp_proc_call(");
     emit_expr(c, recv, b);
-    buf_printf(b, ", %d, ", argc);
-    /* A TY_POLY (sp_RbVal) argument doesn't fit the mrb_int slot. When any arg
-       is poly, evaluate every argument into a temp first (so a nested poly-proc
-       call in an arg expression finishes), then publish the poly ones to the
-       _sp_proc_poly_args side-channel and pass a 0 placeholder in the slot --
-       re-entrancy-safe, mirroring the _sp_proc_poly_ret return path. */
-    int any_poly_arg = 0;
-    for (int k = 0; k < argc; k++) if (comp_ntype(c, argv[k]) == TY_POLY) { any_poly_arg = 1; break; }
-    if (any_poly_arg) {
-      if (!g_needs_proc_poly_argslot) {
-        g_needs_proc_poly_argslot = 1;
-        buf_puts(&g_proc_protos, "static sp_RbVal _sp_proc_poly_args[16];\n");
-      }
-      int atmp[16]; int nargs = argc < 16 ? argc : 16;  /* proc-call ABI caps args at the mrb_int[16] slot */
-      for (int k = 0; k < nargs; k++) {
-        TyKind at = comp_ntype(c, argv[k]);
-        atmp[k] = ++g_tmp;
-        Buf vb; memset(&vb, 0, sizeof vb); emit_expr(c, argv[k], &vb);
-        emit_indent(g_pre, g_indent);
-        if (at == TY_POLY) buf_printf(g_pre, "sp_RbVal _t%d = %s;\n", atmp[k], vb.p ? vb.p : "");
-        else if (proc_slot_is_ptr(at)) buf_printf(g_pre, "mrb_int _t%d = (mrb_int)(uintptr_t)(%s);\n", atmp[k], vb.p ? vb.p : "");
-        else buf_printf(g_pre, "mrb_int _t%d = %s;\n", atmp[k], vb.p ? vb.p : "");
-        free(vb.p);
-      }
-      for (int k = 0; k < nargs; k++) if (comp_ntype(c, argv[k]) == TY_POLY) {
-        emit_indent(g_pre, g_indent); buf_printf(g_pre, "_sp_proc_poly_args[%d] = _t%d;\n", k, atmp[k]);
-      }
-      buf_puts(b, "(mrb_int[16]){");
-      for (int k = 0; k < nargs; k++) {
-        if (k) buf_puts(b, ", ");
-        if (comp_ntype(c, argv[k]) == TY_POLY) buf_puts(b, "0");
-        else buf_printf(b, "_t%d", atmp[k]);
-      }
-      buf_puts(b, "})");
-    }
-    else {
-      buf_puts(b, "(mrb_int[16]){");
-      for (int k = 0; k < argc; k++) {
-        if (k) buf_puts(b, ", ");
-        /* a heap-pointer argument is laundered into the mrb_int slot */
-        if (proc_slot_is_ptr(comp_ntype(c, argv[k]))) { buf_puts(b, "(mrb_int)(uintptr_t)("); emit_expr(c, argv[k], b); buf_puts(b, ")"); }
-        else emit_expr(c, argv[k], b);
-      }
-      if (argc == 0) buf_puts(b, "0");  /* C99: no empty initializer list */
-      buf_puts(b, "})");
-    }
+    buf_puts(b, ", ");
+    emit_proc_call_args(c, argc, argv, b);
     if (unbox_ptr) buf_puts(b, ")");
     if (unbox_poly) buf_puts(b, ", _sp_proc_poly_ret)");
     if (unbox_float) buf_puts(b, ", sp_poly_to_f(_sp_proc_poly_ret))");

--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -642,10 +642,8 @@ void emit_expr(Compiler *c, int id, Buf *b) {
          sp_proc_call already returns mrb_int; emit it directly with no cast. */
       buf_puts(b, "sp_proc_call(");
       emit_yblk_ref(b);
-      buf_printf(b, ", %d, (mrb_int[16]){", yargc);
-      for (int k = 0; k < yargc; k++) { if (k) buf_puts(b, ", "); emit_expr(c, yargv[k], b); }
-      if (yargc == 0) buf_puts(b, "0");
-      buf_puts(b, "})");
+      buf_puts(b, ", ");
+      emit_proc_call_args(c, yargc, yargv, b);
       return;
     }
     if (g_block_id < 0) { buf_puts(b, "SP_INT_NIL"); return; }  /* no block: yield is nil */

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -285,6 +285,7 @@ void emit_unbox_text(Compiler *c, TyKind t, const char *expr, Buf *b);
 void emit_proc_literal(Compiler *c, int create, Buf *b);
 int proc_slot_is_direct(TyKind t);
 int proc_slot_is_ptr(TyKind t);
+void emit_proc_call_args(Compiler *c, int argc, const int *argv, Buf *b);
 void emit_case_expr(Compiler *c, int id, Buf *b);
 
 /* Strip ParenthesesNode wrappers to reach the inner expression. */

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -2338,10 +2338,9 @@ void emit_stmt_inner(Compiler *c, int id, Buf *b, int indent) {
       emit_indent(b, indent);
       buf_puts(b, "sp_proc_call(");
       emit_yblk_ref(b);
-      buf_printf(b, ", %d, (mrb_int[16]){", yargc);
-      for (int k = 0; k < yargc; k++) { if (k) buf_puts(b, ", "); emit_expr(c, yargv[k], b); }
-      if (yargc == 0) buf_puts(b, "0");
-      buf_puts(b, "});\n");
+      buf_puts(b, ", ");
+      emit_proc_call_args(c, yargc, yargv, b);
+      buf_puts(b, ";\n");
       return;
     }
     if (g_block_id < 0) return;  /* inlined without block: yield is dead code */

--- a/test/enum_for_each.rb
+++ b/test/enum_for_each.rb
@@ -1,0 +1,49 @@
+# enum_for(:each) / to_enum materializes a user class's #each into an array, so
+# the full Enumerable surface (to_a/map/select/count/...) works on a class that
+# only defines #each. The compiler synthesizes a per-class helper that drives
+# the (lowered) #each with a collector block.
+class Bag
+  include Enumerable
+
+  def initialize
+    @items = []
+  end
+
+  def add(x)
+    @items << x
+    self
+  end
+
+  def each
+    @items.each { |x| yield x }
+  end
+end
+
+class Counter
+  def initialize(n)
+    @n = n
+  end
+
+  def each
+    i = 1
+    while i <= @n
+      yield i
+      i += 1
+    end
+  end
+end
+
+b = Bag.new
+b.add("apple").add("banana").add("cherry")
+
+p b.enum_for(:each).to_a
+p b.to_enum.to_a
+p b.enum_for(:each).map { |s| s.upcase }
+p b.to_enum.select { |s| s.length > 5 }
+puts b.enum_for(:each).count
+puts b.enum_for(:each).include?("banana")
+
+c = Counter.new(4)
+p c.enum_for(:each).to_a
+p c.to_enum.map { |n| n * n }
+puts c.enum_for(:each).select { |n| n.even? }.length

--- a/test/enum_for_each.rb.expected
+++ b/test/enum_for_each.rb.expected
@@ -1,0 +1,9 @@
+["apple", "banana", "cherry"]
+["apple", "banana", "cherry"]
+["APPLE", "BANANA", "CHERRY"]
+["banana", "cherry"]
+3
+true
+[1, 2, 3, 4]
+[1, 4, 9, 16]
+2


### PR DESCRIPTION
A user class that defines `#each` but not `map`/`select`/`to_a` had no path to the Enumerable surface — those calls silently folded to `[]`, and `enum_for`/`to_enum` were unsupported:

```ruby
class Bag
  include Enumerable
  def initialize = @items = []
  def add(x) = (@items << x; self)
  def each = @items.each { |x| yield x }
end

b = Bag.new.add("apple").add("banana")
b.enum_for(:each).to_a            # before: unsupported ; now: ["apple", "banana"]
b.to_enum.map { |s| s.upcase }    # before: unsupported ; now: ["APPLE", "BANANA"]
```

Eager *inline* materialization is impossible here: yielding methods are inline-only, and the canonical `return enum_for(:each) unless block_given?` idiom puts a `return` inside `#each` that can neither be inlined nor placed in a statement-expression. This reuses the existing lowered-yield machinery instead.

For every class with a yielding instance `#each`, synthesize a helper:

```ruby
def __enum_to_a
  __enum_acc = []
  each { |__enum_e| __enum_acc << __enum_e }
  __enum_acc
end
```

and rewrite `recv.enum_for(:each)` / `recv.to_enum` → `recv.__enum_to_a`. When such a helper is actually called, the class's `#each` is force-lowered to its real function form (block passed as an `sp_Proc`), so the collector block drives it and accumulates into an array. The full Enumerable API then flows through the existing array path. Synthesis runs before the inference fixpoint (the helper body types normally), and unused helpers are pruned by reachability — so this is completely inert for programs that never call `enum_for`/`to_enum` (the self-host compiler included; the bootstrap is untouched).

Out of scope (unchanged behavior, still a loud reject): lazy / `.next` external iteration, infinite enumerators, and `enum_for(:other_method)` — only `:each` (or the no-arg default) materializes.

Two supporting fixes: (1) the lowered-yield emission packed yield arguments straight into the `mrb_int[16]` proc-call slots, which is wrong for a poly (or heap-pointer) value; factored the `<proc>.call` argument packing into `emit_proc_call_args` (poly args via the `_sp_proc_poly_args` side-channel, pointers laundered) and shared it across the `.call` path and both yield sites. (2) `a_block_is_lifted` excluded lowered methods, so a block passed to one never had its captured locals celled; a lowered method receives its block as a real proc, so its block is lifted like any other — dropped the exclusion.

Builds on the `block_given?`-in-lowered-methods fix (matz/spinel#1506).

Verified: `test/enum_for_each.rb` (expected regenerated from CRuby) covers `to_a`/`map`/`select`/`count`/`include?` via `enum_for(:each)` and `to_enum` on an array-backed `#each` (`Bag`) and a `while`-loop `#each` (`Counter`). `make test` 984 pass, 0 fail; `make bootstrap` analyze + codegen IR and C fixpoints byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
