### PR TITLE
Add String substring-index, regex start_with?, sum, unpack1

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -2252,6 +2252,8 @@ else {
         !strcmp(name, "casecmp") ||
         !strcmp(name, "bytesize") || !strcmp(name, "setbyte") || !strcmp(name, "getbyte")) return TY_INT;
     if (!strcmp(name, "scrub") || !strcmp(name, "crypt")) return TY_STRING;
+    if (!strcmp(name, "sum") && argc == 0) return TY_INT;
+    if (!strcmp(name, "unpack1") && argc == 1) return TY_POLY;
     if (!strcmp(name, "rindex")) return TY_INT;
     if (!strcmp(name, "partition") || !strcmp(name, "rpartition")) return TY_STR_ARRAY;
     if (!strcmp(name, "casecmp?") || !strcmp(name, "ascii_only?") || !strcmp(name, "valid_encoding?")) return TY_BOOL;

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -2351,6 +2351,10 @@ static int emit_scalar_call(Compiler *c, int id, Buf *b) {
       else if (!strcmp(name, "include?") && argc == 1) {
         buf_printf(b, "sp_str_include(%s, ", r); emit_str_expr(c, argv[0], b); buf_puts(b, ")");
       }
+      else if (!strcmp(name, "start_with?") && argc == 1 && re_lit_index(c, argv[0]) >= 0) {
+        /* s.start_with?(/re/): true when the pattern matches at index 0 */
+        buf_printf(b, "(sp_re_match(sp_re_pat_%d, %s) == 0)", re_lit_index(c, argv[0]), r);
+      }
       else if (!strcmp(name, "start_with?") && argc == 1) {
         buf_printf(b, "sp_str_start_with(%s, ", r); emit_str_expr(c, argv[0], b); buf_puts(b, ")");
       }
@@ -2417,6 +2421,12 @@ static int emit_scalar_call(Compiler *c, int id, Buf *b) {
         /* s[start, len] */
         buf_printf(b, "sp_str_sub_range(%s, ", r);
         emit_int_expr(c, argv[0], b); buf_puts(b, ", "); emit_int_expr(c, argv[1], b); buf_puts(b, ")");
+      }
+      else if ((!strcmp(name, "[]") || !strcmp(name, "slice")) && argc == 1 && comp_ntype(c, argv[0]) == TY_STRING) {
+        /* s["sub"] -> the substring if present, else nil */
+        int tsub = ++g_tmp;
+        buf_printf(b, "({ const char *_t%d = ", tsub); emit_str_expr(c, argv[0], b);
+        buf_printf(b, "; (strstr(%s, _t%d) ? _t%d : NULL); })", r, tsub, tsub);
       }
       else if ((!strcmp(name, "[]") || !strcmp(name, "slice")) && argc == 1) {
         buf_printf(b, "sp_str_char_at_or_nil(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ")");
@@ -2499,6 +2509,13 @@ static int emit_scalar_call(Compiler *c, int id, Buf *b) {
       else if (!strcmp(name, "bytes") && argc == 0)   buf_printf(b, "sp_str_bytes(%s)", r);
       else if (!strcmp(name, "codepoints") && argc == 0) buf_printf(b, "sp_str_codepoints(%s)", r);
       else if (!strcmp(name, "unpack") && argc == 1)  { buf_printf(b, "sp_str_unpack(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+      else if (!strcmp(name, "unpack1") && argc == 1) { buf_printf(b, "sp_PolyArray_get(sp_str_unpack(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, "), 0)"); }
+      else if (!strcmp(name, "sum") && argc == 0) {
+        /* default 16-bit byte checksum: sum of byte values modulo 2**16 */
+        int ts = ++g_tmp, tp = ++g_tmp, tacc = ++g_tmp;
+        buf_printf(b, "({ const char *_t%d = %s; mrb_int _t%d = 0; for (const char *_t%d = _t%d; *_t%d; _t%d++)"
+                      " _t%d += (unsigned char)*_t%d; _t%d & 0xffff; })", ts, r, tacc, tp, ts, tp, tp, tacc, tp, tacc);
+      }
       else if (!strcmp(name, "chars") && argc == 0)   buf_printf(b, "sp_str_chars(%s)", r);
       else if ((!strcmp(name, "succ") || !strcmp(name, "next")) && argc == 0) buf_printf(b, "sp_str_succ(%s)", r);
       else if (!strcmp(name, "to_i") && argc == 0)    buf_printf(b, "sp_str_to_i_cruby(%s)", r);

--- a/test/string_search_slice.rb
+++ b/test/string_search_slice.rb
@@ -1,0 +1,24 @@
+# String search/slice coverage: index-by-substring (returns the substring or
+# nil), start_with? with a regex (anchored at index 0), the byte-sum checksum,
+# and unpack1 (the first element of unpack). Receivers go through a method
+# param so the runtime path is exercised rather than constant folding.
+def s(x); x; end
+
+# s["sub"]: the matched substring, or nil
+p s("hello")["ll"]
+p s("hello")["zz"]
+p s("hello")["hello"]
+
+# start_with? accepts a regex, true only when it matches at the start
+p s("hello").start_with?(/he/)
+p s("hello").start_with?(/ell/)
+p s("hello").start_with?(/zz/)
+p s("hello").start_with?("he")
+
+# sum: 16-bit byte checksum
+p s("hello").sum
+p s("abc").sum
+
+# unpack1: first element of unpack
+p s("AB").unpack1("C")
+p s("ABCD").unpack1("N")

--- a/test/string_search_slice.rb.expected
+++ b/test/string_search_slice.rb.expected
@@ -1,0 +1,11 @@
+"ll"
+nil
+"hello"
+true
+false
+false
+true
+532
+294
+65
+1094861636


### PR DESCRIPTION
## Summary

Four `String` methods were rejected or miscompiled. This PR makes them
match CRuby:

- **`s["sub"]`** — passed the substring where an integer index was
  expected; it now returns the matched substring (via `strstr`) or `nil`.
- **`start_with?(/re/)`** — ignored the regex form and answered `false`;
  it now reports whether the pattern matches at index 0.
- **`sum`** — a 16-bit byte checksum (sum of byte values modulo `2**16`).
- **`unpack1(fmt)`** — returns the first element of `unpack`.

## Inference

`sum` is typed as an `int` and `unpack1` as a poly value; the existing
string `[]`/`start_with?` inference already covered the rest.

## Test

`test/string_search_slice.rb` exercises each surface through a method
parameter so the receiver reaches the runtime path rather than being
constant-folded. The `.expected` output is generated from `ruby`.