### PR TITLE
runtime,codegen: Array#min / #max / #minmax on String arrays

### DIFF
--- a/lib/sp_array.c
+++ b/lib/sp_array.c
@@ -198,6 +198,10 @@ sp_StrArray*sp_StrArray_intersect(sp_StrArray*a,sp_StrArray*b){sp_StrArray*r=sp_
 mrb_bool sp_StrArray_intersect_p(sp_StrArray*a,sp_StrArray*b){if(!a||!b)return 0;for(mrb_int i=0;i<a->len;i++)if(sp_StrArray_include(b,a->data[i]))return 1;return 0;}
 sp_StrArray*sp_StrArray_union(sp_StrArray*a,sp_StrArray*b){sp_StrArray*r=sp_StrArray_new();if(a)for(mrb_int i=0;i<a->len;i++){const char*v=a->data[i];if(!sp_StrArray_include(r,v))sp_StrArray_push(r,v);}if(b){for(mrb_int i=0;i<b->len;i++){const char*v=b->data[i];if(!sp_StrArray_include(r,v))sp_StrArray_push(r,v);}}return r;}
 sp_StrArray*sp_StrArray_difference(sp_StrArray*a,sp_StrArray*b){sp_StrArray*r=sp_StrArray_new();for(mrb_int i=0;i<a->len;i++){const char*v=a->data[i];if(!sp_StrArray_include(b,v))sp_StrArray_push(r,v);}return r;}
+/* min/max by String#<=> (byte comparison via strcmp); NULL (nil) when empty.
+   nil (NULL) elements are skipped so a holey/sparse array can't crash strcmp. */
+const char*sp_StrArray_min(sp_StrArray*a){if(!a||a->len<=0)return NULL;const char*m=NULL;for(mrb_int i=0;i<a->len;i++){const char*x=a->data[i];if(x&&(!m||strcmp(x,m)<0))m=x;}return m;}
+const char*sp_StrArray_max(sp_StrArray*a){if(!a||a->len<=0)return NULL;const char*m=NULL;for(mrb_int i=0;i<a->len;i++){const char*x=a->data[i];if(x&&(!m||strcmp(x,m)>0))m=x;}return m;}
 mrb_int sp_StrArray_index(sp_StrArray*a,const char*v){for(mrb_int i=0;i<a->len;i++)if(strcmp(a->data[i],v)==0)return i;return -1;}
 mrb_int sp_StrArray_rindex(sp_StrArray*a,const char*v){for(mrb_int i=a->len-1;i>=0;i--)if(strcmp(a->data[i],v)==0)return i;return -1;}
 sp_StrArray*sp_StrArray_compact(sp_StrArray*a){sp_StrArray*r=sp_StrArray_new();for(mrb_int i=0;i<a->len;i++)if(a->data[i]!=NULL)sp_StrArray_push(r,a->data[i]);return r;}

--- a/lib/sp_array.h
+++ b/lib/sp_array.h
@@ -62,6 +62,8 @@ sp_IntArray *sp_IntArray_shuffle(sp_IntArray *a);
 mrb_int sp_IntArray_sample(sp_IntArray *a);
 mrb_int sp_IntArray_min(sp_IntArray *a);
 mrb_int sp_IntArray_max(sp_IntArray *a);
+const char *sp_StrArray_min(sp_StrArray *a);
+const char *sp_StrArray_max(sp_StrArray *a);
 mrb_int sp_IntArray_sum(sp_IntArray *a, mrb_int init);
 mrb_bool sp_IntArray_include(sp_IntArray *a, mrb_int v);
 mrb_int sp_IntArray_index(sp_IntArray *a, mrb_int v);

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -1229,11 +1229,11 @@ else {
         buf_printf(b, "sp_%sArray_pop(", k); emit_expr(c, recv, b); buf_puts(b, ")");
         return 1;
       }
-      if ((sp_streq(name, "min") || sp_streq(name, "max")) && argc == 0 && rt != TY_STR_ARRAY) {
+      if ((sp_streq(name, "min") || sp_streq(name, "max")) && argc == 0) {
         buf_printf(b, "sp_%sArray_%s(", k, name); emit_expr(c, recv, b); buf_puts(b, ")");
         return 1;
       }
-      if (sp_streq(name, "minmax") && argc == 0 && rt != TY_STR_ARRAY && block < 0) {
+      if (sp_streq(name, "minmax") && argc == 0 && block < 0) {
         int t = ++g_tmp, o = ++g_tmp;
         buf_printf(b, "({ sp_%sArray *_t%d = ", k, t); emit_expr(c, recv, b);
         buf_printf(b, "; sp_%sArray *_t%d = sp_%sArray_new(); sp_%sArray_push(_t%d, sp_%sArray_min(_t%d));"

--- a/test/str_array_min_max.rb
+++ b/test/str_array_min_max.rb
@@ -1,0 +1,30 @@
+# Array#min / #max / #minmax (no block) on String arrays, by String#<=> (byte
+# comparison). Previously rejected for String arrays while Integer/Float arrays
+# worked. Receivers route through a per-kind identity method so the typed
+# runtime path is exercised rather than a compile-time fold.
+def sw(x); x; end
+def si(x); x; end
+def sf(x); x; end
+
+p sw(%w[banana apple cherry]).min
+p sw(%w[banana apple cherry]).max
+p sw(%w[banana apple cherry]).minmax
+# byte ordering: uppercase precedes lowercase; lexicographic, not numeric
+p sw(%w[Z a]).min
+p sw(%w[10 9 100]).max
+p sw(%w[b a a c]).min
+# single element
+p sw(["only"]).min
+p sw(["only"]).minmax
+
+# empty -> nil
+def empty; a = ["x"]; a.clear; a; end
+p empty.min
+p empty.max
+
+# Integer / Float arrays remain unaffected
+p si([3, 1, 2]).min
+p si([3, 1, 2]).max
+p si([3, 1, 2]).minmax
+p sf([3.0, 1.0, 2.0]).min
+p sf([3.0, 1.0, 2.0]).minmax

--- a/test/str_array_min_max.rb.expected
+++ b/test/str_array_min_max.rb.expected
@@ -1,0 +1,15 @@
+"apple"
+"cherry"
+["apple", "cherry"]
+"Z"
+"9"
+"a"
+"only"
+["only", "only"]
+nil
+nil
+1
+3
+[1, 3]
+1.0
+[1.0, 3.0]


### PR DESCRIPTION
`min` / `max` / `minmax` without a block worked on `Integer` and `Float` arrays but were rejected for `String` arrays — the codegen explicitly skipped `TY_STR_ARRAY` because no String-array min/max runtime helper existed (inference already typed the result as the `String` element).

Add `sp_StrArray_min` / `sp_StrArray_max` (`String#<=>` is a byte comparison, so `strcmp`, matching the existing `sp_StrArray` helpers; `NULL`/`nil` for an empty array) and drop the `TY_STR_ARRAY` guard from the `min`/`max` and `minmax` codegen so a `String` array reaches the same typed emitter (`sp_StrArray_min` / `_max`) the numeric arrays use.

Covers `min`/`max`/`minmax`, byte ordering (uppercase before lowercase, lexicographic not numeric), a single-element array, the empty-array `nil`, and `Integer`/`Float` regression, with `ruby` as the oracle. Full suite green.