### PR TITLE
codegen: let case/in pattern guards see the pattern's bindings

### DIFF
--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -1401,6 +1401,24 @@ void emit_case_match(Compiler *c, int id, Buf *b, int indent, int tail, int valu
     const char *pty = nt_type(nt, pat);
     if (!pty) continue;
 
+    /* `in PATTERN if GUARD` (or `unless GUARD`) is parsed as an If/UnlessNode
+       wrapping the real pattern. Unwrap it so the pattern flows through the
+       normal match/bind logic, and apply the guard after the bindings are in
+       scope (a guard can reference them). */
+    int arm_guard = -1, arm_guard_negate = 0;
+    if (sp_streq(pty, "IfNode") || sp_streq(pty, "UnlessNode")) {
+      int istmts = nt_ref(nt, pat, "statements");
+      int in = 0; const int *ib = istmts >= 0 ? nt_arr(nt, istmts, "body", &in) : NULL;
+      int gp = nt_ref(nt, pat, "predicate");
+      if (in >= 1 && gp >= 0) {
+        arm_guard = gp;
+        arm_guard_negate = sp_streq(pty, "UnlessNode");
+        pat = ib[0];
+        pty = nt_type(nt, pat);
+        if (!pty) continue;
+      }
+    }
+
     emit_indent(b, indent); buf_puts(b, "{\n");
 
     /* --- compute match condition --- */
@@ -1518,7 +1536,7 @@ void emit_case_match(Compiler *c, int id, Buf *b, int indent, int tail, int valu
     free(cond_buf.p);
 
     /* --- bindings --- */
-    int guard = -1;
+    int guard = arm_guard;
     int array_pat = -1;
 
     if (sp_streq(pty, "LocalVariableTargetNode")) {
@@ -1703,9 +1721,9 @@ void emit_case_match(Compiler *c, int id, Buf *b, int indent, int tail, int valu
 
     /* --- body with optional guard --- */
     if (guard >= 0) {
-      emit_indent(b, body_indent); buf_puts(b, "if (");
-      emit_expr(c, guard, b);
-      buf_puts(b, ") {\n");
+      emit_indent(b, body_indent); buf_puts(b, arm_guard_negate ? "if (!(" : "if (");
+      emit_cond(c, guard, b);  /* Ruby truthiness for every guard type (0/"" are truthy) */
+      buf_puts(b, arm_guard_negate ? ")) {\n" : ") {\n");
       if (value_cr >= 0) { emit_pm_body_value(c, stmts, rt, value_cr, b, body_indent + 1); emit_indent(b, body_indent + 1); buf_printf(b, "goto _pm_%d;\n", lbl); }
       else if (tail) emit_stmts_tail(c, stmts, b, body_indent + 1);
       else { emit_stmts(c, stmts, b, body_indent + 1); emit_indent(b, body_indent + 1); buf_printf(b, "goto _pm_%d;\n", lbl); }

--- a/test/case_in_guard_bindings.rb
+++ b/test/case_in_guard_bindings.rb
@@ -1,0 +1,51 @@
+# A pattern guard (`in PATTERN if GUARD` / `unless GUARD`) can reference the
+# bindings introduced by the pattern. Receivers go through per-type identity
+# methods to defeat constant folding while keeping each scrutinee monomorphic.
+# Binding names are unique per arm so cross-arm type unification can't muddy them.
+def ai(x); x; end
+def aii(x); x; end
+def hh(x); x; end
+def ii(x); x; end
+
+# array pattern + if guard referencing the bindings
+case ai([1, 2])
+in [p1, q1] if p1 + q1 == 3 then p "sum3"
+else p "no"
+end                                       # "sum3"
+
+case ai([1, 2])
+in [p2, q2] if p2 + q2 == 99 then p "yes"
+else p "fell-through"
+end                                       # "fell-through"
+
+# three-element array, guard chooses among arms
+case aii([1, 2, 3])
+in [p3, q3, r3] if p3 + q3 + r3 == 6 then p "six"
+in [p3b, q3b, r3b] then p "other"
+end                                       # "six"
+
+# hash pattern + guard over its typed-capture bindings
+case hh({ name: "x", age: 5 })
+in { name: String => nm, age: Integer => ag } if ag > 3 then p [nm, ag]
+else p "no"
+end                                       # ["x", 5]
+
+# unless guard negates
+case ai([1, 2])
+in [p4, q4] unless p4 == q4 then p "diff"
+else p "same"
+end                                       # "diff"
+
+# a plain local-binding pattern with a guard still works
+case ii(7)
+in n5 if n5 > 5 then p "big"
+else p "small"
+end                                       # "big"
+
+# a guard of a concrete (non-bool) type follows Ruby truthiness: 0 is truthy,
+# so an Integer-valued guard that evaluates to 0 still passes (C would treat 0
+# as falsy without the truthiness wrapper).
+case ii(5)
+in n6 if n6 - 5 then p "truthy-zero"
+else p "wrongly-falsy"
+end                                       # "truthy-zero"

--- a/test/case_in_guard_bindings.rb.expected
+++ b/test/case_in_guard_bindings.rb.expected
@@ -1,0 +1,7 @@
+"sum3"
+"fell-through"
+"six"
+["x", 5]
+"diff"
+"big"
+"truthy-zero"


### PR DESCRIPTION
A guarded pattern arm (`in [a, b] if a + b == 3`) is parsed as an If/Unless node wrapping the real pattern. Codegen treated that wrapper as a flat local-binding pattern: it skipped the structured pattern's match condition and its bindings, then evaluated the guard against unbound (zero) variables, so the arm never matched.

Unwrap the If/Unless wrapper up front so the inner pattern flows through the normal match-condition and binding logic, and apply the guard after the bindings are established (an `unless` guard is negated, and a poly-typed guard goes through `sp_poly_truthy`). The guard now sees the destructured array, hash, and find-pattern bindings. Adds a test covering array/hash/typed-capture bindings under both `if` and `unless` guards.