### PR TITLE
Return an empty array from caller_locations

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -478,6 +478,11 @@ TyKind infer_call(Compiler *c, int id) {
 
   /* Kernel#caller -> the call stack as strings (empty in release builds) */
   if (recv < 0 && !strcmp(name, "caller") && argc <= 2) return TY_STR_ARRAY;
+  /* caller_locations -> an array of Backtrace::Location objects. AOT builds keep
+     no runtime frame stack (like `caller`, which is empty in release), so this is
+     an empty array. Returning a poly array (not nil) keeps `&.first&.label`,
+     `.each`, `.map`, and `.is_a?(Array)` well-typed and nil-safe. */
+  if (recv < 0 && !strcmp(name, "caller_locations") && argc <= 2) return TY_POLY_ARRAY;
 
   /* bare `name` inside a class method body -> the class name string */
   if (recv < 0 && !strcmp(name, "name") && argc == 0) {

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -3967,6 +3967,17 @@ void emit_call(Compiler *c, int id, Buf *b) {
   }
   /* eval(string) / Kernel.eval(string): a hard AOT boundary (see helper). */
   if (diagnose_eval_call(c, id)) return;
+  /* caller_locations: no runtime frame stack in AOT builds (as with `caller`),
+     so this is an empty array of locations -- an Array, never nil. The (start,
+     length) arguments are still evaluated for their side effects, as CRuby
+     evaluates them before the call; the `(void)` casts keep a literal arg from
+     tripping -Wunused-value. */
+  if (recv < 0 && !strcmp(name, "caller_locations") && argc <= 2) {
+    buf_puts(b, "(");
+    for (int ai = 0; ai < argc; ai++) { buf_puts(b, "(void)("); emit_expr(c, argv[ai], b); buf_puts(b, "), "); }
+    buf_puts(b, "sp_PolyArray_new())");
+    return;
+  }
   if (recv < 0 && !strcmp(name, "loop") && argc == 0) {
     int blk = nt_ref(nt, id, "block");
     if (blk >= 0) {

--- a/test/caller_locations.rb
+++ b/test/caller_locations.rb
@@ -1,0 +1,23 @@
+# AOT builds keep no runtime call-stack frames (as with Kernel#caller), so
+# caller_locations is an empty array rather than nil. The array-shaped contract
+# still holds: it is an Array, is iterable, and is nil-safe under &..
+def frames = caller_locations(1, 1)
+
+puts frames.is_a?(Array)
+puts(frames.length >= 0)
+
+# iterating / mapping the result must not crash regardless of frame count
+frames.each { |loc| }
+puts frames.map { |loc| 1 }.length >= 0
+
+# the common guard idiom is nil-safe
+label = caller_locations(1, 1)&.first&.label
+puts label.nil? || label.is_a?(String)
+
+# arguments are still evaluated for their side effects (as CRuby does before the
+# call), even though the result is an empty array
+def noisy_start
+  puts "arg evaluated"
+  1
+end
+caller_locations(noisy_start, 1)

--- a/test/caller_locations.rb.expected
+++ b/test/caller_locations.rb.expected
@@ -1,0 +1,5 @@
+true
+true
+true
+true
+arg evaluated


### PR DESCRIPTION
## Summary

`caller_locations` had no handler and silently produced **nil**, so the common `caller_locations(1, 1)&.first&.label` guard — and any `.each` / `.map` / `.is_a?(Array)` on the result — saw nil instead of an array (a silent-wrong type, the worst failure mode).

AOT builds keep no runtime call-stack frames: `Kernel#caller` is already empty in release builds, and `caller_locations(n)` asks for a *dynamic caller* frame that cannot be reconstructed at compile time. So this mirrors `caller` — return an **empty array** (a poly array, never nil) so the result is well-typed, iterable, and nil-safe.

```ruby
caller_locations(1, 1).is_a?(Array)          #=> true  (was: NoMethodError on nil)
caller_locations(1, 1)&.first&.label         #=> nil   (was: nil, but by accident)
caller_locations(1, 1).map { |loc| loc }     #=> []    (was: crash)
```

This is a faithful *degradation*, not full parity: the array is empty rather than populated with `Backtrace::Location` frames. That empty-vs-populated gap is identical to `caller` in release builds — not a new silent-nil. Reconstructing real frames would need a runtime frame stack, which AOT builds deliberately omit.

## Implementation

* Inference: a receiverless `caller_locations` with ≤ 2 args is a poly array.
* Codegen: emit `sp_PolyArray_new()` (an empty `Array`), parallel to the existing `caller` handling.
* The `(start, length)` arguments are still emitted for their side effects (CRuby evaluates them before the call), via a comma expression with `(void)` casts so a literal argument does not trip `-Wunused-value`.

## Testing

`test/caller_locations.rb` asserts the array-shaped contract that must hold regardless of frame count: `is_a?(Array)`, iterable via `.each` / `.map`, and the `&.first&.label` guard is nil-safe. The assertions hold identically under `ruby` (the expected output is generated from it) and spinel. Verified clean under ASAN+UBSAN with `SPINEL_GC_STRESS=1`.