### PR TITLE
test: assert stderr in the suite (empty by default, optional .err.expected)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ RBS_LIB      = build/librbs.a
 
 .PHONY: all parse legacy bootstrap codegen regexp rbs_extract rbs-test rbs-seed-test \
         analyze-fail-test test test-run clean-test-results regen-rbs-expected \
-        regen-expected bench optcarrot gate check gate-legs gate-test gate-bench \
+        regen-expected regen-expected-err bench optcarrot gate check gate-legs gate-test gate-bench \
         gate-optcarrot clean install uninstall deps tools
 
 # `make all` includes the RBS extractor when vendor/rbs has been fetched
@@ -446,6 +446,8 @@ build/test-results/%.ok: test/%.rb $(SP_RT_LIB) | $(SPINEL)
 	bin=$$tmpdir/test_bin; \
 	exp=$$tmpdir/expected; \
 	act=$$tmpdir/actual; \
+	experr=$$tmpdir/experr; \
+	acterr=$$tmpdir/acterr; \
 	args=""; \
 	if [ -f "$<.args" ]; then args=$$(cat "$<.args"); fi; \
 	rm -f "$@.diff"; \
@@ -462,14 +464,21 @@ build/test-results/%.ok: test/%.rb $(SP_RT_LIB) | $(SPINEL)
 	    fi; \
 	    LC_ALL=C sed 's/\r$$//' "$$exp" >"$$exp.n"; \
 	  fi; \
-	  $(TIMEOUT10) "$$bin" $$args >"$$act" 2>/dev/null; \
+	  $(TIMEOUT10) "$$bin" $$args >"$$act" 2>"$$acterr"; \
 	  LC_ALL=C sed 's/\r$$//' "$$act" >"$$act.n"; \
-	  if cmp -s "$$exp.n" "$$act.n"; then \
+	  LC_ALL=C sed 's/\r$$//' "$$acterr" >"$$acterr.n"; \
+	  if [ -f "$<.err.expected" ]; then \
+	    LC_ALL=C sed 's/\r$$//' "$<.err.expected" >"$$experr.n"; \
+	  else \
+	    : > "$$experr.n"; \
+	  fi; \
+	  if cmp -s "$$exp.n" "$$act.n" && cmp -s "$$experr.n" "$$acterr.n"; then \
 	    echo PASS > "$@"; \
 	    if [ -t 1 ]; then printf .; fi; \
 	  else \
 	    echo FAIL > "$@"; \
-	    diff -u "$$exp.n" "$$act.n" > "$@.diff" 2>&1 || true; \
+	    { echo "=== stdout diff (expected vs actual) ==="; diff -u "$$exp.n" "$$act.n" || true; \
+	      echo "=== stderr diff (expected vs actual) ==="; diff -u "$$experr.n" "$$acterr.n" || true; } > "$@.diff" 2>&1; \
 	    if [ -t 1 ]; then printf F; fi; \
 	  fi; \
 	else \
@@ -482,28 +491,40 @@ clean-test-results:
 	@rm -rf build/test-results build/analyze-fail-results
 
 # ---- Expected-output regeneration ----
-# Capture each test's reference Ruby output into test/<name>.rb.expected;
-# once committed the test target uses it directly and skips per-test ruby.
-EXPECTED_FILES := $(patsubst test/%.rb,test/%.rb.expected,$(TESTS))
+# Snapshot each test's reference Ruby output so the test target uses the file
+# directly and skips per-test ruby. .expected is stdout; .err.expected is stderr
+# and is refreshed only where it already exists (a missing one means "stderr
+# must be empty" and is left untouched).
+EXPECTED_FILES     := $(patsubst test/%.rb,test/%.rb.expected,$(TESTS))
+ERR_EXPECTED_FILES := $(wildcard test/*.rb.err.expected)
 
 regen-expected: $(EXPECTED_FILES)
+# Separate from regen-expected so a routine stdout refresh never rewrites the
+# stderr sidecars (e.g. while a developer is using stderr for debugging).
+regen-expected-err: $(ERR_EXPECTED_FILES)
+
+# Regenerate $@ from the reference Ruby (falling back to a system ruby); $1 is
+# the redirection selecting which stream to capture into $@.tmp. A failing
+# oracle is skipped so a stale snapshot is kept rather than clobbered.
+define regen-snapshot
+@args=""; \
+if [ -f "$<.args" ]; then args=$$(cat "$<.args"); fi; \
+rc=0; $(TIMEOUT10) $(REF_RUBY) $< $$args $1 || rc=$$?; \
+if [ $$rc -ne 0 ] && [ "$(REF_RUBY)" != "ruby" ]; then \
+  rc=0; $(TIMEOUT10) ruby $< $$args $1 || rc=$$?; \
+fi; \
+if [ $$rc -ne 0 ]; then \
+  echo "regen-expected: $< failed (rc=$$rc); skipping $@" >&2; rm -f $@.tmp; \
+else \
+  LC_ALL=C sed 's/\r$$//' $@.tmp > $@; rm -f $@.tmp; \
+fi
+endef
 
 test/%.rb.expected: test/%.rb
-	@args=""; \
-	if [ -f "$<.args" ]; then args=$$(cat "$<.args"); fi; \
-	$(TIMEOUT10) $(REF_RUBY) $< $$args >$@.tmp 2>/dev/null; \
-	rc=$$?; \
-	if [ $$rc -ne 0 ] && [ "$(REF_RUBY)" != "ruby" ]; then \
-	  $(TIMEOUT10) ruby $< $$args >$@.tmp 2>/dev/null; \
-	  rc=$$?; \
-	fi; \
-	if [ $$rc -ne 0 ]; then \
-	  echo "regen-expected: $< failed (rc=$$rc); skipping" >&2; \
-	  rm -f $@.tmp; \
-	else \
-	  LC_ALL=C sed 's/\r$$//' $@.tmp > $@; \
-	  rm -f $@.tmp; \
-	fi
+	$(call regen-snapshot,>$@.tmp 2>/dev/null)
+
+test/%.rb.err.expected: test/%.rb
+	$(call regen-snapshot,2>$@.tmp >/dev/null)
 
 bench: $(SPINEL) $(SP_RT_LIB)
 	@if [ -z "$(TIMEOUT_BIN)" ]; then echo "Note: no 'timeout' command found; running without time limits."; fi

--- a/test/bundle_misc_c_36.rb
+++ b/test/bundle_misc_c_36.rb
@@ -132,9 +132,6 @@ def t_stdlib
   # ARGV.length
   puts ARGV.length
 
-  # $stderr.puts
-  $stderr.puts("stderr msg")
-
   puts "done"
 end
 t_stdlib

--- a/test/io_write_stdout_stderr.rb
+++ b/test/io_write_stdout_stderr.rb
@@ -24,6 +24,6 @@ t = $stdout.write("a", "b", "c")
 $stdout.write("\n")
 p t                       # 3
 
-# STDERR goes to stderr (merged into output under 2>&1 in the harness).
+# STDERR goes to stderr (asserted against the .err.expected sidecar).
 STDERR.write("err\n")     # err
 $stderr.puts "gerr"       # gerr

--- a/test/io_write_stdout_stderr.rb.err.expected
+++ b/test/io_write_stdout_stderr.rb.err.expected
@@ -1,0 +1,2 @@
+err
+gerr

--- a/test/lambda_strict_arity.rb
+++ b/test/lambda_strict_arity.rb
@@ -2,10 +2,14 @@
 pr = proc { |x| x }
 puts pr.call(1, 2)
 
-# A lambda raises ArgumentError on the wrong argument count and aborts,
-# so "after" is never printed (matching CRuby). stderr differs but the
-# suite compares stdout only.
+# A lambda is strict: the wrong argument count raises ArgumentError
+# (matching CRuby). Rescue it so the program completes normally and
+# "after" still prints.
 puts "before"
 f = ->(x) { x }
-f.call(1, 2)
+begin
+  f.call(1, 2)
+rescue ArgumentError => e
+  puts "rescued: #{e.class}"
+end
 puts "after"

--- a/test/lambda_strict_arity.rb.expected
+++ b/test/lambda_strict_arity.rb.expected
@@ -1,2 +1,4 @@
 1
 before
+rescued: ArgumentError
+after

--- a/test/warn_kernel.rb
+++ b/test/warn_kernel.rb
@@ -3,9 +3,8 @@
 # call warning and drop the IO silently.
 #
 # at_exit + warn -- both used to fall through to the unresolved-call
-# warning. The test runner only captures stdout, so warn's stderr
-# output isn't part of the expected diff. at_exit now runs in LIFO
-# after main returns (#990).
+# warning. warn's stderr output is asserted via the .err.expected file
+# alongside this test. at_exit now runs in LIFO after main returns (#990).
 at_exit { puts "from at_exit" }
 warn "hello stderr"
 puts "after warn"

--- a/test/warn_kernel.rb.err.expected
+++ b/test/warn_kernel.rb.err.expected
@@ -1,0 +1,3 @@
+hello stderr
+two
+args


### PR DESCRIPTION
The test harness ran both the compiled binary and the `ruby` oracle with
`2>/dev/null`, so anything written to stderr — `warn`, `$stderr`, an uncaught
exception report — went completely unchecked.

The `.ok` rule now captures the binary's stderr to its own stream and asserts it:

* no `<test>.rb.err.expected` file  -> stderr must be EMPTY; any output fails the
  test (so a stray warning or unexpected exception can't slip by unnoticed);
* `<test>.rb.err.expected` present  -> stderr must match it exactly and in order.

stdout and stderr are captured to separate files rather than merged with `2>&1`,
so there is no nondeterministic interleaving (stdout is block-buffered, stderr is
not). A failing test's `.diff` now shows both the stdout and stderr diffs.

Tests that legitimately write to stderr (`warn_kernel` via `warn`,
`io_write_stdout_stderr` via `$stderr` / `STDERR`) gain a `.err.expected`
capturing the oracle's stderr, which spinel matches. Outdated "the runner only
captures stdout" comments in those tests are corrected.

`lambda_strict_arity` previously let an uncaught `ArgumentError` abort the
program; it now rescues the error so it exits cleanly with empty stderr, keeping
the test on the lambda-vs-proc arity distinction without depending on the
uncaught-exception report format (an AOT divergence from CRuby's backtrace).

A separate `regen-expected-err` target refreshes existing `.err.expected` files
from the reference Ruby stderr, kept apart from `regen-expected` so a routine
stdout refresh never regenerates the stderr sidecars (a workflow that prints to
stderr while debugging won't have them rewritten out from under it). It touches
only files that already exist, so the empty-by-default contract is preserved, and
skips any test whose oracle exits non-zero (its backtrace format is not something
the compiled binary reproduces).
