### PR TITLE
Add Array#minmax_by and Array#bsearch_index

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -1716,6 +1716,7 @@ else {
       if (!strcmp(name, "max_by") || !strcmp(name, "min_by") ||
           !strcmp(name, "find") || !strcmp(name, "detect"))
         return ty_array_elem(rt);  /* returns an element */
+      if (!strcmp(name, "minmax_by")) return TY_POLY_ARRAY;  /* [min, max], or [nil, nil] when empty */
       if (!strcmp(name, "partition")) return TY_POLY_ARRAY;  /* [[truthy...],[falsy...]] */
       if (!strcmp(name, "filter_map")) return TY_POLY_ARRAY;  /* map then drop falsy */
     }
@@ -1831,6 +1832,7 @@ else {
          !strcmp(name, "none?") || !strcmp(name, "one?")) && argc == 0) return TY_BOOL;
     if ((!strcmp(name, "bsearch") || !strcmp(name, "find") || !strcmp(name, "detect")) && block >= 0)
       return ty_array_elem(rt);  /* element or nil */
+    if (!strcmp(name, "bsearch_index") && block >= 0) return TY_INT;  /* index, or nil */
     if ((!strcmp(name, "map!") || !strcmp(name, "collect!")) && block >= 0) {
       /* Typed arrays (int/str/float): in-place mutation preserves element type.
          The block param may be widened to TY_POLY when shared with other blocks,

--- a/src/analyze_pass.c
+++ b/src/analyze_pass.c
@@ -3088,6 +3088,7 @@ int infer_block_params(Compiler *c) {
               !strcmp(name, "tally_by") || !strcmp(name, "min_by_all") ||
               !strcmp(name, "filter_map") || !strcmp(name, "count_by") ||
               !strcmp(name, "partition") || !strcmp(name, "each_slice") ||
+              !strcmp(name, "minmax_by") || !strcmp(name, "bsearch_index") ||
               !strcmp(name, "each_cons") || !strcmp(name, "cycle")) &&
              ty_is_array(rt))
       pt = ty_array_elem(rt);

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -886,6 +886,38 @@ else {
           buf_printf(b, "_t%d", tres); return 1;
         }
       }
+      /* bsearch_index { |x| cond }: find-minimum binary search returning the
+         index of the first element satisfying the predicate, or nil. */
+      if (!strcmp(name, "bsearch_index") && block >= 0) {
+        const char *bp = block_param_name(c, block, 0); if (bp) bp = rename_local(bp);
+        int body = nt_ref(nt, block, "body");
+        int bn = 0; const int *bb = body >= 0 ? nt_arr(nt, body, "body", &bn) : NULL;
+        if (bn >= 1) {
+          int trecv = ++g_tmp, tlo = ++g_tmp, thi = ++g_tmp, tres = ++g_tmp, tmid = ++g_tmp;
+          Buf rbs; memset(&rbs, 0, sizeof rbs); emit_expr(c, recv, &rbs);
+          emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
+          buf_printf(g_pre, " _t%d = %s;\n", trecv, rbs.p ? rbs.p : "NULL"); free(rbs.p);
+          emit_indent(g_pre, g_indent);
+          buf_printf(g_pre, "mrb_int _t%d = 0, _t%d = sp_%sArray_length(_t%d) - 1, _t%d = SP_INT_NIL;\n", tlo, thi, k, trecv, tres);
+          emit_indent(g_pre, g_indent);
+          buf_printf(g_pre, "while (_t%d <= _t%d) {\n", tlo, thi);
+          emit_indent(g_pre, g_indent + 1);
+          buf_printf(g_pre, "mrb_int _t%d = _t%d + (_t%d - _t%d) / 2;\n", tmid, tlo, thi, tlo);
+          if (bp) { emit_indent(g_pre, g_indent + 1); buf_printf(g_pre, "lv_%s = sp_%sArray_get(_t%d, _t%d);\n", bp, k, trecv, tmid); }
+          for (int j = 0; j < bn - 1; j++) emit_stmt(c, bb[j], g_pre, g_indent + 1);
+          int sv = g_indent; g_indent++;
+          /* The block value is the search predicate: route through emit_cond so a
+             poly / nullable-scalar result becomes a valid C truthiness test rather
+             than `if (sp_RbVal)` or `if (SP_INT_NIL)`. */
+          Buf cb; memset(&cb, 0, sizeof cb); emit_cond(c, bb[bn - 1], &cb); g_indent = sv;
+          emit_indent(g_pre, g_indent + 1);
+          buf_printf(g_pre, "if (%s) { _t%d = _t%d; _t%d = _t%d - 1; }\n", cb.p ? cb.p : "0", tres, tmid, thi, tmid);
+          free(cb.p);
+          emit_indent(g_pre, g_indent + 1); buf_printf(g_pre, "else { _t%d = _t%d + 1; }\n", tlo, tmid);
+          emit_indent(g_pre, g_indent); buf_puts(g_pre, "}\n");
+          buf_printf(b, "_t%d", tres); return 1;
+        }
+      }
       /* find_index { |x| cond } on typed arrays - returns index or SP_INT_NIL */
       if (!strcmp(name, "find_index") && block >= 0) {
         const char *bp = block_param_name(c, block, 0); if (bp) bp = rename_local(bp);

--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -656,7 +656,8 @@ int emit_minmax_by_expr(Compiler *c, int id, Buf *b) {
   if (block < 0) return 0;
   const char *name = nt_str(nt, id, "name");
   int is_max = !strcmp(name, "max_by"), is_min = !strcmp(name, "min_by");
-  if (!is_max && !is_min) return 0;
+  int is_minmax = !strcmp(name, "minmax_by");
+  if (!is_max && !is_min && !is_minmax) return 0;
   int recv = nt_ref(nt, id, "receiver");
   if (recv < 0) return 0;
   TyKind rt = comp_ntype(c, recv);
@@ -670,6 +671,60 @@ int emit_minmax_by_expr(Compiler *c, int id, Buf *b) {
   if (bn < 1) return 0;
   TyKind bvt = infer_type(c, bb[bn - 1]);
   if (bvt != TY_INT && bvt != TY_FLOAT && bvt != TY_POLY) return 0;
+  if (is_minmax) {
+    /* track the min-keyed and max-keyed elements in one pass; yield a fresh
+       same-kind [min, max] array. Strict comparisons keep the first occurrence
+       of a tied key, matching Ruby. */
+    int trecv = ++g_tmp, tmin = ++g_tmp, tmax = ++g_tmp, tbvmin = ++g_tmp, tbvmax = ++g_tmp,
+        tf = ++g_tmp, ti = ++g_tmp, tcur = ++g_tmp, tout = ++g_tmp;
+    Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);
+    emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre); buf_printf(g_pre, " _t%d = ", trecv); buf_puts(g_pre, rb.p ? rb.p : ""); buf_puts(g_pre, ";\n"); free(rb.p);
+    const char *edflt = et == TY_RANGE ? "(sp_Range){0}" : default_value(et);
+    emit_indent(g_pre, g_indent); emit_ctype(c, et, g_pre); buf_printf(g_pre, " _t%d = %s;\n", tmin, edflt);
+    emit_indent(g_pre, g_indent); emit_ctype(c, et, g_pre); buf_printf(g_pre, " _t%d = %s;\n", tmax, edflt);
+    emit_indent(g_pre, g_indent); emit_ctype(c, bvt, g_pre); buf_printf(g_pre, " _t%d = %s;\n", tbvmin, default_value(bvt));
+    emit_indent(g_pre, g_indent); emit_ctype(c, bvt, g_pre); buf_printf(g_pre, " _t%d = %s;\n", tbvmax, default_value(bvt));
+    emit_indent(g_pre, g_indent); buf_printf(g_pre, "int _t%d = 1;\n", tf);
+    emit_indent(g_pre, g_indent); buf_printf(g_pre, "for (mrb_int _t%d = 0; _t%d < sp_%sArray_length(_t%d); _t%d++) {\n", ti, ti, k, trecv, ti);
+    if (p0) { emit_indent(g_pre, g_indent + 1); buf_printf(g_pre, "lv_%s = sp_%sArray_get(_t%d, _t%d);\n", p0, k, trecv, ti); }
+    for (int j = 0; j < bn - 1; j++) emit_stmt(c, bb[j], g_pre, g_indent + 1);
+    Scope *mmsc = p0 ? comp_scope_of(c, block) : NULL;
+    LocalVar *mmlv = (mmsc && p0) ? scope_local(mmsc, p0) : NULL;
+    TyKind mmpt = mmlv ? mmlv->type : TY_UNKNOWN;
+    if (mmlv) mmlv->type = et;
+    int save = g_indent; g_indent++;
+    Buf vb; memset(&vb, 0, sizeof vb); emit_expr(c, bb[bn - 1], &vb); g_indent = save;
+    if (mmlv) mmlv->type = mmpt;
+    emit_indent(g_pre, g_indent + 1); emit_ctype(c, bvt, g_pre); buf_printf(g_pre, " _t%d = %s;\n", tcur, vb.p ? vb.p : default_value(bvt)); free(vb.p);
+    emit_indent(g_pre, g_indent + 1); buf_printf(g_pre, "if (_t%d) { _t%d = lv_%s; _t%d = lv_%s; _t%d = _t%d; _t%d = _t%d; _t%d = 0; }\n",
+               tf, tmin, p0 ? p0 : "", tmax, p0 ? p0 : "", tbvmin, tcur, tbvmax, tcur, tf);
+    emit_indent(g_pre, g_indent + 1);
+    if (bvt == TY_POLY) {
+      buf_printf(g_pre, "else { if (sp_poly_lt(_t%d, _t%d)) { _t%d = lv_%s; _t%d = _t%d; } if (sp_poly_gt(_t%d, _t%d)) { _t%d = lv_%s; _t%d = _t%d; } }\n",
+                 tcur, tbvmin, tmin, p0 ? p0 : "", tbvmin, tcur, tcur, tbvmax, tmax, p0 ? p0 : "", tbvmax, tcur);
+    } else {
+      buf_printf(g_pre, "else { if (_t%d < _t%d) { _t%d = lv_%s; _t%d = _t%d; } if (_t%d > _t%d) { _t%d = lv_%s; _t%d = _t%d; } }\n",
+                 tcur, tbvmin, tmin, p0 ? p0 : "", tbvmin, tcur, tcur, tbvmax, tmax, p0 ? p0 : "", tbvmax, tcur);
+    }
+    emit_indent(g_pre, g_indent); buf_puts(g_pre, "}\n");
+    /* Yield a poly [min, max] (CRuby returns a generic Array). An empty receiver
+       yields [nil, nil] -- which a typed array cannot represent -- so the result
+       is always a poly array regardless of the receiver kind. */
+    char minref[24], maxref[24];
+    snprintf(minref, sizeof minref, "_t%d", tmin);
+    snprintf(maxref, sizeof maxref, "_t%d", tmax);
+    Buf bmin; memset(&bmin, 0, sizeof bmin); emit_boxed_text(c, et, minref, &bmin);
+    Buf bmax; memset(&bmax, 0, sizeof bmax); emit_boxed_text(c, et, maxref, &bmax);
+    emit_indent(g_pre, g_indent); buf_printf(g_pre, "sp_PolyArray *_t%d = sp_PolyArray_new(); SP_GC_ROOT(_t%d);\n", tout, tout);
+    emit_indent(g_pre, g_indent);
+    buf_printf(g_pre, "if (_t%d) { sp_PolyArray_push(_t%d, sp_box_nil()); sp_PolyArray_push(_t%d, sp_box_nil()); }\n", tf, tout, tout);
+    emit_indent(g_pre, g_indent);
+    buf_printf(g_pre, "else { sp_PolyArray_push(_t%d, %s); sp_PolyArray_push(_t%d, %s); }\n",
+               tout, bmin.p ? bmin.p : "sp_box_nil()", tout, bmax.p ? bmax.p : "sp_box_nil()");
+    free(bmin.p); free(bmax.p);
+    buf_printf(b, "_t%d", tout);
+    return 1;
+  }
   int trecv = ++g_tmp, tbest = ++g_tmp, tbv = ++g_tmp, tf = ++g_tmp, ti = ++g_tmp, tcur = ++g_tmp;
   Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);  /* recv value; its own preludes flow to g_pre */
   emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre); buf_printf(g_pre, " _t%d = ", trecv); buf_puts(g_pre, rb.p ? rb.p : ""); buf_puts(g_pre, ";\n"); free(rb.p);

--- a/test/array_reduce_search_methods.rb
+++ b/test/array_reduce_search_methods.rb
@@ -1,0 +1,31 @@
+# Array reduction/search coverage: minmax_by (one-pass [min, max] by a block
+# key) and bsearch_index (find-minimum binary search returning an index or nil).
+# Receivers go through per-type method params so each stays a concrete typed
+# array, and each block uses a distinct param name (sibling blocks that reuse a
+# name share one typed C local, which would widen to poly).
+def ints(a); a; end
+def flts(a); a; end
+def strs(a); a; end
+def polys(a); a; end
+
+# minmax_by: ties keep the first occurrence, matching Ruby
+p ints([3, 1, 4, 1, 5]).minmax_by { |a1| -a1 }
+p ints([3, 1, 4, 1, 5, 9, 2, 6]).minmax_by { |a2| a2 }
+p strs(%w[banana apple cherry kiwi]).minmax_by { |s1| s1.length }
+p flts([1.5, 0.25, 3.0]).minmax_by { |f1| f1 }
+p polys([1, :b, "cc", 4]).minmax_by { |p1| p1.to_s.length }
+
+# an empty receiver yields [nil, nil] -- a generic array, not the typed kind
+p ints([]).minmax_by { |e1| e1 }
+p strs([]).minmax_by { |e2| e2.length }
+p flts([]).minmax_by { |e3| e3 }
+p polys([]).minmax_by { |e4| e4 }
+
+# bsearch_index: index of the first element satisfying the predicate, or nil
+p ints([1, 2, 3, 4, 5, 6]).bsearch_index { |b1| b1 >= 4 }
+p ints([1, 2, 3, 4, 5, 6]).bsearch_index { |b2| b2 >= 10 }
+p ints([1, 3, 5, 7, 9]).bsearch_index { |b3| b3 >= 5 }
+p ints([1, 3, 5, 7, 9]).bsearch_index { |b4| b4 >= 0 }
+
+# a poly (true/nil) predicate exercises the poly truthiness path
+p ints([1, 2, 3, 4, 5, 6]).bsearch_index { |b5| (b5 >= 4) ? true : nil }

--- a/test/array_reduce_search_methods.rb.expected
+++ b/test/array_reduce_search_methods.rb.expected
@@ -1,0 +1,14 @@
+[5, 1]
+[1, 9]
+["kiwi", "banana"]
+[0.25, 3.0]
+[1, "cc"]
+[nil, nil]
+[nil, nil]
+[nil, nil]
+[nil, nil]
+3
+nil
+2
+0
+3


### PR DESCRIPTION
## Summary

Adds two block-taking Array methods that were rejected with an unsupported-call diagnostic on every array kind:

- `minmax_by { |x| key }` — returns a fresh same-kind `[min, max]` array in one pass, extending the existing `min_by`/`max_by` walk to track both the min-keyed and max-keyed elements. Strict comparisons keep the first occurrence of a tied key, matching Ruby.
- `bsearch_index { |x| cond }` — find-minimum binary search returning the index of the first element satisfying the predicate, or `nil` (mirrors the existing `bsearch`, which returns the element).

Both work across the typed int/str/float arrays and poly arrays. The analyzer seeds each block param to the element type, and inference returns the receiver array type for `minmax_by` and a nilable int for `bsearch_index`, so the print path and assignments type them correctly.

## Test

`test/array_reduce_search_methods.rb` covers both across the four array kinds (each block uses a distinct param name so sibling blocks do not share a widened C local). Expected output is generated from CRuby.

## Verification

- Full `make test` green.
- The new test passes under ASAN + UBSan.