### PR TITLE
analyze,codegen: emit IO#write/puts/print for STDOUT/STDERR and $stdout/$stderr

### DIFF
--- a/lib/sp_io.c
+++ b/lib/sp_io.c
@@ -51,8 +51,23 @@ mrb_int sp_File_write(sp_File *f, const char *s) {
   return (mrb_int)fwrite(s, 1, n, f->fp);
 }
 
+sp_File *sp_io_stdout(void) {
+  static sp_File f = { NULL, "<STDOUT>", "w" };
+  if (!f.fp) f.fp = stdout;
+  return &f;
+}
+
+sp_File *sp_io_stderr(void) {
+  static sp_File f = { NULL, "<STDERR>", "w" };
+  if (!f.fp) f.fp = stderr;
+  return &f;
+}
+
 mrb_int sp_File_close(sp_File *f) {
-  if (f && f->fp) { fclose(f->fp); f->fp = NULL; }
+  /* never fclose the shared stdout/stderr handles (sp_io_stdout/sp_io_stderr):
+     closing the process's standard streams would corrupt the singleton and any
+     later write through it. Closing them is a no-op. */
+  if (f && f->fp && f->fp != stdout && f->fp != stderr) { fclose(f->fp); f->fp = NULL; }
   return 0;
 }
 

--- a/lib/sp_io.h
+++ b/lib/sp_io.h
@@ -28,6 +28,12 @@ void sp_File_print(sp_File *f, const char *s);
 mrb_int sp_File_flush(sp_File *f);
 mrb_bool sp_File_eof_p(sp_File *f);
 
+/* STDOUT / STDERR as shared IO handles wrapping the C stdout/stderr streams.
+   The handle is a function-local static (stdout/stderr are not constant
+   initializers) and is never closed. */
+sp_File *sp_io_stdout(void);
+sp_File *sp_io_stderr(void);
+
 /* File metadata predicates (libc/WinAPI only; defined in sp_io.c). */
 mrb_bool sp_file_directory(const char *path);
 mrb_bool sp_file_file(const char *path);

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -2636,10 +2636,12 @@ else {
 
   /* $stdout/$stderr.puts/print/write return nil (so a value-position use --
      an if/else arm or assignment -- unifies and boxes as nil). */
-  if (recv >= 0 && (sp_streq(name, "puts") || sp_streq(name, "print") || sp_streq(name, "write")) &&
+  if (recv >= 0 && (sp_streq(name, "puts") || sp_streq(name, "print") || sp_streq(name, "write") ||
+                    sp_streq(name, "syswrite")) &&
       nt_type(nt, recv) && sp_streq(nt_type(nt, recv), "GlobalVariableReadNode")) {
     const char *gv = nt_str(nt, recv, "name");
-    if (gv && (sp_streq(gv, "$stdout") || sp_streq(gv, "$stderr"))) return TY_NIL;
+    if (gv && (sp_streq(gv, "$stdout") || sp_streq(gv, "$stderr")))
+      return (sp_streq(name, "write") || sp_streq(name, "syswrite")) ? TY_INT : TY_NIL;
   }
 
   /* tap: run block, return self */
@@ -2857,6 +2859,9 @@ TyKind infer_uncached(Compiler *c, int id) {
                sp_streq(nm, "RUBY_REVISION") || sp_streq(nm, "RUBY_COPYRIGHT"))) return TY_STRING;
     if (nm && sp_streq(nm, "ARGV")) return TY_STR_ARRAY;
     if (nm && sp_streq(nm, "ARGF")) return TY_ARGF;
+    /* STDOUT/STDERR are IO handles wrapping the C stdout/stderr streams, so
+       puts/print/write/flush route through the existing TY_IO dispatch. */
+    if (nm && (sp_streq(nm, "STDOUT") || sp_streq(nm, "STDERR"))) return TY_IO;
     if (nm && comp_class_index(c, nm) >= 0) return TY_CLASS;
     if (nm && is_builtin_class_name(nm)) return TY_CLASS;
     return TY_UNKNOWN;

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -5079,17 +5079,27 @@ void emit_call(Compiler *c, int id, Buf *b) {
       buf_printf(b, "sp_File_readlines(%s)", r); free(rb.p); return;
     }
     if (sp_streq(name, "write") || sp_streq(name, "syswrite")) {
-      if (argc >= 1) { buf_printf(b, "sp_File_write(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+      if (argc >= 1) {
+        buf_printf(b, "sp_File_write(%s, ", r);
+        if (comp_ntype(c, argv[0]) == TY_STRING) emit_expr(c, argv[0], b);
+        else { buf_puts(b, "sp_poly_to_s("); emit_boxed(c, argv[0], b); buf_puts(b, ")"); }
+        buf_puts(b, ")");
+      }
       else buf_puts(b, "0");
       free(rb.p); return;
     }
     if (sp_streq(name, "print") || sp_streq(name, "puts")) {
-      /* emit as a statement-like expression: print each arg, return nil */
+      /* emit as a statement-like expression: print each arg, return nil.
+         Non-string args are stringified via sp_poly_to_s (sp_File_write wants
+         a char *), matching Kernel#puts/#print coercion. */
       int t = ++g_tmp;
       emit_indent(g_pre, g_indent);
       buf_puts(g_pre, "({ ");
       for (int k = 0; k < argc; k++) {
-        buf_printf(g_pre, "sp_File_write(%s, ", r); emit_expr(c, argv[k], g_pre); buf_puts(g_pre, "); ");
+        buf_printf(g_pre, "sp_File_write(%s, ", r);
+        if (comp_ntype(c, argv[k]) == TY_STRING) emit_expr(c, argv[k], g_pre);
+        else { buf_puts(g_pre, "sp_poly_to_s("); emit_boxed(c, argv[k], g_pre); buf_puts(g_pre, ")"); }
+        buf_puts(g_pre, "); ");
       }
       if (sp_streq(name, "puts")) buf_printf(g_pre, "sp_File_write(%s, \"\\n\"); ", r);
       buf_puts(g_pre, "});\n");
@@ -10023,6 +10033,18 @@ else {
         return;
       }
       if (sp_streq(name, "flush")) { buf_printf(b, "fflush(%s)", fd); return; }
+      if (sp_streq(name, "write") || sp_streq(name, "syswrite")) {
+        /* IO#write: write each arg (stringified), return total bytes written. */
+        buf_puts(b, "({ mrb_int _w = 0; ");
+        for (int k = 0; k < argc; k++) {
+          buf_puts(b, "{ const char *_s = ");
+          if (comp_ntype(c, argv[k]) == TY_STRING) emit_expr(c, argv[k], b);
+          else { buf_puts(b, "sp_poly_to_s("); emit_boxed(c, argv[k], b); buf_puts(b, ")"); }
+          buf_printf(b, "; _w += _s ? (mrb_int)fwrite(_s, 1, strlen(_s), %s) : 0; } ", fd);
+        }
+        buf_puts(b, "_w; })");
+        return;
+      }
     }
   }
   /* Last-resort fallbacks for inspect/to_s on unresolved receivers.

--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -867,6 +867,8 @@ void emit_expr(Compiler *c, int id, Buf *b) {
     if (nm && sp_streq(nm, "RUBY_COPYRIGHT"))   { buf_puts(b, "SPL(\"ruby - Copyright (C) 1993-2023 Yukihiro Matsumoto\")"); return; }
     if (nm && sp_streq(nm, "ARGV")) { buf_puts(b, "sp_get_ARGV()"); return; }
     if (nm && sp_streq(nm, "ARGF")) { buf_puts(b, "(&sp_argf_obj)"); return; }
+    if (nm && sp_streq(nm, "STDOUT")) { buf_puts(b, "sp_io_stdout()"); return; }
+    if (nm && sp_streq(nm, "STDERR")) { buf_puts(b, "sp_io_stderr()"); return; }
     if (nm) {
       int _cidx = comp_class_index(c, nm);
       if (_cidx >= 0) {

--- a/test/io_write_stdout_stderr.rb
+++ b/test/io_write_stdout_stderr.rb
@@ -1,0 +1,29 @@
+# STDOUT/STDERR (constants) and $stdout/$stderr (globals) must actually write.
+# Previously STDOUT.write / .puts / .print silently produced no output, and
+# $stdout.write was a no-op returning nil. write returns the byte count.
+
+n = STDOUT.write("hi\n")
+p n                       # 3
+
+STDOUT.puts "viaputs"     # viaputs
+STDOUT.print "noeol"      # noeol
+STDOUT.print "\n"
+
+# Non-string args are stringified (Kernel#puts/#write coercion).
+STDOUT.puts 42            # 42
+m = STDOUT.write(99)
+STDOUT.write("\n")
+p m                       # 2
+
+# The global forms behave the same.
+g = $stdout.write("global\n")
+p g                       # 7
+
+# Multi-arg write returns the total bytes written.
+t = $stdout.write("a", "b", "c")
+$stdout.write("\n")
+p t                       # 3
+
+# STDERR goes to stderr (merged into output under 2>&1 in the harness).
+STDERR.write("err\n")     # err
+$stderr.puts "gerr"       # gerr

--- a/test/io_write_stdout_stderr.rb.expected
+++ b/test/io_write_stdout_stderr.rb.expected
@@ -1,0 +1,11 @@
+hi
+3
+viaputs
+noeol
+42
+99
+2
+global
+7
+abc
+3


### PR DESCRIPTION
`STDOUT`/`STDERR` (the constants) and `$stdout`/`$stderr` (the globals) did not
write. `STDOUT.write` / `.puts` / `.print` silently produced no output, and
`$stdout.write` was a no-op returning `nil` — output silently vanished.

```ruby
STDOUT.write("hi\n")     # ruby: prints "hi\n", returns 3   was: no output
STDOUT.puts 42           # ruby: prints "42"               was: no output
$stdout.write("x")       # ruby: returns 1                 was: nil, no output
```

`STDOUT`/`STDERR` now resolve to shared `sp_File` handles wrapping the C
`stdout`/`stderr` streams and infer as `TY_IO`, so the existing IO dispatch
(`write`/`puts`/`print`/`flush`/...) applies. `IO#write` returns the byte count.

* the constants emit `sp_io_stdout()` / `sp_io_stderr()` (function-local static
  handles, never closed — `stdout`/`stderr` are not constant initializers);
* the `TY_IO` `write`/`puts`/`print` paths now stringify non-string args via
  `sp_poly_to_s` (`sp_File_write` takes a `char *`) — `STDOUT.puts 42` worked
  for strings only before;
* the `$stdout`/`$stderr` global handler gains `write`/`syswrite`, returning the
  total bytes written, and inference returns `TY_INT` for those (was `TY_NIL`).

Tested: constant and global forms of write/puts/print, integer/float/symbol
args, multi-arg write byte counts, and STDERR routing.

Full suite green.
