### PR TITLE
analyze,codegen,runtime: Integer#clamp keeps the applied operand's class

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -1811,12 +1811,31 @@ static void sp_sort_idx_by_poly(mrb_int *idx, const sp_RbVal *keys, mrb_int n) {
 }
 static sp_RbVal sp_poly_div(sp_RbVal a, sp_RbVal b) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) / sp_poly_to_f(b)); return sp_box_int(sp_idiv(sp_poly_to_i(a), sp_poly_to_i(b))); }
 static sp_RbVal sp_poly_mod(sp_RbVal a, sp_RbVal b) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(fmod(sp_poly_to_f(a), sp_poly_to_f(b))); return sp_box_int(sp_imod(sp_poly_to_i(a), sp_poly_to_i(b))); }
-/* clamp on a boxed numeric: float path when any operand is a float (NaN/order
-   checks via sp_float_clamp_ck), else int path; result keeps the float/int kind. */
+/* Comparable#clamp on boxed numerics, faithful to CRuby: the result is the
+   applied operand returned UNCHANGED, so an in-range Integer receiver stays
+   Integer while a Float bound that clamps stays Float (5.clamp(1.0, 3.0) is
+   3.0 but 5.clamp(1.0, 10.0) is 5). The lo<=>hi then self<=>bound checks
+   mirror CRuby's NaN/ordering ArgumentErrors. The operand class and value in
+   the message go through the generic sp_poly_class_name / sp_poly_to_s helpers
+   (as the sort/min/max comparison errors already do), so a non-numeric poly
+   bound names its real class and renders its value rather than reinterpreting
+   the union as an integer. */
+static sp_RbVal sp_num_clamp(sp_RbVal v, sp_RbVal lo, sp_RbVal hi) {
+  mrb_float dv = sp_poly_to_f(v), dlo = sp_poly_to_f(lo), dhi = sp_poly_to_f(hi);
+  if (dlo != dlo || dhi != dhi)
+    sp_raise_cls("ArgumentError", sp_sprintf("comparison of %s with %s failed", sp_poly_class_name(lo), sp_poly_to_s(hi)));
+  if (dlo > dhi)
+    sp_raise_cls("ArgumentError", "min argument must be less than or equal to max argument");
+  if (dv != dv)
+    sp_raise_cls("ArgumentError", sp_sprintf("comparison of %s with %s failed", sp_poly_class_name(v), sp_poly_to_s(lo)));
+  if (dv < dlo) return lo;
+  if (dv > dhi) return hi;
+  return v;
+}
+/* clamp on a boxed numeric: routes through sp_num_clamp so the returned operand
+   keeps its own Integer/Float class (was unconditionally floated up before). */
 static sp_RbVal sp_poly_clamp(sp_RbVal v, sp_RbVal lo, sp_RbVal hi) {
-  if (v.tag == SP_TAG_FLT || lo.tag == SP_TAG_FLT || hi.tag == SP_TAG_FLT)
-    return sp_box_float(sp_float_clamp_ck(sp_poly_to_f(v), sp_poly_to_f(lo), sp_poly_to_f(hi)));
-  return sp_box_int(sp_int_clamp_ck(sp_poly_to_i(v), sp_poly_to_i(lo), sp_poly_to_i(hi)));
+  return sp_num_clamp(v, lo, hi);
 }
 /* Integer #** : Spinel has no Rational, so a negative integer exponent --
    which CRuby evaluates to a Rational like (1/2) -- raises RangeError rather

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -2457,7 +2457,16 @@ else {
     if (sp_streq(name, "fdiv") && argc == 1) return TY_FLOAT;
     if (sp_streq(name, "[]") && (argc == 1 || argc == 2)) return TY_INT;  /* bit access / bit-range field */
     if (sp_streq(name, "div") && argc == 1) return TY_INT;  /* floor division */
-    if (sp_streq(name, "gcd") || sp_streq(name, "lcm") || sp_streq(name, "clamp")) return TY_INT;
+    if (sp_streq(name, "gcd") || sp_streq(name, "lcm")) return TY_INT;
+    /* clamp keeps the applied operand's class: a Float bound can be returned, so
+       the mixed int-receiver/float-bound form is poly; pure-int stays Integer. */
+    if (sp_streq(name, "clamp")) {
+      if (argc == 2) {
+        TyKind b0 = infer_type(c, argv[0]), b1 = infer_type(c, argv[1]);
+        if (b0 == TY_FLOAT || b1 == TY_FLOAT || b0 == TY_POLY || b1 == TY_POLY) return TY_POLY;
+      }
+      return TY_INT;
+    }
     if (sp_streq(name, "magnitude") && argc == 0) return TY_INT;  /* alias for abs */
     if ((sp_streq(name, "modulo") || sp_streq(name, "remainder")) && argc == 1) return TY_INT;
     if (sp_streq(name, "gcdlcm") && argc == 1) return TY_INT_ARRAY;  /* [gcd, lcm] */

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -2859,6 +2859,14 @@ static int emit_scalar_call(Compiler *c, int id, Buf *b) {
         buf_printf(b, "; sp_IntArray *_t%d = sp_IntArray_new(); sp_IntArray_push(_t%d, sp_gcd(%s, _t%d));"
                       " sp_IntArray_push(_t%d, sp_lcm(%s, _t%d)); _t%d; })", o, o, r, ta, o, r, ta, o);
       }
+      /* A Float (or runtime-typed poly) bound makes the applied bound or the
+         in-range receiver decide the result class at runtime, so box the
+         operands and return whichever is chosen unchanged via sp_num_clamp. */
+      else if (sp_streq(name, "clamp") && argc == 2 &&
+               (comp_ntype(c, argv[0]) == TY_FLOAT || comp_ntype(c, argv[1]) == TY_FLOAT ||
+                comp_ntype(c, argv[0]) == TY_POLY || comp_ntype(c, argv[1]) == TY_POLY)) {
+        buf_printf(b, "sp_num_clamp(sp_box_int(%s), ", r); emit_boxed(c, argv[0], b); buf_puts(b, ", "); emit_boxed(c, argv[1], b); buf_puts(b, ")");
+      }
       else if (sp_streq(name, "clamp") && argc == 2) { buf_printf(b, "sp_int_clamp_ck(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ", "); emit_expr(c, argv[1], b); buf_puts(b, ")"); }
       else if (sp_streq(name, "clamp") && argc == 1 && nt_type(c->nt, argv[0]) && sp_streq(nt_type(c->nt, argv[0]), "RangeNode")) {
         int rn = argv[0]; int tcr = ++g_tmp;

--- a/test/integer_clamp_float_bound.rb
+++ b/test/integer_clamp_float_bound.rb
@@ -1,0 +1,35 @@
+# Integer#clamp returns the applied operand unchanged, so a Float bound that
+# clamps yields a Float while an in-range Integer receiver stays an Integer.
+# Receiver and bounds route through a method param so the runtime helper is
+# exercised rather than a compile-time fold.
+def s(x); x; end
+
+# clamped to a Float bound -> Float
+p s(5).clamp(1.0, 3.0)
+p s(0).clamp(1.0, 10.0)
+# in range with Float bounds -> Integer receiver kept
+p s(5).clamp(1.0, 10.0)
+# one int bound, one float bound
+p s(5).clamp(1, 3.0)
+p s(2).clamp(1, 3.5)
+p s(7).clamp(1, 3.5)
+# pure-int bounds still Integer
+p s(5).clamp(1, 10)
+p s(-4).clamp(0, 9)
+# classes
+p s(5).clamp(1.0, 3.0).class
+p s(5).clamp(1.0, 10.0).class
+p s(2).clamp(1, 3.5).class
+
+# exceptional: disordered / NaN bounds raise ArgumentError with CRuby messages
+def show(x, lo, hi)
+  p x.clamp(lo, hi)
+rescue => e
+  puts "#{e.class}: #{e.message}"
+end
+nan = 0.0 / 0.0
+show(s(5), 10, 2)
+show(s(5), nan, 2.0)
+show(s(5), 1.0, nan)
+show(s(5), 1, nan)
+show(s(5), nan, 2)

--- a/test/integer_clamp_float_bound.rb.expected
+++ b/test/integer_clamp_float_bound.rb.expected
@@ -1,0 +1,16 @@
+3.0
+1.0
+5
+3.0
+2
+3.5
+5
+0
+Float
+Integer
+Integer
+ArgumentError: min argument must be less than or equal to max argument
+ArgumentError: comparison of Float with 2.0 failed
+ArgumentError: comparison of Float with NaN failed
+ArgumentError: comparison of Integer with NaN failed
+ArgumentError: comparison of Float with 2 failed


### PR DESCRIPTION
`Integer#clamp` with a `Float` bound returned an `Integer` — `5.clamp(1.0, 3.0)` gave `3` instead of `3.0`.

CRuby's `Comparable#clamp` returns whichever of the receiver, min, or max bound was applied, unchanged: an in-range `Integer` receiver stays `Integer`, while a `Float` bound that clamps stays `Float` (`5.clamp(1.0, 10.0)` is `5` but `5.clamp(1.0, 3.0)` is `3.0`).

The typed `Integer` receiver path emitted `sp_int_clamp_ck`, which truncates a `Float` bound to `mrb_int`; the boxed `sp_poly_clamp` helper floated the result up unconditionally rather than preserving the applied operand's class; and a non-`Float` poly bound on a typed `Integer` receiver was a hard compile error (`sp_RbVal` passed to an `mrb_int` parameter).

Add `sp_num_clamp`, which boxes the operands, performs CRuby's `lo<=>hi` then `self<=>bound` NaN/ordering checks (naming the operand classes in the `ArgumentError`), and returns the applied operand unchanged. Route the mixed `Integer`-receiver form (any `Float` or runtime-typed poly bound) through it with a poly result type, and reuse it for `sp_poly_clamp` so the boxed path is faithful too. Pure-integer bounds keep the existing fast `sp_int_clamp_ck` path.

Covers clamped-to-float, in-range-stays-integer, mixed int/float bounds, result classes, and the disordered/NaN `ArgumentError` messages, with `ruby` as the oracle. Full suite green.