### PR TITLE
codegen: honor Kernel#warn(category:) and forward a keyword-rest splat

### DIFF
--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -411,8 +411,53 @@ else {
     return 1;
   }
   if (sp_streq(name, "warn")) {
-    /* Kernel#warn: each argument to stderr with a trailing newline */
+    /* Kernel#warn(*msgs, uplevel:, category:): positional messages go to stderr
+       with a trailing newline. The trailing keyword hash carries options:
+         - a forwarded `**opts` (AssocSplat) is an options bundle: evaluate the
+           splat values for side effects and otherwise ignore them;
+         - `category:` selects a warning category. CRuby suppresses the
+           `:deprecated` category by default (Warning[:deprecated] == false with
+           no -W:deprecated), so a literal `category: :deprecated` prints nothing
+           (messages are still evaluated for side effects); other categories print
+           normally;
+         - `uplevel:` prefixes each line with the caller's source location, which
+           needs a runtime line-granularity call stack spinel does not have.
+           Emitting any prefix would be a wrong location, so it loud-rejects. */
+    int kw_idx = -1, suppress = 0;
+    if (argc > 0) {
+      int last = argv[argc - 1];
+      const char *lt = nt_type(c->nt, last);
+      if (lt && sp_streq(lt, "KeywordHashNode")) {
+        kw_idx = argc - 1;
+        int en = 0; const int *elems = nt_arr(c->nt, last, "elements", &en);
+        for (int e = 0; e < en; e++) {
+          const char *ety = nt_type(c->nt, elems[e]);
+          if (ety && sp_streq(ety, "AssocSplatNode")) {
+            int val = nt_ref(c->nt, elems[e], "value");
+            if (val >= 0) { emit_indent(b, indent); buf_puts(b, "(void)("); emit_expr(c, val, b); buf_puts(b, ");\n"); }
+            continue;
+          }
+          int key = nt_ref(c->nt, elems[e], "key");
+          int val = nt_ref(c->nt, elems[e], "value");
+          const char *kty = key >= 0 ? nt_type(c->nt, key) : NULL;
+          const char *kname = (kty && sp_streq(kty, "SymbolNode")) ? nt_str(c->nt, key, "value") : NULL;
+          if (kname && sp_streq(kname, "uplevel")) {
+            unsupported(c, elems[e], "warn(uplevel:) caller-location prefix (no runtime source-line stack)");
+          }
+          else if (kname && sp_streq(kname, "category")) {
+            const char *vty = val >= 0 ? nt_type(c->nt, val) : NULL;
+            const char *vname = (vty && sp_streq(vty, "SymbolNode")) ? nt_str(c->nt, val, "value") : NULL;
+            if (vname && sp_streq(vname, "deprecated"))
+              suppress = 1;
+            else if (val >= 0) { emit_indent(b, indent); buf_puts(b, "(void)("); emit_expr(c, val, b); buf_puts(b, ");\n"); }
+          }
+          else if (val >= 0) { emit_indent(b, indent); buf_puts(b, "(void)("); emit_expr(c, val, b); buf_puts(b, ");\n"); }
+        }
+      }
+    }
     for (int k = 0; k < argc; k++) {
+      if (k == kw_idx) continue;
+      if (suppress) { emit_indent(b, indent); buf_puts(b, "(void)("); emit_expr(c, argv[k], b); buf_puts(b, ");\n"); continue; }
       TyKind at = comp_ntype(c, argv[k]);
       emit_indent(b, indent); buf_puts(b, "fputs(");
       if (at == TY_STRING) emit_expr(c, argv[k], b);

--- a/test/warn_category.rb
+++ b/test/warn_category.rb
@@ -1,0 +1,15 @@
+# Kernel#warn(category:) honors CRuby's default warning levels. The :deprecated
+# category is off by default (Warning[:deprecated] == false without -W:deprecated),
+# so those warnings print nothing; other categories print normally. Suppressed
+# messages are still evaluated for their side effects.
+warn("plain warning")
+warn("deprecated thing", category: :deprecated)
+warn("experimental thing", category: :experimental)
+warn("a", "b", category: :deprecated)
+warn("c", "d", category: :experimental)
+
+# the message expression of a suppressed warning is still evaluated
+def shout; $stdout.puts "evaluated"; "msg"; end
+warn(shout, category: :deprecated)
+
+$stdout.puts "done"

--- a/test/warn_category.rb.err.expected
+++ b/test/warn_category.rb.err.expected
@@ -1,0 +1,4 @@
+plain warning
+experimental thing
+c
+d

--- a/test/warn_category.rb.expected
+++ b/test/warn_category.rb.expected
@@ -1,0 +1,2 @@
+evaluated
+done

--- a/test/warn_double_splat.rb
+++ b/test/warn_double_splat.rb
@@ -1,0 +1,18 @@
+# Kernel#warn accepts a forwarded keyword-rest (`**opts`) as its options
+# bundle rather than a message. A double-splat made solely of forwarded hashes
+# is evaluated for side effects and otherwise ignored; positional messages
+# still reach stderr. (Literal uplevel:/category: keywords are unsupported and
+# rejected at compile time, since spinel models neither.)
+def s(x); x; end
+
+opts = s({})
+warn(**opts)              # forwarded empty options: no output
+warn("with opts", **opts) # positional message + forwarded options
+warn(**{})                # empty literal double-splat
+puts "stdout done"
+
+# the splat value is still evaluated (side effect preserved)
+$count = 0
+def make_opts; $count += 1; {}; end
+warn(**make_opts)
+p $count

--- a/test/warn_double_splat.rb.err.expected
+++ b/test/warn_double_splat.rb.err.expected
@@ -1,0 +1,1 @@
+with opts

--- a/test/warn_double_splat.rb.expected
+++ b/test/warn_double_splat.rb.expected
@@ -1,0 +1,2 @@
+stdout done
+1


### PR DESCRIPTION
Kernel#warn handles its trailing keyword options. A forwarded `**opts` (a keyword hash made solely of double-splats) is an options bundle: its values are evaluated for side effects and ignored. A literal `category:` selects the warning category — `:deprecated` is suppressed by default (matching CRuby's `Warning[:deprecated] == false` with no `-W:deprecated`), other categories print normally, and a suppressed message is still evaluated for its side effects. `uplevel:` would prefix each line with the caller's source location, which needs a runtime line-granularity call stack spinel does not have, so it loud-rejects rather than emit a wrong location.