### PR TITLE
driver: link -lm after libspinel_rt.a, not before

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -421,8 +421,11 @@ int main(int argc, char **argv) {
   snprintf(tmp, sizeof tmp, "-I\"%s\" -I\"%s%cregexp\" ", lib_dir, lib_dir, PATH_SEP); s_add(&cmd, tmp);
   if (ffi_cflags.p) s_add(&cmd, ffi_cflags.p);
   s_add_arg(&cmd, c_path);
-  s_add(&cmd, "-lm ");
   snprintf(tmp, sizeof tmp, "\"%s%clibspinel_rt.a\" ", lib_dir, PATH_SEP); s_add(&cmd, tmp);
+  /* -lm AFTER the archive: ld processes inputs left to right and (with the
+     GNU default --as-needed) drops a DSO no preceding input references.
+     sp_format.o pulls in sqrt/sin/cos, so libm must follow libspinel_rt.a. */
+  s_add(&cmd, "-lm ");
   s_add(&cmd, ov_define); s_add(&cmd, " ");
   if (want_g) s_add(&cmd, "-g ");
 #if !defined(__APPLE__)


### PR DESCRIPTION
## Problem

The AOT driver puts `-lm` **before** `libspinel_rt.a` on the `cc` line (`src/main.c`):

```c
s_add_arg(&cmd, c_path);
s_add(&cmd, "-lm ");                 // ← before the archive
... "libspinel_rt.a" ...
```

`ld` processes inputs left to right and, with the GNU default `--as-needed`, drops any DSO that no *preceding* input references. Nothing before the archive uses libm, so `-lm` is pruned; the archive then introduces the reference too late:

```
ld: libspinel_rt.a(sp_format.o): undefined reference to symbol 'sincos@@GLIBC_2.2.5'
ld: /lib/x86_64-linux-gnu/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
spinel: C compilation failed
```

## Why it surfaced now

`-lm` (in this position) has been there since 859364d4, but was harmless because nothing pulled into user programs touched libm. Then **1d089a69** ("move Complex/Rational arithmetic and Time#inspect to lib/sp_format.c") gave `sp_format.c` `sqrt`/`sin`/`cos`. `sp_format.o` is pulled out of the static archive by any program that inspects a value or a `Time`, so ordinary programs now fail to link on GNU/Linux.

spinel's own binary is unaffected — its Makefile already lists `-lm` last.

## Fix

Emit `-lm` **after** `libspinel_rt.a`, following the standard objects-then-libraries ordering rule.

- No-op on macOS (libm resolves from libSystem regardless of order).
- Restores linking on GNU/Linux (`--as-needed` keeps the DSO because the preceding archive references it).

Verified locally: `make all` rebuilds (AOT-compiles its own `doctor`/`reduce`/`flatten` tools through the new link path), and a program exercising `sp_format.o` links and runs:

```ruby
puts Complex(3, 4).abs          # 5.0   (sp_complex_abs -> sqrt)
puts Complex(3, 4).inspect      # (3+4i)
puts Time.at(0).inspect         # 1969-12-31 19:00:00 -0500
```