### PR TITLE
codegen: resolve untyped interpolation values against the emitting class

### DIFF
--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -65,6 +65,23 @@ void emit_interp(Compiler *c, int id, Buf *b) {
       for (int si = 0; si + 1 < bn; si++) emit_stmt(c, body[si], g_pre, g_indent);
       const char *ety = expr >= 0 ? nt_type(nt, expr) : NULL;
       TyKind t = comp_ntype(c, expr);
+      /* A bare implicit-self call inside an included-module method is analyzed
+         generically (self type unknown -> TY_UNKNOWN), but codegen emits the
+         method for a concrete class. Re-resolve the call against the class
+         being emitted so the interpolation dispatches on the real return type
+         (the same self-class lookup codegen uses for implicit-self calls). */
+      if (t == TY_UNKNOWN && ety && sp_streq(ety, "CallNode") &&
+          nt_ref(nt, expr, "receiver") < 0) {
+        const char *cn = nt_str(nt, expr, "name");
+        Scope *cs = comp_scope_of(c, expr);
+        int dcid = g_ie_class_id >= 0 ? g_ie_class_id
+                 : g_emitting_class_id >= 0 ? g_emitting_class_id
+                 : cs->class_id;
+        if (cn && dcid >= 0) {
+          int mi = comp_method_in_chain(c, dcid, cn, NULL);
+          if (mi >= 0) t = c->scopes[mi].ret;
+        }
+      }
       if (ety && (sp_streq(ety, "LocalVariableWriteNode") || sp_streq(ety, "LocalVariableOperatorWriteNode") ||
                   sp_streq(ety, "LocalVariableOrWriteNode") || sp_streq(ety, "LocalVariableAndWriteNode"))) {
         emit_stmt(c, expr, g_pre, g_indent);
@@ -158,6 +175,13 @@ void emit_interp(Compiler *c, int id, Buf *b) {
         int en = 0; nt_arr(nt, expr, "elements", &en);
         if (en == 0) { buf_puts(&fmt, "%s"); buf_puts(&conv, "\"[]\""); }
         else { free(fmt.p); free(argbuf.p); free(decls.p); free(conv.p); free(flat); unsupported(c, pid, "interpolation value"); }
+      }
+      else if (t == TY_UNKNOWN) {
+        /* An untyped value (e.g. a method resolved only through an included
+           module) is already emitted as a boxed sp_RbVal, so stringify it the
+           same way as a poly value rather than rejecting the interpolation. */
+        buf_puts(&fmt, "%s"); buf_puts(&conv, "sp_poly_to_s(");
+        EMIT_IV(); buf_puts(&conv, ")");
       }
       else {
         free(fmt.p); free(argbuf.p); free(decls.p); free(conv.p); free(flat);

--- a/test/interp_mixin_method.rb
+++ b/test/interp_mixin_method.rb
@@ -1,0 +1,16 @@
+# Interpolating a method whose type is known only through the including module:
+# the module method is analyzed with an unknown self, so the call types as
+# unknown; codegen re-resolves it against the class being emitted.
+module Greeting
+  def greet; "hi #{name}, you are #{age}"; end   # name -> String, age -> Integer
+end
+
+class Person
+  include Greeting
+  def initialize(n, a); @n = n; @a = a; end
+  def name; @n; end
+  def age; @a; end
+end
+
+puts Person.new("bob", 42).greet
+puts Person.new("amy", 7).greet

--- a/test/interp_mixin_method.rb.expected
+++ b/test/interp_mixin_method.rb.expected
@@ -1,0 +1,2 @@
+hi bob, you are 42
+hi amy, you are 7


### PR DESCRIPTION
A method defined in a module and analyzed with an unknown self -- so a bare
implicit-self call in its body types as unknown -- is emitted by codegen for
each including class, where that call resolves to a concrete typed method.
String interpolation only saw the unknown node type and rejected the whole
interpolation.

Re-resolve a TY_UNKNOWN implicit-self call against the class being emitted
(g_ie_class_id / g_emitting_class_id, the same lookup codegen already uses for
implicit-self calls) and dispatch on the resolved return type. A still-unknown
value falls back to sp_poly_to_s rather than rejecting.