### PR TITLE
runtime: \k<name> named backreference in gsub/sub replacement

### DIFF
--- a/lib/sp_re.c
+++ b/lib/sp_re.c
@@ -138,7 +138,8 @@ mrb_bool sp_re_match_p_at(mrb_regexp_pattern *pat, const char *str, mrb_int pos)
   int caps[2];
   return re_exec(pat, str, slen, (mrb_int)pos, caps, 2) > 0;
 }
-void sp_re_expand_rep(char **out_io, size_t *olen_io, size_t *cap_io,
+void sp_re_expand_rep(const mrb_regexp_pattern *pat,
+                             char **out_io, size_t *olen_io, size_t *cap_io,
                              const char *rep, size_t rlen,
                              const char *src, int *caps, int ncaps) {
   size_t olen = *olen_io;
@@ -159,6 +160,48 @@ void sp_re_expand_rep(char **out_io, size_t *olen_io, size_t *cap_io,
         }
         i += 2;
         continue;
+      }
+      else if (d == 'k' && i + 2 < rlen && rep[i+2] == '<') {
+       /* \k<name>: named backreference. The name resolves against the
+          pattern; an unknown or empty name raises IndexError (mirroring
+          md[:name]), and a group that did not participate expands to "".
+          Only the angle-bracket form is a replacement backref -- \k'name'
+          is regex-only syntax, so it is left literal (handled by the
+          default copy below when no closing '>' is found). */
+        size_t j = i + 3;
+        while (j < rlen && rep[j] != '>') j++;
+        if (j < rlen) {
+          size_t nlen = j - (i + 3);
+          /* Group names are short; keep them on the stack and only fall back
+             to malloc for an exceptionally long name. */
+          char name_buf[64];
+          char *name = name_buf;
+          if (nlen >= sizeof(name_buf)) {
+            name = (char*)malloc(nlen + 1);
+            if (!name) { perror("malloc"); exit(1); }
+          }
+          memcpy(name, rep + i + 3, nlen);
+          name[nlen] = '\0';
+          int gi = re_named_group(pat, name);
+          if (gi < 0) {
+           /* Build the message before freeing the name, then release the
+              scratch buffer: sp_raise_cls longjmps, so the caller's free()
+              never runs and `out` (post-realloc) would otherwise leak. */
+            const char *msg = sp_sprintf("undefined group name reference: %s", name);
+            if (name != name_buf) free(name);
+            free(out);
+            sp_raise_cls("IndexError", msg);
+          }
+          if (name != name_buf) free(name);
+          if ((gi*2) + 1 < ncaps && caps[gi*2] >= 0 && caps[(gi*2)+1] >= 0) {
+            int g_len = caps[(gi*2)+1] - caps[gi*2];
+            if (olen + g_len + 1 >= cap) { cap = ((olen + g_len) * 2) + 64; out = (char*)realloc(out, cap); }
+            memcpy(out+olen, src + caps[gi*2], g_len);
+            olen += g_len;
+          }
+          i = j + 1;
+          continue;
+        }
       }
 else if (d == '\\') {
         if (olen + 1 >= cap) { cap = (cap * 2) + 64; out = (char*)realloc(out, cap); }
@@ -188,7 +231,7 @@ const char *sp_re_gsub(mrb_regexp_pattern *pat, const char *str, const char *rep
     size_t before = caps[0] - pos;
     if (olen+before+rlen >= cap) { cap = ((olen+before+rlen)*2)+64; out = (char*)realloc(out, cap); }
     memcpy(out+olen, str+pos, before); olen += before;
-    sp_re_expand_rep(&out, &olen, &cap, rep, rlen, str, caps, n);
+    sp_re_expand_rep(pat, &out, &olen, &cap, rep, rlen, str, caps, n);
     if (caps[0] == caps[1]) {
  /* Zero-width match (/^/, /$/, /\b/, an empty pattern): Ruby inserts
     the replacement before the char at this position, keeps that char,
@@ -230,7 +273,7 @@ const char *sp_re_sub(mrb_regexp_pattern *pat, const char *str, const char *rep)
   char *out = (char *)malloc(cap);
   memcpy(out, str, caps[0]);
   size_t olen = caps[0];
-  sp_re_expand_rep(&out, &olen, &cap, rep, rlen, str, caps, n);
+  sp_re_expand_rep(pat, &out, &olen, &cap, rep, rlen, str, caps, n);
   size_t rest = slen - caps[1];
   if (olen + rest + 1 >= cap) { cap = olen + rest + 64; out = (char*)realloc(out, cap); }
   memcpy(out+olen, str+caps[1], rest); olen += rest;

--- a/lib/sp_re.h
+++ b/lib/sp_re.h
@@ -47,7 +47,7 @@ mrb_int sp_re_rindex(mrb_regexp_pattern *pat, const char *str);
 sp_StrArray *sp_re_rpartition(mrb_regexp_pattern *pat, const char *str);
 mrb_bool sp_re_match_p(mrb_regexp_pattern *pat, const char *str);
 mrb_bool sp_re_match_p_at(mrb_regexp_pattern *pat, const char *str, mrb_int pos);
-void sp_re_expand_rep(char **out_io, size_t *olen_io, size_t *cap_io, const char *rep, size_t rlen, const char *src, int *caps, int ncaps);
+void sp_re_expand_rep(const mrb_regexp_pattern *pat, char **out_io, size_t *olen_io, size_t *cap_io, const char *rep, size_t rlen, const char *src, int *caps, int ncaps);
 const char *sp_re_gsub(mrb_regexp_pattern *pat, const char *str, const char *rep);
 const char *sp_re_sub(mrb_regexp_pattern *pat, const char *str, const char *rep);
 sp_StrArray *sp_re_scan(mrb_regexp_pattern *pat, const char *str);

--- a/test/matchdata_gsub_named_backref.rb
+++ b/test/matchdata_gsub_named_backref.rb
@@ -1,0 +1,34 @@
+# String#gsub / #sub expand `\k<name>` in the replacement to the named capture
+# group (empty when the group did not participate). An unknown or empty name
+# raises IndexError, mirroring md[:name]. `\k'name'` is regex-only and stays
+# literal. The subject string is routed through a method param so the
+# substitution runs at runtime rather than being constant-folded.
+def s(x); x; end
+
+# single named backref
+puts s("foobar").gsub(/(?<x>o+)/, "[\\k<x>]")
+# two named groups, swapped
+puts s("abcd").gsub(/(?<a>a)(?<b>b)/, "\\k<b>\\k<a>")
+# \k<name> mixed with \& (whole match)
+puts s("ab").gsub(/(?<a>a)b/, "\\k<a>-\\&")
+# optional group that participated
+p s("xyz").gsub(/(?<a>x)(?<b>y)?/, "[\\k<b>]")
+# optional group that did NOT participate -> empty expansion
+p s("xz").gsub(/(?<a>x)(?<b>y)?/, "[\\k<b>]")
+# single sub
+puts s("foobar").sub(/(?<x>o+)/, "[\\k<x>]")
+# \k'name' is regex-only syntax: left literal in a replacement
+puts s("ab").gsub(/(?<g>a)b/, "\\k'g'")
+
+# unknown name raises IndexError with the exact CRuby message
+begin
+  s("abc").gsub(/(?<x>a)/, "\\k<y>")
+rescue IndexError => e
+  puts "#{e.class}: #{e.message}"
+end
+# empty name likewise raises IndexError
+begin
+  s("abc").gsub(/(?<x>a)/, "\\k<>")
+rescue IndexError => e
+  puts "#{e.class}: #{e.message}"
+end

--- a/test/matchdata_gsub_named_backref.rb.expected
+++ b/test/matchdata_gsub_named_backref.rb.expected
@@ -1,0 +1,9 @@
+f[oo]bar
+bacd
+a-ab
+"[y]z"
+"[]z"
+f[oo]bar
+\k'g'
+IndexError: undefined group name reference: y
+IndexError: undefined group name reference: 


### PR DESCRIPTION
String#gsub and String#sub now expand `\k<name>` in the replacement string to the named capture group.

The replacement expander handled `\0`-`\9` and `\&` but passed `\k<name>` through literally, so a named backreference emitted the raw escape text instead of the capture. It now resolves the name against the pattern's named-group table and splices in the corresponding capture, expanding to an empty string when the group did not participate (matching the numbered-backref behavior).

An unknown or empty name raises `IndexError: undefined group name reference: <name>`, identical to `md[:name]`. The `\k'name'` form is regular-expression-only syntax and is left literal in a replacement, matching CRuby.

Tests cover named expansion, multiple swapped groups, mixing with `\&`, a participating vs non-participating optional group, the single-`sub` path, the literal `\k'name'` form, and the `IndexError` cases (unknown and empty name) asserting the exact class and message.