### PR TITLE
codegen: accept fail as a raise alias

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -5425,7 +5425,8 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
   }
 
   /* raise */
-  if (recv < 0 && sp_streq(name, "raise")) {
+  /* `fail` is an exact alias of `Kernel#raise`. */
+  if (recv < 0 && (sp_streq(name, "raise") || sp_streq(name, "fail"))) {
     int args = nt_ref(nt, id, "arguments");
     int ac = 0; const int *av = args >= 0 ? nt_arr(nt, args, "arguments", &ac) : NULL;
     if (ac == 0) {

--- a/test/kernel_fail_alias.rb
+++ b/test/kernel_fail_alias.rb
@@ -1,0 +1,43 @@
+# Kernel#fail is an exact alias of Kernel#raise: a bare message raises a
+# RuntimeError, an explicit class + message raises that class, and a bare `fail`
+# inside a rescue re-raises the current exception.
+
+# message form -> RuntimeError
+begin
+  fail "boom"
+rescue => e
+  puts "#{e.class}: #{e.message}"   # RuntimeError: boom
+end
+
+# explicit class + message
+class MyError < StandardError; end
+begin
+  fail MyError, "bad input"
+rescue => e
+  puts "#{e.class}: #{e.message}"   # MyError: bad input
+end
+
+# explicit class only -> default message is the class name
+begin
+  fail MyError
+rescue => e
+  puts "#{e.class}: #{e.message}"   # MyError: MyError
+end
+
+# bare `fail` inside a rescue re-raises the current exception
+begin
+  begin
+    raise "original"
+  rescue
+    fail
+  end
+rescue => e
+  puts "#{e.class}: #{e.message}"   # RuntimeError: original
+end
+
+# raise still works alongside fail (regression)
+begin
+  raise ArgumentError, "still works"
+rescue => e
+  puts "#{e.class}: #{e.message}"   # ArgumentError: still works
+end

--- a/test/kernel_fail_alias.rb.expected
+++ b/test/kernel_fail_alias.rb.expected
@@ -1,0 +1,5 @@
+RuntimeError: boom
+MyError: bad input
+MyError: MyError
+RuntimeError: original
+ArgumentError: still works


### PR DESCRIPTION
`Kernel#fail` is an exact alias of `Kernel#raise`, but the receiverless raise
emitter only matched the name `raise`, so `fail "boom"` was rejected as an
unsupported call. The guard now also accepts `fail`, reusing the same emission:
a message form raises `RuntimeError`, an explicit class/message raises that
class, and a bare `fail` inside a rescue re-raises the current exception.

Tests cover the message form, an explicit class + message, a class-only default
message, a bare re-raise inside rescue, and a `raise` regression, asserting the
exact exception class and message with `.expected` generated from ruby. Full
suite green.