### PR TITLE
parse,analyze,codegen,runtime: per-file frozen_string_literal pragma with faithful mutation raises

### DIFF
--- a/lib/sp_alloc.h
+++ b/lib/sp_alloc.h
@@ -256,6 +256,7 @@ void *sp_gc_alloc(size_t sz, void (*fin)(void *), void (*scn)(void *));
 void *sp_gc_alloc_nogc(size_t sz, void (*fin)(void *), void (*scn)(void *));
 
 __attribute__((noreturn)) void sp_raise_cls(const char *cls, const char *msg);  /* lib/sp_core.c */
+__attribute__((noreturn)) void sp_raise_frozen_str(const char *s);              /* lib/sp_str.c */
 static void __attribute__((noinline, cold)) sp_raise_frozen_array(void) { sp_raise_cls("FrozenError", "can't modify frozen Array"); }
 
 /* sp_PolyArray: a growable array of boxed values. */

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -898,7 +898,7 @@ static inline mrb_int sp_str_setbyte(const char *s, mrb_int i, mrb_int v) {
     ((char *)s)[i] = (char)v;
     return v;
   }
-  sp_raise_cls("FrozenError", "can't modify frozen String");
+  sp_raise_frozen_str(s);
   return v;
 }
 
@@ -938,9 +938,8 @@ static inline const char *sp_str_clone_val(const char *s) {
   if (r && sp_str_is_frozen_val(s)) ((unsigned char *)r)[-1] = 0xf1;
   return r;
 }
-static void __attribute__((noinline,cold)) sp_raise_frozen_string(void){sp_raise_cls("FrozenError","can't modify frozen String");}
 static inline void sp_str_check_mutable(const char *s) {
-  if (sp_str_is_frozen_val(s)) sp_raise_frozen_string();
+  if (sp_str_is_frozen_val(s)) sp_raise_frozen_str(s);
 }
 
 /* sp_String (mutable-String builder) moved to sp_string.h / lib/sp_string.c:

--- a/lib/sp_str.c
+++ b/lib/sp_str.c
@@ -45,6 +45,9 @@ const char*sp_str_concat4(const char*a,const char*b,const char*c,const char*d){i
 /* Concatenate N strings into a single GC-managed buffer. */
 /* Issue #760: NULL entries treated as empty strings. */
 const char*sp_str_concat_arr(const char *const *parts,int n){size_t total=0;for(int i=0;i<n;i++)total+=sp_str_byte_len(parts[i]?parts[i]:"");char*r=sp_str_alloc(total);char*p=r;for(int i=0;i<n;i++){const char*s=parts[i]?parts[i]:"";size_t sl=sp_str_byte_len(s);memcpy(p,s,sl);p+=sl;}return r;}
+/* FrozenError naming the receiver, matching CRuby's
+   "can't modify frozen String: \"abc\"" message shape. */
+void sp_raise_frozen_str(const char*s){const char*ins=sp_str_inspect(s);SP_GC_ROOT(ins);const char*msg=sp_str_concat("can't modify frozen String: ",ins);SP_GC_ROOT(msg);sp_raise_cls("FrozenError",msg);}
 /* String#inspect: wrap in double quotes and escape \, ", \n, \t, \r,
    plus any non-printable byte as \xNN. Output is always ASCII-safe. */
 const char*sp_str_inspect(const char*s){if(!s){char*r=sp_str_alloc_raw(4);r[0]='n';r[1]='i';r[2]='l';r[3]=0;return r;}size_t sl=sp_str_byte_len(s);size_t cap=(sl*4)+3;char*r=sp_str_alloc_raw(cap);size_t o=0;r[o++]='"';for(size_t i=0;i<sl;i++){unsigned char c=(unsigned char)s[i];if(c=='\\'||c=='"'){r[o++]='\\';r[o++]=c;}else if(c=='\n'){r[o++]='\\';r[o++]='n';}else if(c=='\t'){r[o++]='\\';r[o++]='t';}else if(c=='\r'){r[o++]='\\';r[o++]='r';}else if(c<0x20||c==0x7f){snprintf(r+o,5,"\\x%02X",c);o+=4;}else{r[o++]=(char)c;}}r[o++]='"';r[o]=0;sp_str_set_len(r,o);return r;}

--- a/lib/sp_string.c
+++ b/lib/sp_string.c
@@ -4,9 +4,9 @@
 #include "sp_string.h"
 #include <string.h>
 
-void sp_String_prepend(sp_String*s,const char*t){if(!s||!t)return;if(sp_String_is_frozen(s)){sp_raise_cls("FrozenError","can't modify frozen String");return;}int64_t tl=(int64_t)strlen(t);if(!sp_fd_grow(s,s->len+tl))return;memmove(s->data+tl,s->data,s->len+1);memcpy(s->data,t,tl);s->len+=tl;sp_fd_publish(s);}
+void sp_String_prepend(sp_String*s,const char*t){if(!s||!t)return;if(sp_String_is_frozen(s)){sp_raise_frozen_str(s->data);return;}int64_t tl=(int64_t)strlen(t);if(!sp_fd_grow(s,s->len+tl))return;memmove(s->data+tl,s->data,s->len+1);memcpy(s->data,t,tl);s->len+=tl;sp_fd_publish(s);}
 /* String#insert(idx, str): insert at idx; negative idx is relative to len+1. */
-void sp_String_insert(sp_String*s,int64_t idx,const char*t){if(!s||!t)return;if(sp_String_is_frozen(s)){sp_raise_cls("FrozenError","can't modify frozen String");return;}int64_t tl=(int64_t)strlen(t);if(tl==0)return;if(idx<0)idx+=s->len+1;if(idx<0)idx=0;if(idx>s->len)idx=s->len;if(!sp_fd_grow(s,s->len+tl))return;memmove(s->data+idx+tl,s->data+idx,s->len-idx+1);memcpy(s->data+idx,t,tl);s->len+=tl;sp_fd_publish(s);}
+void sp_String_insert(sp_String*s,int64_t idx,const char*t){if(!s||!t)return;if(sp_String_is_frozen(s)){sp_raise_frozen_str(s->data);return;}int64_t tl=(int64_t)strlen(t);if(tl==0)return;if(idx<0)idx+=s->len+1;if(idx<0)idx=0;if(idx>s->len)idx=s->len;if(!sp_fd_grow(s,s->len+tl))return;memmove(s->data+idx+tl,s->data+idx,s->len-idx+1);memcpy(s->data+idx,t,tl);s->len+=tl;sp_fd_publish(s);}
 /* String#replace(s): replace entire content. */
-void sp_String_replace(sp_String*s,const char*t){if(!s||!t)return;if(sp_String_is_frozen(s)){sp_raise_cls("FrozenError","can't modify frozen String");return;}int64_t tl=(int64_t)strlen(t);if(!sp_fd_grow(s,tl))return;memcpy(s->data,t,tl);s->data[tl]='\0';s->len=tl;sp_fd_publish(s);}
+void sp_String_replace(sp_String*s,const char*t){if(!s||!t)return;if(sp_String_is_frozen(s)){sp_raise_frozen_str(s->data);return;}int64_t tl=(int64_t)strlen(t);if(!sp_fd_grow(s,tl))return;memcpy(s->data,t,tl);s->data[tl]='\0';s->len=tl;sp_fd_publish(s);}
 sp_String*sp_String_dup(sp_String*s){return sp_String_new(s->data);}

--- a/lib/sp_string.h
+++ b/lib/sp_string.h
@@ -67,10 +67,10 @@ static inline sp_String*sp_String_new(const char*s){
 /* Shared append core: `tl` is the operand byte length (strlen for the
    bare-literal-safe entry, sp_str_byte_len for the binary one). */
 static inline void sp_fd_append_len(sp_String*s,const char*t,int64_t tl){if(!sp_fd_grow(s,s->len+tl))return;memcpy(s->data+s->len,t,tl);s->len+=tl;s->data[s->len]=0;sp_fd_publish(s);}
-static inline void sp_String_append(sp_String*s,const char*t){if(!s||!t)return;if(sp_String_is_frozen(s)){sp_raise_cls("FrozenError","can't modify frozen String");return;}sp_fd_append_len(s,t,(int64_t)strlen(t));}
+static inline void sp_String_append(sp_String*s,const char*t){if(!s||!t)return;if(sp_String_is_frozen(s)){sp_raise_frozen_str(s->data);return;}sp_fd_append_len(s,t,(int64_t)strlen(t));}
 /* Binary-safe append: sizes the operand with the header length so an embedded
    NUL is preserved (Ruby String#<< / concat on a marked spinel string). */
-static inline void sp_String_append_bin(sp_String*s,const char*t){if(!s||!t)return;if(sp_String_is_frozen(s)){sp_raise_cls("FrozenError","can't modify frozen String");return;}sp_fd_append_len(s,t,(int64_t)sp_str_byte_len(t));}
+static inline void sp_String_append_bin(sp_String*s,const char*t){if(!s||!t)return;if(sp_String_is_frozen(s)){sp_raise_frozen_str(s->data);return;}sp_fd_append_len(s,t,(int64_t)sp_str_byte_len(t));}
 static inline const char*sp_String_cstr(sp_String*s){return s->data;}
 static inline int64_t sp_String_length(sp_String*s){return s->len;}
 

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -3193,8 +3193,13 @@ void analyze_program(Compiler *c) {
     /* Only promote when every write to this local is a bare string literal:
        such a value is a fresh mutable string. A `.freeze`/`.dup`/method-result
        write may carry runtime frozen state that sp_String_new would discard,
-       so `<<` would fail to raise FrozenError. Conservative but sound. */
-    int all_literal_writes = 1, saw_write = 0;
+       so `<<` would fail to raise FrozenError. Conservative but sound.
+       Under `# frozen_string_literal: true` (the literal's `fzl` node flag,
+       per file) the premise inverts -- the literal is FROZEN, and copying it
+       into a writable sp_String would let `<<` mutate where CRuby raises
+       FrozenError -- so a frozen contributing literal blocks the promotion
+       and the value path's sp_str_check_mutable raises faithfully. */
+    int all_literal_writes = 1, saw_write = 0, frozen_literal_write = 0;
     for (int w = 0; w < c->nt->count; w++) {
       const char *wty = nt_type(c->nt, w);
       if (!wty || !sp_streq(wty, "LocalVariableWriteNode")) continue;
@@ -3204,8 +3209,9 @@ void analyze_program(Compiler *c) {
       int wv = nt_ref(c->nt, w, "value");
       const char *wvty = wv >= 0 ? nt_type(c->nt, wv) : NULL;
       if (!wvty || !sp_streq(wvty, "StringNode")) { all_literal_writes = 0; break; }
+      if (nt_int(c->nt, wv, "fzl", 0)) { frozen_literal_write = 1; break; }
     }
-    if (!saw_write || !all_literal_writes) continue;
+    if (!saw_write || !all_literal_writes || frozen_literal_write) continue;
     /* Exclude vars used with a reassigning string mutator (replace/prepend/
        insert/clear or a bang method): codegen emits those as `recv = ...`,
        which needs a plain lvalue, not the copy a STRBUF read produces. */

--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -212,7 +212,9 @@ else {
   }
 
   if (nargs == 0) {
-    buf_puts(b, "(&(\"\\xff\" \"");
+    /* adjacent literals ("a" "b") fold to one literal: frozen per the
+       InterpolatedStringNode's own file pragma flag */
+    buf_printf(b, "(&(\"%s\" \"", nt_int(c->nt, id, "fzl", 0) ? "\\xf1" : "\\xff");
     for (const char *p = fmt.p ? fmt.p : ""; *p; p++) {
       if (p[0] == '%' && p[1] == '%') { buf_puts(b, "%"); p++; }
       else buf_printf(b, "%c", *p);
@@ -374,12 +376,15 @@ void emit_expr(Compiler *c, int id, Buf *b) {
   }
   if (sp_streq(ty, "StringNode")) {
     const char *sc = nt_str(nt, id, "content");
-    emit_str_literal_n(b, sc ? sc : "", sc ? nt_str_len(nt, id, "content") : 0);
+    emit_str_literal_n(b, sc ? sc : "", sc ? nt_str_len(nt, id, "content") : 0,
+                       (int)nt_int(nt, id, "fzl", 0));
     return;
   }
   if (sp_streq(ty, "SourceFileNode")) {
+    /* __FILE__ is a literal of its file: frozen under that file's pragma. */
     const char *sc = nt_str(nt, id, "content");
-    emit_str_literal_n(b, sc ? sc : "", sc ? strlen(sc) : 0);
+    emit_str_literal_n(b, sc ? sc : "", sc ? strlen(sc) : 0,
+                       (int)nt_int(nt, id, "fzl", 0));
     return;
   }
   if (sp_streq(ty, "SourceLineNode")) {
@@ -397,9 +402,10 @@ void emit_expr(Compiler *c, int id, Buf *b) {
   }
   if (sp_streq(ty, "InterpolatedStringNode")) { emit_interp(c, id, b); return; }
   if (sp_streq(ty, "XStringNode")) {
+    /* backtick content is a command argument, never a user-visible string */
     const char *sc = nt_str(nt, id, "content");
     buf_puts(b, "sp_backtick(");
-    emit_str_literal_n(b, sc ? sc : "", sc ? nt_str_len(nt, id, "content") : 0);
+    emit_str_literal_n(b, sc ? sc : "", sc ? nt_str_len(nt, id, "content") : 0, 0);
     buf_puts(b, ")");
     return;
   }

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -368,7 +368,7 @@ void emit_box_close(Compiler *c, TyKind t, Buf *b);
 const char *array_kind(TyKind t);
 void emit_c_escaped_n(Buf *b, const char *s, size_t len);
 void emit_c_escaped(Buf *b, const char *s);
-void emit_str_literal_n(Buf *b, const char *content, size_t len);
+void emit_str_literal_n(Buf *b, const char *content, size_t len, int frozen);
 void emit_str_literal(Buf *b, const char *content);
 void emit_catch_tag(Compiler *c, int id, Buf *b);
 void emit_hash_key(Compiler *c, int key, TyKind kt, Buf *b);

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -5129,7 +5129,7 @@ int emit_array_mutate_stmt(Compiler *c, int id, Buf *b, int indent) {
     /* `<<` onto a frozen string literal raises FrozenError */
     if (rty && sp_streq(rty, "StringNode")) {
       emit_indent(b, indent);
-      buf_puts(b, "sp_raise_cls(\"FrozenError\", \"can't modify frozen String\");\n");
+      buf_puts(b, "sp_raise_frozen_str("); emit_expr(c, cur, b); buf_puts(b, ");\n");
       return 1;
     }
     return 0;
@@ -5169,7 +5169,7 @@ int emit_array_mutate_stmt(Compiler *c, int id, Buf *b, int indent) {
          sp_streq(name, "concat") || sp_streq(name, "replace") || sp_streq(name, "clear") ||
          sp_streq(name, "delete_prefix!") || sp_streq(name, "delete_suffix!"))) {
       emit_indent(b, indent);
-      buf_puts(b, "sp_raise_cls(\"FrozenError\", \"can't modify frozen String\");\n");
+      buf_puts(b, "sp_raise_frozen_str("); emit_expr(c, recv, b); buf_puts(b, ");\n");
       return 1;
     }
     if (assignable && sp_streq(name, "replace") && argc == 1) {

--- a/src/codegen_util.c
+++ b/src/codegen_util.c
@@ -602,22 +602,33 @@ void emit_c_escaped_n(Buf *b, const char *s, size_t len) {
 void emit_c_escaped(Buf *b, const char *s) {
   if (s) emit_c_escaped_n(b, s, strlen(s));
 }
-void emit_str_literal_n(Buf *b, const char *content, size_t len) {
-  if (!content || len == 0) { buf_puts(b, "(&(\"\\xff\")[1])"); return; }
-  /* NUL-containing strings: use sp_str_from_bytes with explicit byte count. */
+/* Marker byte before string-literal data: 0xff is an immutable rodata literal
+   (frozen? false, value semantics); `frozen` -- set from the node's `fzl` flag
+   when its file has `# frozen_string_literal: true` -- switches to 0xf1 so
+   `frozen?` is true and mutation raises FrozenError. Synthesized strings
+   (symbol names, ivar names, ...) go through emit_str_literal, which is never
+   frozen: the pragma only affects literals written in the source. */
+void emit_str_literal_n(Buf *b, const char *content, size_t len, int frozen) {
+  const char *mk = frozen ? "\\xf1" : "\\xff";
+  if (!content || len == 0) { buf_printf(b, "(&(\"%s\")[1])", mk); return; }
+  /* NUL-containing strings: use sp_str_from_bytes with explicit byte count.
+     The heap string it builds is writable (0xfe), so a frozen literal is
+     sealed with sp_str_freeze_val (flips the heap marker to 0xf1 in place). */
   if (len > strlen(content)) {
+    if (frozen) buf_puts(b, "sp_str_freeze_val(");
     buf_puts(b, "sp_str_from_bytes(\"");
     emit_c_escaped_n(b, content, len);
     buf_printf(b, "\", %zu)", len);
+    if (frozen) buf_puts(b, ")");
     return;
   }
-  buf_puts(b, "(&(\"\\xff\" \"");
+  buf_printf(b, "(&(\"%s\" \"", mk);
   emit_c_escaped_n(b, content, len);
   buf_puts(b, "\")[1])");
 }
 void emit_str_literal(Buf *b, const char *content) {
   if (!content) { buf_puts(b, "(&(\"\\xff\")[1])"); return; }
-  emit_str_literal_n(b, content, strlen(content));
+  emit_str_literal_n(b, content, strlen(content), 0);
 }
 void emit_catch_tag(Compiler *c, int id, Buf *b) {
   const char *ty = nt_type(c->nt, id);

--- a/src/spinel_parse.c
+++ b/src/spinel_parse.c
@@ -117,6 +117,84 @@ static char *g_source_file_escaped = NULL;  /* escape_str(g_source_file), set on
    `node_line` field so codegen can place C `#line` directives. Off by
    default so the AST text format (and golden tests) are unchanged. */
 static int g_emit_line = 0;
+/* Set from the ENTRY file's `# frozen_string_literal: true` magic comment.
+   The pragma is per-file in Ruby: the require resolvers build g_fsl_lines
+   (one flag byte per line of the final spliced buffer, from each spliced
+   file's own head), and flatten() stamps an `fzl` field on string-literal
+   nodes from it. This global is the fallback -- used when the per-line
+   table is unavailable (syntax-sugar changed the line count) -- and the
+   whole-program gate read by the analyzer's mutable-string-buffer pass. */
+int g_frozen_string_literal = 0;
+/* Per-line pragma flags for the final spliced buffer (0-based line index). */
+static unsigned char *g_fsl_lines = NULL;
+static size_t g_fsl_nlines = 0;
+
+/* `# frozen_string_literal: true` on the first line (or the second when the
+   first is a shebang); scanning stops at the first non-comment line. */
+static int sp_scan_fsl_pragma(const char *src) {
+  const char *p = src;
+  for (int line = 0; line < 2 && p && *p; line++) {
+    const char *nl = strchr(p, '\n');
+    size_t len = nl ? (size_t)(nl - p) : strlen(p);
+    const char *q = p; while (*q == ' ' || *q == '\t') q++;
+    if (*q != '#') break;                      /* code reached: stop scanning */
+    if (line == 0 && q[1] == '!') { p = nl ? nl + 1 : NULL; continue; }  /* shebang */
+    char linebuf[512];
+    size_t rem = len - (size_t)(q - p);
+    size_t cl = rem < sizeof(linebuf) - 1 ? rem : sizeof(linebuf) - 1;
+    memcpy(linebuf, q, cl); linebuf[cl] = '\0';
+    const char *m = strstr(linebuf, "frozen_string_literal:");
+    if (m) {
+      m += strlen("frozen_string_literal:");
+      while (*m == ' ' || *m == '\t') m++;
+      if (strncmp(m, "true", 4) == 0) {
+        char c = m[4];
+        return !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+                 (c >= '0' && c <= '9') || c == '_');
+      }
+      return 0;
+    }
+    p = nl ? nl + 1 : NULL;
+  }
+  return 0;
+}
+
+/* Lines of `s` as the require splicers count them: one per '\n', plus one for
+   a trailing unterminated fragment (the splicers append the missing '\n'). */
+static size_t sp_count_lines(const char *s) {
+  size_t n = 0; const char *p = s;
+  for (; *p; p++) if (*p == '\n') n++;
+  if (p != s && p[-1] != '\n') n++;
+  return n;
+}
+
+/* Fresh flag buffer for `text`, every line carrying that file's pragma flag. */
+static unsigned char *sp_fsl_make(const char *text, int flag, size_t *n_out) {
+  size_t n = sp_count_lines(text);
+  unsigned char *v = malloc(n ? n : 1);
+  if (!v) { fprintf(stderr, "spinel_parse: out of memory\n"); exit(1); }
+  memset(v, flag ? 1 : 0, n);
+  *n_out = n;
+  return v;
+}
+
+/* Replace `remove` entries at line index `at` with the `insn` entries of
+   `ins`, mirroring a text splice on the flag buffer. */
+static void sp_fsl_splice(unsigned char **buf, size_t *n, size_t at,
+                          size_t remove, const unsigned char *ins, size_t insn) {
+  if (at > *n) at = *n;
+  if (remove > *n - at) remove = *n - at;
+  size_t newn = *n - remove + insn;
+  unsigned char *nv = malloc(newn ? newn : 1);
+  if (!nv) { fprintf(stderr, "spinel_parse: out of memory\n"); exit(1); }
+  if (at) memcpy(nv, *buf, at);
+  if (insn) memcpy(nv + at, ins, insn);
+  size_t rest = *n - at - remove;
+  if (rest) memcpy(nv + at + insn, *buf + at + remove, rest);
+  free(*buf);
+  *buf = nv;
+  *n = newn;
+}
 /* Debug multi-file source map, populated by sp_build_line_map() before
    flatten() runs and read in flatten() to attribute each node to its
    original file/line. Declared here because flatten() precedes the
@@ -298,6 +376,17 @@ static int pm_int_overflows(pm_integer_t *integer) {
   uint64_t max_negative = max_positive + 1ULL;
   if (integer->negative) return overflow || val >= max_negative;
   return overflow || val > max_positive;
+}
+
+/* frozen_string_literal flag for the file `node`'s source line came from:
+   the per-line table when available, else the entry file's pragma. */
+static int sp_node_fsl(pm_node_t *node) {
+  if (g_fsl_lines) {
+    int32_t bl = pm_newline_list_line(&g_parser->newline_list,
+                                      node->location.start, g_parser->start_line);
+    if (bl >= 1 && (size_t)bl <= g_fsl_nlines) return g_fsl_lines[bl - 1];
+  }
+  return g_frozen_string_literal;
 }
 
 /* ---- Main flattening ---- */
@@ -793,12 +882,16 @@ else {
     pm_string_node_t *n = (pm_string_node_t *)node;
     N("StringNode");
     S("content", escape_pm_string(&n->unescaped));
+    /* `fzl` only when the literal's file has the frozen pragma, so the AST
+       text is byte-identical for programs without one. */
+    if (sp_node_fsl(node)) I("fzl", 1);
     break;
   }
   case PM_INTERPOLATED_STRING_NODE: {
     pm_interpolated_string_node_t *n = (pm_interpolated_string_node_t *)node;
     N("InterpolatedStringNode");
     A("parts", &n->parts);
+    if (sp_node_fsl(node)) I("fzl", 1);  /* adjacent-literal fold ("a" "b") */
     break;
   }
   case PM_EMBEDDED_STATEMENTS_NODE: {
@@ -1145,6 +1238,7 @@ else {
        in g_source_file_escaped at init since it never changes. */
     N("SourceFileNode");
     emit_str(id, "content", g_source_file_escaped);
+    if (sp_node_fsl(node)) I("fzl", 1);  /* __FILE__ is a literal of its file */
     break;
   }
   case PM_SOURCE_ENCODING_NODE: {
@@ -1865,7 +1959,25 @@ static void sp_normalize_dots(char *path) {
    require_relative "path" with the file content. Files that have
    already been included once are silently skipped on subsequent
    requires (matching Ruby's load-once semantics). */
-static char *resolve_requires(const char *source, const char *source_path) {
+/* PUSH/POP wrap adds one marker line before and after (--debug only): pad the
+   file's flag lines to match so the buffer stays aligned with the text. */
+static void sp_fsl_pad_wrap(unsigned char **v, size_t *n) {
+  unsigned char z = 0;
+  if (!g_emit_line) return;
+  sp_fsl_splice(v, n, 0, 0, &z, 1);
+  sp_fsl_splice(v, n, *n, 0, &z, 1);
+}
+
+/* 0-based line index of byte offset `at` in `text` (both resolvers splice at
+   line starts, so this is the spliced line's index in the flag buffer). */
+static size_t sp_fsl_line_at(const char *text, size_t at) {
+  size_t line = 0;
+  for (size_t i = 0; i < at; i++) if (text[i] == '\n') line++;
+  return line;
+}
+
+static char *resolve_requires(const char *source, const char *source_path,
+                              unsigned char **fsl_out, size_t *fsl_n_out) {
   /* Get base directory */
   char *path_copy = strdup(source_path);
   char *dir = strdup(path_copy);
@@ -1876,6 +1988,10 @@ static char *resolve_requires(const char *source, const char *source_path) {
   free(path_copy);
 
   char *result = strdup(source);
+  /* One pragma flag per line of `result`, kept in lockstep with every text
+     splice below so each literal keeps its own file's flag. */
+  size_t fsl_n;
+  unsigned char *fsl = sp_fsl_make(source, sp_scan_fsl_pragma(source), &fsl_n);
   char *pos;
   char *scan_from = result;
   while ((pos = strstr(scan_from, "require_relative")) != NULL) {
@@ -1931,9 +2047,11 @@ else { scan_from = pos + 1; continue; }
 
     char *canonical = sp_canonical_path(full_path);
     char *content;
+    unsigned char *cfsl = NULL; size_t cfsl_n = 0;   /* spliced content's flags */
     if (sp_path_already_included(canonical)) {
       /* Already inlined once -- replace require with empty content */
       content = strdup("# require_relative skipped (already included)");
+      cfsl = sp_fsl_make(content, 0, &cfsl_n);
       free(canonical);
     }
 else {
@@ -1953,7 +2071,7 @@ else {
       }
 else {
         /* Recursively resolve */
-        char *resolved = resolve_requires(content, full_path);
+        char *resolved = resolve_requires(content, full_path, &cfsl, &cfsl_n);
         free(content);
         content = resolved;
       }
@@ -1963,12 +2081,18 @@ else {
     /* Debug: wrap with PUSH/POP markers so the line map can attribute this
        file's nodes to the right source. No-op outside --debug. */
     content = sp_wrap_included(content, full_path);
+    sp_fsl_pad_wrap(&cfsl, &cfsl_n);
 
     /* Replace the line */
     size_t line_len = (line_end - pos) + ((*line_end == '\n') ? 1 : 0);
     size_t content_len = strlen(content);
     size_t result_len = strlen(result);
     size_t before_len = pos - result;
+
+    /* Mirror the splice on the flag buffer: the require line's one entry is
+       replaced by the included file's entries. */
+    sp_fsl_splice(&fsl, &fsl_n, sp_fsl_line_at(result, before_len), 1, cfsl, cfsl_n);
+    free(cfsl);
 
     char *new_result = malloc(result_len - line_len + content_len + 2);
     memcpy(new_result, result, before_len);
@@ -1984,6 +2108,8 @@ else {
     free(content);
   }
   free(dir);
+  *fsl_out = fsl;
+  *fsl_n_out = fsl_n;
   return result;
 }
 
@@ -2014,7 +2140,8 @@ static int sp_require_tolerated(const char *name) {
 }
 
 /* ---- Plain require resolution ---- */
-static char *resolve_plain_requires(char *source, const char *exe_path) {
+static char *resolve_plain_requires(char *source, const char *exe_path,
+                                    unsigned char **fsl, size_t *fsl_n) {
   /* Find lib/ directory relative to this executable */
   char lib_dir[1024];
   strncpy(lib_dir, exe_path, sizeof(lib_dir) - 1);
@@ -2087,6 +2214,7 @@ else {
        still produces struct-redefinition errors. */
     char *canonical = sp_canonical_path(lib_path);
     char *content;
+    unsigned char *cfsl = NULL; size_t cfsl_n = 0;   /* spliced content's flags */
     if (sp_path_already_included(canonical)) {
       content = strdup("# require skipped (already included)");
       free(canonical);
@@ -2156,11 +2284,13 @@ else {
         /* A bundled lib/<name>.rb was found and spliced; record the feature so
            the require-gate enables any C-native methods it stands in for. */
         sp_feature_mark(lib_name);
-        char *resolved = resolve_requires(content, lib_path);
+        char *resolved = resolve_requires(content, lib_path, &cfsl, &cfsl_n);
         free(content);
         content = resolved;
       }
     }
+    /* Stub arms above leave cfsl NULL: their content is a one-line comment. */
+    if (!cfsl) cfsl = sp_fsl_make(content, 0, &cfsl_n);
 
     /* A trailing same-line modifier (`rescue`, `if`, `unless`, `and`,
        `&&`, ...) puts the require in expression position: `require 'x'
@@ -2179,6 +2309,7 @@ else {
       if (*trail != '\n' && *trail != '\r' && *trail != ';' &&
           *trail != '\0' && *trail != '#') {
         free(content);
+        free(cfsl);   /* same-line `nil` substitution: line count unchanged */
         size_t rl_len = (size_t)((end + 1) - pos);   /* the `require 'x'` span */
         size_t result_len = strlen(result);
         size_t before_len = (size_t)(pos - result);
@@ -2197,6 +2328,7 @@ else {
     /* Debug: marker-wrap so plain-require'd lib content doesn't corrupt the
        line map's accounting for code after the require. No-op without --debug. */
     content = sp_wrap_included(content, lib_path);
+    sp_fsl_pad_wrap(&cfsl, &cfsl_n);
 
     /* Replace only the `require "name"` statement itself, not the whole
        line, so `require "x"; code` keeps `code`. Consume trailing
@@ -2206,11 +2338,21 @@ else {
        then pushes onto its own line. */
     char *stmt_end = end + 1;  /* just past the closing quote */
     while (*stmt_end == ' ' || *stmt_end == '\t') stmt_end++;
-    if (*stmt_end == '\n') stmt_end++;
+    int consumed_nl = (*stmt_end == '\n');
+    if (consumed_nl) stmt_end++;
     size_t line_len = stmt_end - pos;
     size_t content_len = strlen(content);
     size_t result_len = strlen(result);
     size_t before_len = pos - result;
+
+    /* Flag-buffer mirror: the require line is consumed entirely (its one
+       entry replaced by the lib's entries) -- unless trailing code stayed on
+       it, in which case that remainder becomes its own line and keeps the
+       original line's entry (insert the lib's entries before it). At EOF
+       with no trailing newline there is no remainder either. */
+    sp_fsl_splice(fsl, fsl_n, sp_fsl_line_at(result, before_len),
+                  (consumed_nl || *stmt_end == '\0') ? 1 : 0, cfsl, cfsl_n);
+    free(cfsl);
     char *new_result = malloc(result_len - line_len + content_len + 2);
     memcpy(new_result, result, before_len);
     memcpy(new_result + before_len, content, content_len);
@@ -2452,6 +2594,11 @@ static int sp_parse_emit(const char *source_file, const char *argv0, SpStrBuf *o
     return 1;
   }
 
+  /* `# frozen_string_literal: true` magic comment, per file: the entry file's
+     flag is the whole-program fallback; the require resolvers below build the
+     per-line table each spliced file's literals are stamped from. */
+  g_frozen_string_literal = sp_scan_fsl_pragma(source);
+
   /* Set the debug flag before resolving requires so the resolvers insert the
      PUSH/POP markers used to rebuild the multi-file source map. */
   {
@@ -2472,9 +2619,10 @@ static int sp_parse_emit(const char *source_file, const char *argv0, SpStrBuf *o
     free(entry_canon);
   }
   g_require_gate = getenv("SPINEL_REQUIRE_GATE") ? 1 : 0;
-  char *resolved = resolve_requires(source, source_file);
+  unsigned char *fsl = NULL; size_t fsl_n = 0;
+  char *resolved = resolve_requires(source, source_file, &fsl, &fsl_n);
   free(source);
-  source = resolve_plain_requires(resolved, argv0);
+  source = resolve_plain_requires(resolved, argv0, &fsl, &fsl_n);
 
   /* Debug: build the buffer-line -> (file, original line) map from the
      marker-annotated buffer *before* syntax-sugar rewriting (which could
@@ -2487,6 +2635,18 @@ static int sp_parse_emit(const char *source_file, const char *argv0, SpStrBuf *o
     if (!premap) { fprintf(stderr, "spinel_parse: out of memory\n"); exit(1); }
   }
   source = rewrite_syntax_sugar(source);
+  /* Adopt the per-line pragma table only while it provably still lines up
+     with the buffer (sugar preserves line count); on mismatch fall back to
+     the entry file's flag rather than misattribute. */
+  if (sp_count_lines(source) == fsl_n) {
+    g_fsl_lines = fsl;
+    g_fsl_nlines = fsl_n;
+  }
+else {
+    free(fsl);
+    g_fsl_lines = NULL;
+    g_fsl_nlines = 0;
+  }
   if (g_emit_line) {
     size_t la = 1, lb = 1;
     for (const char *p = premap; *p; p++) if (*p == '\n') la++;
@@ -2526,6 +2686,7 @@ else {
     pm_node_destroy(&parser, root);
     pm_parser_free(&parser);
     free(source);
+    free(g_fsl_lines); g_fsl_lines = NULL; g_fsl_nlines = 0;
     sp_includes_free();
     return 1;
   }
@@ -2566,6 +2727,7 @@ else {
   pm_node_destroy(&parser, root);
   pm_parser_free(&parser);
   free(source);
+  free(g_fsl_lines); g_fsl_lines = NULL; g_fsl_nlines = 0;
   free(g_source_file_escaped);  /* paired with the escape_str() in init */
   g_source_file_escaped = NULL;
   sp_includes_free();

--- a/test/bundle_classd_43.rb
+++ b/test/bundle_classd_43.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Bundled tests:
 #   - str_setbyte_frozen_literal
 #   - strip_nullable_int_cast

--- a/test/bundle_classd_43.rb.expected
+++ b/test/bundle_classd_43.rb.expected
@@ -1,5 +1,5 @@
-literal: can't modify frozen String
-lv-literal: can't modify frozen String
+literal: can't modify frozen String: "abc"
+lv-literal: can't modify frozen String: "abc"
 Cbc
 Zy
 Cb

--- a/test/frozen_string_literal_per_file.rb
+++ b/test/frozen_string_literal_per_file.rb
@@ -1,0 +1,20 @@
+# Per-file frozen_string_literal: each literal carries its OWN file's pragma,
+# not the entry file's. helper_frozen.rb has the pragma; this entry file and
+# helper_plain.rb do not.
+require_relative "frozen_string_literal_per_file/helper_frozen"
+require_relative "frozen_string_literal_per_file/helper_plain"
+
+p frozen_helper_lit.frozen?   # true  -- literal from the pragma file
+p plain_helper_lit.frozen?    # false -- literal from a plain file
+p "entry lit".frozen?         # false -- entry has no pragma
+
+# mutating a pragma-file literal raises even when called from a plain file
+begin
+  frozen_helper_mutate
+  puts "BUG: no raise"
+rescue FrozenError => e
+  puts e.message
+end
+
+# a plain-file literal stays mutable
+p plain_helper_build

--- a/test/frozen_string_literal_per_file.rb.expected
+++ b/test/frozen_string_literal_per_file.rb.expected
@@ -1,0 +1,5 @@
+true
+false
+false
+can't modify frozen String: "helper buf"
+"plain!"

--- a/test/frozen_string_literal_per_file/helper_frozen.rb
+++ b/test/frozen_string_literal_per_file/helper_frozen.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+def frozen_helper_lit
+  "helper frozen lit"
+end
+
+def frozen_helper_mutate
+  s = "helper buf"
+  s << "y"   # FrozenError: the literal comes from a pragma file
+end

--- a/test/frozen_string_literal_per_file/helper_plain.rb
+++ b/test/frozen_string_literal_per_file/helper_plain.rb
@@ -1,0 +1,9 @@
+def plain_helper_lit
+  "helper plain lit"
+end
+
+def plain_helper_build
+  s = "plain"
+  s << "!"
+  s
+end

--- a/test/frozen_string_literal_per_file_rev.rb
+++ b/test/frozen_string_literal_per_file_rev.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# Reverse direction: pragma entry + plain helper. The helper's literals stay
+# unfrozen and mutable; the entry's literals are frozen.
+require_relative "frozen_string_literal_per_file/helper_plain"
+
+p "entry lit".frozen?         # true
+p plain_helper_lit.frozen?    # false
+p plain_helper_build          # helper literals stay mutable

--- a/test/frozen_string_literal_per_file_rev.rb.expected
+++ b/test/frozen_string_literal_per_file_rev.rb.expected
@@ -1,0 +1,3 @@
+true
+false
+"plain!"

--- a/test/frozen_string_literal_pragma.rb
+++ b/test/frozen_string_literal_pragma.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+# With the magic comment, string literals are frozen: frozen? is true and
+# mutation raises FrozenError (including through the mutable-string-buffer
+# optimization, which is disabled for pragma literals).
+def s(x); x; end
+
+p "abc".frozen?            # true
+p s("via method").frozen?  # true -- literal stays frozen through a call
+x = "local"
+p x.frozen?                # true
+p "interp #{1 + 1}".frozen?  # false -- interpolation builds a new string
+p "".frozen?               # true -- empty literal
+p :sym.frozen?             # true (symbols always)
+p [1, 2].frozen?           # false (array literal not affected by the pragma)
+
+# dup produces an unfrozen copy
+p "abc".dup.frozen?        # false
+
+# mutating a frozen literal raises; without the pragma this local would take
+# the in-place string-buffer path
+buf = "abc"
+begin
+  buf << "y"
+  puts "BUG: << did not raise"
+rescue FrozenError => e
+  puts e.message
+end
+
+# a dup'd copy mutates freely
+cpy = "abc".dup
+cpy << "y"
+p cpy
+
+# synthesized strings are not literals: Symbol#to_s and Integer#to_s stay
+# unfrozen under the pragma
+p :sym.to_s.frozen?        # false
+p 42.to_s.frozen?          # false
+p __FILE__.frozen?         # true -- __FILE__ is a literal of its file

--- a/test/frozen_string_literal_pragma.rb.expected
+++ b/test/frozen_string_literal_pragma.rb.expected
@@ -1,0 +1,13 @@
+true
+true
+true
+false
+true
+true
+false
+false
+can't modify frozen String: "abc"
+"abcy"
+false
+false
+true

--- a/test/str_method_nil_arg_no_segv.rb.expected
+++ b/test/str_method_nil_arg_no_segv.rb.expected
@@ -2,6 +2,6 @@ count: no implicit conversion of nil into String
 "foo"
 nil
 6
-send-lshift: can't modify frozen String
-frozen literal: can't modify frozen String
+send-lshift: can't modify frozen String: "foo"
+frozen literal: can't modify frozen String: "a"
 b

--- a/test/string_delete_prefix_suffix_bang.rb
+++ b/test/string_delete_prefix_suffix_bang.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # String#delete_prefix! / delete_suffix! on a mutable_str mutate in
 # place and return the receiver. On a frozen string literal they
 # raise FrozenError, consistent with chomp! / upcase! et al.

--- a/test/string_delete_prefix_suffix_bang.rb.expected
+++ b/test/string_delete_prefix_suffix_bang.rb.expected
@@ -1,5 +1,5 @@
 lo
 he
 hello
-delete_prefix!: can't modify frozen String
-delete_suffix!: can't modify frozen String
+delete_prefix!: can't modify frozen String: "hello"
+delete_suffix!: can't modify frozen String: "hello"

--- a/test/string_frozen_mutation_raises.rb
+++ b/test/string_frozen_mutation_raises.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Issue #886: Mutating methods on a frozen string literal raise
 # FrozenError per MRI. spinel string literals are always frozen.
 # Mutable strings (String.new("...")) keep working via the

--- a/test/string_frozen_mutation_raises.rb.expected
+++ b/test/string_frozen_mutation_raises.rb.expected
@@ -1,4 +1,4 @@
-insert: can't modify frozen String
-prepend: can't modify frozen String
-<<: can't modify frozen String
+insert: can't modify frozen String: "hello"
+prepend: can't modify frozen String: "hello"
+<<: can't modify frozen String: "hello"
 hi!


### PR DESCRIPTION
The `# frozen_string_literal: true` magic comment was ignored, so `"abc".frozen?` was always false. This implements it with CRuby-faithful per-file scoping and mutation semantics.

**Per-file pragma.** Ruby scopes the pragma to each file. The require resolvers keep a per-line flag table in lockstep with every text splice (each spliced file is scanned for its own magic comment), and flatten stamps an `fzl` field on string-literal nodes from it — emitted only when true, so the AST text stays byte-identical for programs without a pragma. If syntax-sugar rewriting ever changes the line count, the table is dropped and the entry file's flag is the fallback. String-literal codegen then emits the frozen heap marker (`0xf1`) per literal instead of the plain rodata marker (`0xff`).

**Only real literals freeze.** The frozen flag rides `emit_str_literal_n` as a parameter from the node; the `emit_str_literal` wrapper used for synthesized strings (symbol names, ivar names, trap defaults, …) never freezes — so `:sym.to_s.frozen?` stays false under the pragma, matching CRuby. `__FILE__` freezes with its file (CRuby behavior); backtick command text never does; NUL-containing frozen literals are sealed with `sp_str_freeze_val`; interpolated strings stay unfrozen.

**Mutation raises faithfully.** The mutable-string-buffer optimization used to copy a literal into a writable wrapper, so `s = "abc"; s << "y"` would mutate where CRuby raises. The promotion now skips a local when any contributing literal is frozen, so mutation raises `FrozenError` through the value path. Frozen-String raises also gained the receiver inspect — `can't modify frozen String: "abc"` — matching CRuby's message exactly (a shared `sp_raise_frozen_str` used by the marker checks, `setbyte`, and the `sp_String` mutators; the Array/Hash message suffix is a separate follow-up).

Three existing literal-mutation tests gained the pragma line and are now oracle-faithful (CRuby raises under the pragma too) instead of hand-maintained divergence snapshots.

Covered by `test/frozen_string_literal_pragma.rb` (frozen?, mutation raise, buffer-optimization interplay, synthesized strings, `__FILE__`) and the two-direction `test/frozen_string_literal_per_file{,_rev}.rb` (pragma helper required from a plain entry file, and the reverse). Full suite + `make check` green; verified under ASAN+UBSAN with GC stress.