### PR TITLE
analyze,codegen: expand a call-site positional splat f(*args)

### DIFF
--- a/src/analyze_pass.c
+++ b/src/analyze_pass.c
@@ -1206,18 +1206,26 @@ int bind_call_params(Compiler *c, int call_id, int mi) {
   if (m->rest_idx >= 0 && max_bind > m->rest_idx) max_bind = m->rest_idx;
   int n = pos_argc < max_bind ? pos_argc : max_bind;
   for (int k = 0; k < n; k++) {
-    /* When the call has a single SplatNode covering this fixed param,
-       infer the element type of the splatted array instead. */
-    TyKind at;
     const char *apty = argv ? nt_type(nt, argv[k]) : NULL;
+    /* A single SplatNode spreads its array across every remaining fixed param,
+       not just this position. Bind each from the array's element type so a
+       splat-only call site (`f(*args)`) still types — and therefore emits —
+       the callee, then stop (the splat consumes the rest of the positionals). */
     if (apty && sp_streq(apty, "SplatNode")) {
       int inner = nt_ref(nt, argv[k], "expression");
       TyKind arr = inner >= 0 ? infer_type(c, inner) : TY_UNKNOWN;
-      at = ty_is_array(arr) ? ty_array_elem(arr) : TY_POLY;
+      TyKind at = ty_is_array(arr) ? ty_array_elem(arr) : TY_POLY;
+      if (at == TY_VOID || at == TY_NIL) at = TY_POLY;
+      for (int pk = k; pk < max_bind; pk++) {
+        if (!m->pnames[pk]) continue;
+        LocalVar *p = scope_local(m, m->pnames[pk]);
+        if (!p || p->rbs_seeded) continue;
+        TyKind merged = ty_unify(p->type, at);
+        if (merged != p->type) { p->type = merged; changed = 1; }
+      }
+      break;
     }
-else {
-      at = infer_type(c, argv[k]);
-    }
+    TyKind at = infer_type(c, argv[k]);
     LocalVar *p = scope_local(m, m->pnames[k]);
     if (!p || p->rbs_seeded) continue;
     /* A void arg (`sink(always_raising_method)`) is nil-ish in value position:

--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -3657,11 +3657,36 @@ void emit_args_filled(Compiler *c, int callee_idx, int argsNode, const char *lea
         splat_at = inner >= 0 ? comp_ntype(c, inner) : TY_UNKNOWN;
         if (ty_is_array(splat_at) || splat_at == TY_POLY_ARRAY) {
           splat_tmp = ++g_tmp;
+          /* Evaluate the splat operand into a side buffer: a literal array or a
+             call result emits its own setup (a fresh `_tN = ..._new()` decl)
+             into g_pre, which must land before this temp's declaration line --
+             a bare local read has no setup, which is why those already worked. */
+          Buf sb; memset(&sb, 0, sizeof sb);
+          emit_expr(c, inner, &sb);
           emit_indent(g_pre, g_indent);
           emit_ctype(c, splat_at, g_pre);
-          buf_printf(g_pre, " _t%d = ", splat_tmp);
-          emit_expr(c, inner, g_pre);
-          buf_puts(g_pre, ";\n");
+          buf_printf(g_pre, " _t%d = %s;\n", splat_tmp, sb.p ? sb.p : "");
+          emit_indent(g_pre, g_indent);
+          buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", splat_tmp);
+          free(sb.p);
+          /* Arity check: splatting into a fixed-arity (no-rest) method must
+             supply a valid element count, else CRuby raises ArgumentError.
+             Only emit when the splat is the last positional group, so the
+             total given count is `splat_idx + array length`. */
+          if (m->rest_idx < 0 && k == pos_argc - 1) {
+            char expbuf[48];
+            if (m->nrequired == m->nparams)
+              snprintf(expbuf, sizeof expbuf, "expected %d", m->nparams);
+            else
+              snprintf(expbuf, sizeof expbuf, "expected %d..%d", m->nrequired, m->nparams);
+            int gv = ++g_tmp;
+            emit_indent(g_pre, g_indent);
+            buf_printf(g_pre, "mrb_int _t%d = %d + (_t%d ? _t%d->len : 0);\n", gv, splat_idx, splat_tmp, splat_tmp);
+            emit_indent(g_pre, g_indent);
+            buf_printf(g_pre,
+                       "if (_t%d < %d || _t%d > %d) sp_raise_cls(\"ArgumentError\", sp_sprintf(\"wrong number of arguments (given %%lld, %s)\", (long long)_t%d));\n",
+                       gv, m->nrequired, gv, m->nparams, expbuf, gv);
+          }
         }
       }
       break;
@@ -3737,15 +3762,30 @@ else if (m->rest_idx >= 0 && m->npost_rest > 0 && i > m->rest_idx) {
     }
 else if (splat_tmp >= 0 && i >= splat_idx) {
       /* this param comes from the splatted array at offset (i - splat_idx) */
-      LocalVar *sp = m ? scope_local(m, m->pnames[i]) : NULL;
+      int off = i - splat_idx;
+      LocalVar *sp = (m && m->pnames[i]) ? scope_local(m, m->pnames[i]) : NULL;
       TyKind set = ty_array_elem(splat_at);
+      Buf eb; memset(&eb, 0, sizeof eb);
       if (sp && sp->type == TY_POLY && set != TY_POLY && set != TY_UNKNOWN) {
         /* a scalar splat element into a poly-widened param: box it */
-        Buf eb; memset(&eb, 0, sizeof eb);
-        emit_array_elem_at(splat_at, splat_tmp, i - splat_idx, &eb);
-        emit_boxed_text(c, set, eb.p ? eb.p : "0", out); free(eb.p);
+        Buf raw; memset(&raw, 0, sizeof raw);
+        emit_array_elem_at(splat_at, splat_tmp, off, &raw);
+        emit_boxed_text(c, set, raw.p ? raw.p : "0", &eb); free(raw.p);
       }
-      else emit_array_elem_at(splat_at, splat_tmp, i - splat_idx, out);
+      else emit_array_elem_at(splat_at, splat_tmp, off, &eb);
+      /* An optional param may fall past the end of a (runtime-sized) splat
+         array; the arity check guarantees the required params are present, so
+         guard only the optionals and fall back to their default. */
+      if (i >= m->nrequired) {
+        Buf db; memset(&db, 0, sizeof db);
+        emit_arg_or_default(c, m, i, -1, &db);
+        TyKind pt = sp ? sp->type : TY_INT;
+        buf_printf(out, "(%d < (_t%d ? _t%d->len : 0) ? %s : %s)", off, splat_tmp, splat_tmp,
+                   eb.p ? eb.p : "", db.p ? db.p : default_value(pt));
+        free(db.p);
+      }
+      else buf_puts(out, eb.p ? eb.p : "");
+      free(eb.p);
     }
 else {
       /* Check if this param has a keyword match (lookup by param name in kwh). */

--- a/test/call_splat_positional.rb
+++ b/test/call_splat_positional.rb
@@ -1,0 +1,57 @@
+# Call-site positional splat `f(*args)`: a single trailing splat expands an
+# array across a method's fixed parameters. Previously rejected at compile time
+# (the callee was left untyped and dead-code-eliminated, or the splat arg failed
+# to emit). The splat array's element type now propagates to the callee's params
+# so it is emitted, the operand is evaluated once into a rooted temp, and a
+# fixed-arity mismatch raises ArgumentError exactly as CRuby does.
+def s(x); x; end
+
+def add3(a, b, c); a + b + c; end
+def join2(a, b); a + b; end
+
+# splat of a local, a literal, and a method-call result
+nums = [1, 2, 3]
+p add3(*nums)
+p add3(*[4, 5, 6])
+p add3(*s([7, 8, 9]))
+
+# string and float element kinds
+p join2(*["x", "y"])
+p join2(*[1.5, 2.5])
+
+# splat after a fixed leading arg
+rest = [20, 30]
+p add3(10, *rest)
+
+# value position vs statement position
+total = add3(*nums)
+p total
+add3(*nums)  # statement: no output, must still compile
+
+# optional params: a short splat falls back to the defaults
+def opt(a, b = 9, c = 100); a + b + c; end
+p opt(*[1])
+p opt(*[1, 2])
+p opt(*[1, 2, 3])
+p opt(*s([5]))
+
+# rest-param callee absorbs any length
+def collect(*xs); xs.sum; end
+p collect(*[1, 2, 3, 4])
+
+# arity mismatch raises ArgumentError with CRuby's exact message
+begin
+  add3(*[1, 2])
+rescue ArgumentError => e
+  p e.message
+end
+begin
+  join2(*[1, 2, 3])
+rescue ArgumentError => e
+  p e.message
+end
+begin
+  opt(*[1, 2, 3, 4])
+rescue ArgumentError => e
+  p e.message
+end

--- a/test/call_splat_positional.rb.expected
+++ b/test/call_splat_positional.rb.expected
@@ -1,0 +1,15 @@
+6
+15
+24
+"xy"
+4.0
+60
+6
+110
+103
+6
+114
+10
+"wrong number of arguments (given 2, expected 3)"
+"wrong number of arguments (given 3, expected 2)"
+"wrong number of arguments (given 4, expected 1..3)"


### PR DESCRIPTION
A call passing a single trailing splat to a fixed-arity method (`args = [1, 2, 3]; f(*args)`) was rejected: only the first parameter was bound from the splat array during inference, so the callee's remaining params stayed untyped, the method was dead-code-eliminated, and the call referenced an undefined symbol. Literal, method-call, and string splat operands also mis-emitted.

Inference now fans the splat array's element type across every remaining fixed parameter, so a splat-only call site types — and therefore emits — the callee. Codegen evaluates the splat operand once into a rooted temp (through a side buffer, so a literal or call operand's own setup lands before the temp's declaration line, which is why bare-local operands already worked), then fills each parameter from it.

A no-rest arity mismatch raises `ArgumentError` with CRuby's exact message — `wrong number of arguments (given N, expected M)`, or an `A..B` range when the callee has optional parameters — and a short splat into an optional parameter falls back to that parameter's default value.

Splatting into a method with a rest parameter already worked and is unchanged. A splat to a call with an explicit receiver (`obj.f(*args)`) stays a loud reject for now.

Tests cover local/literal/method-call/string/float operands, splat after a fixed leading arg, value and statement position, optional-default fallback, the rest-param case, and the three arity-error messages. Full suite green; the new test is also ASAN + UBSan clean under `SPINEL_GC_STRESS`.