### PR TITLE
Add Integer#bit_length/#fdiv, Float#eql?, Math.gamma

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -251,6 +251,10 @@ static inline mrb_float sp_math_acos(mrb_float x){if(x<-1.0||x>1.0)sp_raise_cls(
 static inline mrb_float sp_math_asin(mrb_float x){if(x<-1.0||x>1.0)sp_raise_cls("Math_DomainError","Numerical argument is out of domain - asin");return asin(x);}
 static inline mrb_float sp_math_acosh(mrb_float x){if(x<1.0)sp_raise_cls("Math_DomainError","Numerical argument is out of domain - acosh");return acosh(x);}
 static inline mrb_float sp_math_atanh(mrb_float x){if(x<-1.0||x>1.0)sp_raise_cls("Math_DomainError","Numerical argument is out of domain - atanh");return atanh(x);}
+/* gamma has poles at the non-positive integers, but CRuby only raises at the
+   NEGATIVE integers (gamma(0.0) is +Infinity, gamma(-0.0) -Infinity, which
+   tgamma already yields); negative non-integers are in-domain. */
+static inline mrb_float sp_math_gamma(mrb_float x){if(x<0.0&&x==floor(x))sp_raise_cls("Math_DomainError","Numerical argument is out of domain - gamma");return tgamma(x);}
 
 static sp_Range sp_range_new(mrb_int f,mrb_int l,mrb_int e){sp_Range r;r.first=f;r.last=l;r.excl=e;return r;}
 static mrb_bool sp_range_eq(sp_Range a,sp_Range b){return a.first==b.first&&a.last==b.last&&a.excl==b.excl;}
@@ -1137,6 +1141,9 @@ static mrb_int sp_IntArray_delete(sp_IntArray*a,mrb_int v){if(a&&a->frozen){sp_r
    a->start and write into the array's GC header. */
 static void sp_IntArray_insert(sp_IntArray*a,mrb_int i,mrb_int v){if(!a)return;if(a->frozen){sp_raise_frozen_array();return;}if(i<0)i+=a->len+1;if(i<0)i=0;if(i>a->len)i=a->len;sp_IntArray_push(a,0);for(mrb_int j=a->len-1;j>i;j--)a->data[a->start+j]=a->data[a->start+j-1];a->data[a->start+i]=v;}
 static sp_IntArray*sp_int_digits(mrb_int n,mrb_int base){sp_IntArray*a=sp_IntArray_new();if(base<2)base=10;if(n==0){sp_IntArray_push(a,0);return a;}if(n<0)n=-n;while(n>0){sp_IntArray_push(a,n%base);n/=base;}return a;}
+/* Integer#bit_length: bits in the two's-complement representation excluding
+   the sign bit (a negative n counts the bits of ~n). */
+static mrb_int sp_int_bit_length(mrb_int n){unsigned long long x=(n<0)?(unsigned long long)(~n):(unsigned long long)n;mrb_int b=0;if(x>=1ULL<<32){b+=32;x>>=32;}if(x>=1ULL<<16){b+=16;x>>=16;}if(x>=1ULL<<8){b+=8;x>>=8;}if(x>=1ULL<<4){b+=4;x>>=4;}if(x>=1ULL<<2){b+=2;x>>=2;}if(x>=1ULL<<1){b+=1;x>>=1;}return b+(mrb_int)x;}
 static sp_IntArray*sp_IntArray_uniq(sp_IntArray*a){sp_IntArray*b=sp_IntArray_new();for(mrb_int i=0;i<a->len;i++){int found=0;for(mrb_int j=0;j<b->len;j++){if(b->data[b->start+j]==a->data[a->start+i]){found=1;break;}}if(!found)sp_IntArray_push(b,a->data[a->start+i]);}return b;}
 static sp_IntArray*sp_IntArray_intersect(sp_IntArray*a,sp_IntArray*b){sp_IntArray*r=sp_IntArray_new();if(!a||!b)return r;for(mrb_int i=0;i<a->len;i++){mrb_int v=a->data[a->start+i];if(sp_IntArray_include(b,v)&&!sp_IntArray_include(r,v))sp_IntArray_push(r,v);}return r;}
 static sp_IntArray*sp_IntArray_union(sp_IntArray*a,sp_IntArray*b){sp_IntArray*r=sp_IntArray_new();if(a)for(mrb_int i=0;i<a->len;i++){mrb_int v=a->data[a->start+i];if(!sp_IntArray_include(r,v))sp_IntArray_push(r,v);}if(b){for(mrb_int i=0;i<b->len;i++){mrb_int v=b->data[b->start+i];if(!sp_IntArray_include(r,v))sp_IntArray_push(r,v);}}return r;}

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -971,7 +971,8 @@ else {
          !strcmp(name, "atanh") || !strcmp(name, "exp") || !strcmp(name, "log") ||
          !strcmp(name, "log2") || !strcmp(name, "log10") || !strcmp(name, "sqrt") ||
          !strcmp(name, "cbrt") || !strcmp(name, "hypot") || !strcmp(name, "frexp") ||
-         !strcmp(name, "ldexp") || !strcmp(name, "erf") || !strcmp(name, "erfc")))
+         !strcmp(name, "ldexp") || !strcmp(name, "erf") || !strcmp(name, "erfc") ||
+         !strcmp(name, "gamma")))
       return TY_FLOAT;
     if (rty && !strcmp(rty, "ConstantReadNode") &&
         nt_str(nt, recv, "name") && !strcmp(nt_str(nt, recv, "name"), "JSON") &&
@@ -2299,6 +2300,8 @@ else {
         nt_ref(nt, id, "block") < 0) return TY_RANGE;
     if (!strcmp(name, "chr")) return TY_STRING;
     if (!strcmp(name, "[]") && argc == 1) return TY_INT;  /* bit access */
+    if (!strcmp(name, "bit_length") && argc == 0) return TY_INT;
+    if (!strcmp(name, "fdiv") && argc == 1) return TY_FLOAT;
     if (!strcmp(name, "div") && argc == 1) return TY_INT;  /* floor division */
     if (!strcmp(name, "gcd") || !strcmp(name, "lcm") || !strcmp(name, "clamp")) return TY_INT;
     if (!strcmp(name, "magnitude") && argc == 0) return TY_INT;  /* alias for abs */
@@ -2321,7 +2324,9 @@ else {
         !strcmp(name, "zero?")) return TY_BOOL;
     if (!strcmp(name, "next_float") || !strcmp(name, "prev_float") ||
         !strcmp(name, "abs") || !strcmp(name, "magnitude") ||
-        !strcmp(name, "modulo") || !strcmp(name, "to_f")) return TY_FLOAT;
+        !strcmp(name, "modulo") || !strcmp(name, "to_f") ||
+        (!strcmp(name, "fdiv") && argc == 1)) return TY_FLOAT;
+    if (!strcmp(name, "eql?") && argc == 1) return TY_BOOL;
     /* clamp with float bounds returns a float (matches codegen in codegen_call.c);
        a mixed/int bound can return the Integer bound, so leave that poly. */
     if (!strcmp(name, "clamp") && argc == 2 &&

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -2469,6 +2469,8 @@ static int emit_scalar_call(Compiler *c, int id, Buf *b) {
       else if (!strcmp(name, "abs"))    buf_printf(b, "((%s) < 0 ? -(%s) : (%s))", r, r, r);
       else if (!strcmp(name, "chr"))    buf_printf(b, "sp_int_chr(%s)", r);
       else if (!strcmp(name, "[]") && argc == 1) { buf_printf(b, "(((%s) >> (", r); emit_expr(c, argv[0], b); buf_puts(b, ")) & 1)"); }
+      else if (!strcmp(name, "bit_length") && argc == 0) buf_printf(b, "sp_int_bit_length(%s)", r);
+      else if (!strcmp(name, "fdiv") && argc == 1) { buf_printf(b, "((mrb_float)(%s) / (", r); emit_float_expr(c, argv[0], b); buf_puts(b, "))"); }
       else if (!strcmp(name, "even?"))  buf_printf(b, "((%s) %% 2 == 0)", r);
       else if (!strcmp(name, "odd?"))   buf_printf(b, "((%s) %% 2 != 0)", r);
       else if (!strcmp(name, "zero?"))  buf_printf(b, "((%s) == 0)", r);
@@ -2610,6 +2612,19 @@ static int emit_scalar_call(Compiler *c, int id, Buf *b) {
           buf_printf(b, "; sp_FloatArray *_t%d = sp_FloatArray_new();"
                         " sp_FloatArray_push(_t%d, _t%d);"
                         " sp_FloatArray_push(_t%d, (%s)); _t%d; })", o, o, ta, o, r, o);
+        }
+      }
+      else if (!strcmp(name, "fdiv") && argc == 1) { buf_printf(b, "((%s) / (", r); emit_float_expr(c, argv[0], b); buf_puts(b, "))"); }
+      /* Float#eql?(x): true only when x is itself a Float of equal value (no
+         numeric coercion, unlike ==). A float-typed arg compares directly; any
+         other arg is boxed and rejected unless it is tagged float at runtime. */
+      else if (!strcmp(name, "eql?") && argc == 1) {
+        TyKind a0 = comp_ntype(c, argv[0]);
+        if (a0 == TY_FLOAT) { buf_printf(b, "((%s) == (", r); emit_expr(c, argv[0], b); buf_puts(b, "))"); }
+        else {
+          int te = ++g_tmp;
+          buf_printf(b, "({ sp_RbVal _t%d = ", te); emit_boxed(c, argv[0], b);
+          buf_printf(b, "; _t%d.tag == SP_TAG_FLT && _t%d.v.f == (%s); })", te, te, r);
         }
       }
       else handled = 0;
@@ -6444,6 +6459,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     else if (!strcmp(name, "cbrt"))  cfn = "cbrt";
     else if (!strcmp(name, "erf"))   cfn = "erf";
     else if (!strcmp(name, "erfc"))  cfn = "erfc";
+    else if (!strcmp(name, "gamma")) cfn = "sp_math_gamma";
     if (cfn && argc == 1) {
       TyKind a0t = comp_ntype(c, argv[0]);
       buf_printf(b, "%s(", cfn);

--- a/test/numeric_tower_methods.rb
+++ b/test/numeric_tower_methods.rb
@@ -1,0 +1,45 @@
+# Integer#bit_length, Integer#fdiv / Float#fdiv, Float#eql? (type-strict),
+# and Math.gamma. fdiv always returns a Float; eql? is true only for a Float
+# of equal value (no numeric coercion).
+p 42.bit_length
+p 0.bit_length
+p 255.bit_length
+p 1024.bit_length
+
+p 10.fdiv(3)
+p 7.fdiv(2)
+p 2.5.fdiv(2)
+
+p 1.0.eql?(1)
+p 1.0.eql?(1.0)
+p 2.0.eql?(2)
+
+# eql? is never true for NaN: it returns false when either side is NaN, matching
+# CRuby (a NaN matches as a hash key only by object identity, not via eql?). Both
+# the float-typed and the boxed-argument paths go through value equality.
+def nan; 0.0 / 0.0; end
+p nan.eql?(nan)
+mixed = [0.0 / 0.0, 7]
+p nan.eql?(mixed.first)
+
+p Math.gamma(5)
+p Math.gamma(1)
+
+def bl(n)
+  n.bit_length
+end
+p bl(65535)
+
+# Math.gamma raises Math::DomainError at the negative-integer poles, but 0.0
+# is +Infinity (not a raising pole).
+begin
+  Math.gamma(-1.0)
+rescue Math::DomainError => e
+  puts e.message
+end
+p Math.gamma(0.0)
+
+# fdiv unboxes a polymorphic argument (here an element of a mixed array).
+bases = [2, "x"]
+p 10.fdiv(bases.first)
+p 2.5.fdiv(bases.first)

--- a/test/numeric_tower_methods.rb.expected
+++ b/test/numeric_tower_methods.rb.expected
@@ -1,0 +1,19 @@
+6
+0
+8
+11
+3.3333333333333335
+3.5
+1.25
+false
+true
+false
+false
+false
+24.0
+1.0
+16
+Numerical argument is out of domain - gamma
+Infinity
+5.0
+1.25


### PR DESCRIPTION
## Summary

`Integer#bit_length`, `Integer#fdiv` / `Float#fdiv`, `Float#eql?`, and `Math.gamma` were unsupported and rejected at compile time. This adds them.

## Details

- **`bit_length`** counts the magnitude bits of an integer via a small runtime helper; a negative receiver counts the bits of its complement, matching CRuby. The count uses a fixed binary search, so it is bounded at the word width regardless of magnitude.
- **`fdiv`** divides as floating point and is typed `Float` on both `Integer` and `Float` receivers. The divisor is emitted through `emit_float_expr`, so a polymorphic argument is unboxed to a float rather than passed as a raw tagged value.
- **`Float#eql?`** is type-strict: a float-typed argument compares directly, while any other argument is boxed and accepted only when it is tagged float at runtime. So `1.0.eql?(1)` is `false` while `1.0.eql?(1.0)` is `true`. Comparison is by value equality, so `NaN` is never `eql?` to `NaN` — matching CRuby (where a `NaN` hash key matches only by object identity, not via `eql?`).
- **`Math.gamma`** maps to a `sp_math_gamma` wrapper that raises `Math::DomainError` at the negative-integer poles, as in CRuby; `gamma(0.0)` stays `+Infinity` (only negative integers are poles).

`Math.lgamma` returns a `[value, sign]` pair and needs array-return `Math` support (currently absent, like `frexp`), so it is left for a follow-up.

## Test

`test/numeric_tower_methods.rb` covers `bit_length` (including `0` and a method-parameter receiver to exercise the runtime path), int/float `fdiv`, the `eql?` cases — including `nan.eql?(nan)` across both the float-typed and boxed-argument paths — the `gamma` pole raise, and `gamma(0.0)`. Expected output is generated from CRuby.

## Verification

- Full `make test` green.
- The new test is ASAN + UBSan clean under `SPINEL_GC_STRESS=1`.