### PR TITLE
docs: update stale docs/FLOAT-ROUNDING.md references to lowercase path

### DIFF
--- a/test/float_round_ndigits_return_type.rb
+++ b/test/float_round_ndigits_return_type.rb
@@ -1,7 +1,7 @@
 # Float#ceil/floor/round/truncate return type is value-based on a
 # literal ndigits, matching CRuby: Integer when ndigits <= 0 (or
 # absent), Float when > 0. (A non-literal ndigits stays Float.) Values
-# stay numerically correct. See docs/FLOAT-ROUNDING.md.
+# stay numerically correct. See docs/float-rounding.md.
 
 # no-arg -> Integer
 puts 1.9.ceil.class

--- a/test/float_round_zero.rb
+++ b/test/float_round_zero.rb
@@ -1,7 +1,7 @@
 # Float#round/ceil/floor/truncate return type matches CRuby's
 # value-based rule for a literal ndigits: no-arg and ndigits <= 0 return
 # Integer, ndigits > 0 returns Float. (A non-literal ndigits stays
-# Float.) See docs/FLOAT-ROUNDING.md.
+# Float.) See docs/float-rounding.md.
 puts 3.5.round(0).inspect
 puts 3.5.round.inspect
 puts 3.5.round(1).inspect


### PR DESCRIPTION
97bac89c renamed docs/FLOAT-ROUNDING.md to docs/float-rounding.md but missed these comment references.