### PR TITLE
codegen: reject Hash#compare_by_identity, report compare_by_identity? false

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -1907,6 +1907,12 @@ static int emit_hash_call(Compiler *c, int id, Buf *b) {
   if (args >= 0) argv = nt_arr(nt, args, "arguments", &argc);
   TyKind rt = recv >= 0 ? comp_ntype(c, recv) : TY_UNKNOWN;
   if (recv >= 0 && ty_is_hash(rt)) {
+    /* compare_by_identity? is always false for a value-keyed hash; the mutating
+       compare_by_identity cannot be honored (keys are compared by value) and is
+       rejected loudly rather than silently no-op'd. */
+    if (sp_streq(name, "compare_by_identity?") && argc == 0) { buf_puts(b, "0"); return 1; }
+    if (sp_streq(name, "compare_by_identity"))  /* any arity: identity hashing is unsupported */
+      unsupported(c, id, "Hash#compare_by_identity (identity-keyed hashing)");
     const char *hn = ty_hash_cname(rt);
     if (hn) {
       /* select! / filter! / reject! / keep_if / delete_if { |k, v| cond } in
@@ -3862,6 +3868,14 @@ static int emit_poly_call(Compiler *c, int id, Buf *b) {
   const int *argv = NULL;
   if (args >= 0) argv = nt_arr(nt, args, "arguments", &argc);
   TyKind rt = recv >= 0 ? comp_ntype(c, recv) : TY_UNKNOWN;
+  /* Hash#compare_by_identity switches a hash to identity (equal?/object_id)
+     key comparison. Spinel's hash machinery compares keys by value, so the
+     mutator can't take effect; emitting it as a no-op would silently diverge
+     (subsequent lookups behave as a value-keyed hash). Reject loudly instead.
+     The `compare_by_identity?` predicate is left to report false, which is
+     correct for any hash this mutator never (successfully) ran on. */
+  if (sp_streq(name, "compare_by_identity"))  /* any arity: identity hashing is unsupported */
+    unsupported(c, id, "Hash#compare_by_identity (identity-keyed hashing)");
   /* encoding.name -> the encoding name string */
   if (sp_streq(name, "name") && argc == 0 && recv >= 0 && comp_ntype(c, recv) == TY_POLY) {
     const char *rty2 = nt_type(nt, recv);

--- a/test/compare_by_identity_predicate.rb
+++ b/test/compare_by_identity_predicate.rb
@@ -1,0 +1,10 @@
+# Hash#compare_by_identity? reports false for an ordinary (value-keyed) hash.
+# The mutating Hash#compare_by_identity is rejected at compile time, since
+# spinel compares hash keys by value and cannot switch a hash to identity
+# comparison; emitting it as a no-op would silently diverge from CRuby. This
+# test pins the predicate's correct value-keyed answer.
+def s(x); x; end
+p s({}).compare_by_identity?
+p s({ "a" => 1 }).compare_by_identity?
+h = {}
+p h.compare_by_identity?

--- a/test/compare_by_identity_predicate.rb.expected
+++ b/test/compare_by_identity_predicate.rb.expected
@@ -1,0 +1,3 @@
+false
+false
+false


### PR DESCRIPTION
Spinel hashes compare keys by value, so the mutating `Hash#compare_by_identity` cannot switch a hash to identity comparison. It was silently emitted as a no-op on the poly-hash path, so a program that relied on identity keys quietly behaved as a value-keyed hash. Reject it loudly instead, on both the typed and poly hash paths.

`compare_by_identity?` now consistently reports false for any value-keyed hash (previously it returned false on the poly path but rejected on typed hashes), which is the correct answer for a hash the mutator never (successfully) ran on.