### PR TITLE
analyze,codegen,runtime: Regexp#encoding/#fixed_encoding?/Regexp.linear_time?

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -392,6 +392,7 @@ static inline double sp_process_clock_gettime(void) {
    has no controlled preceding byte, so that read is a global-buffer-overflow
    (ASAN-caught) and could spuriously hit the heap-header cache path (#282). */
 static inline sp_Encoding sp_encoding_utf8(void){return(sp_Encoding){&("\xff" "UTF-8")[1]};}
+static inline sp_Encoding sp_encoding_us_ascii(void){return(sp_Encoding){&("\xff" "US-ASCII")[1]};}
 static inline const char*sp_encoding_name(sp_Encoding e){return e.name?e.name:sp_str_empty;}
 static inline const char*sp_encoding_inspect(sp_Encoding e){return sp_sprintf("#<Encoding:%s>",sp_encoding_name(e));}
 static inline mrb_bool sp_encoding_eq(sp_Encoding a,sp_Encoding b){const char*an=sp_encoding_name(a);const char*bn=sp_encoding_name(b);return strcmp(an,bn)==0;}

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -914,6 +914,7 @@ else {
     if (sp_streq(name, "union") && argc >= 1) return TY_REGEX;
     if (sp_streq(name, "last_match") && argc == 0) return TY_POLY;
     if (sp_streq(name, "last_match") && argc == 1) return TY_STRING;
+    if (sp_streq(name, "linear_time?") && argc == 1) return TY_BOOL;
   }
 
   /* Regexp instance methods */
@@ -923,6 +924,8 @@ else {
     if (sp_streq(name, "=~")) return TY_POLY;
     if (sp_streq(name, "source") || sp_streq(name, "inspect") || sp_streq(name, "to_s")) return TY_STRING;
     if (sp_streq(name, "freeze") || sp_streq(name, "dup") || sp_streq(name, "clone")) return TY_REGEX;
+    if (sp_streq(name, "encoding")) return TY_POLY;  /* a boxed Encoding value */
+    if (sp_streq(name, "fixed_encoding?")) return TY_BOOL;
   }
 
   /* MatchData instance methods */

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -1,5 +1,35 @@
 #include "codegen_internal.h"
 
+/* A regexp's encoding is US-ASCII when its source is 7-bit clean (the common
+   case), else UTF-8. Spinel is ASCII/UTF-8 only, so this covers the supported
+   domain; fixed_encoding? is true exactly when the encoding is not US-ASCII. */
+static int re_src_all_ascii(const char *s) {
+  if (!s) return 1;
+  for (; *s; s++) if ((unsigned char)*s >= 0x80) return 0;
+  return 1;
+}
+
+/* A backreference (\1..\9, \k<name>, \g<name>) defeats the linear-time matcher,
+   so Regexp.linear_time? is false for such a pattern and true otherwise. */
+static int re_src_has_backref(const char *s) {
+  if (!s) return 0;
+  /* Inside a [...] character class a `\1` is an octal escape and `\k`/`\g` are
+     literal, none of them backreferences. Track class membership (classes do
+     not nest; the first `]` closes) so those don't false-positive. */
+  int in_class = 0;
+  for (; *s; s++) {
+    if (*s == '\\' && s[1]) {
+      char n = s[1];
+      if (!in_class && ((n >= '1' && n <= '9') || n == 'k' || n == 'g')) return 1;
+      s++;  /* skip the escaped char (in or out of a class) */
+      continue;
+    }
+    if (in_class) { if (*s == ']') in_class = 0; }
+    else if (*s == '[') in_class = 1;
+  }
+  return 0;
+}
+
 int emit_ctor_yield_inline(Compiler *c, int id, int ci, Buf *b) {
   const NodeTable *nt = c->nt;
   int block = nt_ref(nt, id, "block");
@@ -5949,6 +5979,18 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     else { buf_puts(b, "sp_re_escape("); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
     return;
   }
+  /* Regexp.linear_time?(re) -> whether re matches in linear time. A literal arg
+     is inspected for a backreference (the construct that defeats it); a
+     non-literal regexp value defaults to true (the answer for backref-free
+     patterns, which is the supported domain). */
+  if (recv >= 0 && argc == 1 && sp_streq(name, "linear_time?") &&
+      nt_type(nt, recv) && sp_streq(nt_type(nt, recv), "ConstantReadNode") &&
+      nt_str(nt, recv, "name") && sp_streq(nt_str(nt, recv, "name"), "Regexp")) {
+    if (nt_type(nt, argv[0]) && sp_streq(nt_type(nt, argv[0]), "RegularExpressionNode"))
+      buf_puts(b, re_src_has_backref(nt_str(nt, argv[0], "unescaped")) ? "FALSE" : "TRUE");
+    else { buf_puts(b, "((void)("); emit_expr(c, argv[0], b); buf_puts(b, "), TRUE)"); }
+    return;
+  }
   /* Regexp.compile is an alias for Regexp.new */
   if (recv >= 0 && argc >= 1 && sp_streq(name, "compile") &&
       nt_type(nt, recv) && sp_streq(nt_type(nt, recv), "ConstantReadNode") &&
@@ -7894,6 +7936,27 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       int pf = (int)nt_int(nt, recv, "flags", 0);
       int opt = ((pf & 4) ? 1 : 0) | ((pf & 8) ? 2 : 0) | ((pf & 16) ? 4 : 0);
       buf_printf(b, "%d", opt); return;
+    }
+    if (rre >= 0 && sp_streq(name, "encoding") && argc == 0) {
+      int ascii = re_src_all_ascii(nt_str(nt, recv, "unescaped"));
+      buf_printf(b, "sp_box_encoding(%s)", ascii ? "sp_encoding_us_ascii()" : "sp_encoding_utf8()");
+      return;
+    }
+    if (rre >= 0 && sp_streq(name, "fixed_encoding?") && argc == 0) {
+      buf_puts(b, re_src_all_ascii(nt_str(nt, recv, "unescaped")) ? "FALSE" : "TRUE");
+      return;
+    }
+  }
+  /* encoding/fixed_encoding? on a non-literal regexp value: the source is not
+     visible at compile time, so default to US-ASCII (the answer for any 7-bit
+     pattern, which is the supported domain). */
+  if (recv >= 0 && comp_ntype(c, recv) == TY_REGEX && argc == 0) {
+    if (sp_streq(name, "encoding")) {
+      buf_puts(b, "((void)("); emit_expr(c, recv, b);
+      buf_puts(b, "), sp_box_encoding(sp_encoding_us_ascii()))"); return;
+    }
+    if (sp_streq(name, "fixed_encoding?")) {
+      buf_puts(b, "((void)("); emit_expr(c, recv, b); buf_puts(b, "), FALSE)"); return;
     }
   }
   if (recv >= 0 && argc >= 1 && rt != TY_SYMBOL &&

--- a/test/regexp_encoding_introspection.rb
+++ b/test/regexp_encoding_introspection.rb
@@ -1,0 +1,34 @@
+# Regexp introspection: #encoding (was silently ""), #fixed_encoding?, and
+# Regexp.linear_time? (both previously rejected at compile time).
+
+# An ASCII-only regexp is US-ASCII and not fixed-encoding.
+p(/abc/.encoding.name)      # "US-ASCII"
+p(/abc/.encoding)           # #<Encoding:US-ASCII>
+p(/abc/.fixed_encoding?)    # false
+p(/a(b)c/.fixed_encoding?)  # false
+
+# A regexp with multibyte UTF-8 source is UTF-8 and fixed-encoding.
+p(/café/.encoding.name)  # "UTF-8"
+p(/café/.fixed_encoding?) # true
+
+# Regexp.linear_time?: true for backref-free patterns, false when a
+# backreference (which defeats the linear matcher) is present.
+p Regexp.linear_time?(/abc/)              # true
+p Regexp.linear_time?(/(a|b)*c/)          # true
+p Regexp.linear_time?(/(a)\1/)            # false  (numbered backref)
+p Regexp.linear_time?(/(?<n>\w+)\k<n>/)   # false  (named backref)
+
+# Backref-like syntax inside a [...] class is octal / literal, not a real
+# backreference, so the pattern stays linear; a real backref after the class
+# still trips (escaped brackets inside the class are handled too).
+p Regexp.linear_time?(/[\1]/)             # true   (\1 is octal in a class)
+p Regexp.linear_time?(/[a-z\k<x>]/)       # true   (\k literal in a class)
+p Regexp.linear_time?(/[\1](a)\1/)        # false  (class \1 ignored; real \1 caught)
+p Regexp.linear_time?(/[\]]\1(a)/)        # false  (escaped ] in class, then backref)
+
+# Non-literal regexp (routed through a method) defaults to the supported
+# ASCII domain.
+def s(x); x; end
+p s(/xyz/).encoding.name      # "US-ASCII"
+p s(/xyz/).fixed_encoding?    # false
+p Regexp.linear_time?(s(/xyz/))  # true

--- a/test/regexp_encoding_introspection.rb.expected
+++ b/test/regexp_encoding_introspection.rb.expected
@@ -1,0 +1,17 @@
+"US-ASCII"
+#<Encoding:US-ASCII>
+false
+false
+"UTF-8"
+true
+true
+true
+false
+false
+true
+true
+false
+false
+"US-ASCII"
+false
+true


### PR DESCRIPTION
`Regexp#encoding` returned an empty encoding name (silent), and
`Regexp#fixed_encoding?` / `Regexp.linear_time?` were rejected at compile time.

```ruby
/abc/.encoding.name          # ruby: "US-ASCII"   was: ""
/abc/.fixed_encoding?        # ruby: false        was: compile error
Regexp.linear_time?(/abc/)   # ruby: true         was: compile error
Regexp.linear_time?(/(a)\1/) # ruby: false (backref defeats linear matcher)
```

A regexp's encoding is US-ASCII when its source is 7-bit clean (the common case)
and UTF-8 when it contains multibyte source — spinel's supported domain. The
literal forms inspect the pattern source at compile time; a non-literal regexp
value defaults to US-ASCII / not-fixed (the answer for any 7-bit pattern).

* `#encoding` -> a boxed `Encoding` (new `sp_encoding_us_ascii()` runtime handle);
* `#fixed_encoding?` -> true exactly when the encoding is not US-ASCII;
* `Regexp.linear_time?(re)` -> false when the pattern contains a backreference
  (`\1`..`\9`, `\k<name>`, `\g<name>`), which defeats the linear-time matcher,
  true otherwise; a non-literal arg defaults to true.

Tested: ASCII and UTF-8 literals, grouped patterns, numbered and named
backreferences, and non-literal (method-routed) receivers.

Full suite green.
