### PR TITLE
analyze,codegen: evaluate while/until in value position to nil

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -2749,6 +2749,9 @@ TyKind infer_uncached(Compiler *c, int id) {
   if (nk == NK_TrueNode)                return TY_BOOL;
   if (nk == NK_FalseNode)               return TY_BOOL;
   if (nk == NK_NilNode)                 return TY_NIL;
+  /* A while/until loop in value position evaluates to nil (a valued `break`
+     is a separate gap); type it as poly so the slot holds a boxed nil. */
+  if (nk == NK_WhileNode || nk == NK_UntilNode) return TY_POLY;
   if (nk == NK_RangeNode) {
     /* infer the bounds so codegen can tell an int range from a string range */
     int lo = nt_ref(nt, id, "left"), hi = nt_ref(nt, id, "right");

--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -286,6 +286,38 @@ void emit_int_divisor(Compiler *c, int node, Buf *b) {
   emit_expr(c, node, b);
 }
 
+/* True if `root` contains a `break <value>` that binds to the enclosing loop
+   (not one inside a nested loop, block, lambda, or def/class/module scope, which
+   capture their own break — but a break in a block-bearing call's receiver or
+   arguments does bind to the loop, so those are still traversed). A valued break
+   makes the loop's value the break value rather than nil; detect it so a loop in
+   value position rejects instead of silently yielding nil. */
+static int loop_has_valued_break(Compiler *c, int root) {
+  if (root < 0) return 0;
+  const NodeTable *nt = c->nt;
+  const char *ty = nt_type(nt, root);
+  if (ty) {
+    if (sp_streq(ty, "BreakNode")) {
+      int a = nt_ref(nt, root, "arguments");
+      int an = 0;
+      if (a >= 0) nt_arr(nt, a, "arguments", &an);
+      return an > 0;
+    }
+    if (sp_streq(ty, "WhileNode") || sp_streq(ty, "UntilNode") || sp_streq(ty, "ForNode") ||
+        sp_streq(ty, "BlockNode") || sp_streq(ty, "LambdaNode") || sp_streq(ty, "DefNode") ||
+        sp_streq(ty, "ClassNode") || sp_streq(ty, "ModuleNode") || sp_streq(ty, "SingletonClassNode"))
+      return 0;
+  }
+  int nr = nt_num_refs(nt, root);
+  for (int i = 0; i < nr; i++) if (loop_has_valued_break(c, nt_ref_at(nt, root, i))) return 1;
+  int na = nt_num_arrs(nt, root);
+  for (int i = 0; i < na; i++) {
+    int n = 0; const int *el = nt_arr_at(nt, root, i, &n);
+    for (int j = 0; j < n; j++) if (loop_has_valued_break(c, el[j])) return 1;
+  }
+  return 0;
+}
+
 void emit_expr(Compiler *c, int id, Buf *b) {
   const NodeTable *nt = c->nt;
   const char *ty = nt_type(nt, id);
@@ -578,6 +610,19 @@ void emit_expr(Compiler *c, int id, Buf *b) {
     else {
       buf_printf(b, "lv_%s", en);
     }
+    return;
+  }
+  if (sp_streq(ty, "WhileNode") || sp_streq(ty, "UntilNode")) {
+    /* A loop in value position runs for its side effects and evaluates to nil.
+       A valued `break` would instead make the loop yield that value; that is a
+       separate gap, so reject it here rather than silently producing nil. */
+    if (loop_has_valued_break(c, nt_ref(nt, id, "statements")))
+      unsupported(c, id, "valued break in loop used as a value");
+    /* Run the loop as a statement inside a GCC statement-expression, then
+       yield the boxed nil. */
+    buf_puts(b, "({ ");
+    emit_while(c, id, b, 0, sp_streq(ty, "UntilNode"));
+    buf_puts(b, "sp_box_nil(); })");
     return;
   }
   if (sp_streq(ty, "IndexOrWriteNode") || sp_streq(ty, "IndexAndWriteNode")) {

--- a/test/while_until_as_value.rb
+++ b/test/while_until_as_value.rb
@@ -1,0 +1,43 @@
+# A while/until loop used in value position evaluates to nil (CRuby semantics).
+# (A valued `break` would change this, but that is a separate gap and is
+# rejected at compile time rather than silently yielding nil.)
+
+# while as an assignment RHS
+i = 0
+r = while i < 3; i += 1; end
+p r                 # nil
+p i                 # 3 (the loop ran)
+
+# until in parentheses as an RHS
+done = false
+n = 0
+x = (until done; n += 1; done = n >= 2; end)
+p x                 # nil
+p n                 # 2
+
+# loop value embedded in an array literal
+j = 0
+a = [1, (while j < 2; j += 1; end), 2]
+p a                 # [1, nil, 2]
+
+# loop value passed as a method argument
+def f(v); v.inspect; end
+k = 0
+p f(while k < 1; k += 1; end)   # "nil"
+
+# post-test begin..end while, used as a value
+m = 0
+post = begin; m += 1; end while m < 3
+p [post, m]         # [nil, 3]
+
+# a plain (valueless) break still yields nil
+b = 0
+br = while b < 5; b += 1; break if b == 2; end
+p [br, b]           # [nil, 2]
+
+# while as the last expression of a method returns nil
+def loop_ret
+  c = 0
+  while c < 2; c += 1; end
+end
+p loop_ret          # nil

--- a/test/while_until_as_value.rb.expected
+++ b/test/while_until_as_value.rb.expected
@@ -1,0 +1,9 @@
+nil
+3
+nil
+2
+[1, nil, 2]
+"nil"
+[3, 3]
+[nil, 2]
+nil


### PR DESCRIPTION
A `while` or `until` loop used in value position — an assignment RHS, a method
argument, an array element, or a method's last expression — was rejected as
an unsupported expression, even though it compiled fine as a statement. In Ruby
such a loop evaluates to `nil`.

`emit_expr` now lowers a loop in value position to a statement-expression that
runs the loop and yields a boxed `nil`, and inference types the loop as poly so
the slot carries that nil. A valued `break` (`break 5`) would instead make the
loop yield the break value; that is a separate gap, so the loop-as-value path
detects a `break` that binds to this loop and rejects it rather than silently
producing `nil`. A plain valueless `break`, and a `break` that binds to a
nested loop or block, are unaffected.

Tests cover a loop as an assignment RHS, an `until` in parentheses, a loop
value inside an array literal, as a method argument, a post-test
`begin..end while`, a valueless `break`, and a loop as a method's last
expression, with `.expected` generated from ruby. Full suite green.