### PR TITLE
analyze,codegen,runtime: named-capture binding for regexp =~

### DIFF
--- a/lib/sp_re.c
+++ b/lib/sp_re.c
@@ -336,6 +336,23 @@ mrb_int sp_re_rindex_opt(mrb_regexp_pattern *pat, const char *str)  { mrb_int n 
 sp_RbVal sp_re_rindex_poly(mrb_regexp_pattern *pat, const char *str) { mrb_int n = sp_re_rindex(pat, str); return n < 0 ? sp_box_nil() : sp_box_int(n); }
 sp_RbVal sp_re_index_poly(mrb_regexp_pattern *pat, const char *str) { mrb_int n = sp_re_match(pat, str); return n < 0 ? sp_box_nil() : sp_box_int(n); }
 sp_RbVal sp_re_match_poly(mrb_regexp_pattern *pat, const char *str) { mrb_int n = sp_re_match(pat, str); return n < 0 ? sp_box_nil() : sp_box_int(n); }
+/* Value of the named group `name` from the most recent match registers (set by
+   sp_re_match / sp_re_match_poly). NULL (nil) when the last match failed, the
+   name is unknown, or the group did not participate. Used by `/(?<n>..)/ =~ s`
+   named-capture local binding (MatchWriteNode). */
+const char *sp_re_named_capture(const mrb_regexp_pattern *pat, const char *name) {
+  if (!pat || !name || !sp_re_last_str) return NULL;
+  int g = re_named_group(pat, name);
+  if (g < 0 || (g * 2) + 1 >= 64) return NULL;
+  int b = sp_re_caps[g * 2], e = sp_re_caps[(g * 2) + 1];
+  /* e < b also covers e < 0 once b >= 0; guards against a malformed register
+     state yielding a negative len that would cast to a huge size_t. */
+  if (b < 0 || e < b) return NULL;
+  int len = e - b;
+  char *out = sp_str_alloc(len);
+  memcpy(out, sp_re_last_str + b, len);
+  return out;
+}
 const char *sp_re_escape(const char *src) {
   size_t i, in_len = strlen(src);
   size_t out_len = 0;

--- a/lib/sp_re.h
+++ b/lib/sp_re.h
@@ -57,6 +57,7 @@ mrb_int sp_re_rindex_opt(mrb_regexp_pattern *pat, const char *str);
 sp_RbVal sp_re_rindex_poly(mrb_regexp_pattern *pat, const char *str);
 sp_RbVal sp_re_index_poly(mrb_regexp_pattern *pat, const char *str);
 sp_RbVal sp_re_match_poly(mrb_regexp_pattern *pat, const char *str);
+const char *sp_re_named_capture(const mrb_regexp_pattern *pat, const char *name);
 const char *sp_re_escape(const char *src);
 sp_PolyArray *sp_re_scan_poly(mrb_regexp_pattern *pat, const char *str);
 sp_PolyArray *sp_re_match_data(mrb_regexp_pattern *pat, const char *str);

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -2800,6 +2800,8 @@ TyKind infer_uncached(Compiler *c, int id) {
   if (nk == NK_SourceEncodingNode)      return TY_POLY;
   if (nk == NK_RegularExpressionNode ||
       nk == NK_InterpolatedRegularExpressionNode) return TY_REGEX;
+  /* `/(?<n>..)/ =~ str` -- the value is the `=~` result (match index or nil). */
+  if (sp_streq(ty, "MatchWriteNode")) return TY_POLY;
   if (nk == NK_InterpolatedStringNode)  return TY_STRING;
   if (nk == NK_XStringNode || nk == NK_InterpolatedXStringNode) return TY_STRING;
   if (nk == NK_InterpolatedSymbolNode)  return TY_SYMBOL;

--- a/src/analyze_pass.c
+++ b/src/analyze_pass.c
@@ -438,6 +438,22 @@ int infer_write_types(Compiler *c) {
       TyKind ct = cur ? (TyKind)cur->gc_root : TY_UNKNOWN;
       newt = ty_unify(ct, infer_type(c, nt_ref(nt, id, "value")));
     }
+    else if (sp_streq(ty, "MatchWriteNode")) {
+      /* `/(?<n>..)/ =~ str` binds each named group to a local: a String when
+         the group participated, nil otherwise (NULL-encoded), so type each
+         target as a nilable String. */
+      int tn = 0; const int *tv = nt_arr(nt, id, "targets", &tn);
+      for (int ti = 0; ti < tn; ti++) {
+        const char *tnm = nt_str(nt, tv[ti], "name");
+        if (!tnm) continue;
+        LocalVar *tlv = scope_local(comp_scope_of(c, tv[ti]), tnm);
+        if (tlv && !tlv->is_param && !tlv->is_block_param) {
+          TyKind m = ty_unify(tlv->type, TY_STRING);
+          if (m != tlv->type) { tlv->type = m; changed = 1; }
+        }
+      }
+      continue;
+    }
     else {
       continue;
     }

--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -437,6 +437,31 @@ void emit_expr(Compiler *c, int id, Buf *b) {
     return;
   }
 
+  if (sp_streq(ty, "MatchWriteNode")) {
+    /* `/(?<n>..)/ =~ str`: run the match (setting the match registers), bind
+       each named group to its local (NULL = nil when it did not participate),
+       and yield the `=~` result (match index, or nil). */
+    int call = nt_ref(nt, id, "call");
+    int recv = call >= 0 ? nt_ref(nt, call, "receiver") : -1;
+    int reidx = re_lit_index(c, recv);
+    int args = call >= 0 ? nt_ref(nt, call, "arguments") : -1;
+    int ac = 0; const int *av = args >= 0 ? nt_arr(nt, args, "arguments", &ac) : NULL;
+    if (reidx < 0 || ac < 1) { unsupported(c, id, "named-capture =~ (non-literal regexp)"); return; }
+    int tcount = 0; const int *tv = nt_arr(nt, id, "targets", &tcount);
+    int t = ++g_tmp;
+    buf_printf(b, "({ sp_RbVal _t%d = sp_re_match_poly(sp_re_pat_%d, ", t, reidx);
+    emit_str_expr(c, av[0], b);
+    buf_puts(b, "); ");
+    for (int ti = 0; ti < tcount; ti++) {
+      const char *tnm = nt_str(nt, tv[ti], "name");
+      if (!tnm) continue;
+      buf_printf(b, "lv_%s = sp_re_named_capture(sp_re_pat_%d, ", rename_local(tnm), reidx);
+      emit_str_literal(b, tnm);
+      buf_puts(b, "); ");
+    }
+    buf_printf(b, "_t%d; })", t);
+    return;
+  }
   if (sp_streq(ty, "RangeNode")) {
     int left = nt_ref(nt, id, "left");
     int right = nt_ref(nt, id, "right");

--- a/src/spinel_parse.c
+++ b/src/spinel_parse.c
@@ -1296,6 +1296,7 @@ else if (PM_NODE_TYPE(n->parameters) != PM_NUMBERED_PARAMETERS_NODE) {
     pm_match_write_node_t *n = (pm_match_write_node_t *)node;
     N("MatchWriteNode");
     R("call", n->call);
+    A("targets", &n->targets);  /* LocalVariableTargetNode per named group */
     break;
   }
   case PM_MATCH_REQUIRED_NODE: {

--- a/test/regexp_named_capture_match.rb
+++ b/test/regexp_named_capture_match.rb
@@ -1,0 +1,43 @@
+# A literal regexp on the left of `=~` binds each named group to a local
+# variable (CRuby's MatchWriteNode): a String when the group participated, nil
+# otherwise. The `=~` itself yields the match index, or nil on no match. The
+# subject string is a local so the match runs at runtime.
+
+date = "2026-06-15"
+if /(?<year>\d+)-(?<mon>\d+)-(?<day>\d+)/ =~ date
+  puts year
+  puts mon
+  puts day
+end
+
+# the bound locals are usable as ordinary strings
+if /(?<word>\w+)/ =~ "hello"
+  puts word.upcase
+  puts word.length
+end
+
+# interpolation with two captures
+pair = "key=value"
+if /(?<k>\w+)=(?<v>\w+)/ =~ pair
+  puts "#{k} -> #{v}"
+end
+
+# a group that did not participate binds nil
+if /(?<a>x)(?<b>y)?/ =~ "x"
+  p a
+  p b
+end
+
+# the value of `=~` is the match index, or nil on no match
+p(/(?<n>\d+)/ =~ "abc123")
+p(/(?<n>\d+)/ =~ "no digits here")
+
+# in a ternary / value position
+s = "id-7"
+label = (/(?<num>\d+)/ =~ s) ? "has #{num}" : "none"
+puts label
+
+# no match leaves the captures nil
+/(?<gone>\d+)/ =~ "letters"
+p defined?(gone)
+p gone

--- a/test/regexp_named_capture_match.rb.expected
+++ b/test/regexp_named_capture_match.rb.expected
@@ -1,0 +1,13 @@
+2026
+06
+15
+HELLO
+5
+key -> value
+"x"
+nil
+3
+nil
+has 7
+"local-variable"
+nil


### PR DESCRIPTION
A literal regexp on the left of `=~` binds each named group to a local variable (CRuby's MatchWriteNode): `/(?<y>\d+)-(?<m>\d+)/ =~ s` sets `y` and `m`. This previously rejected with `unsupported condition (non-bool): MatchWriteNode`.

The parser now carries the node's `targets` (one `LocalVariableTargetNode` per named group). `register_locals` already interns them, and the type-inference pass types each as a nilable `String`. Codegen runs the match (setting the `$~`/`$1` registers), binds each named group from the post-match state via a new `sp_re_named_capture` runtime helper (`NULL` = nil when the group did not participate or the match failed), and yields the `=~` result (the match index, or nil).

Tests cover a multi-group match with bound locals, using a bound capture as a string, interpolation, a non-participating optional group (nil), the `=~` value (index / nil), value/ternary position, and the no-match case leaving captures nil (incl. `defined?`).