### PR TITLE
analyze,codegen: support Exception#detailed_message

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -1992,7 +1992,8 @@ else {
   if (recv >= 0 && exc_shaped) {
     if (sp_streq(name, "message") || sp_streq(name, "to_s") ||
         sp_streq(name, "to_str") || sp_streq(name, "inspect") ||
-        sp_streq(name, "full_message") || sp_streq(name, "class")) return TY_STRING;
+        sp_streq(name, "full_message") || sp_streq(name, "detailed_message") ||
+        sp_streq(name, "class")) return TY_STRING;
     if (sp_streq(name, "backtrace")) return TY_STR_ARRAY;  /* empty: no frames captured */
   }
 

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -5500,6 +5500,16 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       buf_printf(b, "sp_sprintf(\"%%s: %%s\", sp_exc_class_name(_t%d), sp_exc_message(_t%d))", t, t);
       return;
     }
+    /* detailed_message -> "message (ClassName)" (kwargs like highlight: ignored) */
+    if (sp_streq(name, "detailed_message")) {
+      int t = ++g_tmp;
+      Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);
+      emit_indent(g_pre, g_indent);
+      buf_printf(g_pre, "sp_Exception *_t%d = ", t);
+      buf_puts(g_pre, rb.p ? rb.p : ""); buf_puts(g_pre, ";\n"); free(rb.p);
+      buf_printf(b, "sp_sprintf(\"%%s (%%s)\", sp_exc_message(_t%d), sp_exc_class_name(_t%d))", t, t);
+      return;
+    }
     if (sp_streq(name, "inspect")) {
       /* #<ClassName: message> */
       int t = ++g_tmp;

--- a/test/exception_detailed_message.rb
+++ b/test/exception_detailed_message.rb
@@ -1,0 +1,39 @@
+# Exception#detailed_message returns "message (ClassName)". (The core method;
+# the optional error_highlight gem's source-snippet augmentation, which applies
+# to a few argument-style errors, is a separate concern and not reproduced.)
+
+# a RuntimeError carrying a message
+begin
+  raise "boom"
+rescue => e
+  p e.detailed_message            # "boom (RuntimeError)"
+end
+
+# an explicit class with a message
+begin
+  raise StandardError, "bad state"
+rescue => e
+  p e.detailed_message            # "bad state (StandardError)"
+end
+
+# no message -> the class name is used as the message
+begin
+  raise RuntimeError
+rescue => e
+  p e.detailed_message            # "RuntimeError (RuntimeError)"
+end
+
+# a user-defined exception subclass
+class MyError < StandardError; end
+begin
+  raise MyError, "oops"
+rescue => e
+  p e.detailed_message            # "oops (MyError)"
+end
+
+# message and detailed_message side by side
+begin
+  raise "x"
+rescue => e
+  p [e.message, e.detailed_message]   # ["x", "x (RuntimeError)"]
+end

--- a/test/exception_detailed_message.rb.expected
+++ b/test/exception_detailed_message.rb.expected
@@ -1,0 +1,5 @@
+"boom (RuntimeError)"
+"bad state (StandardError)"
+"RuntimeError (RuntimeError)"
+"oops (MyError)"
+["x", "x (RuntimeError)"]


### PR DESCRIPTION
`Exception#detailed_message` was unsupported. It returns the exception's message
followed by its class in parentheses — `"message (ClassName)"` — the same shape
the existing `full_message` emitter uses, with a different format string.

Inference types it as a string. The optional `error_highlight` source-snippet
augmentation that MRI layers on a few argument-style errors is a separate gem
concern and not reproduced; this is the core `Exception#detailed_message`.

`Exception#cause` is left for a follow-up: it needs a currently-handled-exception
global threaded through the raise and rescue paths plus a `cause` field on the
exception struct, which the runtime does not yet have.

Tests cover a RuntimeError message, an explicit class with a message, the
no-message default, a user-defined subclass, and message/detailed_message side
by side, with `.expected` generated from ruby. Full suite green.