### PR TITLE
Unbox polymorphic integer arguments to Integer bit and arithmetic methods

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -94,6 +94,12 @@ static inline mrb_int sp_imod(mrb_int a, mrb_int b) {
   if ((r != 0) && ((r ^ b) < 0)) r += b;
   return r;
 }
+/* Integer#remainder: truncated remainder (sign follows the dividend, i.e. plain
+   C `%`), unlike the floored sp_imod. Zero divisor raises like sp_imod/sp_idiv. */
+static inline mrb_int sp_iremainder(mrb_int a, mrb_int b) {
+  if (b == 0) sp_raise_cls("ZeroDivisionError", "divided by 0");
+  return a % b;
+}
 /* Overflow-checked integer arithmetic (BIGINT.md option β: raise on
    overflow, keep locals at native mrb_int width).
 

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -2627,11 +2627,11 @@ static int emit_scalar_call(Compiler *c, int id, Buf *b) {
                       " sp_IntArray_push(_t%d, sp_imod(%s, _t%d)); _t%d; })", o, o, r, tb, o, r, tb, o);
       }
       else if (!strcmp(name, "div") && argc == 1) { buf_printf(b, "sp_idiv(%s, ", r); emit_int_divisor(c, argv[0], b); buf_puts(b, ")"); }
-      else if (!strcmp(name, "gcd") && argc == 1) { buf_printf(b, "sp_gcd(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
-      else if (!strcmp(name, "lcm") && argc == 1) { buf_printf(b, "sp_lcm(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+      else if (!strcmp(name, "gcd") && argc == 1) { buf_printf(b, "sp_gcd(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ")"); }
+      else if (!strcmp(name, "lcm") && argc == 1) { buf_printf(b, "sp_lcm(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ")"); }
       else if (!strcmp(name, "magnitude") && argc == 0) buf_printf(b, "((%s) < 0 ? -(%s) : (%s))", r, r, r);
       else if (!strcmp(name, "modulo") && argc == 1) { buf_printf(b, "sp_imod(%s, ", r); emit_int_divisor(c, argv[0], b); buf_puts(b, ")"); }
-      else if (!strcmp(name, "remainder") && argc == 1) { buf_printf(b, "((%s) %% (", r); emit_expr(c, argv[0], b); buf_puts(b, "))"); }
+      else if (!strcmp(name, "remainder") && argc == 1) { buf_printf(b, "sp_iremainder(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ")"); }
       else if (!strcmp(name, "size") && argc == 0) buf_puts(b, "((mrb_int)sizeof(mrb_int))");
       else if (!strcmp(name, "gcdlcm") && argc == 1) {
         int ta = ++g_tmp, o = ++g_tmp;
@@ -2648,15 +2648,15 @@ static int emit_scalar_call(Compiler *c, int id, Buf *b) {
       }
       else if (!strcmp(name, "digits") && argc == 0) buf_printf(b, "sp_int_digits(%s, 10)", r);
       else if (!strcmp(name, "digits") && argc == 1) { buf_printf(b, "sp_int_digits(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ")"); }
-      else if (!strcmp(name, "allbits?") && argc == 1) { buf_printf(b, "(((%s) & (", r); emit_expr(c, argv[0], b); buf_printf(b, ")) == ("); emit_expr(c, argv[0], b); buf_puts(b, "))"); }
-      else if (!strcmp(name, "anybits?") && argc == 1) { buf_printf(b, "(((%s) & (", r); emit_expr(c, argv[0], b); buf_puts(b, ")) != 0)"); }
-      else if (!strcmp(name, "nobits?") && argc == 1) { buf_printf(b, "(((%s) & (", r); emit_expr(c, argv[0], b); buf_puts(b, ")) == 0)"); }
-      else if (!strcmp(name, "ceildiv") && argc == 1) { buf_printf(b, "sp_ceildiv(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
-      else if (!strcmp(name, "pow") && argc == 2) { buf_printf(b, "sp_powmod(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ", "); emit_expr(c, argv[1], b); buf_puts(b, ")"); }
-      else if (!strcmp(name, "pow") && argc == 1) { buf_printf(b, "sp_int_pow(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+      else if (!strcmp(name, "allbits?") && argc == 1) { int t = ++g_tmp; buf_printf(b, "({ mrb_int _t%d = ", t); emit_int_expr(c, argv[0], b); buf_printf(b, "; (((%s) & _t%d) == _t%d); })", r, t, t); }
+      else if (!strcmp(name, "anybits?") && argc == 1) { buf_printf(b, "(((%s) & (", r); emit_int_expr(c, argv[0], b); buf_puts(b, ")) != 0)"); }
+      else if (!strcmp(name, "nobits?") && argc == 1) { buf_printf(b, "(((%s) & (", r); emit_int_expr(c, argv[0], b); buf_puts(b, ")) == 0)"); }
+      else if (!strcmp(name, "ceildiv") && argc == 1) { buf_printf(b, "sp_ceildiv(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ")"); }
+      else if (!strcmp(name, "pow") && argc == 2) { buf_printf(b, "sp_powmod(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ", "); emit_int_expr(c, argv[1], b); buf_puts(b, ")"); }
+      else if (!strcmp(name, "pow") && argc == 1) { buf_printf(b, "sp_int_pow(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ")"); }
       else if (!strcmp(name, "pred") && argc == 0) buf_printf(b, "((%s) - 1)", r);
       else if ((!strcmp(name, "succ") || !strcmp(name, "next")) && argc == 0) buf_printf(b, "((%s) + 1)", r);
-      else if (!strcmp(name, "to_s") && argc == 1) { buf_printf(b, "sp_int_to_s_base(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+      else if (!strcmp(name, "to_s") && argc == 1) { buf_printf(b, "sp_int_to_s_base(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ")"); }
       else if (!strcmp(name, "coerce") && argc == 1) {
         TyKind a0 = comp_ntype(c, argv[0]);
         if (a0 == TY_FLOAT) {

--- a/test/integer_poly_arg_methods.rb
+++ b/test/integer_poly_arg_methods.rb
@@ -1,0 +1,31 @@
+# Integer methods whose argument the runtime takes as an mrb_int must unbox a
+# polymorphic argument (here an element of a mixed array, poly-typed but an
+# integer at runtime) rather than emitting it as a raw boxed value.
+mix = [6, "x"]
+b = mix.first
+
+p 255.allbits?(b)
+p 255.anybits?(b)
+p 256.nobits?(b)
+p 100.ceildiv(b)
+p 2.pow(b)
+p 2.pow(b, 100)
+p 255.to_s(b)
+p 12.gcd(b)
+p 4.lcm(b)
+p 17.remainder(b)
+
+# remainder by zero raises ZeroDivisionError (not a SIGFPE crash)
+z = [0, "x"].first
+begin
+  p 17.remainder(z)
+rescue ZeroDivisionError => e
+  puts "ZeroDivisionError: #{e.message}"
+end
+
+# allbits? evaluates its argument exactly once (the side effect prints once)
+def bit
+  puts "bit evaluated"
+  6
+end
+p 255.allbits?(bit)

--- a/test/integer_poly_arg_methods.rb.expected
+++ b/test/integer_poly_arg_methods.rb.expected
@@ -1,0 +1,13 @@
+true
+true
+true
+17
+64
+64
+"1103"
+6
+12
+5
+ZeroDivisionError: divided by 0
+bit evaluated
+true


### PR DESCRIPTION
## Summary

Nine `Integer` methods emit an `mrb_int`-typed argument through `emit_expr`, which renders a `TY_POLY` value as its raw `sp_RbVal` struct. When the argument is polymorphic (e.g. an element drawn from a mixed array), the generated C passes that struct where the runtime — or a bare C operator like `&` / `%` — expects an `mrb_int`, so it fails to compile.

Route those arguments through `emit_int_expr` (unbox a poly value to `mrb_int`, pass a typed int through unchanged):

* `allbits?` / `anybits?` / `nobits?`
* `ceildiv`
* `pow` (both the one- and two-argument forms)
* `to_s(base)`
* `gcd` / `lcm` / `remainder`

For example `255.allbits?(b)` where `b` is poly now emits `((255LL) & sp_poly_to_i(lv_b)) == sp_poly_to_i(lv_b)` instead of `&`-ing a struct.

## Context

The `digits(base)` case from this same family already landed upstream as the narrower matz/spinel#1539 (merge `1b4ba85`), so `digits` is fixed in master and is not part of this diff. This PR completes the sibling methods that share the bug.

## Testing

`test/integer_poly_arg_methods.rb` exercises each method with a polymorphic argument (an element of a mixed array, poly-typed but an integer at runtime, routed through a local so it is not constant-folded). The generated C unboxes via `sp_poly_to_i`. Expected regenerated from `ruby`.

## Two faithfulness fixes on the touched arms

* `remainder` lowered to a bare C `%`, which is a SIGFPE on a zero divisor. Added `sp_iremainder` — a truncated remainder that raises `ZeroDivisionError` on zero, mirroring the sibling `sp_imod`/`sp_idiv` helpers used by `modulo`/`div`.
* `allbits?` emitted its argument twice (`(x & arg) == arg`), double-evaluating a side-effecting argument. It now evaluates the argument once into a temp.

The test covers `remainder(0)` raising `ZeroDivisionError` and an `allbits?` argument that prints (proving single evaluation).