### PR TITLE
codegen: skip poly [] arms whose key type mismatches the param

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -9887,6 +9887,25 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
            this poly value's receiver anyway -- that is why it was pruned, and a
            yielding method's value-position dispatch is moot here (issue #1583). */
         if (!scope_has_callable_symbol(c, mi)) continue;
+        /* A candidate whose concrete key parameter type is incompatible with the
+           concrete call-site key cannot be this poly value's receiver for that
+           key -- e.g. a Symbol-keyed user `[]` reached by a String key, where the
+           value's real class is a string-keyed Hash. Passing the key raw would be
+           a C pointer/integer type error (const char * into an sp_sym slot), so
+           skip the arm. Mirrors the key-type-mismatch handling for typed hashes. */
+        int arm_key_incompat = 0;
+        for (int a = 0; a < c->scopes[mi].nparams && a < argc; a++) {
+          LocalVar *pv0 = (c->scopes[mi].pnames && c->scopes[mi].pnames[a])
+                            ? scope_local(&c->scopes[mi], c->scopes[mi].pnames[a]) : NULL;
+          TyKind pt0 = pv0 ? pv0->type : TY_UNKNOWN;
+          TyKind at0 = atmp_ty[a];
+          int pc = pt0 != TY_POLY && pt0 != TY_UNKNOWN && pt0 != TY_NIL && pt0 != TY_VOID;
+          int ac = at0 != TY_POLY && at0 != TY_UNKNOWN && at0 != TY_NIL && at0 != TY_VOID;
+          if (pc && ac && pt0 != at0 && (pt0 == TY_STRING || at0 == TY_STRING)) {
+            arm_key_incompat = 1; break;
+          }
+        }
+        if (arm_key_incompat) continue;
         TyKind mret = c->scopes[mi].ret;
         int mnp = c->scopes[mi].nparams;
         Buf cb; memset(&cb, 0, sizeof cb);


### PR DESCRIPTION
A polymorphic `[]` dispatch enumerates every class that defines `[]` (plus the builtin hash arms). When the receiver type is fully unknown, the analyzer never records a String-key call edge into a Symbol-keyed user `[]`, so that method's key parameter stays a concrete `sp_sym`. Codegen still emitted its arm and coerced the key once to `const char *`, handing the String key raw to the `sp_sym` slot — invalid C:

```
error: incompatible pointer to integer conversion passing 'const char *'
to parameter of type 'sp_sym' (aka 'long')
  static mrb_int sp_Box__lb_rb(sp_Box *self, sp_sym lv_k) { … }
```

This surfaces on a String-keyed row read (`rows[0]["n"]`, where `rows` comes from an opaque source) when model classes also define a Symbol-keyed `[]`: the poly `[]` switch includes those Symbol-keyed arms, all handed the one `const char *` key.

## Fix

Before emitting a candidate class's arm, skip it when the candidate's concrete key-parameter type is incompatible with the concrete call-site key (a `String`-vs-other mismatch). Such a class can never be the receiver for that key, so the arm is dead — and passing the key raw is a C pointer/integer type error. This mirrors the key-type-mismatch handling already used for typed hashes.

The String-keyed builtin hash arms remain, so a String key still dispatches correctly. The constrained-receiver path (where the key parameter widens to poly and the arg is boxed) is unaffected — a real user-class receiver indexed by a String still dispatches.

## Testing

Full suite green (`-Werror`).

No dedicated regression `.rb` is included: the miscompile only fires when the receiver is fully un-inferred, which in self-contained Ruby requires an identity-laundering function that the compiler cannot emit (a separate, pre-existing limitation). A self-contained reproducer therefore cannot both compile after the fix and run, so the suite plus a manual compile-probe of the original repro are the validation.

Same family as the incompatible-poly-dispatch-arm signatures in https://github.com/matz/spinel/issues/1576, https://github.com/matz/spinel/issues/1437, and https://github.com/matz/spinel/issues/1438 — here for `[]` with a String-vs-Symbol key-type mismatch.