### PR TITLE
Add Symbol string-surface methods (succ, slice, start_with?, end_with?, match?)

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -2025,6 +2025,10 @@ else {
         !strcmp(name, "to_sym") || !strcmp(name, "itself")) return TY_SYMBOL;
     if (!strcmp(name, "length") || !strcmp(name, "size")) return TY_INT;
     if (!strcmp(name, "empty?") || !strcmp(name, "==") || !strcmp(name, "!=")) return TY_BOOL;
+    if (!strcmp(name, "succ") || !strcmp(name, "next")) return TY_SYMBOL;
+    if ((!strcmp(name, "[]") || !strcmp(name, "slice")) && (argc == 1 || argc == 2)) return TY_STRING;
+    if ((!strcmp(name, "start_with?") || !strcmp(name, "end_with?") || !strcmp(name, "match?")) && argc == 1)
+      return TY_BOOL;
   }
 
   /* range receiver methods */

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -7094,7 +7094,8 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       buf_printf(b, "%d", opt); return;
     }
   }
-  if (recv >= 0 && argc >= 1 && (!strcmp(name, "match?") || !strcmp(name, "!~") || !strcmp(name, "=~") || !strcmp(name, "match"))) {
+  if (recv >= 0 && argc >= 1 && rt != TY_SYMBOL &&
+      (!strcmp(name, "match?") || !strcmp(name, "!~") || !strcmp(name, "=~") || !strcmp(name, "match"))) {
     int are = re_lit_index(c, argv[0]);
     if (are >= 0 && !strcmp(name, "=~") && rt == TY_STRING) {
       buf_printf(b, "sp_re_match_poly(sp_re_pat_%d, ", are); emit_expr(c, recv, b); buf_puts(b, ")");
@@ -7165,7 +7166,10 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
         }
         if (rp_ok && rp.p) {
           if (!strcmp(name, "match?") && argc == 1) {
-            buf_printf(b, "sp_re_match_p(%s, ", rp.p); emit_expr(c, recv, b); buf_puts(b, ")");
+            /* A symbol receiver matches over its name, so feed the runtime
+               pattern the symbol's string rather than the raw sp_sym. */
+            if (rt == TY_SYMBOL) { buf_printf(b, "sp_re_match_p(%s, sp_sym_to_s(", rp.p); emit_expr(c, recv, b); buf_puts(b, "))"); }
+            else { buf_printf(b, "sp_re_match_p(%s, ", rp.p); emit_expr(c, recv, b); buf_puts(b, ")"); }
             free(rp.p); return;
           }
           if (!strcmp(name, "=~") && rt == TY_STRING) {
@@ -9100,6 +9104,35 @@ else {
       emit_expr(c, recv, b); buf_puts(b, " == "); emit_expr(c, argv[0], b);
       buf_puts(b, name[0] == '=' ? ")" : "))");
       return;
+    }
+    /* string-surface methods over the symbol's name; succ re-interns a symbol,
+       index/slice yield a substring (or nil), the predicates yield a bool. */
+    if (!strcmp(name, "succ") || !strcmp(name, "next")) {
+      buf_puts(b, "sp_sym_intern(sp_str_succ(sp_sym_to_s("); emit_expr(c, recv, b); buf_puts(b, ")))");
+      return;
+    }
+    if ((!strcmp(name, "[]") || !strcmp(name, "slice")) && argc == 1) {
+      buf_puts(b, "sp_str_char_at_or_nil(sp_sym_to_s("); emit_expr(c, recv, b); buf_puts(b, "), ");
+      emit_int_expr(c, argv[0], b); buf_puts(b, ")");
+      return;
+    }
+    if ((!strcmp(name, "[]") || !strcmp(name, "slice")) && argc == 2) {
+      buf_puts(b, "sp_str_sub_range(sp_sym_to_s("); emit_expr(c, recv, b); buf_puts(b, "), ");
+      emit_int_expr(c, argv[0], b); buf_puts(b, ", "); emit_int_expr(c, argv[1], b); buf_puts(b, ")");
+      return;
+    }
+    if ((!strcmp(name, "start_with?") || !strcmp(name, "end_with?")) && argc == 1) {
+      buf_printf(b, "sp_str_%s(sp_sym_to_s(", !strcmp(name, "start_with?") ? "start_with" : "end_with");
+      emit_expr(c, recv, b); buf_puts(b, "), "); emit_str_expr(c, argv[0], b); buf_puts(b, ")");
+      return;
+    }
+    if (!strcmp(name, "match?") && argc == 1) {
+      int rre = re_lit_index(c, argv[0]);
+      if (rre >= 0) {
+        buf_printf(b, "(sp_re_match(sp_re_pat_%d, sp_sym_to_s(", rre); emit_expr(c, recv, b);
+        buf_puts(b, ")) >= 0)");
+        return;
+      }
     }
   }
 

--- a/test/symbol_string_methods.rb
+++ b/test/symbol_string_methods.rb
@@ -1,0 +1,25 @@
+# Symbol string-surface methods, lowered over the symbol's name: index/slice
+# yield a substring (or nil), succ re-interns a symbol, and start_with?/
+# end_with?/match? yield a bool. Receivers go through a method param so the
+# symbol value reaches the runtime path rather than being folded.
+def wrap(x); x; end
+
+p wrap(:hello)[1]
+p wrap(:hello)[1, 3]
+p wrap(:hello)[10]
+p wrap(:abc).succ
+p wrap(:az).succ
+p wrap(:hello).start_with?("he")
+p wrap(:hello).start_with?("xx")
+p wrap(:hello).end_with?("lo")
+p wrap(:hello).end_with?("xx")
+p wrap(:hello).match?(/ell/)
+p wrap(:hello).match?(/zzz/)
+
+# match? also works when the pattern is a non-literal regex (a local / param),
+# matching over the symbol's name rather than the raw symbol value.
+rx = /^he/
+p wrap(:hello).match?(rx)
+def sym_match(s, r); s.match?(r); end
+p sym_match(:hello, /lo$/)
+p sym_match(:hello, /zzz/)

--- a/test/symbol_string_methods.rb.expected
+++ b/test/symbol_string_methods.rb.expected
@@ -1,0 +1,14 @@
+"e"
+"ell"
+nil
+:abd
+:ba
+true
+false
+true
+false
+true
+false
+true
+true
+false


### PR DESCRIPTION
## Summary

`succ` / `next`, index/slice (`:s[i]`, `:s[i, n]`), `start_with?`, `end_with?`, and `match?` were rejected on a symbol receiver.

## Details

Each is lowered over the symbol name string via `sp_sym_to_s`:

- `succ` / `next` re-interns the incremented name as a symbol.
- `[i]` / `[i, n]` (and `slice`) yield a substring, or `nil` when out of range.
- `start_with?` / `end_with?` yield a bool over the name.
- `match?` yields a bool. A literal regex is handled by the dedicated symbol arm; a non-literal regex (a local, constant, or interpolated pattern) reaches the shared runtime matcher, which is fed the symbol name string rather than the raw `sp_sym` (passing an `sp_sym` where a `const char *` is expected is a type error under `-Werror`).

Inference types each method accordingly (symbol for `succ`, string/nil for slice, bool for the predicates).

## Test

`test/symbol_string_methods.rb` routes the receiver through a method param so the symbol reaches the runtime path, and covers index/slice (including out-of-range), `succ` (including the carry case `:az` -> `:ba`), the predicates, and `match?` with both literal and non-literal regex patterns. Expected output is generated from CRuby.

## Verification

- Full `make test` green.
- The new test passes under ASAN + UBSan.