### PR TITLE
codegen: forward renamed locals from bare super in a block_given? body

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -2256,7 +2256,7 @@ void emit_super(Compiler *c, int id, Buf *b) {
                c->classes[s->class_id].name, mc(shadow),
                c->classes[s->class_id].name, g_self);
     if (ty && sp_streq(ty, "ForwardingSuperNode")) {
-      for (int i = 0; i < s->nparams; i++) buf_printf(b, ", lv_%s", s->pnames[i]);
+      for (int i = 0; i < s->nparams; i++) buf_printf(b, ", lv_%s", rename_local(s->pnames[i]));
     }
     else {
       int smi = -1;
@@ -2288,7 +2288,7 @@ void emit_super(Compiler *c, int id, Buf *b) {
         buf_puts(b, "))");
       }
       else if (ty && sp_streq(ty, "ForwardingSuperNode") && s->nparams > 0)
-        buf_printf(b, "(%s->msg = lv_%s)", g_self, s->pnames[0]);
+        buf_printf(b, "(%s->msg = lv_%s)", g_self, rename_local(s->pnames[0]));
       else
         buf_puts(b, "((void)0)");
       return;
@@ -2323,15 +2323,18 @@ void emit_super(Compiler *c, int id, Buf *b) {
       LocalVar *dst = scope_local(pm, pm->pnames[i]);
       TyKind st = src ? src->type : TY_UNKNOWN;
       TyKind dt = dst ? dst->type : TY_UNKNOWN;
+      /* Use the local's emitted C name: when this method body is inlined at a
+         block call site the params are renamed (e.g. `x` -> `_y5_x`), so bare
+         `super`'s implicit forwarding must reference the renamed identifier. */
       if (dt == TY_POLY && st != TY_POLY && st != TY_UNKNOWN) {
         buf_puts(b, ", ");
         Buf _bx; memset(&_bx, 0, sizeof _bx);
-        buf_printf(&_bx, "lv_%s", s->pnames[i]);
+        buf_printf(&_bx, "lv_%s", rename_local(s->pnames[i]));
         emit_boxed_text(c, st, _bx.p, b);
         free(_bx.p);
       }
       else {
-        buf_printf(b, ", lv_%s", s->pnames[i]);
+        buf_printf(b, ", lv_%s", rename_local(s->pnames[i]));
       }
     }
   }

--- a/test/super_forward_block_given.rb
+++ b/test/super_forward_block_given.rb
@@ -1,0 +1,50 @@
+# Bare `super` (implicit argument forwarding) inside a `block_given?` branch.
+# When a method body references block_given?, calling it with a block inlines
+# the body and renames the param locals for the capture context; bare super's
+# forwarded arguments must reference the renamed locals, not the original names.
+class Base
+  def m(x = nil); "base(#{x})"; end
+  def two(a, b); "base(#{a},#{b})"; end
+end
+
+class Sub < Base
+  def m(x = nil)
+    if block_given? then super else "self" end
+  end
+  def two(a, b)
+    if block_given? then super else "self" end
+  end
+end
+
+# with a block: inlined, params renamed -> super forwards the renamed locals
+p Sub.new.m(1) { 0 }
+p Sub.new.two(1, 2) { 0 }
+# without a block: the non-inlined path still works
+p Sub.new.m(7)
+p Sub.new.two(3, 4)
+
+# a poly-typed forwarded argument (boxing branch) in the same context
+class Wrap
+  def m(x); "wrap:#{x.inspect}"; end
+end
+class WrapSub < Wrap
+  def m(x); block_given? ? super : "self"; end
+end
+def val(v); v; end
+p WrapSub.new.m(val("hi")) { 0 }
+
+# prepend chain: a prepended method referencing block_given? is inlined at a
+# block call site and its params renamed; the bare super to the prepended-over
+# method must forward the renamed locals too (a sibling of the parent-chain
+# forwarding above).
+module Logged
+  def compute(x)
+    if block_given? then super else "noblock" end
+  end
+end
+class Calc
+  prepend Logged
+  def compute(x); "calc(#{x})"; end
+end
+p Calc.new.compute(5) { 0 }
+p Calc.new.compute(7)

--- a/test/super_forward_block_given.rb.expected
+++ b/test/super_forward_block_given.rb.expected
@@ -1,0 +1,7 @@
+"base(1)"
+"base(1,2)"
+"self"
+"self"
+"wrap:\"hi\""
+"calc(5)"
+"noblock"


### PR DESCRIPTION
A method whose body references `block_given?` is inlined at a call site that passes a block, and its parameter locals are renamed for the capture context (`x` -> `_y5_x`). Bare `super`'s implicit argument forwarding emitted the original `lv_x` instead of the renamed identifier, so the generated C referenced an undeclared variable and failed to compile.

Route the forwarded parameter names through `rename_local` so they match the inlined locals. Explicit `super()` and bare `super` outside a `block_given?` branch were unaffected and stay correct. Adds a test covering inlined bare super (single and multiple params, including a poly-typed boxed-forward) alongside the non-inlined path.