### PR TITLE
codegen: Method#name returns a Symbol

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -602,9 +602,9 @@ TyKind infer_call(Compiler *c, int id) {
        invoked through the poly ABI (sp_RbVal), so the call yields poly. */
     return g_promote_mode ? TY_POLY : TY_INT;
   }
-  /* <method>.name -> the method name string; .arity -> int */
+  /* <method>.name -> the method name as a Symbol; .arity -> int */
   if (recv >= 0 && rt == TY_METHOD && argc == 0) {
-    if (sp_streq(name, "name")) return TY_STRING;
+    if (sp_streq(name, "name")) return TY_SYMBOL;
     if (sp_streq(name, "arity")) return TY_INT;
   }
   /* <poly>.call(args): a boxed Proc/Method called through the runtime ABI,

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -5080,9 +5080,10 @@ void emit_call(Compiler *c, int id, Buf *b) {
     buf_puts(b, ")");
     return;
   }
-  /* <method>.name -> the stored method name. */
+  /* <method>.name -> the stored method name, interned to a Symbol (CRuby
+     Method#name returns a Symbol, not a String). */
   if (recv >= 0 && comp_ntype(c, recv) == TY_METHOD && argc == 0 && sp_streq(name, "name")) {
-    buf_puts(b, "(const char *)("); emit_expr(c, recv, b); buf_puts(b, ")->name");
+    buf_puts(b, "sp_sym_intern((const char *)("); emit_expr(c, recv, b); buf_puts(b, ")->name)");
     return;
   }
   /* <method>.arity -> a compile-time constant from the target method's param

--- a/test/method_name_symbol.rb
+++ b/test/method_name_symbol.rb
@@ -1,0 +1,32 @@
+# Method#name returns a Symbol (not a String), matching CRuby. The method
+# object is also routed through a param so the `.name` runs on a non-folded
+# TY_METHOD value.
+class Calc
+  def add(a, b); a + b; end
+  def noarg; 0; end
+  def +(other); 1; end
+end
+c = Calc.new
+
+m = c.method(:add)
+p m.name                  # :add
+puts m.name.inspect       # :add
+puts m.name == :add       # true
+puts m.name.class         # Symbol
+puts m.name.to_s          # add
+
+# no-arg method
+puts c.method(:noarg).name.inspect   # :noarg
+
+# operator method name
+p c.method(:+).name       # :+
+
+# routed through a method param to defeat constant-folding
+def id(x); x; end
+p id(c.method(:add)).name # :add
+
+# usable as a case/when scrutinee against symbol literals
+case m.name
+when :add then puts "is add"
+else puts "other"
+end

--- a/test/method_name_symbol.rb.expected
+++ b/test/method_name_symbol.rb.expected
@@ -1,0 +1,9 @@
+:add
+:add
+true
+Symbol
+add
+:noarg
+:+
+:add
+is add


### PR DESCRIPTION
`Method#name` returned the stored method name as a String, but CRuby returns a Symbol. Infer it as a Symbol and intern the stored name (`sp_sym_intern`) at the call site, so comparisons against symbol literals, `case/when`, `#inspect`, and `#class` all behave as in CRuby. `#to_s` still yields the plain name.