### PR TITLE
analyze,codegen: support Symbol#casecmp and Symbol#casecmp?

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -2101,6 +2101,8 @@ else {
     if ((sp_streq(name, "[]") || sp_streq(name, "slice")) && (argc == 1 || argc == 2)) return TY_STRING;
     if ((sp_streq(name, "start_with?") || sp_streq(name, "end_with?") || sp_streq(name, "match?")) && argc == 1)
       return TY_BOOL;
+    if (sp_streq(name, "casecmp") && argc == 1) return TY_INT;
+    if (sp_streq(name, "casecmp?") && argc == 1) return TY_BOOL;
   }
 
   /* range receiver methods */

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -9762,6 +9762,17 @@ else {
       buf_puts(b, name[0] == '=' ? ")" : "))");
       return;
     }
+    /* case-insensitive compare over the symbols' names; a symbol argument only
+       (a non-symbol arg yields nil in Ruby and is left to the unsupported path) */
+    if ((sp_streq(name, "casecmp") || sp_streq(name, "casecmp?")) && argc == 1 &&
+        comp_ntype(c, argv[0]) == TY_SYMBOL) {
+      int q = sp_streq(name, "casecmp?");
+      if (q) buf_puts(b, "(");
+      buf_puts(b, "sp_str_casecmp(sp_sym_to_s("); emit_expr(c, recv, b);
+      buf_puts(b, "), sp_sym_to_s("); emit_expr(c, argv[0], b); buf_puts(b, "))");
+      if (q) buf_puts(b, " == 0)");
+      return;
+    }
     /* string-surface methods over the symbol's name; succ re-interns a symbol,
        index/slice yield a substring (or nil), the predicates yield a bool. */
     if (sp_streq(name, "succ") || sp_streq(name, "next")) {

--- a/test/symbol_casecmp.rb
+++ b/test/symbol_casecmp.rb
@@ -1,0 +1,27 @@
+# Symbol#casecmp and Symbol#casecmp? compare two symbols' names case-folded.
+# casecmp returns -1/0/1 (like <=>); casecmp? returns a boolean.
+# (String#casecmp/casecmp? already work; a couple are kept here as a guard.)
+def sy(x); x; end   # symbol receiver
+def st(x); x; end   # string receiver
+
+# casecmp orders case-insensitively
+p sy(:Foo).casecmp(:foo)      # 0
+p sy(:abc).casecmp(:abd)      # -1
+p sy(:b).casecmp(:A)          # 1  (case-folded: 'b' > 'a')
+p sy(:Foo).casecmp(:foobar)   # -1 (prefix is shorter)
+
+# casecmp? is the boolean case-insensitive equality
+p sy(:Foo).casecmp?(:foo)     # true
+p sy(:Foo).casecmp?(:FOO)     # true
+p sy(:Foo).casecmp?(:bar)     # false
+
+# literal-receiver forms
+p :HELLO.casecmp(:hello)      # 0
+p :HELLO.casecmp?(:world)     # false
+
+# usable directly in a condition
+puts(sy(:Yes).casecmp?(:yes) ? "match" : "no")   # match
+
+# String#casecmp / casecmp? remain correct
+p st("Foo").casecmp("FOO")    # 0
+p st("Foo").casecmp?("foo")   # true

--- a/test/symbol_casecmp.rb.expected
+++ b/test/symbol_casecmp.rb.expected
@@ -1,0 +1,12 @@
+0
+-1
+1
+-1
+true
+true
+false
+0
+false
+match
+0
+true


### PR DESCRIPTION
`Symbol#casecmp` and `Symbol#casecmp?` were unsupported, even though the String
forms already work. They compare two symbols' names case-insensitively:
`casecmp` returns `-1`/`0`/`1` like `<=>`, `casecmp?` returns a boolean.

Both reuse the existing `sp_str_casecmp` runtime helper over the symbols' names
(`sp_sym_to_s`). Inference types `casecmp` as an integer and `casecmp?` as a
boolean. A non-symbol argument (which yields `nil` in Ruby) is left to the
unsupported path rather than answering a wrong value.

Tests cover equal/less/greater ordering, casecmp? true/false, prefix handling,
literal receivers, use in a condition, and unchanged String#casecmp/casecmp?,
with `.expected` generated from ruby. Full suite green.