### PR TITLE
codegen: mutable-string +@, String#concat, single-index String#[]=

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -2559,8 +2559,10 @@ else {
       nt_type(nt, recv) && sp_streq(nt_type(nt, recv), "ConstantReadNode"))
     return TY_BOOL;
 
-  if ((sp_streq(name, "-@") || sp_streq(name, "+@")) && recv >= 0 && argc == 0)
+  if ((sp_streq(name, "-@") || sp_streq(name, "+@")) && recv >= 0 && argc == 0) {
+    if (rt == TY_STRING) return TY_STRING;  /* +str = mutable copy; -str = frozen self */
     return ty_is_numeric(rt) ? rt : rt == TY_POLY ? TY_POLY : TY_UNKNOWN;
+  }
   /* unary bitwise complement: ~int / ~poly -> int (poly value coerced via to_i) */
   if (sp_streq(name, "~") && recv >= 0 && argc == 0 && (rt == TY_INT || rt == TY_POLY))
     return TY_INT;

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -8724,6 +8724,12 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       if (name[0] == '-') { buf_puts(b, "sp_poly_neg("); emit_expr(c, recv, b); buf_puts(b, ")"); }
       else { emit_expr(c, recv, b); }  /* +@ is identity on poly */
     }
+    else if (rt == TY_STRING) {
+      /* +str returns a mutable copy (so subsequent <</concat/upcase! mutate a
+         fresh string); -str returns the (already-immutable) string itself. */
+      if (name[0] == '+') { buf_puts(b, "sp_str_dup_external("); emit_expr(c, recv, b); buf_puts(b, ")"); }
+      else emit_expr(c, recv, b);
+    }
     else { buf_puts(b, name[0] == '-' ? "(-" : "(+"); emit_expr(c, recv, b); buf_puts(b, ")"); }
     return;
   }
@@ -11310,6 +11316,41 @@ int emit_array_mutate_stmt(Compiler *c, int id, Buf *b, int indent) {
     if (assignable && (sp_streq(name, "delete_prefix!") || sp_streq(name, "delete_suffix!")) && argc == 1) {
       const char *base = sp_streq(name, "delete_prefix!") ? "delete_prefix" : "delete_suffix";
       emit_indent(b, indent); emit_expr(c, recv, b); buf_printf(b, " = sp_str_%s(", base); emit_expr(c, recv, b); buf_puts(b, ", "); emit_expr(c, argv[0], b); buf_puts(b, ");\n");
+      return 1;
+    }
+    /* concat(a, b, ...): append each argument in order (multi-arg `<<`). An
+       Integer argument appends its codepoint, like `<<`. */
+    if (assignable && sp_streq(name, "concat") && argc >= 1) {
+      emit_indent(b, indent); buf_puts(b, "sp_str_check_mutable("); emit_expr(c, recv, b); buf_puts(b, ");\n");
+      for (int a = 0; a < argc; a++) {
+        TyKind at = comp_ntype(c, argv[a]);
+        emit_indent(b, indent);
+        emit_expr(c, recv, b); buf_puts(b, " = sp_str_concat("); emit_expr(c, recv, b); buf_puts(b, ", ");
+        if (at == TY_INT) { buf_puts(b, "sp_int_codepoint_to_str("); emit_expr(c, argv[a], b); buf_puts(b, ")"); }
+        else if (at == TY_POLY) { buf_puts(b, "sp_poly_to_s("); emit_expr(c, argv[a], b); buf_puts(b, ")"); }
+        else emit_expr(c, argv[a], b);
+        buf_puts(b, ");\n");
+      }
+      return 1;
+    }
+    /* s[i] = str: replace the single character at index i (negative from the
+       end) with the (string) value -> s[0,i] + val + s[i+1..]. Valid range is
+       -len..len (i == len appends, matching CRuby); anything outside raises
+       IndexError with the original index. The (start,len) and Range / Regexp
+       forms remain unsupported (string splice). */
+    if (assignable && sp_streq(name, "[]=") && argc == 2 && comp_ntype(c, argv[0]) == TY_INT) {
+      int ti = ++g_tmp;
+      emit_indent(b, indent); buf_puts(b, "sp_str_check_mutable("); emit_expr(c, recv, b); buf_puts(b, ");\n");
+      emit_indent(b, indent);
+      buf_printf(b, "{ mrb_int _t%d = ", ti); emit_int_expr(c, argv[0], b);
+      buf_printf(b, "; mrb_int _len%d = (mrb_int)sp_str_length(", ti); emit_expr(c, recv, b); buf_puts(b, ");");
+      buf_printf(b, " mrb_int _a%d = _t%d < 0 ? _t%d + _len%d : _t%d;", ti, ti, ti, ti, ti);
+      buf_printf(b, " if (_a%d < 0 || _a%d > _len%d) sp_raise_cls(\"IndexError\", sp_sprintf(\"index %%lld out of string\", (long long)_t%d));",
+                 ti, ti, ti, ti);
+      buf_puts(b, " "); emit_expr(c, recv, b); buf_puts(b, " = sp_str_concat(sp_str_concat(sp_str_sub_range(");
+      emit_expr(c, recv, b); buf_printf(b, ", 0, _a%d), ", ti); emit_str_expr(c, argv[1], b);
+      buf_printf(b, "), sp_str_sub_range("); emit_expr(c, recv, b);
+      buf_printf(b, ", _a%d + 1 < _len%d ? _a%d + 1 : _len%d, _len%d)); }\n", ti, ti, ti, ti, ti);
       return 1;
     }
   }

--- a/test/string_mutation_plus.rb
+++ b/test/string_mutation_plus.rb
@@ -1,0 +1,54 @@
+# Unary +@ on a string returns a mutable copy (so a literal can be built up),
+# and concat / []= mutate a mutable string local in place (statement position,
+# like the existing <</upcase!). -@ returns the string unchanged.
+
+# +"..." yields a mutable string; appends build it up
+s = +"abc"
+s << "d"
+p s
+s.concat("ef")
+p s
+s.concat("g", "h", "i")
+p s
+s.concat(33)            # an Integer appends its codepoint
+p s
+
+# build-in-a-loop starting from +""
+acc = +""
+3.times { |i| acc << i.to_s }
+p acc
+
+# in-place bang methods on a +string
+u = +"Hello"
+u.upcase!
+p u
+u.reverse!
+p u
+
+# []= single-index assignment (negative index counts from the end; the value
+# may be longer than one character)
+t = +"abcde"
+t[0] = "X"
+p t
+t[-1] = "Z"
+p t
+t[2] = "YY"
+p t
+# index == length appends (matches CRuby); out-of-range raises IndexError
+# carrying the original index
+g = +"abc"
+g[3] = "d"
+p g
+oob = +"abc"
+begin; oob[5] = "x"; rescue IndexError => e; puts "#{e.class}: #{e.message}"; end
+begin; oob[-4] = "x"; rescue IndexError => e; puts "#{e.class}: #{e.message}"; end
+
+# +@ / -@ as plain values
+p(+"plus")
+p(-"minus")
+
+# concat / []= also work on a dup'd string
+d = "orig".dup
+d.concat("!")
+d[0] = "O"
+p d

--- a/test/string_mutation_plus.rb.expected
+++ b/test/string_mutation_plus.rb.expected
@@ -1,0 +1,16 @@
+"abcd"
+"abcdef"
+"abcdefghi"
+"abcdefghi!"
+"012"
+"HELLO"
+"OLLEH"
+"Xbcde"
+"XbcdZ"
+"XbYYdZ"
+"abcd"
+IndexError: index 5 out of string
+IndexError: index -4 out of string
+"plus"
+"minus"
+"Orig!"


### PR DESCRIPTION
`+"abc"` (unary plus on a string) emitted invalid C — a unary `+` applied to a `char*` — so any use of a `+string` failed to compile. It now returns a mutable copy (like `dup`), so `s = +""; s << ...` builds up a string, and `-str` returns the (already-immutable) string unchanged.

`String#concat` (one or more arguments; an Integer argument appends its codepoint, matching `<<`) and the single-index `String#[]=` (negative index counts from the end; the replacement may be longer than one character) now mutate a mutable string local in place, via the same value-semantics reassignment the existing `<<` and bang mutators already use.

These are statement-position mutations, consistent with every existing string mutator in the codebase (`<<`, `upcase!`, `replace`, ...); the expression-position return value of a string mutator remains a pre-existing cross-cutting limitation shared with `<<`, out of scope here.

Tests cover `+@`/`-@` as values, append/`concat` (string, multi-arg, Integer codepoint), build-in-a-loop from `+""`, bang mutators on a `+string`, single-index `[]=` (index 0, negative, multi-char replacement), and `concat`/`[]=` on a `dup`'d string.