### PR TITLE
build: fix threaded-runtime build under GNU Make 3.81

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 /lib/regexp/libspre.a
 lib/libspinel_rt.a
 lib/libspinel_rt_mt.a
+lib/libspinel_rt_mt_tsan.a
 lib/libspbi.a
 HANDOFF.md
 

--- a/Makefile
+++ b/Makefile
@@ -305,13 +305,15 @@ SP_RT_MT_LIB = lib/libspinel_rt_mt.a
 MT_DEF = -DSP_THREADS -ftls-model=initial-exec
 RT_HDRS = $(wildcard lib/*.h lib/regexp/*.h)
 
-build/mt/%.o: lib/%.c $(RT_HDRS)
-	@mkdir -p build/mt
-	$(CC) -c -O2 -Wno-all $(SEC_FLAGS) $(MT_DEF) -Ilib -Ilib/regexp $< -o $@
-
+# Specific rule before generic: GNU Make 3.81 (macOS system make) picks the
+# first matching pattern rule, not the shortest-stem one (3.82+).
 build/mt/regexp/%.o: lib/regexp/%.c lib/regexp/re_internal.h
-	@mkdir -p build/mt/regexp
+	@mkdir -p $(@D)
 	$(CC) -c -O2 $(SEC_FLAGS) $(MT_DEF) -Ilib/regexp $< -o $@
+
+build/mt/%.o: lib/%.c $(RT_HDRS)
+	@mkdir -p $(@D)
+	$(CC) -c -O2 -Wno-all $(SEC_FLAGS) $(MT_DEF) -Ilib -Ilib/regexp $< -o $@
 
 RE_MT_OBJ = $(patsubst lib/regexp/%.c,build/mt/regexp/%.o,$(RE_SRC))
 
@@ -329,13 +331,14 @@ $(SP_RT_MT_LIB): $(RE_MT_OBJ) $(addprefix build/mt/,$(addsuffix .o,$(RT_MEMBERS)
 SP_RT_MT_TSAN_LIB = lib/libspinel_rt_mt_tsan.a
 TSAN_DEF = $(MT_DEF) -fsanitize=thread -g
 
-build/mt-tsan/%.o: lib/%.c $(RT_HDRS)
-	@mkdir -p build/mt-tsan
-	$(CC) -c -O1 -Wno-all $(SEC_FLAGS) $(TSAN_DEF) -Ilib -Ilib/regexp $< -o $@
-
+# Specific before generic, as in the mt pair above.
 build/mt-tsan/regexp/%.o: lib/regexp/%.c lib/regexp/re_internal.h
-	@mkdir -p build/mt-tsan/regexp
+	@mkdir -p $(@D)
 	$(CC) -c -O1 $(SEC_FLAGS) $(TSAN_DEF) -Ilib/regexp $< -o $@
+
+build/mt-tsan/%.o: lib/%.c $(RT_HDRS)
+	@mkdir -p $(@D)
+	$(CC) -c -O1 -Wno-all $(SEC_FLAGS) $(TSAN_DEF) -Ilib -Ilib/regexp $< -o $@
 
 RE_MT_TSAN_OBJ = $(patsubst lib/regexp/%.c,build/mt-tsan/regexp/%.o,$(RE_SRC))
 


### PR DESCRIPTION
## Symptom

The threaded-runtime archive build fails under the macOS toolchain:

```
error: unable to open output file 'build/mt/regexp/re_compile.o': 'No such file or directory'
1 error generated.
make: *** [build/mt/regexp/re_compile.o] Error 1
```

The object's parent directory `build/mt/regexp/` is never created, so `clang` cannot write the output file.

## Root cause: GNU Make pattern-rule selection differs by version

The threaded-runtime section defines two pattern rules that both match `build/mt/regexp/re_compile.o`:

| Rule | Stem for that target | Recipe creates |
| --- | --- | --- |
| `build/mt/%.o` (generic, defined first) | `regexp/re_compile` | `build/mt` only |
| `build/mt/regexp/%.o` (specific) | `re_compile` | `build/mt/regexp` |

When more than one pattern rule matches a target, the two make versions in play disagree on which to use:

* **GNU Make 3.82+** prefers the rule with the **shortest stem** -> the specific `build/mt/regexp/%.o` rule, whose recipe creates `build/mt/regexp`. Builds succeed.
* **GNU Make 3.81** (Apple's `/usr/bin/make`, used by the macOS CI runner) has no shortest-stem tie-break -- it takes the **first matching rule in file order**. The generic `build/mt/%.o` rule is defined first, so it wins; its recipe only runs `mkdir -p build/mt`, and the compile into `build/mt/regexp/` then fails.

This is why it is not caught everywhere: it builds on any machine with a modern `make` (Linux, or Homebrew `gmake`) and only fails under the stock macOS toolchain.

Confirmed locally:

```
$ make --version | head -1
GNU Make 3.81
$ rm -rf build/mt && make -n build/mt/regexp/re_compile.o
mkdir -p build/mt        # <- generic rule selected; wrong directory
cc ... -o build/mt/regexp/re_compile.o
```

## Fix

* **Order the specific `build/mt/regexp/%.o` rule before the generic `build/mt/%.o` rule** so Make 3.81's first-match selection picks it. This also restores the recipe the regexp objects are supposed to use: their `lib/regexp/re_internal.h` prerequisite (so they rebuild when that header changes) and the `-Ilib/regexp`-only include path. Under the bug the generic rule was building them with its own `-Ilib -Ilib/regexp` recipe and no header dependency.
* **Use `mkdir -p $(@D)` in the generic rules** (the target's own directory) instead of a hardcoded `mkdir -p build/mt`, so the correct directory is created regardless of which rule make selects -- robust on 3.81 and 3.82+ alike.
* Apply both changes to the `mt-tsan` pair, which had the identical structure and latent bug.

## Secondary fix: gitignore the TSan archive

`lib/libspinel_rt_mt_tsan.a` (the on-demand ThreadSanitizer archive, built by `make tsan-archive`) was added next to the other ignored runtime archives but never added to `.gitignore`. Building it dirtied the working tree. Added the missing ignore entry alongside `libspinel_rt.a` and `libspinel_rt_mt.a`.

## Verification

* Reproduced the failure locally from a clean `build/mt` under Make 3.81, then confirmed both `lib/libspinel_rt_mt.a` and `lib/libspinel_rt_mt_tsan.a` build cleanly from scratch after the fix.
* `make -n` now selects the specific regexp rule (`mkdir -p build/mt/regexp`, `-Ilib/regexp` recipe).
* Full suite green: **1164 pass, 0 fail, 0 error**.

## Scope

Build-system only -- no compiler or runtime code changes. This is a regression from the threaded-runtime archive build rules.