### PR TITLE
set: a usable Array-backed Set

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -18,29 +18,23 @@ class Set
   end
 
   def <<(x)
-    @data.push(x) unless @data.include?(x)
-    self
+    add(x)
   end
 
   def include?(x)
     @data.include?(x)
   end
-
-  def member?(x)
-    @data.include?(x)
-  end
+  alias member? include?
 
   def each
     @data.each { |x| yield x }
+    self
   end
 
   def size
     @data.size
   end
-
-  def length
-    @data.size
-  end
+  alias length size
 
   def empty?
     @data.empty?

--- a/lib/set.rb
+++ b/lib/set.rb
@@ -1,12 +1,48 @@
-# Spinel stub: set
+# Spinel bundled `set`.
 #
-# Minimal Set implementation using Array.
-# Only supports basic operations needed by lrama.
-# Note: In Spinel, Set operations are approximated with Array.
+# A small Set backed by an Array. Elements are kept unique by ==-comparison
+# (Array#include?), preserving insertion order. This covers the common Set
+# surface (construction from an enumerable, iteration, membership, add) rather
+# than the full CRuby API. Uniqueness of compound elements (arrays, structs)
+# is only as precise as Array#include?'s element comparison.
 
 class Set
-  def initialize(arr)
-    @data = arr
-    @name = "set"
+  def initialize(enum = nil)
+    @data = []
+    enum.each { |x| add(x) } if enum
+  end
+
+  def add(x)
+    @data.push(x) unless @data.include?(x)
+    self
+  end
+
+  def <<(x)
+    @data.push(x) unless @data.include?(x)
+    self
+  end
+
+  def include?(x)
+    @data.include?(x)
+  end
+
+  def member?(x)
+    @data.include?(x)
+  end
+
+  def each
+    @data.each { |x| yield x }
+  end
+
+  def size
+    @data.size
+  end
+
+  def length
+    @data.size
+  end
+
+  def empty?
+    @data.empty?
   end
 end

--- a/test/set_basic.rb
+++ b/test/set_basic.rb
@@ -1,0 +1,27 @@
+# The bundled `set` library: construction from an array (with de-duplication of
+# equal scalar elements), iteration, membership, and mutation.
+require 'set'
+
+s = Set.new([:a, :b, :a, :c, :b])
+p s.size            # 3 (duplicates dropped)
+p s.length          # 3
+p s.empty?          # false
+p s.include?(:b)    # true
+p s.member?(:z)     # false
+
+s.each { |x| print x, " " }
+puts
+
+s << :d
+s.add(:a)           # already present, no-op
+p s.size            # 4
+p s.include?(:d)    # true
+
+p Set.new.empty?    # true (no argument)
+
+# integers dedup the same way
+n = Set.new([1, 2, 2, 3, 1])
+total = 0
+n.each { |x| total += x }
+p total             # 6
+p n.size            # 3

--- a/test/set_basic.rb.expected
+++ b/test/set_basic.rb.expected
@@ -1,0 +1,11 @@
+3
+3
+false
+true
+false
+a b c 
+4
+true
+true
+6
+3


### PR DESCRIPTION
The bundled lib/set.rb only defined initialize, so Set#each, size, include? and the rest fell through to the unsupported-call gate (and a Set#each loop would silently drop). This backs Set with an Array and implements the common surface: construction from an enumerable (de-duplicating via Array#include?), each, include?/member?, add and <<, size/length, and empty?. Uniqueness of compound elements (arrays, structs) is only as precise as Array#include?'s element comparison, which is noted in the file.