### PR TITLE
codegen: accept Range index for Symbol string methods, guard arg types

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -9768,7 +9768,25 @@ else {
       buf_puts(b, "sp_sym_intern(sp_str_succ(sp_sym_to_s("); emit_expr(c, recv, b); buf_puts(b, ")))");
       return;
     }
-    if ((sp_streq(name, "[]") || sp_streq(name, "slice")) && argc == 1) {
+    if ((sp_streq(name, "[]") || sp_streq(name, "slice")) && argc == 1 &&
+        nt_type(c->nt, argv[0]) && sp_streq(nt_type(c->nt, argv[0]), "RangeNode")) {
+      /* :s[a..b] / :s[a...b] over the name; a beginless/endless bound is 0 /
+         the name length. The name is materialized once to avoid re-evaluating
+         the receiver for an endless range. */
+      int rn = argv[0];
+      int excl = (int)(nt_int(c->nt, rn, "flags", 0) & 4) ? 1 : 0;
+      int lo = nt_ref(c->nt, rn, "left"), hi = nt_ref(c->nt, rn, "right");
+      int t = ++g_tmp;
+      buf_printf(b, "({ const char *_t%d = sp_sym_to_s(", t); emit_expr(c, recv, b);
+      buf_printf(b, "); sp_str_sub_range_r(_t%d, ", t);
+      if (lo >= 0) emit_int_expr(c, lo, b); else buf_puts(b, "0");
+      buf_puts(b, ", ");
+      if (hi >= 0) { emit_int_expr(c, hi, b); buf_printf(b, ", %d); })", excl); }
+      else buf_printf(b, "(mrb_int)sp_str_length(_t%d), 0); })", t);
+      return;
+    }
+    if ((sp_streq(name, "[]") || sp_streq(name, "slice")) && argc == 1 &&
+        (comp_ntype(c, argv[0]) == TY_INT || comp_ntype(c, argv[0]) == TY_POLY)) {
       buf_puts(b, "sp_str_char_at_or_nil(sp_sym_to_s("); emit_expr(c, recv, b); buf_puts(b, "), ");
       emit_int_expr(c, argv[0], b); buf_puts(b, ")");
       return;
@@ -9778,7 +9796,8 @@ else {
       emit_int_expr(c, argv[0], b); buf_puts(b, ", "); emit_int_expr(c, argv[1], b); buf_puts(b, ")");
       return;
     }
-    if ((sp_streq(name, "start_with?") || sp_streq(name, "end_with?")) && argc == 1) {
+    if ((sp_streq(name, "start_with?") || sp_streq(name, "end_with?")) && argc == 1 &&
+        (comp_ntype(c, argv[0]) == TY_STRING || comp_ntype(c, argv[0]) == TY_POLY)) {
       buf_printf(b, "sp_str_%s(sp_sym_to_s(", sp_streq(name, "start_with?") ? "start_with" : "end_with");
       emit_expr(c, recv, b); buf_puts(b, "), "); emit_str_expr(c, argv[0], b); buf_puts(b, ")");
       return;

--- a/test/symbol_string_methods.rb
+++ b/test/symbol_string_methods.rb
@@ -7,6 +7,10 @@ def wrap(x); x; end
 p wrap(:hello)[1]
 p wrap(:hello)[1, 3]
 p wrap(:hello)[10]
+# a Range index yields a substring (inclusive, exclusive, and endless forms)
+p wrap(:hello)[1..3]
+p wrap(:hello)[1...3]
+p wrap(:hello)[2..]
 p wrap(:abc).succ
 p wrap(:az).succ
 p wrap(:hello).start_with?("he")

--- a/test/symbol_string_methods.rb.expected
+++ b/test/symbol_string_methods.rb.expected
@@ -1,6 +1,9 @@
 "e"
 "ell"
 nil
+"ell"
+"el"
+"llo"
 :abd
 :ba
 true


### PR DESCRIPTION
Follow-up to the symbol string-surface methods.

`Symbol#[]` / `#slice` now accept a Range, lowering `:s[a..b]` (inclusive,
exclusive, or endless) to a substring over the name. The name is
materialized once so an endless range does not re-evaluate the receiver.
The integer-index arm is gated to an integer argument.

`start_with?` / `end_with?` are gated to a String argument, so a
non-string argument (for example a Symbol, which CRuby answers with a
TypeError rather than a coercion) is a clean compile-time rejection
instead of feeding a non-string to the string emitter.

Tests add the inclusive / exclusive / endless Range forms to the existing
symbol string-methods coverage, with `.expected` generated from ruby.
Full suite green.