### PR TITLE
codegen,runtime: String#clone preserves frozen state

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -927,6 +927,15 @@ static inline const char *sp_str_freeze_val(const char *s) {
   }
   return s;
 }
+/* String#clone: a copy that preserves the frozen state, unlike #dup which always
+   returns an unfrozen copy (CRuby semantics). Carries the 0xf1 heap-frozen marker
+   across to the fresh buffer. */
+static inline const char *sp_str_clone_val(const char *s) {
+  if (!s) return NULL;
+  const char *r = sp_str_dup_external(s);
+  if (r && sp_str_is_frozen_val(s)) ((unsigned char *)r)[-1] = 0xf1;
+  return r;
+}
 static void __attribute__((noinline,cold)) sp_raise_frozen_string(void){sp_raise_cls("FrozenError","can't modify frozen String");}
 static inline void sp_str_check_mutable(const char *s) {
   if (sp_str_is_frozen_val(s)) sp_raise_frozen_string();

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -4465,7 +4465,9 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       emit_expr(c, recv, b); return;
     }
     if (argc0 == 0 && recv_t == TY_STRING && is_dup_clone) {
-      buf_puts(b, "sp_str_dup_external("); emit_expr(c, recv, b); buf_puts(b, ")"); return;
+      /* clone preserves the frozen state; dup always returns an unfrozen copy. */
+      buf_printf(b, "%s(", sp_streq(name, "clone") ? "sp_str_clone_val" : "sp_str_dup_external");
+      emit_expr(c, recv, b); buf_puts(b, ")"); return;
     }
   }
 

--- a/test/string_clone_frozen.rb
+++ b/test/string_clone_frozen.rb
@@ -1,0 +1,26 @@
+# String#clone preserves the frozen state; String#dup always returns unfrozen.
+def id(x) = x
+
+# clone keeps frozen, dup clears it
+p id("x").freeze.clone.frozen?     # true
+p id("x").freeze.dup.frozen?       # false
+# unfrozen original: both stay unfrozen
+p id("abc").clone.frozen?          # false
+p id("abc").dup.frozen?            # false
+# value is preserved across clone
+p id("hi").freeze.clone            # "hi"
+# through a local variable
+s = "y".freeze
+c = s.clone
+p c.frozen?                        # true
+p c                                # "y"
+d = s.dup
+p d.frozen?                        # false
+# a frozen clone still raises on mutation
+begin
+  c << "z"
+rescue FrozenError => e
+  p e.class                        # FrozenError
+end
+# literal receiver
+p "lit".freeze.clone.frozen?       # true

--- a/test/string_clone_frozen.rb.expected
+++ b/test/string_clone_frozen.rb.expected
@@ -1,0 +1,10 @@
+true
+false
+false
+false
+"hi"
+true
+"y"
+false
+FrozenError
+true


### PR DESCRIPTION
Fixes `String#clone` to preserve the frozen state.

CRuby semantics: `clone` copies the frozen flag, while `dup` always returns an unfrozen copy. Spinel routed both through `sp_str_dup_external`, so `"x".freeze.clone.frozen?` returned `false`.

`clone` now routes to a new `sp_str_clone_val` that duplicates the buffer and re-applies the `0xf1` heap-frozen marker when the receiver is frozen; `dup` is unchanged. A frozen clone bound to a local correctly raises `FrozenError` on mutation, matching the existing freeze guards.

Tests cover clone-vs-dup on frozen and unfrozen receivers, value preservation, the local-bound mutation guard, and folded-literal receivers; `.expected` generated from `ruby`. Full suite green; the new test is ASAN + UBSan + `GC_STRESS` clean.