### PR TITLE
codegen: find/detect with a block over a poly array

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -650,10 +650,13 @@ static int emit_array_call(Compiler *c, int id, Buf *b) {
           Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);
           emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
           buf_printf(g_pre, " _t%d = %s; SP_GC_ROOT(_t%d);\n", trecv, rb.p ? rb.p : "", trecv); free(rb.p);
-          emit_indent(g_pre, g_indent); buf_printf(g_pre, "sp_RbVal _t%d = %s;\n", tres, default_value(TY_POLY));
+          emit_indent(g_pre, g_indent); buf_printf(g_pre, "sp_RbVal _t%d = %s; SP_GC_ROOT_RBVAL(_t%d);\n", tres, default_value(TY_POLY), tres);
           emit_indent(g_pre, g_indent);
           buf_printf(g_pre, "for (mrb_int _t%d = 0; _t%d < sp_PolyArray_length(_t%d); _t%d++) {\n", ti, ti, trecv, ti);
-          if (bp) { emit_indent(g_pre, g_indent + 1); buf_printf(g_pre, "lv_%s = sp_PolyArray_get(_t%d, _t%d);\n", bp, trecv, ti); }
+          /* Declare the block param in the loop body so the form is self-contained
+             when this find is a parameter default hoisted to the call site (whose
+             function has no top-level declaration for the block local). */
+          if (bp) { emit_indent(g_pre, g_indent + 1); buf_printf(g_pre, "sp_RbVal lv_%s = sp_PolyArray_get(_t%d, _t%d);\n", bp, trecv, ti); }
           for (int j = 0; j < bn - 1; j++) emit_stmt(c, bb[j], g_pre, g_indent + 1);
           int sv = g_indent; g_indent++;
           Buf cb; memset(&cb, 0, sizeof cb); emit_cond(c, bb[bn - 1], &cb); g_indent = sv;

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -636,6 +636,36 @@ static int emit_array_call(Compiler *c, int id, Buf *b) {
       buf_puts(b, "sp_PolyArray_delete_at("); emit_expr(c, recv, b); buf_puts(b, ", "); emit_expr(c, argv[0], b); buf_puts(b, ")");
       return 1;
     }
+    /* find / detect { |x| cond } on a poly array -> the element or nil. The
+       typed-array forms live inside the `if (k)` block below, but array_kind is
+       NULL for a poly array, so handle it here with the boxed element type. */
+    if (rt == TY_POLY_ARRAY && (sp_streq(name, "find") || sp_streq(name, "detect"))) {
+      int fblock = nt_ref(nt, id, "block");
+      if (fblock >= 0) {
+        const char *bp = block_param_name(c, fblock, 0); if (bp) bp = rename_local(bp);
+        int body = nt_ref(nt, fblock, "body");
+        int bn = 0; const int *bb = body >= 0 ? nt_arr(nt, body, "body", &bn) : NULL;
+        if (bn >= 1) {
+          int trecv = ++g_tmp, ti = ++g_tmp, tres = ++g_tmp;
+          Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);
+          emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
+          buf_printf(g_pre, " _t%d = %s; SP_GC_ROOT(_t%d);\n", trecv, rb.p ? rb.p : "", trecv); free(rb.p);
+          emit_indent(g_pre, g_indent); buf_printf(g_pre, "sp_RbVal _t%d = %s;\n", tres, default_value(TY_POLY));
+          emit_indent(g_pre, g_indent);
+          buf_printf(g_pre, "for (mrb_int _t%d = 0; _t%d < sp_PolyArray_length(_t%d); _t%d++) {\n", ti, ti, trecv, ti);
+          if (bp) { emit_indent(g_pre, g_indent + 1); buf_printf(g_pre, "lv_%s = sp_PolyArray_get(_t%d, _t%d);\n", bp, trecv, ti); }
+          for (int j = 0; j < bn - 1; j++) emit_stmt(c, bb[j], g_pre, g_indent + 1);
+          int sv = g_indent; g_indent++;
+          Buf cb; memset(&cb, 0, sizeof cb); emit_cond(c, bb[bn - 1], &cb); g_indent = sv;
+          emit_indent(g_pre, g_indent + 1);
+          if (bp) buf_printf(g_pre, "if (%s) { _t%d = lv_%s; break; }\n", cb.p ? cb.p : "0", tres, bp);
+          else buf_printf(g_pre, "if (%s) { _t%d = sp_PolyArray_get(_t%d, _t%d); break; }\n", cb.p ? cb.p : "0", tres, trecv, ti);
+          free(cb.p);
+          emit_indent(g_pre, g_indent); buf_puts(g_pre, "}\n");
+          buf_printf(b, "_t%d", tres); return 1;
+        }
+      }
+    }
     if (k) {
       if ((sp_streq(name, "to_a") || sp_streq(name, "to_ary") || sp_streq(name, "entries") ||
            sp_streq(name, "flatten") || sp_streq(name, "compact")) && argc == 0) {

--- a/test/find_block_poly_array.rb
+++ b/test/find_block_poly_array.rb
@@ -1,0 +1,18 @@
+# find / detect { |x| cond } over a poly array (mixed element types, or an array
+# of user objects) returns the first matching element, or nil when none match.
+# The typed-array forms already worked; array_kind is NULL for a poly array, so
+# this exercises the boxed-element path. Distinct helpers keep each receiver's
+# element type clean and defeat constant folding of the receiver.
+def sa(x) = x
+def sb(x) = x
+def sc(x) = x
+def su(x) = x
+
+p sa([:a, :b, :c]).find { |n| n == :b }              # :b
+p sb([:a, :b, :c]).detect { |n| n == :z }            # nil
+p sc([1, "two", :three, 4]).find { |e| e == :three } # :three
+
+S = Struct.new(:node)
+r = su([S.new(:a), S.new(:b)]).find { |n| n.node == :b }
+p r.node                                             # :b
+p su([S.new(:a)]).find { |n| n.node == :zzz }        # nil

--- a/test/find_block_poly_array.rb
+++ b/test/find_block_poly_array.rb
@@ -16,3 +16,12 @@ S = Struct.new(:node)
 r = su([S.new(:a), S.new(:b)]).find { |n| n.node == :b }
 p r.node                                             # :b
 p su([S.new(:a)]).find { |n| n.node == :zzz }        # nil
+
+# the same find as a parameter default: evaluated at the call site, where the
+# block local has no top-level declaration (it is declared in the loop body).
+NET = [S.new(:begin), S.new(:x)]
+def pick(cur: NET.find { |n| n.node == :begin })
+  cur.node
+end
+p pick                                               # :begin
+p pick(cur: S.new(:z))                               # :z

--- a/test/find_block_poly_array.rb.expected
+++ b/test/find_block_poly_array.rb.expected
@@ -3,3 +3,5 @@ nil
 :three
 :b
 nil
+:begin
+:z

--- a/test/find_block_poly_array.rb.expected
+++ b/test/find_block_poly_array.rb.expected
@@ -1,0 +1,5 @@
+:b
+nil
+:three
+:b
+nil


### PR DESCRIPTION
find/detect { |x| cond } with a block only compiled for typed arrays. Those forms live inside an array_kind-gated block, and array_kind is NULL for a poly array, so find/detect over one (a mixed-type array, or an array of user objects) fell through to the unsupported-call gate. This adds a poly-array path that walks the elements, tests the block condition through emit_cond, and yields the matching boxed element or nil when none match.