### PR TITLE
Add Hash#sum, #count, #all?, #any? block forms

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -2193,6 +2193,10 @@ else {
       return TY_POLY_ARRAY;   /* the winning [k, v] pair, or nil */
     if (nt_ref(nt, id, "block") >= 0 && !strcmp(name, "sort_by"))
       return TY_POLY_ARRAY;   /* [k, v] pairs ordered by the block value */
+    if (nt_ref(nt, id, "block") >= 0 && (!strcmp(name, "all?") || !strcmp(name, "any?")))
+      return TY_BOOL;
+    if (nt_ref(nt, id, "block") >= 0 && !strcmp(name, "sum"))
+      return TY_POLY;   /* boxed accumulation via sp_poly_add */
     {
       if (block >= 0 && (ty_iter_shape(name) == TY_ITER_MAP)) {
         int body = nt_ref(nt, block, "body");

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -1954,7 +1954,8 @@ else {
         buf_puts(b, "; })");
         return 1;
       }
-      if ((!strcmp(name, "length") || !strcmp(name, "size") || !strcmp(name, "count")) && argc == 0) {
+      if ((!strcmp(name, "length") || !strcmp(name, "size") ||
+           (!strcmp(name, "count") && nt_ref(nt, id, "block") < 0)) && argc == 0) {
         buf_printf(b, "sp_%sHash_length(", hn); emit_expr(c, recv, b); buf_puts(b, ")");
         return 1;
       }

--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -386,6 +386,85 @@ int emit_hash_sort_by_expr(Compiler *c, int id, Buf *b) {
   return 1;
 }
 
+/* hash.sum(init) / count / all? / any? { |k, v| ... } -> a scalar reduction.
+   sum accumulates the block value (boxed, via sp_poly_add); count tallies truthy
+   results; all?/any? short-circuit to a boolean. */
+int emit_hash_reduce_scalar_expr(Compiler *c, int id, Buf *b) {
+  const NodeTable *nt = c->nt;
+  int block = nt_ref(nt, id, "block");
+  if (block < 0) return 0;
+  const char *name = nt_str(nt, id, "name");
+  int is_sum = !strcmp(name, "sum"), is_count = !strcmp(name, "count");
+  int is_all = !strcmp(name, "all?"), is_any = !strcmp(name, "any?");
+  if (!is_sum && !is_count && !is_all && !is_any) return 0;
+  int argc = 0; { int ar = nt_ref(nt, id, "arguments"); if (ar >= 0) nt_arr(nt, ar, "arguments", &argc); }
+  if (is_sum ? argc > 1 : argc != 0) return 0;
+  int recv = nt_ref(nt, id, "receiver");
+  TyKind rt = comp_ntype(c, recv);
+  const char *hn = ty_hash_cname(rt);
+  if (!hn) return 0;
+  int body = nt_ref(nt, block, "body");
+  int bn = 0; if (body >= 0) nt_arr(nt, body, "body", &bn);
+  if (bn < 1) return 0;
+
+  int sum_init = -1;
+  if (is_sum && argc == 1) {
+    int ar = nt_ref(nt, id, "arguments"); int an = 0;
+    const int *aa = ar >= 0 ? nt_arr(nt, ar, "arguments", &an) : NULL;
+    if (aa && an >= 1) sum_init = aa[0];
+  }
+
+  int trecv = ++g_tmp, tacc = ++g_tmp, ti = ++g_tmp;
+  { Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);
+    emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
+    buf_printf(g_pre, " _t%d = ", trecv); buf_puts(g_pre, rb.p ? rb.p : ""); buf_puts(g_pre, ";\n"); free(rb.p); }
+  emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", trecv);
+  emit_indent(g_pre, g_indent);
+  if (is_sum) {
+    buf_printf(g_pre, "sp_RbVal _t%d = ", tacc);
+    if (sum_init >= 0) emit_boxed(c, sum_init, g_pre);
+    else buf_puts(g_pre, "sp_box_int(0)");
+    buf_puts(g_pre, ";\n");
+    emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT_RBVAL(_t%d);\n", tacc);
+  }
+  else if (is_count)
+    buf_printf(g_pre, "mrb_int _t%d = 0;\n", tacc);
+  else
+    buf_printf(g_pre, "mrb_bool _t%d = %s;\n", tacc, is_all ? "TRUE" : "FALSE");
+
+  emit_indent(g_pre, g_indent);
+  buf_printf(g_pre, "for (mrb_int _t%d = 0; _t%d < _t%d->len; _t%d++) {\n", ti, ti, trecv, ti);
+  TyKind bret;
+  char *vb = emit_hash_block_eval(c, block, rt, hn, trecv, ti, 0, &bret);
+  if (is_sum) {
+    emit_indent(g_pre, g_indent + 1);
+    buf_printf(g_pre, "_t%d = sp_poly_add(_t%d, ", tacc, tacc);
+    if (bret == TY_POLY) buf_puts(g_pre, vb ? vb : "sp_box_nil()");
+    else { Buf bx; memset(&bx, 0, sizeof bx); emit_boxed_text(c, bret, vb ? vb : "", &bx);
+           buf_puts(g_pre, bx.p ? bx.p : "sp_box_nil()"); free(bx.p); }
+    buf_puts(g_pre, ");\n");
+  }
+  else {
+    /* truthiness of the block result, formatted into a dynamic Buf so a long
+       boxed expression can never be silently truncated */
+    Buf cond; memset(&cond, 0, sizeof cond);
+    if (bret == TY_BOOL) buf_printf(&cond, "(%s)", vb ? vb : "0");
+    else if (bret == TY_POLY) buf_printf(&cond, "sp_poly_truthy(%s)", vb ? vb : "sp_box_nil()");
+    else { Buf bx; memset(&bx, 0, sizeof bx); emit_boxed_text(c, bret, vb ? vb : "", &bx);
+           buf_printf(&cond, "sp_poly_truthy(%s)", bx.p ? bx.p : "sp_box_nil()"); free(bx.p); }
+    const char *cs = cond.p ? cond.p : "0";
+    emit_indent(g_pre, g_indent + 1);
+    if (is_count) buf_printf(g_pre, "if (%s) _t%d++;\n", cs, tacc);
+    else if (is_all) buf_printf(g_pre, "if (!(%s)) { _t%d = FALSE; break; }\n", cs, tacc);
+    else buf_printf(g_pre, "if (%s) { _t%d = TRUE; break; }\n", cs, tacc);
+    free(cond.p);
+  }
+  free(vb);
+  emit_indent(g_pre, g_indent); buf_puts(g_pre, "}\n");
+  buf_printf(b, "_t%d", tacc);
+  return 1;
+}
+
 /* Recursively patch c->ntype[id]=ty for every LocalVariableReadNode named nm
    within the subtree at id. Saved old values in ids_out/ty_out (max cap).
    Returns count of patched nodes. */
@@ -2513,6 +2592,7 @@ int emit_collect_expr(Compiler *c, int id, Buf *b) {
     if (emit_hash_collect_expr(c, id, b)) return 1;
     if (emit_hash_reduce_search_expr(c, id, b)) return 1;
     if (emit_hash_sort_by_expr(c, id, b)) return 1;
+    if (emit_hash_reduce_scalar_expr(c, id, b)) return 1;
     return 0;
   }
   int range_recv = (rt == TY_RANGE);

--- a/test/hash_reduce_predicate.rb
+++ b/test/hash_reduce_predicate.rb
@@ -1,0 +1,24 @@
+# Hash#sum / #count / #all? / #any? with a block reduce the entries to a scalar:
+# sum accumulates the block value, count tallies truthy results, all?/any?
+# short-circuit to a boolean. Helpers are monomorphic so the runtime walk is
+# exercised without widening the parameter to poly.
+
+def sum_v(h)     = h.sum { |k, v| v }
+def sum_init(h)  = h.sum(10) { |k, v| v }
+def sum_float(h) = h.sum { |k, v| v * 1.0 }
+def count_gt(h)  = h.count { |k, v| v > 1 }
+def count_key(h) = h.count { |k, v| k == :a }
+def all_pos(h)   = h.all? { |k, v| v > 0 }
+def all_big(h)   = h.all? { |k, v| v > 1 }
+def any_big(h)   = h.any? { |k, v| v > 2 }
+def any_mid(h)   = h.any? { |k, v| v > 1 }
+
+p sum_v({ a: 1, b: 2, c: 3 })
+p sum_init({ a: 1, b: 2 })
+p sum_float({ a: 1, b: 2 })
+p count_gt({ a: 1, b: 2, c: 3 })
+p count_key({ a: 1, b: 2 })
+p all_pos({ a: 1, b: 2 })
+p all_big({ a: 1, b: 2 })
+p any_big({ a: 1, b: 2 })
+p any_mid({ a: 1, b: 2 })

--- a/test/hash_reduce_predicate.rb.expected
+++ b/test/hash_reduce_predicate.rb.expected
@@ -1,0 +1,9 @@
+6
+13
+3.0
+2
+1
+true
+false
+false
+true


### PR DESCRIPTION
Implements the block forms of `Hash#sum`, `#count`, `#all?`, and `#any?`. The first three were unsupported on a hash, and `count { ... }` silently returned the entry count because the `size` arm ignored the block.

## What

* `emit_hash_reduce_scalar_expr` walks the entries through the shared `emit_hash_block_eval` binder and folds them:
  * `sum` accumulates the block value with `sp_poly_add`, seeded by the optional argument (default `0`).
  * `count` tallies truthy block results.
  * `all?` / `any?` short-circuit (`break`) to a boolean.
* The hash `count`/`size`/`length` arm now defers to this path when a block is present, fixing the silent-wrong `count { ... }`.
* Inference: `all?`/`any?` → boolean, `sum` → poly (boxed accumulation), `count` stays an integer.

## Testing

* New `test/hash_reduce_predicate.rb` covers `sum` (default and explicit seed, integer and float blocks), `count` by value and by key, and `all?`/`any?` true and false outcomes. Expected generated from real `ruby`.
* Generated C is ASAN-clean.

