### PR TITLE
codegen: build Regexp.union over string, Regexp, and array operands

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -6177,6 +6177,56 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     else { buf_puts(b, "sp_re_escape("); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
     return;
   }
+  /* Regexp.union(pat, ...) -> a pattern matching the alternation of its operands.
+     A String operand is regexp-escaped; a Regexp operand (literal or a constant
+     bound to one) contributes its source wrapped in CRuby's `(?on-off:src)` option
+     group so its flags survive; a single Array argument is expanded into its
+     elements. A runtime Regexp value has no recoverable source (patterns compile
+     to bytecode), so that lone form still loud-rejects. */
+  if (recv >= 0 && argc >= 0 && sp_streq(name, "union") &&
+      nt_type(nt, recv) && sp_streq(nt_type(nt, recv), "ConstantReadNode") &&
+      nt_str(nt, recv, "name") && sp_streq(nt_str(nt, recv, "name"), "Regexp")) {
+    /* `Regexp.union([a, b])`: a lone Array argument supplies the operands. */
+    const int *ops = argv; int nops = argc;
+    if (argc == 1 && nt_type(nt, argv[0]) && sp_streq(nt_type(nt, argv[0]), "ArrayNode"))
+      ops = nt_arr(nt, argv[0], "elements", &nops);
+    /* A single Regexp operand is returned unchanged (CRuby keeps its source and
+       flags verbatim, no option-group wrapper). */
+    if (nops == 1 && re_lit_src(c, ops[0]) && emit_regex_pat_to_buf(c, ops[0], b))
+      return;
+    int ts = ++g_tmp, tp = ++g_tmp;
+    for (int i = 0; i < nops; i++) {
+      Buf ab; memset(&ab, 0, sizeof ab);
+      const char *resrc = re_lit_src(c, ops[i]);
+      if (resrc) {
+        /* Regexp operand: splice its bare source. The engine has no inline
+           option group (?on-off:...), so an operand carrying an i/x/m option
+           (re_engine_flags strips the encoding bits, leaving only the
+           matching-relevant options; 0 for a flagless operand) can't have its
+           flags preserved in the joined pattern -- reject rather than drop them. */
+        if (re_engine_flags(re_lit_flags(c, ops[i])) != 0)
+          unsupported(c, id, "Regexp.union with a flagged Regexp operand (engine lacks inline option groups)");
+        emit_str_literal(&ab, resrc);
+      } else {
+        TyKind at = comp_ntype(c, ops[i]);
+        if (at != TY_STRING && at != TY_POLY)
+          unsupported(c, id, "Regexp.union operand without a compile-time source (runtime Regexp or non-String value)");
+        if (at == TY_POLY) { buf_puts(&ab, "sp_re_escape(sp_poly_to_s("); emit_expr(c, ops[i], &ab); buf_puts(&ab, "))"); }
+        else { buf_puts(&ab, "sp_re_escape("); emit_expr(c, ops[i], &ab); buf_puts(&ab, ")"); }
+      }
+      emit_indent(g_pre, g_indent);
+      if (i == 0) buf_printf(g_pre, "const char *_t%d = %s;\n", ts, ab.p ? ab.p : "\"\"");
+      else buf_printf(g_pre, "_t%d = sp_sprintf(\"%%s|%%s\", _t%d, %s);\n", ts, ts, ab.p ? ab.p : "\"\"");
+      free(ab.p);
+    }
+    /* an empty union (`Regexp.union()` or `Regexp.union([])`) never matches */
+    if (nops == 0) { emit_indent(g_pre, g_indent); buf_printf(g_pre, "const char *_t%d = \"(?!)\";\n", ts); }
+    emit_indent(g_pre, g_indent);
+    buf_printf(g_pre, "mrb_regexp_pattern *_t%d = re_compile(_t%d, (int64_t)strlen(_t%d ? _t%d : \"\"), 0);\n",
+               tp, ts, ts, ts);
+    buf_printf(b, "_t%d", tp);
+    return;
+  }
   /* Regexp.linear_time?(re) -> whether re matches in linear time. A literal arg
      is inspected for a backreference (the construct that defeats it); a
      non-literal regexp value defaults to true (the answer for backref-free

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -334,6 +334,7 @@ int re_engine_flags(int pf);
 int re_has_captures(const char *src);
 int re_lit_index(Compiler *c, int nid);
 const char *re_lit_src(Compiler *c, int nid);
+int re_lit_flags(Compiler *c, int nid);
 void emit_interp(Compiler *c, int id, Buf *b);
 int emit_regex_pat_to_buf(Compiler *c, int nid, Buf *b);
 int nameset_has(NameSet *s, const char *nm);

--- a/src/codegen_util.c
+++ b/src/codegen_util.c
@@ -218,6 +218,31 @@ const char *re_lit_src(Compiler *c, int nid) {
   }
   return NULL;
 }
+/* Prism flags of a literal/const-bound regexp (-1 if `nid` is not one). Mirrors
+   re_lit_src's resolution so callers can check a regex operand for flags. */
+int re_lit_flags(Compiler *c, int nid) {
+  if (nid < 0) return -1;
+  const char *ty = nt_type(c->nt, nid);
+  if (!ty) return -1;
+  if (sp_streq(ty, "RegularExpressionNode")) return (int)nt_int(c->nt, nid, "flags", 0);
+  if (sp_streq(ty, "ConstantReadNode") || sp_streq(ty, "ConstantPathNode")) {
+    const char *nm = nt_str(c->nt, nid, "name");
+    if (!nm) return -1;
+    for (int k = 0; k < c->nt->count; k++) {
+      const char *kt = nt_type(c->nt, k);
+      if (!kt || (!sp_streq(kt, "ConstantWriteNode") && !sp_streq(kt, "ConstantPathWriteNode"))) continue;
+      const char *kn = nt_str(c->nt, k, "name");
+      if (!kn || !sp_streq(kn, nm)) continue;
+      int v = nt_ref(c->nt, k, "value");
+      if (v >= 0 && nt_type(c->nt, v) && sp_streq(nt_type(c->nt, v), "CallNode") &&
+          nt_str(c->nt, v, "name") && sp_streq(nt_str(c->nt, v, "name"), "freeze"))
+        v = nt_ref(c->nt, v, "receiver");
+      if (v >= 0 && nt_type(c->nt, v) && sp_streq(nt_type(c->nt, v), "RegularExpressionNode"))
+        return (int)nt_int(c->nt, v, "flags", 0);
+    }
+  }
+  return -1;
+}
 void emit_interp(Compiler *c, int id, Buf *b);  /* forward */
 
 /* Emit a regex pattern expression to `b`, handling both static literals and

--- a/test/regexp_union_strings.rb
+++ b/test/regexp_union_strings.rb
@@ -1,0 +1,36 @@
+# Regexp.union builds an alternation of its operands. A String operand is
+# regexp-escaped; a (flagless) Regexp operand contributes its source; a single
+# Array argument is expanded into its elements; a single Regexp operand is
+# returned unchanged. Operands are routed through a method param where possible
+# to exercise the runtime build path too.
+def id(x); x; end
+
+# string operands, escaped
+p Regexp.union("a", "b").match?("xby")
+p Regexp.union("a", "b").match?("zz")
+p Regexp.union("a.c").match?("a.c")
+p Regexp.union("a.c").match?("abc")
+
+# regex operands (flagless) and mixed string/regex
+p Regexp.union(/a/, /b/).match?("zb")
+p Regexp.union(/foo/, "ba.r").match?("ba.r")
+p Regexp.union(/foo/, "ba.r").match?("baXr")
+
+# a constant bound to a regex literal resolves to its source
+PAT = /pp/
+p Regexp.union(PAT, "q").match?("ppx")
+
+# a single Array argument supplies the operands
+p Regexp.union(["x", "y"]).match?("zy")
+
+# a single operand: string is escaped, regex is returned unchanged (flags kept)
+p Regexp.union("only").match?("only")
+p Regexp.union(/sing/i).match?("SING")
+
+# usable as a normal Regexp (=~, non-literal string operand)
+p(Regexp.union("foo", "bar") =~ "say bar now")
+p Regexp.union(id("x"), "y").match?("zy")
+
+# empty union -> a pattern that never matches (CRuby's /(?!)/)
+p Regexp.union().match?("")
+p Regexp.union([]).match?("")

--- a/test/regexp_union_strings.rb.expected
+++ b/test/regexp_union_strings.rb.expected
@@ -1,0 +1,15 @@
+true
+false
+true
+false
+true
+true
+false
+true
+true
+true
+true
+4
+true
+false
+false


### PR DESCRIPTION
Regexp.union builds an alternation of its operands directly. A String operand is regexp-escaped so its metacharacters stay literal; a Regexp operand (a literal or a constant bound to one) contributes its source; a single Array argument is expanded into its elements; and a single operand is returned essentially unchanged (a lone Regexp keeps its own flags via its compiled pattern). The joined source is compiled into an ordinary Regexp usable with match?/=~.

A Regexp operand carrying an i/x/m option in a multi-operand union still rejects: the engine has no inline option group ((?on-off:...)), so its flags cannot be preserved in the spliced source, and dropping them silently would diverge. A runtime Regexp value likewise rejects — patterns compile to bytecode with no recoverable source.