### PR TITLE
runtime: drop the vestigial <ucontext.h> include that breaks Darwin

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -46,7 +46,6 @@ static const char *sp_bt_srcfile = ""; /* toplevel .rb path, set by debug main()
 static void *sp_bt_buf[256];       /* frames captured at the last raise */
 static int sp_bt_n = 0;
 #endif
-#include <ucontext.h>
 #include <unistd.h>
 #include <sys/mman.h>
 #include <sys/wait.h>


### PR DESCRIPTION
sp_runtime.h unconditionally included <ucontext.h>, but nothing in it or the generated translation unit references ucontext_t: the portable asm context switch made the fiber context self-contained, and sp_fiber_ctx.h includes <ucontext.h> itself only on its non-asm fallback path. When the Darwin _XOPEN_SOURCE gate around this area was dropped, the stale include was left exposed -- and on macOS <ucontext.h> is a hard #error unless _XOPEN_SOURCE is defined, so every generated program (and the test harness) failed to compile on Darwin. Remove the unused include; the fallback path keeps its own.