### PR TITLE
analyze,codegen,runtime: MatchData named-capture access

### DIFF
--- a/lib/regexp/re_compile.c
+++ b/lib/regexp/re_compile.c
@@ -1442,3 +1442,32 @@ re_free(mrb_regexp_pattern *pat)
     free(pat);
   }
 }
+
+/* ---- named-capture introspection (engine ABI) ----
+   The compiled pattern retains every `(?<name>...)` group's name and 1-based
+   group index; these expose that table so the MatchData layer can resolve a
+   name to a capture group without reaching into the internal struct. */
+int re_num_named(const mrb_regexp_pattern *pat) {
+  return pat ? (int)pat->num_named : 0;
+}
+const char *re_named_name(const mrb_regexp_pattern *pat, int i, int *group_out) {
+  if (!pat || i < 0 || i >= (int)pat->num_named) return NULL;
+  if (group_out) *group_out = (int)pat->named_captures[i].group;
+  return pat->named_captures[i].name;
+}
+int re_named_group(const mrb_regexp_pattern *pat, const char *name) {
+  if (!pat || !name) return -1;
+  size_t nlen = strlen(name);
+  int group = -1;
+  /* A name may repeat across alternation branches; CRuby resolves to the last
+     declared group, so keep scanning and take the final match. */
+  for (uint16_t i = 0; i < pat->num_named; i++) {
+    const re_named_capture *nc = &pat->named_captures[i];
+    /* compare name_len (uint16_t, promoted to size_t) against nlen directly: a
+       name >= 65536 chars must never spuriously match a truncated 16-bit length
+       and then memcmp past the stored name. */
+    if (nc->name_len == nlen && memcmp(nc->name, name, nlen) == 0)
+      group = (int)nc->group;
+  }
+  return group;
+}

--- a/lib/sp_re.c
+++ b/lib/sp_re.c
@@ -460,6 +460,7 @@ sp_MatchData *sp_re_matchdata(mrb_regexp_pattern *pat, const char *str) {
   sp_MatchData *m = (sp_MatchData *)sp_gc_alloc(sizeof(sp_MatchData), NULL, sp_MatchData_scan);
   m->source = str;
   m->ncap = pairs;
+  m->pat = pat;
   for (int i = 0; i < pairs * 2; i++) m->caps[i] = caps[i];
   return m;
 }
@@ -483,6 +484,7 @@ sp_MatchData *sp_re_matchdata_at(mrb_regexp_pattern *pat, const char *str, mrb_i
   sp_MatchData *m = (sp_MatchData *)sp_gc_alloc(sizeof(sp_MatchData), NULL, sp_MatchData_scan);
   m->source = str;
   m->ncap = pairs;
+  m->pat = pat;
   for (int i = 0; i < pairs * 2; i++) m->caps[i] = caps[i];
   return m;
 }
@@ -497,6 +499,26 @@ const char *sp_MatchData_aref(sp_MatchData *m, mrb_int i) {
   b[len] = 0;
   sp_str_set_len(b, (size_t)len);
   return b;
+}
+/* group by name (`md[:name]` / `md["name"]`): resolve the name to its capture
+   group via the pattern, then return that group's substring (NULL if the name
+   is unknown or the group did not participate). */
+const char *sp_MatchData_aref_name(sp_MatchData *m, const char *name) {
+  if (!m || !name) return NULL;
+  int g = re_named_group(m->pat, name);
+  if (g < 0) sp_raise_cls("IndexError", sp_sprintf("undefined group name reference: %s", name));
+  return sp_MatchData_aref(m, g);
+}
+/* `md.names`: the capture names in declaration order. */
+sp_StrArray *sp_MatchData_names(sp_MatchData *m) {
+  sp_StrArray *a = sp_StrArray_new();
+  if (!m) return a;
+  int n = re_num_named(m->pat);
+  for (int i = 0; i < n; i++) {
+    const char *nm = re_named_name(m->pat, i, NULL);
+    if (nm) sp_StrArray_push(a, sp_str_dup(nm));
+  }
+  return a;
 }
 mrb_int sp_MatchData_length(sp_MatchData *m) { return m ? m->ncap : 0; }
 /* char offset of a byte position within source */

--- a/lib/sp_re.h
+++ b/lib/sp_re.h
@@ -22,8 +22,12 @@ typedef struct mrb_regexp_pattern mrb_regexp_pattern;
 mrb_regexp_pattern* re_compile(const char *pattern, int64_t len, uint32_t flags);
 void re_free(mrb_regexp_pattern *pat);
 int re_exec(const mrb_regexp_pattern *pat, const char *str, int64_t len, int64_t start, int *captures, int captures_size);
+/* named-capture introspection (lib/regexp/re_compile.c) */
+int re_num_named(const mrb_regexp_pattern *pat);
+const char *re_named_name(const mrb_regexp_pattern *pat, int i, int *group_out);
+int re_named_group(const mrb_regexp_pattern *pat, const char *name);
 
-typedef struct { const char *source; int caps[64]; int ncap; } sp_MatchData;
+typedef struct { const char *source; int caps[64]; int ncap; const mrb_regexp_pattern *pat; } sp_MatchData;
 
 /* ---- match-register state (per-process; read by the generated TU and
    marked by its GC root hook) ---- */
@@ -60,6 +64,8 @@ void sp_MatchData_scan(void *p);
 sp_MatchData *sp_re_matchdata(mrb_regexp_pattern *pat, const char *str);
 sp_MatchData *sp_re_matchdata_at(mrb_regexp_pattern *pat, const char *str, mrb_int cpos);
 const char *sp_MatchData_aref(sp_MatchData *m, mrb_int i);
+const char *sp_MatchData_aref_name(sp_MatchData *m, const char *name);
+sp_StrArray *sp_MatchData_names(sp_MatchData *m);
 mrb_int sp_MatchData_length(sp_MatchData *m);
 mrb_int sp_md_char_off(sp_MatchData *m, int byteoff);
 mrb_int sp_MatchData_begin(sp_MatchData *m, mrb_int i);

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -2774,6 +2774,20 @@ static const char*sp_StrPolyHash_inspect(sp_StrPolyHash*h){return h?sp_inspect_c
    raw pointer assignment would mix incompatible struct layouts
    (vals[] of const char** vs sp_RbVal*). See issue #614. */
 static sp_StrPolyHash*sp_StrPolyHash_from_str_str_hash(sp_StrStrHash*h){sp_StrPolyHash*r=sp_StrPolyHash_new();if(!h)return r;if(h->default_v)r->default_v=sp_box_str(h->default_v);for(mrb_int i=0;i<h->len;i++){const char*k=h->order[i];sp_StrPolyHash_set(r,k,sp_box_str(sp_StrStrHash_get(h,k)));}return r;}
+/* MatchData#named_captures: {String name => group substring | nil}. A
+   non-participating named group maps to nil, so the value side is poly. Lives
+   here (not sp_re.c) because the typed-hash machinery is TU-coupled. */
+static sp_StrPolyHash *sp_md_named_captures(sp_MatchData *m) {
+  sp_StrPolyHash *h = sp_StrPolyHash_new();
+  if (!m) return h;
+  int n = re_num_named(m->pat);
+  for (int i = 0; i < n; i++) {
+    int g = -1;
+    const char *nm = re_named_name(m->pat, i, &g);
+    if (nm) sp_StrPolyHash_set(h, sp_str_dup(nm), sp_box_nullable_str(sp_MatchData_aref(m, g)));
+  }
+  return h;
+}
 static sp_StrPolyHash*sp_StrPolyHash_from_str_int_hash(sp_StrIntHash*h){sp_StrPolyHash*r=sp_StrPolyHash_new();if(!h)return r;r->default_v=sp_box_int(h->default_v);for(mrb_int i=0;i<h->len;i++){const char*k=h->order[i];sp_StrPolyHash_set(r,k,sp_box_int(sp_StrIntHash_get(h,k)));}return r;}
 
 /* SymPolyHash: symbol keys, sp_RbVal values — same shape as SymStrHash but with poly values. */

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -931,7 +931,9 @@ else {
     if (sp_streq(name, "pre_match") || sp_streq(name, "post_match") || sp_streq(name, "to_s")) return TY_STRING;
     if (sp_streq(name, "begin") || sp_streq(name, "end") || sp_streq(name, "length") || sp_streq(name, "size")) return TY_INT;
     if (sp_streq(name, "offset")) return TY_INT_ARRAY;
-    if (sp_streq(name, "captures") || sp_streq(name, "to_a") || sp_streq(name, "named_captures")) return TY_POLY_ARRAY;
+    if (sp_streq(name, "captures") || sp_streq(name, "to_a")) return TY_POLY_ARRAY;
+    if (sp_streq(name, "named_captures")) return TY_STR_POLY_HASH;  /* {String => String|nil} */
+    if (sp_streq(name, "names")) return TY_STR_ARRAY;
     if (sp_streq(name, "nil?")) return TY_BOOL;
   }
 

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -3445,8 +3445,15 @@ static int emit_value_recv_call(Compiler *c, int id, Buf *b) {
     Buf rs; memset(&rs, 0, sizeof rs); emit_expr(c, recv, &rs);
     const char *r = rs.p ? rs.p : "";
     if (sp_streq(name, "[]") && argc == 1) {
-      buf_printf(b, "sp_MatchData_aref(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")");
+      /* A Symbol/String key selects a named capture group; an Integer key is a
+         positional group (the existing path). */
+      TyKind kt = comp_ntype(c, argv[0]);
+      if (kt == TY_SYMBOL) { buf_printf(b, "sp_MatchData_aref_name(%s, sp_sym_to_s(", r); emit_expr(c, argv[0], b); buf_puts(b, "))"); }
+      else if (kt == TY_STRING) { buf_printf(b, "sp_MatchData_aref_name(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+      else { buf_printf(b, "sp_MatchData_aref(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
     }
+    else if (sp_streq(name, "named_captures") && argc == 0) buf_printf(b, "sp_md_named_captures(%s)", r);
+    else if (sp_streq(name, "names") && argc == 0) buf_printf(b, "sp_MatchData_names(%s)", r);
     else if (sp_streq(name, "pre_match"))  buf_printf(b, "sp_MatchData_pre_match(%s)", r);
     else if (sp_streq(name, "post_match")) buf_printf(b, "sp_MatchData_post_match(%s)", r);
     else if (sp_streq(name, "to_s"))       buf_printf(b, "sp_MatchData_to_s(%s)", r);

--- a/test/matchdata_named_groups.rb
+++ b/test/matchdata_named_groups.rb
@@ -1,0 +1,36 @@
+# MatchData named-group access: md[:name] / md["name"] select a named capture
+# group (previously returned the whole match), plus #named_captures and #names.
+# A non-participating named group is nil; an unknown name raises IndexError.
+def s(x); x; end
+
+m = "2026-06".match(/(?<y>\d+)-(?<mo>\d+)/)
+p m[:mo]
+p m[:y]
+p m["mo"]
+p m.named_captures
+p m.names
+# positional indexing is unchanged
+p m[0]
+p m[1]
+
+# non-literal symbol key routes through the runtime path
+k = s(:mo)
+p m[k]
+
+# non-participating named group -> nil (value side is poly)
+alt = "x".match(/(?<a>x)|(?<b>y)/)
+p alt[:a]
+p alt[:b]
+p alt.named_captures
+
+# no named groups
+plain = "ab".match(/(a)(b)/)
+p plain.named_captures
+p plain.names
+
+# unknown name raises IndexError
+begin
+  p m[:nope]
+rescue => e
+  puts "#{e.class}: #{e.message}"
+end

--- a/test/matchdata_named_groups.rb.expected
+++ b/test/matchdata_named_groups.rb.expected
@@ -1,0 +1,14 @@
+"06"
+"2026"
+"06"
+{"y" => "2026", "mo" => "06"}
+["y", "mo"]
+"2026-06"
+"2026"
+"06"
+"x"
+nil
+{"a" => "x", "b" => nil}
+{}
+[]
+IndexError: undefined group name reference: nope


### PR DESCRIPTION
A `MatchData` indexed by a `Symbol` or `String` returned the whole match instead of the named capture group — `md[:mo]` and `md["mo"]` were silently wrong — and `#named_captures` / `#names` were rejected at compile time.

The compiled pattern already retains each `(?<name>...)` group's name and 1-based index, but the `MatchData` had no link back to its pattern. Add a pattern pointer to `sp_MatchData` (set when the match is built; it references the compiled-once pattern singleton, so it needs no GC marking) and three name-resolution accessors to the engine ABI (`re_num_named` / `re_named_name` / `re_named_group`).

With those:

- `md[:name]` / `md["name"]` resolve the name to its group and return that group's substring (`nil` for a non-participating group; an unknown name raises `IndexError`, matching CRuby).
- `md.named_captures` returns `{String => String|nil}` — the value side is poly so a non-participating group reads back `nil`.
- `md.names` returns the capture names in declaration order.

Positional `Integer` indexing is unchanged. `named_captures` builds its typed hash in `sp_runtime.h` (TU-coupled) while the string-only accessors live in the decoupled `sp_re.c`.

Covers symbol and string keys, positional keys, non-participating groups, no-named-groups, a non-literal key, and the unknown-name `IndexError`, with `ruby` as the oracle. Full suite green.