### PR TITLE
codegen: Array#sample on a poly receiver

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -3263,6 +3263,10 @@ static sp_RbVal sp_poly_last(sp_RbVal v) {
   mrb_int n = sp_poly_length(v);
   return n > 0 ? sp_poly_arr_get(v, n - 1) : sp_box_nil();
 }
+static sp_RbVal sp_poly_sample(sp_RbVal v) {
+  mrb_int n = sp_poly_length(v);
+  return n > 0 ? sp_poly_arr_get(v, (mrb_int)(rand() % n)) : sp_box_nil();
+}
 /* Thread#value / #join through a poly slot. A Thread is modelled as a Fiber run
    to completion (single-threaded); when one is carried in a poly value -- e.g.
    an array of Threads, `(1..n).map { Thread.new { ... } }` -- #value/#join must

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -2142,7 +2142,7 @@ else {
          result is a boxed poly value resolved at runtime by cls_id. */
       if (argc == 0 &&
           (sp_streq(name, "sum") || sp_streq(name, "min") || sp_streq(name, "max") ||
-           sp_streq(name, "first") || sp_streq(name, "last")))
+           sp_streq(name, "first") || sp_streq(name, "last") || sp_streq(name, "sample")))
         return TY_POLY;
       /* Fiber/Thread/IO/File instance methods: fallback when no user class defines `name`. */
       if (sp_streq(name, "resume") || sp_streq(name, "value") || sp_streq(name, "join"))

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -10152,6 +10152,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     else if (sp_streq(name, "max")) pm = "sp_poly_max";
     else if (sp_streq(name, "first")) pm = "sp_poly_first";
     else if (sp_streq(name, "last")) pm = "sp_poly_last";
+    else if (sp_streq(name, "sample")) pm = "sp_poly_sample";
     /* a Thread (Fiber-modelled) carried through a poly slot: #value/#resume/#join
        dispatch on the boxed Fiber when no user class defines the name (#1261). */
     else if (sp_streq(name, "value") || sp_streq(name, "resume")) pm = "sp_poly_fiber_value";

--- a/test/poly_receiver_sample.rb
+++ b/test/poly_receiver_sample.rb
@@ -1,0 +1,20 @@
+# Array#sample on a poly receiver -- a value whose array-ness is only known at
+# runtime, e.g. an object field or hash value that holds an array. It previously
+# fell through the poly dispatch and returned nil; it must pick an element.
+N = Struct.new(:node, :follow)
+dic = { begin: N.new(:begin, []) }
+node = dic[:begin]
+node.follow << N.new(:a, [])
+node.follow << N.new(:b, [])
+
+s = node.follow.sample
+p s.nil?            # false
+p s.is_a?(N)        # true
+
+# a plain poly array receiver
+arr = [N.new(:x, []), N.new(:y, []), 100]
+p arr.sample.nil?   # false
+
+# empty poly value samples to nil
+empty = N.new(:e, [])
+p empty.follow.sample.nil?   # true

--- a/test/poly_receiver_sample.rb.expected
+++ b/test/poly_receiver_sample.rb.expected
@@ -1,0 +1,4 @@
+false
+true
+false
+true


### PR DESCRIPTION
sample on a poly value (one whose array-ness is only known at runtime, e.g. an object field or hash value holding an array) fell through the zero-arg poly dispatch, which typed it as void and discarded the result as nil. Add a sp_poly_sample runtime helper (length plus a random index via sp_poly_arr_get), wire it into the poly reduction dispatch alongside first/last, and infer TY_POLY for it so the value is kept.