### PR TITLE
codegen: implement find patterns and case/in in value position

### DIFF
--- a/src/analyze_pass.c
+++ b/src/analyze_pass.c
@@ -778,6 +778,37 @@ int infer_write_types(Compiler *c) {
         /* in [first, *rest] or in Array(head, *tail) */
         array_pat = pat; array_scrutinee = scrutinee_t;
       }
+      else if (!strcmp(pty, "FindPatternNode")) {
+        /* in [*head, a, b, *tail] -- the two splats bind to arrays of the
+           scrutinee's element type; required LV targets bind to an element. */
+        TyKind arr_t = ty_is_array(scrutinee_t) ? scrutinee_t : TY_POLY_ARRAY;
+        TyKind elem_t = ty_is_array(scrutinee_t) ? ty_array_elem(scrutinee_t) : TY_POLY;
+        int sides[2] = { nt_ref(nt, pat, "left"), nt_ref(nt, pat, "right") };
+        for (int sidx = 0; sidx < 2; sidx++) {
+          int sp = sides[sidx];
+          if (sp < 0 || !nt_type(nt, sp) || strcmp(nt_type(nt, sp), "SplatNode")) continue;
+          int inner = nt_ref(nt, sp, "expression");
+          if (inner < 0 || !nt_type(nt, inner) ||
+              strcmp(nt_type(nt, inner), "LocalVariableTargetNode")) continue;
+          const char *snm = nt_str(nt, inner, "name");
+          LocalVar *lv = snm ? scope_local(ms, snm) : NULL;
+          if (!lv || lv->is_param || lv->is_block_param) continue;
+          TyKind mg = ty_unify(lv->type, arr_t);
+          if (mg != lv->type) { lv->type = mg; changed = 1; }
+        }
+        int rn = 0;
+        const int *reqs = nt_arr(nt, pat, "requireds", &rn);
+        for (int k = 0; k < rn; k++) {
+          const char *lty2 = nt_type(nt, reqs[k]);
+          if (!lty2 || strcmp(lty2, "LocalVariableTargetNode")) continue;
+          const char *lnm = nt_str(nt, reqs[k], "name");
+          LocalVar *lv = lnm ? scope_local(ms, lnm) : NULL;
+          if (!lv || lv->is_param || lv->is_block_param) continue;
+          TyKind et = (elem_t != TY_UNKNOWN) ? elem_t : TY_POLY;
+          TyKind mg = ty_unify(lv->type, et);
+          if (mg != lv->type) { lv->type = mg; changed = 1; }
+        }
+      }
       /* Bind simple LV target to scrutinee type */
       if (bind_lv_node >= 0 && scrutinee_t != TY_UNKNOWN) {
         const char *lnm = nt_str(nt, bind_lv_node, "name");

--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -357,6 +357,20 @@ void emit_expr(Compiler *c, int id, Buf *b) {
   }
   if (!strcmp(ty, "LambdaNode")) { emit_proc_literal(c, id, b); return; }
   if (!strcmp(ty, "CaseNode")) { emit_case_expr(c, id, b); return; }
+  if (!strcmp(ty, "CaseMatchNode")) {
+    /* case/in as a value: declare a result temp, emit the match into g_pre
+       with each arm assigning its body value to it, then yield the temp. */
+    TyKind rt = comp_ntype(c, id);
+    if (rt == TY_UNKNOWN || rt == TY_VOID) rt = TY_POLY;
+    int cr = ++g_tmp;
+    emit_indent(g_pre, g_indent);
+    emit_ctype(c, rt, g_pre);
+    buf_printf(g_pre, " _t%d = %s;\n", cr, rt == TY_RANGE ? "(sp_Range){0}" : default_value(rt));
+    if (needs_root(rt)) { emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", cr); }
+    emit_case_match(c, id, g_pre, g_indent, 0, cr);
+    buf_printf(b, "_t%d", cr);
+    return;
+  }
 
   if (!strcmp(ty, "RangeNode")) {
     int left = nt_ref(nt, id, "left");

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -437,7 +437,7 @@ void emit_if(Compiler *c, int id, Buf *b, int indent, int is_unless, int tail);
 int emit_poly_class_when(Compiler *c, int cond_id, const char *tmp, Buf *b);
 void emit_pm_eq(Compiler *c, int t, TyKind pt, int valnode, Buf *b);
 int emit_pm_cond(Compiler *c, int pat, int t, TyKind pt, Buf *b);
-void emit_case_match(Compiler *c, int id, Buf *b, int indent, int tail);
+void emit_case_match(Compiler *c, int id, Buf *b, int indent, int tail, int value_cr);
 void emit_case(Compiler *c, int id, Buf *b, int indent);
 void emit_case_branch_value(Compiler *c, int stmts, TyKind rt, int cr, Buf *b);
 void emit_case_expr(Compiler *c, int id, Buf *b);

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -1148,7 +1148,14 @@ void emit_case_match(Compiler *c, int id, Buf *b, int indent, int tail, int valu
        position temp (-1 if none). The arm matches when that position >= 0. */
     int find_pat = -1, find_pos = -1;
     const char *find_k = NULL;
-    if (!strcmp(pty, "FindPatternNode") && ty_is_array(pt)) {
+    if (!strcmp(pty, "FindPatternNode") && !ty_is_array(pt)) {
+      /* A find pattern only matches arrays. With a non-array (or statically
+         unknown) scrutinee, fail closed -- never match -- rather than fall
+         through to emit_pm_cond (which has no find-pattern case and would
+         leave has_cond=0, i.e. match unconditionally). */
+      buf_puts(&cond_buf, "0");
+      has_cond = 1;
+    } else if (!strcmp(pty, "FindPatternNode")) {
       find_pat = pat;
       find_k = (pt == TY_POLY_ARRAY) ? "Poly" : array_kind(pt);
       if (!find_k) find_k = "Int";

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -1067,15 +1067,56 @@ int emit_pm_cond(Compiler *c, int pat, int t, TyKind pt, Buf *b) {
 
 /* case/in (pattern match) -> bind pattern vars, optional guard check,
    then body; goto end_label to skip subsequent arms. */
+/* Emit a pattern-arm body in value mode: side-effect stmts, then assign the
+   last expression (boxed to rt) to the result temp _t<cr>. The last expression
+   is captured into a local buffer first so any prelude it emits (e.g. an array
+   literal's construction) lands in g_pre ahead of the assignment, not spliced
+   into it. */
+static void emit_pm_body_value(Compiler *c, int stmts, TyKind rt, int cr,
+                               Buf *b, int indent) {
+  const NodeTable *nt = c->nt;
+  int n = 0;
+  const int *bb = stmts >= 0 ? nt_arr(nt, stmts, "body", &n) : NULL;
+  for (int k = 0; k < n - 1; k++) emit_stmt(c, bb[k], b, indent);
+  if (n <= 0) {
+    emit_indent(b, indent);
+    buf_printf(b, "_t%d = %s;\n", cr, rt == TY_POLY ? "sp_box_nil()" : default_value(rt));
+    return;
+  }
+  int last = bb[n - 1];
+  TyKind lt = comp_ntype(c, last);
+  if (lt == TY_NIL || lt == TY_UNKNOWN) {
+    /* a valueless last expr (e.g. a bare assignment / void call): run it for
+       its side effect, then default the result. */
+    emit_stmt(c, last, b, indent);
+    emit_indent(b, indent);
+    buf_printf(b, "_t%d = %s;\n", cr, rt == TY_POLY ? "sp_box_nil()" : default_value(rt));
+    return;
+  }
+  Buf le; memset(&le, 0, sizeof le);
+  int saved_gi = g_indent; g_indent = indent;
+  if (rt == TY_POLY && lt != TY_POLY) emit_boxed(c, last, &le);
+  else emit_expr(c, last, &le);
+  g_indent = saved_gi;
+  emit_indent(b, indent);
+  buf_printf(b, "_t%d = ", cr);
+  buf_puts(b, le.p ? le.p : default_value(rt));
+  buf_puts(b, ";\n");
+  free(le.p);
+}
+
 /* case/in pattern match. tail=1: each arm's body is in method-return position
    (emitted via emit_stmts_tail), so arms diverge and no fallthrough label is
-   needed. tail=0: statement form, arms fall through to a shared end label. */
-void emit_case_match(Compiler *c, int id, Buf *b, int indent, int tail) {
+   needed. tail=0: statement form, arms fall through to a shared end label.
+   value_cr >= 0: value form -- each arm assigns its body value to _t<value_cr>
+   (boxed to the case's result type) then jumps to the end label. */
+void emit_case_match(Compiler *c, int id, Buf *b, int indent, int tail, int value_cr) {
   const NodeTable *nt = c->nt;
   int pred = nt_ref(nt, id, "predicate");
   int cn = 0;
   const int *conds = nt_arr(nt, id, "conditions", &cn);
   int else_clause = nt_ref(nt, id, "else_clause");
+  TyKind rt = value_cr >= 0 ? comp_ntype(c, id) : TY_UNKNOWN;
 
   int t = ++g_tmp;
   int lbl = ++g_tmp;
@@ -1272,12 +1313,14 @@ void emit_case_match(Compiler *c, int id, Buf *b, int indent, int tail) {
       emit_indent(b, body_indent); buf_puts(b, "if (");
       emit_expr(c, guard, b);
       buf_puts(b, ") {\n");
-      if (tail) emit_stmts_tail(c, stmts, b, body_indent + 1);
+      if (value_cr >= 0) { emit_pm_body_value(c, stmts, rt, value_cr, b, body_indent + 1); emit_indent(b, body_indent + 1); buf_printf(b, "goto _pm_%d;\n", lbl); }
+      else if (tail) emit_stmts_tail(c, stmts, b, body_indent + 1);
       else { emit_stmts(c, stmts, b, body_indent + 1); emit_indent(b, body_indent + 1); buf_printf(b, "goto _pm_%d;\n", lbl); }
       emit_indent(b, body_indent); buf_puts(b, "}\n");
     }
     else {
-      if (tail) emit_stmts_tail(c, stmts, b, body_indent);
+      if (value_cr >= 0) { emit_pm_body_value(c, stmts, rt, value_cr, b, body_indent); emit_indent(b, body_indent); buf_printf(b, "goto _pm_%d;\n", lbl); }
+      else if (tail) emit_stmts_tail(c, stmts, b, body_indent);
       else { emit_stmts(c, stmts, b, body_indent); emit_indent(b, body_indent); buf_printf(b, "goto _pm_%d;\n", lbl); }
     }
 
@@ -1287,7 +1330,8 @@ void emit_case_match(Compiler *c, int id, Buf *b, int indent, int tail) {
 
   if (else_clause >= 0) {
     emit_indent(b, indent); buf_puts(b, "{\n");
-    if (tail) emit_stmts_tail(c, nt_ref(nt, else_clause, "statements"), b, indent + 1);
+    if (value_cr >= 0) emit_pm_body_value(c, nt_ref(nt, else_clause, "statements"), rt, value_cr, b, indent + 1);
+    else if (tail) emit_stmts_tail(c, nt_ref(nt, else_clause, "statements"), b, indent + 1);
     else emit_stmts(c, nt_ref(nt, else_clause, "statements"), b, indent + 1);
     emit_indent(b, indent); buf_puts(b, "}\n");
   }
@@ -1297,7 +1341,7 @@ void emit_case_match(Compiler *c, int id, Buf *b, int indent, int tail) {
     buf_printf(b, "sp_raise_cls(\"NoMatchingPatternError\", \"no pattern matched\");\n");
   }
 
-  if (!tail) { emit_indent(b, indent); buf_printf(b, "_pm_%d:;\n", lbl); }
+  if (!tail || value_cr >= 0) { emit_indent(b, indent); buf_printf(b, "_pm_%d:;\n", lbl); }
 }
 
 /* case/when -> an if / else-if chain. Statement form. */
@@ -3786,7 +3830,7 @@ else {
     return;
   }
   if (!strcmp(ty, "CaseNode"))      { emit_case(c, id, b, indent); return; }
-  if (!strcmp(ty, "CaseMatchNode")) { emit_case_match(c, id, b, indent, 0); return; }
+  if (!strcmp(ty, "CaseMatchNode")) { emit_case_match(c, id, b, indent, 0, -1); return; }
   if (!strcmp(ty, "BeginNode"))  { emit_begin(c, id, b, indent, NULL); return; }
   if (!strcmp(ty, "RescueModifierNode")) {
     /* `expr rescue fallback` as a statement: run expr under a setjmp guard,
@@ -3825,7 +3869,7 @@ void emit_stmt_tail_inner(Compiler *c, int id, Buf *b, int indent) {
 
   if (!strcmp(ty, "IfNode"))     { emit_if(c, id, b, indent, 0, 1); return; }
   if (!strcmp(ty, "UnlessNode")) { emit_if(c, id, b, indent, 1, 1); return; }
-  if (!strcmp(ty, "CaseMatchNode")) { emit_case_match(c, id, b, indent, 1); return; }
+  if (!strcmp(ty, "CaseMatchNode")) { emit_case_match(c, id, b, indent, 1, -1); return; }
   if (!strcmp(ty, "ReturnNode")) { emit_return(c, id, b, indent); return; }
   /* `raise` diverges -- no value to return; emit as a plain statement. */
   if (!strcmp(ty, "CallNode") && nt_ref(nt, id, "receiver") < 0 &&

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -1101,7 +1101,47 @@ void emit_case_match(Compiler *c, int id, Buf *b, int indent, int tail) {
 
     /* --- compute match condition --- */
     Buf cond_buf = {NULL, 0, 0};
-    int has_cond = emit_pm_cond(c, pat, t, pt, &cond_buf);
+    int has_cond;
+    /* find pattern `in [*head, m1..mk, *tail]`: scan for the first window of
+       k consecutive elements matching the requireds; record its start in a
+       position temp (-1 if none). The arm matches when that position >= 0. */
+    int find_pat = -1, find_pos = -1;
+    const char *find_k = NULL;
+    if (!strcmp(pty, "FindPatternNode") && ty_is_array(pt)) {
+      find_pat = pat;
+      find_k = (pt == TY_POLY_ARRAY) ? "Poly" : array_kind(pt);
+      if (!find_k) find_k = "Int";
+      TyKind elem_t = ty_array_elem(pt);
+      if (elem_t == TY_UNKNOWN) elem_t = TY_POLY;
+      int rn = 0;
+      const int *reqs = nt_arr(nt, pat, "requireds", &rn);
+      find_pos = ++g_tmp;
+      emit_indent(b, indent + 1);
+      buf_printf(b, "mrb_int _t%d = -1;\n", find_pos);
+      emit_indent(b, indent + 1);
+      buf_printf(b, "for (mrb_int _fi = 0; _t%d && _fi + %dLL <= _t%d->len; _fi++) {\n",
+                 t, rn, t);
+      Buf wb = {NULL, 0, 0};
+      for (int j = 0; j < rn; j++) {
+        int e = ++g_tmp;
+        emit_indent(b, indent + 2);
+        emit_ctype(c, elem_t, b);
+        buf_printf(b, " _t%d = sp_%sArray_get(_t%d, _fi + %dLL);\n", e, find_k, t, j);
+        Buf rcb = {NULL, 0, 0};
+        if (emit_pm_cond(c, reqs[j], e, elem_t, &rcb)) {
+          buf_puts(&wb, " && "); buf_puts(&wb, rcb.p ? rcb.p : "1");
+        }
+        free(rcb.p);
+      }
+      emit_indent(b, indent + 2);
+      buf_printf(b, "if (1%s) { _t%d = _fi; break; }\n", wb.p ? wb.p : "", find_pos);
+      free(wb.p);
+      emit_indent(b, indent + 1); buf_puts(b, "}\n");
+      buf_printf(&cond_buf, "_t%d >= 0", find_pos);
+      has_cond = 1;
+    } else {
+      has_cond = emit_pm_cond(c, pat, t, pt, &cond_buf);
+    }
     /* For IfNode the pattern is always a binding (LV), guard is separate */
     if (!strcmp(pty, "IfNode")) has_cond = 0;
 
@@ -1178,6 +1218,50 @@ void emit_case_match(Compiler *c, int id, Buf *b, int indent, int tail) {
             emit_indent(b, body_indent);
             buf_printf(b, "lv_%s = sp_%sArray_slice(_t%d, %dLL, _t%d->len - %dLL);\n",
                        rnm, k, t, (long long)apn, t, (long long)apn);
+          }
+        }
+      }
+    }
+
+    /* --- FindPatternNode destructuring (uses the found position temp) --- */
+    if (find_pat >= 0 && find_pos >= 0) {
+      int rn = 0;
+      const int *reqs = nt_arr(nt, find_pat, "requireds", &rn);
+      /* leading `*head` = elements before the matched window */
+      int left = nt_ref(nt, find_pat, "left");
+      if (left >= 0 && nt_type(nt, left) && !strcmp(nt_type(nt, left), "SplatNode")) {
+        int inner = nt_ref(nt, left, "expression");
+        if (inner >= 0 && nt_type(nt, inner) &&
+            !strcmp(nt_type(nt, inner), "LocalVariableTargetNode")) {
+          const char *lnm = nt_str(nt, inner, "name");
+          if (lnm) {
+            emit_indent(b, body_indent);
+            buf_printf(b, "lv_%s = sp_%sArray_slice(_t%d, 0LL, _t%d);\n",
+                       lnm, find_k, t, find_pos);
+          }
+        }
+      }
+      /* required LV targets = the matched window elements */
+      for (int j = 0; j < rn; j++) {
+        const char *lty2 = nt_type(nt, reqs[j]);
+        if (!lty2 || strcmp(lty2, "LocalVariableTargetNode")) continue;
+        const char *lnm = nt_str(nt, reqs[j], "name");
+        if (!lnm) continue;
+        emit_indent(b, body_indent);
+        buf_printf(b, "lv_%s = sp_%sArray_get(_t%d, _t%d + %dLL);\n",
+                   lnm, find_k, t, find_pos, j);
+      }
+      /* trailing `*tail` = elements after the matched window */
+      int right = nt_ref(nt, find_pat, "right");
+      if (right >= 0 && nt_type(nt, right) && !strcmp(nt_type(nt, right), "SplatNode")) {
+        int inner = nt_ref(nt, right, "expression");
+        if (inner >= 0 && nt_type(nt, inner) &&
+            !strcmp(nt_type(nt, inner), "LocalVariableTargetNode")) {
+          const char *rnm = nt_str(nt, inner, "name");
+          if (rnm) {
+            emit_indent(b, body_indent);
+            buf_printf(b, "lv_%s = sp_%sArray_slice(_t%d, _t%d + %dLL, _t%d->len - (_t%d + %dLL));\n",
+                       rnm, find_k, t, find_pos, rn, t, find_pos, rn);
           }
         }
       }

--- a/test/case_in_value_position.rb
+++ b/test/case_in_value_position.rb
@@ -1,0 +1,24 @@
+# case/in used as a value: assignment RHS, method receiver, and method-return
+# position. Pre-fix this hit "unsupported expression: CaseMatchNode" (or
+# silently produced nil when in return position).
+
+def describe(x)
+  s = case x
+      in [a, b] then "pair #{a},#{b}"
+      in [a] then "one #{a}"
+      else "other"
+      end
+  s
+end
+puts describe([1, 2])
+puts describe([5])
+puts describe([])
+
+def total(x)
+  (case x
+   in [a, b] then [a, b]
+   else [0]
+   end).sum
+end
+p total([3, 4])
+p total([9])

--- a/test/case_in_value_position.rb.expected
+++ b/test/case_in_value_position.rb.expected
@@ -1,0 +1,5 @@
+pair 1,2
+one 5
+other
+7
+0

--- a/test/find_pattern_match.rb
+++ b/test/find_pattern_match.rb
@@ -1,0 +1,20 @@
+# Find patterns `case arr in [*head, m.., *tail]`: scan for the first window of
+# requireds, binding the leading splat (head), required targets, and trailing
+# splat (tail). Pre-fix the arm matched unconditionally with head/tail nil.
+
+def classify(a)
+  case a
+  in [*head, :a, :b, *tail]
+    "ab head=#{head.inspect} tail=#{tail.inspect}"
+  in [*pre, x, :stop, *post]
+    "stop x=#{x} pre=#{pre.inspect} post=#{post.inspect}"
+  else
+    "none"
+  end
+end
+
+puts classify([:x, :y, :a, :b, :z])
+puts classify([:a, :b])
+puts classify([:p, :q, :stop, :r])
+puts classify([:z])
+puts classify([])

--- a/test/find_pattern_match.rb.expected
+++ b/test/find_pattern_match.rb.expected
@@ -1,0 +1,5 @@
+ab head=[:x, :y] tail=[:z]
+ab head=[] tail=[]
+stop x=q pre=[:p] post=[:r]
+none
+none


### PR DESCRIPTION
Two related pattern-matching codegen gaps.

Find patterns (`case x in [*head, a, b, *tail]`) were parsed into a FindPatternNode but never actually matched: emit_pm_cond had no case for the node, so the arm matched unconditionally, and no bindings were emitted, so the splats stayed nil (e.g. `case [:z] in [*h, :a, :b, *t]` wrongly matched with h/t nil). This scans the scrutinee for the first window of consecutive elements matching the requireds, uses its start position as the arm condition, and on a match binds the leading splat to the slice before the window, each required target to its element, and the trailing splat to the slice after; analyze types the bindings.

Separately, a CaseMatchNode used as a value -- assignment RHS, method receiver, or any expression -- hit "unsupported expression" (or silently produced nil in return position). A value mode added to emit_case_match assigns each arm's body value (boxed to the case's result type) to a result temp, and an emit_expr handler declares the temp, emits the match into the prelude, and yields it.