### PR TITLE
codegen,runtime,analyze: user <=> dispatch across the Comparable surface

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -82,6 +82,20 @@ Limited today, but additively fixable; listed roughly easiest-first.
   follows CRuby (Integer for `round` with 0 digits, Float otherwise).
 - **Frozen literals** — explicit `.freeze` then mutation raises `FrozenError`,
   matching CRuby. (String literals are *not* implicitly frozen — see below.)
+- **Comparable is keyed on `<=>` presence** — the Comparable operator methods
+  (`<`, `<=`, `>`, `>=`, `between?`, `clamp`) work on any class that defines
+  `<=>`; CRuby additionally requires `include Comparable` (a `NoMethodError`
+  otherwise). Spinel does not model the mixin, so it is permissive where CRuby
+  raises. `sort`/`min`/`max`/`minmax` need only `<=>` in both. Related edges:
+  the comparison-failed message names an operand's class where CRuby inspects
+  special constants (`NilClass` vs `nil`); `sort_by` keeps incomparable keys
+  in their original order where CRuby raises; `include?`/`index` on arrays of
+  user objects compare by identity unless the class defines its own `==`.
+  Sorts run a deterministic stable merge (identical on every platform, unlike
+  libc `qsort`); it matches CRuby's comparison schedule for small arrays, but
+  for larger ones (roughly 8 elements and up, where CRuby switches to its
+  quicksort) the order of tied elements and which incomparable pair the
+  ArgumentError names can differ from CRuby — deterministically so.
 - **Thread data races are observable** — Spinel runs threads with real
   parallelism and no GVL, so two threads mutating the same `Array`/`Hash`/object
   without a `Mutex` is undefined at the Ruby level, exactly as in JRuby and

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -805,6 +805,17 @@ static inline mrb_float sp_float_clamp_ck(mrb_float v,mrb_float lo,mrb_float hi)
   if(v!=v)sp_raise_cls("ArgumentError",sp_sprintf("comparison of Float with %s failed",sp_float_to_s(lo)));
   return sp_float_clamp(v,lo,hi);
 }
+/* clamp(range): an exclusive range with a real end cannot clamp (CRuby); an
+   exclusive ENDLESS range (`1...`, last is the INTPTR_MAX sentinel) can. The
+   beginless/endless sentinels satisfy sp_int_clamp_ck's bounds naturally. */
+static inline mrb_int sp_int_clamp_range_ck(mrb_int v, sp_Range r) {
+  if (r.excl && r.last != INTPTR_MAX)
+    sp_raise_cls("ArgumentError", "cannot clamp with an exclusive range");
+  /* Reaching here with excl means r.last is the INTPTR_MAX endless sentinel
+     (a real exclusive end raised above); pass it through unchanged -- it means
+     "no upper bound", which sp_int_clamp_ck handles, not INTPTR_MAX-1. */
+  return sp_int_clamp_ck(v, r.first, r.last);
+}
 /* `:name`, or `:"name"` when the name needs quoting -- shares the
    name-string predicates in lib/sp_str.c with the hash-key short form. */
 static const char *sp_sym_inspect(sp_sym id) { return sp_sym_inspect_name(sp_sym_to_s(id)); }
@@ -1785,9 +1796,16 @@ static mrb_bool sp_poly_eq(sp_RbVal a, sp_RbVal b) { if (a.tag == SP_TAG_BIGINT 
 /* sp_sym_name_fn is now an extern hook (sp_gc.h / sp_gc.c) so cold lib readers
    like sp_json.c can resolve symbol names too; the generated TU still sets it. */
 static mrb_int sp_poly_arr_cmp(sp_RbVal a, sp_RbVal b, mrb_bool *comparable);
+/* A user class that mixes in Comparable defines `<=>` in generated code, which
+   the runtime archive cannot call directly. The generated TU installs
+   sp_obj_cmp_hook to dispatch `<=>` by cls_id; sp_poly_cmp consults it for two
+   user objects so no-block sort/min/max/clamp compare correctly. A nil `<=>`
+   result clears *comparable, which the callers turn into an ArgumentError. */
+typedef mrb_int (*sp_obj_cmp_fn)(sp_RbVal a, sp_RbVal b, mrb_bool *comparable);
+static sp_obj_cmp_fn sp_obj_cmp_hook = NULL;
 #define SP_IS_BUILTIN_ARRAY(id) ((id) == SP_BUILTIN_INT_ARRAY || (id) == SP_BUILTIN_STR_ARRAY || \
                                  (id) == SP_BUILTIN_FLT_ARRAY || (id) == SP_BUILTIN_POLY_ARRAY)
-static mrb_int sp_poly_cmp(sp_RbVal a, sp_RbVal b, mrb_bool *comparable) { if (a.tag == SP_TAG_OBJ && b.tag == SP_TAG_OBJ && SP_IS_BUILTIN_ARRAY(a.cls_id) && SP_IS_BUILTIN_ARRAY(b.cls_id)) return sp_poly_arr_cmp(a, b, comparable); if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { sp_Bigint *ba = sp_poly_as_bigint(a), *bb = sp_poly_as_bigint(b); if (ba && bb) { *comparable = TRUE; return sp_bigint_cmp(ba, bb); } if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) { mrb_float af = sp_poly_to_f(a), bf = sp_poly_to_f(b); *comparable = TRUE; return (af > bf) - (af < bf); } *comparable = FALSE; return 0; } if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) { mrb_float af = sp_poly_to_f(a), bf = sp_poly_to_f(b); *comparable = TRUE; return (af > bf) - (af < bf); } if (a.tag == SP_TAG_STR && b.tag == SP_TAG_STR) { if (a.v.s == NULL || b.v.s == NULL) { *comparable = (a.v.s == b.v.s); return 0; } *comparable = TRUE; return strcmp(a.v.s, b.v.s); } if (a.tag == SP_TAG_SYM && b.tag == SP_TAG_SYM) { *comparable = TRUE; if (sp_sym_name_fn) { int _r = strcmp(sp_sym_name_fn((sp_sym)a.v.i), sp_sym_name_fn((sp_sym)b.v.i)); return _r; } return (a.v.i > b.v.i) - (a.v.i < b.v.i); } *comparable = FALSE; return 0; }
+static mrb_int sp_poly_cmp(sp_RbVal a, sp_RbVal b, mrb_bool *comparable) { if (a.tag == SP_TAG_OBJ && b.tag == SP_TAG_OBJ && SP_IS_BUILTIN_ARRAY(a.cls_id) && SP_IS_BUILTIN_ARRAY(b.cls_id)) return sp_poly_arr_cmp(a, b, comparable); if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { sp_Bigint *ba = sp_poly_as_bigint(a), *bb = sp_poly_as_bigint(b); if (ba && bb) { *comparable = TRUE; return sp_bigint_cmp(ba, bb); } if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) { mrb_float af = sp_poly_to_f(a), bf = sp_poly_to_f(b); *comparable = TRUE; return (af > bf) - (af < bf); } *comparable = FALSE; return 0; } if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) { mrb_float af = sp_poly_to_f(a), bf = sp_poly_to_f(b); *comparable = TRUE; return (af > bf) - (af < bf); } if (a.tag == SP_TAG_STR && b.tag == SP_TAG_STR) { if (a.v.s == NULL || b.v.s == NULL) { *comparable = (a.v.s == b.v.s); return 0; } *comparable = TRUE; return strcmp(a.v.s, b.v.s); } if (a.tag == SP_TAG_SYM && b.tag == SP_TAG_SYM) { *comparable = TRUE; if (sp_sym_name_fn) { int _r = strcmp(sp_sym_name_fn((sp_sym)a.v.i), sp_sym_name_fn((sp_sym)b.v.i)); return _r; } return (a.v.i > b.v.i) - (a.v.i < b.v.i); } if (a.tag == SP_TAG_OBJ && sp_obj_cmp_hook) return sp_obj_cmp_hook(a, b, comparable); *comparable = FALSE; return 0; }
 /* Lexicographic <=> between two boxed int arrays (Array#<=> over int elems),
    so Array#max/min/sort work on an array of int pairs ([delta, idx] tuples). */
 static mrb_int sp_poly_cmp_int_arrays(sp_RbVal a, sp_RbVal b, mrb_bool *comparable) {
@@ -1807,6 +1825,55 @@ static mrb_bool sp_poly_lt(sp_RbVal a, sp_RbVal b) { mrb_bool comparable; mrb_in
 static mrb_bool sp_poly_le(sp_RbVal a, sp_RbVal b) { mrb_bool comparable; mrb_int cmp = sp_poly_cmp(a, b, &comparable); return comparable ? (cmp <= 0) : FALSE; }
 static mrb_bool sp_poly_gt(sp_RbVal a, sp_RbVal b) { mrb_bool comparable; mrb_int cmp = sp_poly_cmp(a, b, &comparable); return comparable ? (cmp > 0) : FALSE; }
 static mrb_bool sp_poly_ge(sp_RbVal a, sp_RbVal b) { mrb_bool comparable; mrb_int cmp = sp_poly_cmp(a, b, &comparable); return comparable ? (cmp >= 0) : FALSE; }
+/* rb_cmpint-checked comparison: an incomparable pair (nil `<=>`) raises the
+   Comparable ArgumentError. Backs the object <,<=,>,>=,between? emitters when
+   the user `<=>` can return nil (a TY_INT `<=>` keeps the inline fast path). */
+static mrb_int sp_poly_cmp_ck(sp_RbVal a, sp_RbVal b) __attribute__((unused));
+static mrb_int sp_poly_cmp_ck(sp_RbVal a, sp_RbVal b) {
+  mrb_bool ok = FALSE; mrb_int r = sp_poly_cmp(a, b, &ok);
+  if (!ok) sp_raise_cls("ArgumentError", sp_sprintf("comparison of %s with %s failed", sp_poly_class_name(a), sp_poly_class_name(b)));
+  return r;
+}
+/* Comparable#==: identity is equal; a nil `<=>` makes it false, never an
+   error (CRuby cmp_equal). */
+static mrb_bool sp_poly_cmp_eq(sp_RbVal a, sp_RbVal b) __attribute__((unused));
+static mrb_bool sp_poly_cmp_eq(sp_RbVal a, sp_RbVal b) {
+  if (a.tag == b.tag && a.v.p == b.v.p) return TRUE;
+  mrb_bool ok = FALSE; mrb_int r = sp_poly_cmp(a, b, &ok);
+  return ok ? (r == 0) : FALSE;
+}
+/* Comparable#clamp(lo, hi) for user objects, mirroring CRuby cmp_clamp: a nil
+   bound clamps one-sided; both bounds present and lo > hi (or incomparable)
+   raise ArgumentError; the result is the receiver or the applied bound. The
+   user `<=>` dispatches through sp_obj_cmp_hook (via sp_poly_cmp). */
+static sp_RbVal sp_obj_clamp(sp_RbVal v, sp_RbVal lo, sp_RbVal hi) __attribute__((unused));
+static sp_RbVal sp_obj_clamp(sp_RbVal v, sp_RbVal lo, sp_RbVal hi) {
+  /* Each operand can be a heap object and sp_poly_cmp_ck dispatches the user
+     `<=>` (which allocates), so root all three -- v is live but unused across
+     the first lo<=>hi comparison, lo/hi across the later ones. */
+  SP_GC_ROOT_RBVAL(v); SP_GC_ROOT_RBVAL(lo); SP_GC_ROOT_RBVAL(hi);
+  if (lo.tag != SP_TAG_NIL && hi.tag != SP_TAG_NIL && sp_poly_cmp_ck(lo, hi) > 0)
+    sp_raise_cls("ArgumentError", "min argument must be less than or equal to max argument");
+  if (lo.tag != SP_TAG_NIL) {
+    mrb_int c1 = sp_poly_cmp_ck(v, lo);
+    if (c1 == 0) return v;
+    if (c1 < 0) return lo;
+  }
+  if (hi.tag != SP_TAG_NIL && sp_poly_cmp_ck(v, hi) > 0) return hi;
+  return v;
+}
+/* Comparable#clamp(range) for user objects: an exclusive range with a real
+   end cannot clamp (CRuby); beginless/endless endpoints (the INTPTR_MIN/MAX
+   range sentinels) clamp one-sided as nil bounds. Integer endpoints are boxed
+   and flow to the user `<=>` like any operand. */
+static sp_RbVal sp_obj_clamp_range(sp_RbVal v, sp_Range r) __attribute__((unused));
+static sp_RbVal sp_obj_clamp_range(sp_RbVal v, sp_Range r) {
+  if (r.excl && r.last != INTPTR_MAX)
+    sp_raise_cls("ArgumentError", "cannot clamp with an exclusive range");
+  sp_RbVal lo = r.first == INTPTR_MIN ? sp_box_nil() : sp_box_int(r.first);
+  sp_RbVal hi = r.last == INTPTR_MAX ? sp_box_nil() : sp_box_int(r.last);
+  return sp_obj_clamp(v, lo, hi);
+}
 /* Stable ascending sort of idx[0..n) by the poly key keys[idx[k]], leaving equal
    (or incomparable) keys in their original relative order. Backs sort_by's
    Schwartzian lowering: keys are precomputed once per element, so the comparator
@@ -1858,10 +1925,26 @@ static sp_RbVal sp_num_clamp(sp_RbVal v, sp_RbVal lo, sp_RbVal hi) {
   if (dv > dhi) return hi;
   return v;
 }
-/* clamp on a boxed numeric: routes through sp_num_clamp so the returned operand
-   keeps its own Integer/Float class (was unconditionally floated up before). */
+/* clamp on a boxed value: numerics route through sp_num_clamp so the returned
+   operand keeps its own Integer/Float class; a user object anywhere in the
+   triple routes through sp_obj_clamp (the user `<=>` via the cmp hook) instead
+   of being reinterpreted as a float. */
 static sp_RbVal sp_poly_clamp(sp_RbVal v, sp_RbVal lo, sp_RbVal hi) {
+  if ((v.tag == SP_TAG_OBJ && !sp_poly_numeric_p(v)) ||
+      (lo.tag == SP_TAG_OBJ && !sp_poly_numeric_p(lo)) ||
+      (hi.tag == SP_TAG_OBJ && !sp_poly_numeric_p(hi)))
+    return sp_obj_clamp(v, lo, hi);
   return sp_num_clamp(v, lo, hi);
+}
+/* clamp(range) on a boxed value: an exclusive range with a real end cannot
+   clamp (CRuby); the INTPTR_MIN/MAX beginless/endless sentinels act as
+   unbounded sides for numerics and nil bounds for user objects. */
+static sp_RbVal sp_poly_clamp_range(sp_RbVal v, sp_Range r) __attribute__((unused));
+static sp_RbVal sp_poly_clamp_range(sp_RbVal v, sp_Range r) {
+  if (r.excl && r.last != INTPTR_MAX)
+    sp_raise_cls("ArgumentError", "cannot clamp with an exclusive range");
+  if (v.tag == SP_TAG_OBJ && !sp_poly_numeric_p(v)) return sp_obj_clamp_range(v, r);
+  return sp_num_clamp(v, sp_box_int(r.first), sp_box_int(r.last));
 }
 /* Integer #** : Spinel has no Rational, so a negative integer exponent --
    which CRuby evaluates to a Rational like (1/2) -- raises RangeError rather
@@ -2522,15 +2605,43 @@ static void sp_PolyArray_rotate_bang(sp_PolyArray*a,mrb_int n){if(!a)return;if(a
 static sp_PolyArray *sp_PolyArray_shuffle(sp_PolyArray *a) { sp_PolyArray *b = sp_PolyArray_dup(a); sp_PolyArray_shuffle_bang(b); return b; }
 /* When sort hits an incomparable pair the result is discarded and we raise
    ArgumentError, matching CRuby. The comparator cannot raise (it would longjmp
-   out of qsort), so it records the offending pair and sort_bang raises after. */
+   out of the sort), so it records the offending pair and sort_bang raises after. */
 static int _sp_sort_incomparable;
 static sp_RbVal _sp_sort_inc_a, _sp_sort_inc_b;
-static int _sp_poly_cmp_qsort(const void *pa, const void *pb) {
+static int _sp_poly_cmp_rec(const void *pa, const void *pb) {
   if (_sp_sort_incomparable) return 0;
   mrb_bool ok = FALSE;
   mrb_int r = sp_poly_cmp(*(const sp_RbVal *)pa, *(const sp_RbVal *)pb, &ok);
   if (!ok) { _sp_sort_incomparable = 1; _sp_sort_inc_a = *(const sp_RbVal *)pa; _sp_sort_inc_b = *(const sp_RbVal *)pb; return 0; }
   return (int)r;
+}
+/* Bottom-up merge sort over boxed elements. libc qsort visits pairs in an
+   implementation-defined order, so which pair gets recorded as incomparable
+   (and hence the ArgumentError message operands) would vary by platform; a
+   fixed merge schedule keeps it identical everywhere, with the left/earlier
+   element as the `<=>` receiver like CRuby. Both `a` and the scratch copy
+   are rooted PolyArrays, so every element stays GC-reachable while the
+   comparator (which can allocate) runs; stale slots in the buffer being
+   overwritten are still valid boxed values, so scanning them is safe. */
+static void _sp_poly_msort(sp_PolyArray *a, int (*cmp)(const void *, const void *)) {
+  if (!a || a->len < 2) return;
+  SP_GC_ROOT(a);
+  sp_PolyArray *tmp = sp_PolyArray_dup(a);
+  SP_GC_ROOT(tmp);
+  sp_RbVal *src = a->data, *dst = tmp->data;
+  for (mrb_int w = 1; w < a->len; w *= 2) {
+    for (mrb_int lo = 0; lo < a->len; lo += 2 * w) {
+      mrb_int mid = lo + w < a->len ? lo + w : a->len;
+      mrb_int hi = lo + 2 * w < a->len ? lo + 2 * w : a->len;
+      mrb_int i = lo, j = mid, k = lo;
+      while (i < mid && j < hi)
+        dst[k++] = cmp(&src[i], &src[j]) <= 0 ? src[i++] : src[j++];
+      while (i < mid) dst[k++] = src[i++];
+      while (j < hi) dst[k++] = src[j++];
+    }
+    sp_RbVal *t = src; src = dst; dst = t;
+  }
+  if (src != a->data) memcpy(a->data, src, (size_t)a->len * sizeof(sp_RbVal));
 }
 /* max/min over boxed elements: numerics/strings via sp_poly_cmp, int arrays
    lexicographically. Returns nil for an empty array. */
@@ -2566,7 +2677,7 @@ static void sp_PolyArray_sort_bang(sp_PolyArray *a) {
   if (!a || a->frozen) { if (a && a->frozen) sp_raise_frozen_array(); return; }
   /* Root the array across the sort: the comparator runs sp_poly_cmp, which can
      allocate (e.g. a bigint temp) and trigger GC; without this, a precise sweep
-     could collect a (and its elements) mid-qsort. This also roots the transient
+     could collect a (and its elements) mid-sort. This also roots the transient
      copy made by sp_PolyArray_sort. */
   SP_GC_ROOT(a);
   if (a->len > 1) {
@@ -2575,7 +2686,7 @@ static void sp_PolyArray_sort_bang(sp_PolyArray *a) {
     int prev = _sp_sort_incomparable;
     sp_RbVal prev_a = _sp_sort_inc_a, prev_b = _sp_sort_inc_b;
     _sp_sort_incomparable = 0;
-    qsort(a->data, (size_t)a->len, sizeof(sp_RbVal), _sp_poly_cmp_qsort);
+    _sp_poly_msort(a, _sp_poly_cmp_rec);
     int inc = _sp_sort_incomparable;
     sp_RbVal ia = _sp_sort_inc_a, ib = _sp_sort_inc_b;
     _sp_sort_incomparable = prev;
@@ -2585,11 +2696,60 @@ static void sp_PolyArray_sort_bang(sp_PolyArray *a) {
   }
 }
 static sp_PolyArray *sp_PolyArray_sort(sp_PolyArray *a) { sp_PolyArray *b = sp_PolyArray_dup(a); sp_PolyArray_sort_bang(b); return b; }
+/* Object-array (sp_PtrArray of one user class, TY_OBJ_ARRAY) comparison
+   family: box the elements with the statically-known cls_id (tag assembly,
+   no allocation) and reuse the PolyArray comparator machinery -- the user
+   `<=>` via the cmp hook, incomparable pairs raising the Comparable
+   ArgumentError. Only the fresh result containers allocate; everything live
+   across an allocation is rooted. */
+static sp_PolyArray *sp_ptr_array_box(sp_PtrArray *a, int cls_id) {
+  sp_PolyArray *p = sp_PolyArray_new(); SP_GC_ROOT(p);
+  if (a) for (mrb_int i = 0; i < a->len; i++)
+    sp_PolyArray_push(p, sp_box_nullable_obj(a->data[i], cls_id));
+  return p;
+}
+static sp_PtrArray *sp_PtrArray_sort_obj(sp_PtrArray *a, int cls_id) __attribute__((unused));
+static sp_PtrArray *sp_PtrArray_sort_obj(sp_PtrArray *a, int cls_id) {
+  SP_GC_ROOT(a);
+  sp_PolyArray *p = sp_ptr_array_box(a, cls_id);
+  SP_GC_ROOT(p);   /* box's own root is popped on its return; sort + new_scan below allocate */
+  sp_PolyArray_sort_bang(p);
+  sp_PtrArray *r = a ? sp_PtrArray_new_scan(a->scan_elem) : sp_PtrArray_new();
+  SP_GC_ROOT(r);
+  for (mrb_int i = 0; i < p->len; i++) sp_PtrArray_push(r, p->data[i].v.p);
+  return r;
+}
+static void sp_PtrArray_sort_obj_bang(sp_PtrArray *a, int cls_id) __attribute__((unused));
+static void sp_PtrArray_sort_obj_bang(sp_PtrArray *a, int cls_id) {
+  if (!a) return;
+  if (a->frozen) { sp_raise_frozen_array(); return; }
+  SP_GC_ROOT(a);
+  sp_PolyArray *p = sp_ptr_array_box(a, cls_id);
+  SP_GC_ROOT(p);   /* box's own root is popped on its return; sort_bang runs the user <=> (allocates) */
+  sp_PolyArray_sort_bang(p);
+  for (mrb_int i = 0; i < a->len; i++) a->data[i] = p->data[i].v.p;
+}
+/* min/max over an object array; empty -> NULL (the object-typed nil). */
+static void *sp_PtrArray_minmax_obj(sp_PtrArray *a, int cls_id, int want_max) __attribute__((unused));
+static void *sp_PtrArray_minmax_obj(sp_PtrArray *a, int cls_id, int want_max) {
+  if (!a || a->len == 0) return NULL;
+  SP_GC_ROOT(a);
+  void *best = a->data[0];
+  for (mrb_int i = 1; i < a->len; i++) {
+    mrb_bool ok = FALSE;
+    sp_RbVal bi = sp_box_nullable_obj(a->data[i], cls_id);
+    sp_RbVal bb = sp_box_nullable_obj(best, cls_id);
+    mrb_int r = sp_poly_cmp(bi, bb, &ok);
+    if (!ok) sp_raise_cls("ArgumentError", sp_sprintf("comparison of %s with %s failed", sp_poly_class_name(bi), sp_poly_class_name(bb)));
+    if (want_max ? (r > 0) : (r < 0)) best = a->data[i];
+  }
+  return best;
+}
 /* Compare two boxed arrays element-wise (Array#<=> semantics): first differing
    comparable element decides, else the shorter array sorts first. Used to order
    Hash#sort's [key, value] pairs. */
 static int _sp_pair_cmp_incomparable;  /* set when two pairs cannot be ordered */
-static int _sp_poly_pair_cmp_qsort(const void *pa, const void *pb) {
+static int _sp_poly_pair_cmp(const void *pa, const void *pb) {
   /* Once a pair is found incomparable the sort result is discarded and we
      raise, so skip the remaining comparisons (and any work they would do). */
   if (_sp_pair_cmp_incomparable) return 0;
@@ -2614,7 +2774,7 @@ static sp_PolyArray *sp_PolyArray_sort_pairs(sp_PolyArray *a) {
        sort_pairs (e.g. via a nested sort) cannot clobber this call's state. */
     int prev = _sp_pair_cmp_incomparable;
     _sp_pair_cmp_incomparable = 0;
-    qsort(b->data, (size_t)b->len, sizeof(sp_RbVal), _sp_poly_pair_cmp_qsort);
+    _sp_poly_msort(b, _sp_poly_pair_cmp);
     int incomparable = _sp_pair_cmp_incomparable;
     _sp_pair_cmp_incomparable = prev;
     if (incomparable)
@@ -2624,7 +2784,7 @@ static sp_PolyArray *sp_PolyArray_sort_pairs(sp_PolyArray *a) {
 }
 /* Schwartzian helper for Hash#sort_by: `a` is an array of [sort_key, value]
    tuples; sort it by the comparable sort_key and return the values in order. */
-static int _sp_poly_first_cmp_qsort(const void *pa, const void *pb) {
+static int _sp_poly_first_cmp(const void *pa, const void *pb) {
   mrb_bool ok = FALSE;
   mrb_int r = sp_poly_cmp(sp_poly_arr_get(*(const sp_RbVal *)pa, 0),
                           sp_poly_arr_get(*(const sp_RbVal *)pb, 0), &ok);
@@ -2633,7 +2793,7 @@ static int _sp_poly_first_cmp_qsort(const void *pa, const void *pb) {
 static sp_PolyArray *sp_PolyArray_sort_by_first(sp_PolyArray *a) {
   SP_GC_ROOT(a);
   sp_PolyArray *b = sp_PolyArray_dup(a); SP_GC_ROOT(b);
-  if (b && b->len > 1) qsort(b->data, (size_t)b->len, sizeof(sp_RbVal), _sp_poly_first_cmp_qsort);
+  if (b && b->len > 1) _sp_poly_msort(b, _sp_poly_first_cmp);
   sp_PolyArray *r = sp_PolyArray_new(); SP_GC_ROOT(r);
   for (mrb_int i = 0; b && i < b->len; i++) sp_PolyArray_push(r, sp_poly_arr_get(b->data[i], 1));
   return r;

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -1685,7 +1685,7 @@ int desugar_enum_method_recv(Compiler *c) {
    Strictly conservative: any unmodeled use, class conflict, unresolved flow, or
    absent object evidence kills the component, leaving it TY_POLY_ARRAY. Runs
    ONCE, after the fixpoint, so the new type never feeds forward inference. */
-typedef struct { int sidx; LocalVar *lv; int cls; int alive; int uf; } OAS;
+typedef struct { int sidx; LocalVar *lv; int cls; int alive; int uf; int needs_cmp; } OAS;
 
 static int oa_find(OAS *sl, int n, int sidx, LocalVar *lv) {
   for (int i = 0; i < n; i++) if (sl[i].sidx == sidx && sl[i].lv == lv) return i;
@@ -1719,6 +1719,13 @@ static int oa_recv_op_ok(const char *nm, int argc, int has_block) {
   if ((sp_streq(nm, "length") || sp_streq(nm, "size")) && argc == 0) return 1;
   if (sp_streq(nm, "empty?") && argc == 0) return 1;
   if ((sp_streq(nm, "first") || sp_streq(nm, "last")) && argc == 0) return 1;
+  /* no-block comparisons: usable when the element class has `<=>` (the
+     needs_cmp bit, checked at component resolution). sort's RESULT must
+     also land in a modeled place (slot alias or statement position) --
+     step 4 kills the component otherwise, so an escaping `arr.sort.map`
+     keeps today's boxed poly path instead of becoming a reject. */
+  if ((sp_streq(nm, "min") || sp_streq(nm, "max")) && argc == 0) return 1;
+  if ((sp_streq(nm, "sort") || sp_streq(nm, "sort!")) && argc == 0) return 1;
   return 0;
 }
 
@@ -1732,14 +1739,34 @@ static void narrow_object_arrays(Compiler *c) {
     for (int li = 0; li < sc->nlocals; li++) {
       LocalVar *lv = &sc->locals[li];
       if (lv->type != TY_POLY_ARRAY || lv->is_block_param || lv->rbs_seeded) continue;
-      if (n >= cap) { cap *= 2; sl = (OAS *)realloc(sl, sizeof(OAS) * cap); }
-      sl[n].sidx = s; sl[n].lv = lv; sl[n].cls = -1; sl[n].alive = 1; sl[n].uf = n; n++;
+      if (n >= cap) { cap *= 2; sl = (OAS *)realloc(sl, sizeof(OAS) * cap); if (!sl) { fprintf(stderr, "oom\n"); exit(1); } }
+      sl[n].sidx = s; sl[n].lv = lv; sl[n].cls = -1; sl[n].alive = 1; sl[n].uf = n; sl[n].needs_cmp = 0; n++;
     }
   }
   if (n == 0) { free(sl); return; }
   int nc = nt->count ? nt->count : 1;
   int *read_slot = (int *)malloc(sizeof(int) * nc);
   char *claimed = (char *)calloc(nc, 1);
+  /* value_ok[id]: node id sits in statement position (a StatementsNode body
+     entry) -- one modeled consumer for a `sort`/`sort!` result. The other
+     (slot-alias RHS) is recognized in step 5. */
+  char *value_ok = (char *)calloc(nc, 1);
+  for (int id = 0; id < nt->count; id++) {
+    const char *ty = nt_type(nt, id);
+    if (!ty || !sp_streq(ty, "StatementsNode")) continue;
+    int bn = 0; const int *bl = nt_arr(nt, id, "body", &bn);
+    for (int i = 0; i < bn; i++) if (bl[i] >= 0 && bl[i] < nc) value_ok[bl[i]] = 1;
+  }
+  for (int id = 0; id < nt->count; id++) {
+    const char *ty = nt_type(nt, id);
+    if (!ty || !sp_streq(ty, "LocalVariableWriteNode")) continue;
+    int sidx = c->nscope[id];
+    const char *nm = nt_str(nt, id, "name");
+    LocalVar *lv = nm ? scope_local(&c->scopes[sidx], nm) : NULL;
+    if (!lv || oa_find(sl, n, sidx, lv) < 0) continue;   /* target must be a slot */
+    int v = nt_ref(nt, id, "value");
+    if (v >= 0 && v < nc) value_ok[v] = 1;   /* alias edge made in step 5 */
+  }
 
   /* 2. map each LocalVariableReadNode of a slot to its slot index. */
   for (int id = 0; id < nt->count; id++) {
@@ -1785,6 +1812,16 @@ static void narrow_object_arrays(Compiler *c) {
           for (int a = 0; a < argc; a++) sl[S].cls = oa_cls_join(sl[S].cls, oa_obj_class_of(c, argv[a]));
         else if (name && sp_streq(name, "[]=") && argc == 2)
           sl[S].cls = oa_cls_join(sl[S].cls, oa_obj_class_of(c, argv[1]));
+        else if (name && (sp_streq(name, "min") || sp_streq(name, "max") ||
+                          sp_streq(name, "sort") || sp_streq(name, "sort!"))) {
+          sl[S].needs_cmp = 1;
+          /* a sort/sort! RESULT must land in a modeled consumer (statement
+             position, or a slot-alias write handled in step 5); an escaping
+             result keeps the component on the boxed poly path. */
+          if ((sp_streq(name, "sort") || sp_streq(name, "sort!")) &&
+              !(id < nc && value_ok[id]))
+            sl[S].alive = 0;
+        }
       }
       else sl[S].alive = 0;
     }
@@ -1830,6 +1867,20 @@ static void narrow_object_arrays(Compiler *c) {
       claimed[v] = 1; oa_uf_union(sl, S, read_slot[v]);
     }
     else if (sp_streq(vty, "NilNode")) { /* nullable, neutral */ }
+    else if (sp_streq(vty, "CallNode")) {
+      /* `b = arr.sort` / `b = arr.sort!`: the sorted array shares arr's
+         element class -- an alias edge, like a plain slot-to-slot copy. */
+      const char *cn = nt_str(nt, v, "name");
+      int crecv = nt_ref(nt, v, "receiver");
+      int cargs = nt_ref(nt, v, "arguments");
+      int can = 0; if (cargs >= 0) nt_arr(nt, cargs, "arguments", &can);
+      if (cn && (sp_streq(cn, "sort") || sp_streq(cn, "sort!")) && can == 0 &&
+          nt_ref(nt, v, "block") < 0 && crecv >= 0 && read_slot[crecv] >= 0) {
+        claimed[crecv] = 1;
+        oa_uf_union(sl, S, read_slot[crecv]);
+      }
+      else sl[S].alive = 0;
+    }
     else sl[S].alive = 0;
   }
 
@@ -1843,12 +1894,17 @@ static void narrow_object_arrays(Compiler *c) {
     int r = oa_uf_find(sl, i);
     if (r == i) continue;
     sl[r].cls = oa_cls_join(sl[r].cls, sl[i].cls);
+    if (sl[i].needs_cmp) sl[r].needs_cmp = 1;
     if (!sl[i].alive) sl[r].alive = 0;
   }
   for (int i = 0; i < n; i++) {
     int r = oa_uf_find(sl, i);
-    if (sl[r].alive && sl[r].cls >= 0)
-      sl[i].lv->type = ty_obj_array(sl[r].cls);
+    if (!sl[r].alive || sl[r].cls < 0) continue;
+    /* a component using no-block sort/min/max narrows only when the element
+       class can actually compare (has `<=>` in its chain); otherwise it stays
+       poly, where the boxed comparator raises the CRuby ArgumentError. */
+    if (sl[r].needs_cmp && comp_method_in_chain(c, sl[r].cls, "<=>", NULL) < 0) continue;
+    sl[i].lv->type = ty_obj_array(sl[r].cls);
   }
 
   /* 8. dependent locals: `b = arr[i]` (arr now a narrowed obj array) makes `b`
@@ -1885,7 +1941,7 @@ static void narrow_object_arrays(Compiler *c) {
     }
   }
 
-  free(sl); free(read_slot); free(claimed);
+  free(sl); free(read_slot); free(claimed); free(value_ok);
 }
 
 /* ===== Post-fixpoint: narrow a poly local that is only ever used as an int =====

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -1495,6 +1495,21 @@ else {
     if (sp_streq(name, "is_a?") || sp_streq(name, "kind_of?") || sp_streq(name, "instance_of?") ||
         sp_streq(name, "respond_to?") || sp_streq(name, "==") || sp_streq(name, "!=") ||
         sp_streq(name, "nil?") || sp_streq(name, "equal?") || sp_streq(name, "frozen?")) return TY_BOOL;
+    /* Comparable#clamp returns self or the APPLIED BOUND: the receiver's
+       class only when each bound is statically that class or nil (a nil
+       bound clamps one-sided and is never returned); a mixed-class or
+       Integer-endpoint (range form) bound can be returned as-is, so the
+       result is boxed. */
+    if (sp_streq(name, "clamp") && argc == 2 &&
+        comp_method_in_chain(c, cid, "<=>", NULL) >= 0) {
+      TyKind lo = infer_type(c, argv[0]), hi = infer_type(c, argv[1]);
+      return ((lo == rt || lo == TY_NIL) && (hi == rt || hi == TY_NIL)) ? rt : TY_POLY;
+    }
+    if (sp_streq(name, "clamp") && argc == 1 && infer_type(c, argv[0]) == TY_RANGE &&
+        comp_method_in_chain(c, cid, "<=>", NULL) >= 0) return TY_POLY;
+    /* Comparable#between?(lo, hi) on an object with `<=>` is a boolean. */
+    if (sp_streq(name, "between?") && argc == 2 &&
+        comp_method_in_chain(c, cid, "<=>", NULL) >= 0) return TY_BOOL;
     /* instance_variable_get(:@x) yields @x's declared type; instance_variable_set
        yields the field type too (C `lvalue = v` evaluates to the lvalue). The
        codegen lowers both to a direct iv_ field access on the known layout. */
@@ -1943,6 +1958,11 @@ else {
     if (sp_streq(name, "push") || sp_streq(name, "<<") || sp_streq(name, "append")) return rt;
     if ((sp_streq(name, "length") || sp_streq(name, "size")) && argc == 0) return TY_INT;
     if (sp_streq(name, "empty?") && argc == 0) return TY_BOOL;
+    /* no-block comparisons (admitted by the narrowing pass only for element
+       classes with `<=>`): sort keeps the array type, min/max yield an
+       element (NULL-encoded nil when empty). */
+    if ((sp_streq(name, "sort") || sp_streq(name, "sort!")) && argc == 0) return rt;
+    if ((sp_streq(name, "min") || sp_streq(name, "max")) && argc == 0) return ty_object(ecls);
   }
 
   /* array receiver methods */

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -2406,6 +2406,61 @@ void emit_super(Compiler *c, int id, Buf *b) {
   buf_puts(b, ")");
 }
 
+/* Generate sp_obj_cmp_dispatch: a cls_id switch calling each instantiated
+   Comparable class's user `<=>`, reporting a nil result as not-comparable.
+   Installed as sp_obj_cmp_hook so the runtime comparator (no-block
+   sort/min/max/clamp) can order user objects. Only object- and poly-typed
+   operands are handled; an exotic operand type omits its arm and falls through
+   to not-comparable, which the callers raise as an ArgumentError. */
+static void emit_obj_cmp_dispatch(Compiler *c, Buf *b) {
+  buf_puts(b, "static mrb_int sp_obj_cmp_dispatch(sp_RbVal a, sp_RbVal b, mrb_bool *comparable) {\n");
+  buf_puts(b, "  switch (a.cls_id) {\n");
+  for (int k = 0; k < c->nclasses; k++) {
+    if (!c->classes[k].instantiated) continue;
+    int defcls = -1;
+    int mi = comp_method_in_chain(c, k, "<=>", &defcls);
+    if (mi < 0) continue;
+    Scope *m = &c->scopes[mi];
+    if (m->nparams < 1 || m->rest_idx >= 0) continue;     /* need exactly the one operand */
+    if (m->ret != TY_INT && m->ret != TY_POLY) continue;  /* unusable return -> not-comparable */
+    LocalVar *p = scope_local(m, m->pnames[0]);
+    TyKind pt = (p && p->type != TY_UNKNOWN) ? p->type : TY_POLY;
+    const char *dcn = c->classes[defcls].name;
+    int self_vt = c->classes[defcls].is_value_type;
+    int cid = comp_class_index(c, c->classes[k].name);
+    char argbuf[160];
+    int obj_operand = 0;
+    int pcid = -1;
+    if (ty_is_object(pt)) {
+      int pcls = ty_object_class(pt);
+      const char *pcn = c->classes[pcls].name;
+      pcid = comp_class_index(c, pcn);   /* guard b against the OPERAND's class, not the receiver's */
+      snprintf(argbuf, sizeof argbuf, "%s(sp_%s *)b.v.p",
+               c->classes[pcls].is_value_type ? "*" : "", pcn);
+      obj_operand = 1;
+    } else if (pt == TY_POLY) {
+      snprintf(argbuf, sizeof argbuf, "b");
+    } else {
+      continue;
+    }
+    buf_printf(b, "    case %d: {\n", cid);
+    if (obj_operand)
+      buf_printf(b, "      if (b.tag != SP_TAG_OBJ || b.cls_id != %d) { *comparable = FALSE; return 0; }\n", pcid);
+    if (m->ret == TY_INT) {
+      buf_printf(b, "      *comparable = TRUE; return (mrb_int)sp_%s_%s(%s(sp_%s *)a.v.p, %s);\n",
+                 dcn, mc("<=>"), self_vt ? "*" : "", dcn, argbuf);
+    } else {
+      buf_printf(b, "      sp_RbVal _r = sp_%s_%s(%s(sp_%s *)a.v.p, %s);\n",
+                 dcn, mc("<=>"), self_vt ? "*" : "", dcn, argbuf);
+      buf_puts(b, "      if (_r.tag == SP_TAG_NIL) { *comparable = FALSE; return 0; }\n");
+      buf_puts(b, "      *comparable = TRUE; return _r.v.i;\n");
+    }
+    buf_puts(b, "    }\n");
+  }
+  buf_puts(b, "    default: break;\n");
+  buf_puts(b, "  }\n  *comparable = FALSE; return 0;\n}\n");
+}
+
 /* Emit the static regex-literal globals and, when g_re_init_needed, the
    sp_re_init() that installs the symbol/regex/class/global-mark hooks and
    compiles the literals at startup. */
@@ -2427,9 +2482,13 @@ void emit_regex_section(Buf *b) {
       "static int sp_marshal_obj_dump(sp_mar_buf *b, int cls_id, void *p);\n"
       "static sp_RbVal sp_marshal_obj_load(const char *name, sp_RbVal iv, int *ok);\n");
   }
+  if (g_has_user_cmp)
+    buf_puts(b, "static mrb_int sp_obj_cmp_dispatch(sp_RbVal a, sp_RbVal b, mrb_bool *comparable);\n");
   buf_puts(b, "static void sp_re_init(void) {\n");
   if (g_uses_symbols)
     buf_puts(b, "  sp_sym_name_fn = sp_sym_to_s;\n");
+  if (g_has_user_cmp)
+    buf_puts(b, "  sp_obj_cmp_hook = sp_obj_cmp_dispatch;\n");
   if (g_needs_class_machinery)
     buf_puts(b, "  sp_user_exc_parent_fn = sp_user_exc_parent;\n");
   /* Replace the runtime's hook with the superset that also marks this
@@ -3587,9 +3646,20 @@ char *codegen_program(const NodeTable *nt) {
     }
     free(mk.p);
   }
+  /* An instantiated class that can reach a `<=>` (its own or an ancestor's)
+     needs the cmp-hook so the runtime comparator can order its instances
+     (no-block sort/min/max/clamp and the checked object comparisons). The
+     chain walk matters: a subclass may inherit `<=>` from a base class that
+     is itself never instantiated. */
+  g_has_user_cmp = 0;
+  for (int k = 0; k < c->nclasses; k++) {
+    if (!c->classes[k].instantiated) continue;
+    if (comp_method_in_chain(c, k, "<=>", NULL) >= 0) { g_has_user_cmp = 1; break; }
+  }
+
   /* sp_re_init is worth emitting only if it would set at least one hook. */
   g_re_init_needed = g_uses_symbols || g_uses_marshal || g_uses_regex || g_needs_class_machinery ||
-                     g_has_user_global_marks;
+                     g_has_user_global_marks || g_has_user_cmp;
 
   /* Constructor defs, method defs, and main go into a separate buffer. Any
      proc literals they contain accumulate static functions into g_procs /
@@ -3604,6 +3674,8 @@ char *codegen_program(const NodeTable *nt) {
   for (int s = 1; s < c->nscopes; s++) {
     if (c->scopes[s].yields || !c->scopes[s].reachable || scope_is_shadowed(c, s) || c->scopes[s].is_transplanted_source) continue; EMIT_COLLECT_UNIT(emit_method(c, &c->scopes[s], body));
   }
+  /* Comparable cmp-hook dispatcher (after the user `<=>` definitions it calls). */
+  if (g_has_user_cmp) emit_obj_cmp_dispatch(c, body);
 
   /* Emit END block static functions for atexit registration */
   int end_count = 0;

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -1942,6 +1942,43 @@ static int emit_class_new_call(Compiler *c, int id, Buf *b) {
   return 0;
 }
 
+/* True when the user `<=>` reachable from cid (or a subclass override) can
+   return nil at runtime -- its unified return type is TY_POLY. The object
+   comparison emitters (<, <=, >, >=, ==, between?) then route through the
+   checked boxed comparators (sp_poly_cmp_ck / sp_poly_cmp_eq, dispatching
+   the user `<=>` via sp_obj_cmp_hook) so an incomparable pair raises the
+   Comparable ArgumentError like CRuby; a TY_INT `<=>` keeps the zero-cost
+   inline `<op> 0` path. Value-type classes stay inline (never boxed). */
+static int user_cmp_ret_poly(Compiler *c, int cid) {
+  if (c->classes[cid].is_value_type) return 0;
+  int def = -1;
+  int mi = comp_method_in_chain(c, cid, "<=>", &def);
+  TyKind ret = mi >= 0 ? (TyKind)c->scopes[mi].ret : TY_UNKNOWN;
+  for (int k = 0; k < c->nclasses; k++) {
+    if (!is_descendant(c, k, cid)) continue;
+    int kd = -1;
+    int kmi = comp_method_in_chain(c, k, "<=>", &kd);
+    if (kmi >= 0 && (TyKind)c->scopes[kmi].ret != TY_UNKNOWN)
+      ret = ty_unify(ret, (TyKind)c->scopes[kmi].ret);
+  }
+  return ret == TY_POLY;
+}
+
+/* Bind `node`'s boxed value to a fresh rooted sp_RbVal temp in g_pre and
+   return the temp id. The comparison operand may be a fresh allocation whose
+   only reference is this value, and the user `<=>` (or the other operand's
+   evaluation) can allocate -- rooting keeps it live across those. */
+static int hoist_boxed_rooted(Compiler *c, int node) {
+  int t = ++g_tmp;
+  Buf vb; memset(&vb, 0, sizeof vb);
+  emit_boxed(c, node, &vb);
+  emit_indent(g_pre, g_indent);
+  buf_printf(g_pre, "sp_RbVal _t%d = %s; SP_GC_ROOT_RBVAL(_t%d);\n",
+             t, vb.p ? vb.p : "sp_box_nil()", t);
+  free(vb.p);
+  return t;
+}
+
 static int emit_case_eq_call(Compiler *c, int id, Buf *b) {
   const NodeTable *nt = c->nt;
   const char *name = nt_str(nt, id, "name");
@@ -2139,6 +2176,13 @@ static int emit_case_eq_call(Compiler *c, int id, Buf *b) {
       }
       /* no direct == : use <=> == 0 when the class supports Comparable */
       if (comp_method_in_chain(c, ecid, "<=>", NULL) >= 0) {
+        /* a `<=>` that can return nil: Comparable#== semantics -- identity is
+           equal, an incomparable pair is false (never an error) */
+        if (user_cmp_ret_poly(c, ecid)) {
+          int ta = hoist_boxed_rooted(c, recv), tb2 = hoist_boxed_rooted(c, argv[0]);
+          buf_printf(b, "(%ssp_poly_cmp_eq(_t%d, _t%d))", eq ? "" : "!", ta, tb2);
+          return 1;
+        }
         char selfptr[64];
         const char *rty2 = nt_type(nt, recv);
         if (rty2 && (sp_streq(rty2, "LocalVariableReadNode") ||
@@ -2598,6 +2642,7 @@ void emit_call(Compiler *c, int id, Buf *b) {
         buf_printf(g_pre, " _t%d = %s;\n", t,
                    bt == TY_RANGE ? "(sp_Range){0}" : default_value(bt));
         /* Kernel#loop rescues StopIteration to terminate; wrap in a setjmp. */
+        emit_indent(g_pre, g_indent); buf_printf(g_pre, "int _gcb%d = sp_gc_nroots; (void)_gcb%d;\n", t, t);
         emit_indent(g_pre, g_indent); buf_puts(g_pre, "sp_exc_top++;\n");
         emit_indent(g_pre, g_indent); buf_puts(g_pre, "if (setjmp(sp_exc_stack[sp_exc_top-1]) == 0) {\n");
         emit_indent(g_pre, g_indent + 1); buf_puts(g_pre, "for (;;) {\n");
@@ -2615,6 +2660,7 @@ void emit_call(Compiler *c, int id, Buf *b) {
         emit_indent(g_pre, g_indent); buf_puts(g_pre, "}\n");
         emit_indent(g_pre, g_indent); buf_puts(g_pre, "else {\n");
         emit_indent(g_pre, g_indent + 1); buf_puts(g_pre, "sp_exc_top--;\n");
+        emit_indent(g_pre, g_indent + 1); buf_printf(g_pre, "sp_gc_nroots = _gcb%d;\n", t);
         emit_indent(g_pre, g_indent + 1);
         buf_puts(g_pre, "if (!sp_exc_cls_matches((const char *)sp_last_exc_cls, \"StopIteration\")) sp_raise_cls(sp_exc_cls[sp_exc_top], sp_exc_msg[sp_exc_top]);\n");
         emit_indent(g_pre, g_indent); buf_puts(g_pre, "}\n");
@@ -2642,6 +2688,7 @@ void emit_call(Compiler *c, int id, Buf *b) {
       /* record the exception-handler depth at this catch's entry so a `throw`
          can run intervening `ensure` blocks before delivering here. */
       emit_indent(g_pre, g_indent); buf_puts(g_pre, "sp_catch_exc_top[sp_catch_top] = sp_exc_top;\n");
+      emit_indent(g_pre, g_indent); buf_printf(g_pre, "int _gcb%d = sp_gc_nroots; (void)_gcb%d;\n", t, t);
       emit_indent(g_pre, g_indent); buf_puts(g_pre, "sp_catch_top++;\n");
       emit_indent(g_pre, g_indent);
       buf_puts(g_pre, "if (setjmp(sp_catch_stack[sp_catch_top-1]) == 0) {\n");
@@ -2669,6 +2716,7 @@ void emit_call(Compiler *c, int id, Buf *b) {
       emit_indent(g_pre, g_indent); buf_puts(g_pre, "}\n");
       emit_indent(g_pre, g_indent); buf_puts(g_pre, "else {\n");
       emit_indent(g_pre, g_indent + 1); buf_puts(g_pre, "sp_catch_top--;\n");
+      emit_indent(g_pre, g_indent + 1); buf_printf(g_pre, "sp_gc_nroots = _gcb%d;\n", t);
       emit_indent(g_pre, g_indent + 1);
       if (ptr) {
         buf_printf(g_pre, "_t%d = (", t); emit_ctype(c, bt, g_pre);
@@ -6556,6 +6604,13 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       int cid4 = ty_object_class(rt);
       if (comp_method_in_chain(c, cid4, name, NULL) < 0 &&
           comp_method_in_chain(c, cid4, "<=>", NULL) >= 0) {
+        /* a `<=>` that can return nil: check it -- incomparable raises the
+           Comparable ArgumentError instead of comparing a garbage value */
+        if (user_cmp_ret_poly(c, cid4)) {
+          int ta = hoist_boxed_rooted(c, recv), tb2 = hoist_boxed_rooted(c, argv[0]);
+          buf_printf(b, "(sp_poly_cmp_ck(_t%d, _t%d) %s 0)", ta, tb2, name);
+          return;
+        }
         char selfptr[64];
         const char *rtyp = nt_type(nt, recv);
         if (rtyp && (sp_streq(rtyp, "LocalVariableReadNode") ||
@@ -6707,6 +6762,14 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       int cid_b = ty_object_class(rt);
       int defcls_b = -1;
       int mi_b = comp_method_in_chain(c, cid_b, "<=>", &defcls_b);
+      if (mi_b >= 0 && user_cmp_ret_poly(c, cid_b)) {
+        /* nil-capable `<=>`: checked comparisons (incomparable raises) */
+        int ts = hoist_boxed_rooted(c, recv);
+        int tlo = hoist_boxed_rooted(c, argv[0]), thi = hoist_boxed_rooted(c, argv[1]);
+        buf_printf(b, "(sp_poly_cmp_ck(_t%d, _t%d) >= 0 && sp_poly_cmp_ck(_t%d, _t%d) <= 0)",
+                   ts, tlo, ts, thi);
+        return;
+      }
       if (mi_b >= 0) {
         int ts = ++g_tmp, tlo = ++g_tmp, thi = ++g_tmp;
         const char *cname = c->classes[defcls_b].name;
@@ -7547,6 +7610,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
                  eid, eid, eid, eid);
       if (has_retval) { emit_ctype(c, g_ret_type, b); buf_printf(b, " _retv%d = %s; ", eid, default_value(g_ret_type)); }
       g_ensure_stack[g_ensure_depth++] = (EnsureCtx){ eid, has_retval };
+      buf_printf(b, "int _gcb%d = sp_gc_nroots; (void)_gcb%d; ", eid, eid);
       buf_puts(b, "sp_exc_top++; if (setjmp(sp_exc_stack[sp_exc_top-1]) == 0) { ");
     }
     for (int k = 0; k < bbn - 1; k++) emit_stmt(c, bbb[k], b, 0);
@@ -7567,8 +7631,8 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     }
     if (is_mx) {
       g_ensure_depth--;
-      buf_printf(b, "sp_exc_top--; } else { sp_exc_top--; if (sp_unwind_kind == SP_UNWIND_NONE) { sp_proc_homes_unwind(); _excf%d = 1; _excmsg%d = sp_exc_msg[sp_exc_top]; _exccls%d = sp_exc_cls[sp_exc_top]; } } ",
-                 eid, eid, eid);
+      buf_printf(b, "sp_exc_top--; } else { sp_exc_top--; sp_gc_nroots = _gcb%d; if (sp_unwind_kind == SP_UNWIND_NONE) { sp_proc_homes_unwind(); _excf%d = 1; _excmsg%d = sp_exc_msg[sp_exc_top]; _exccls%d = sp_exc_cls[sp_exc_top]; } } ",
+                 eid, eid, eid, eid);
       buf_printf(b, "_ensure%d: ; sp_Mutex_unlock(_t%d); ", eid, mtmp);
       buf_puts(b, "if (sp_unwind_kind != SP_UNWIND_NONE) sp_unwind_resume(); ");
       if (g_ensure_depth > 0) {

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -88,6 +88,27 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
       buf_puts(b, "sp_PtrArray_empty("); emit_expr(c, recv, b); buf_puts(b, ")");
       return 1;
     }
+    /* no-block comparisons via the boxed comparator (user `<=>` through the
+       cmp hook); the narrowing pass admits these only when the element class
+       has `<=>` and (for sort) the result lands in a modeled consumer. */
+    if (sp_streq(name, "sort") && argc == 0 && nt_ref(nt, id, "block") < 0) {
+      buf_puts(b, "sp_PtrArray_sort_obj("); emit_expr(c, recv, b);
+      buf_printf(b, ", %d)", ecls);
+      return 1;
+    }
+    if (sp_streq(name, "sort!") && argc == 0 && nt_ref(nt, id, "block") < 0) {
+      int tr = ++g_tmp;
+      buf_printf(b, "({ sp_PtrArray *_t%d = ", tr); emit_expr(c, recv, b);
+      buf_printf(b, "; sp_PtrArray_sort_obj_bang(_t%d, %d); _t%d; })", tr, ecls, tr);
+      return 1;
+    }
+    if ((sp_streq(name, "min") || sp_streq(name, "max")) && argc == 0 &&
+        nt_ref(nt, id, "block") < 0) {
+      buf_printf(b, "((sp_%s *)sp_PtrArray_minmax_obj(", ecn);
+      emit_expr(c, recv, b);
+      buf_printf(b, ", %d, %d))", ecls, sp_streq(name, "max") ? 1 : 0);
+      return 1;
+    }
     return 0;  /* unsupported obj-array op: pass should have prevented this. */
   }
   if (recv >= 0 && ty_is_array(rt)) {
@@ -1451,6 +1472,19 @@ else {
         buf_puts(b, "sp_PolyArray_sort("); emit_expr(c, recv, b); buf_puts(b, ")");
         return 1;
       }
+      /* minmax (no block): [min, max] via the poly comparator (user `<=>`
+         through the cmp hook); incomparable raises the Comparable
+         ArgumentError; empty -> [nil, nil]. Both temps rooted: min/max can
+         allocate inside sp_poly_cmp (bigint temps) and push reallocs. */
+      if (sp_streq(name, "minmax") && argc == 0 && nt_ref(nt, id, "block") < 0) {
+        int t = ++g_tmp, o = ++g_tmp;
+        buf_printf(b, "({ sp_PolyArray *_t%d = ", t); emit_expr(c, recv, b);
+        buf_printf(b, "; SP_GC_ROOT(_t%d); sp_PolyArray *_t%d = sp_PolyArray_new(); SP_GC_ROOT(_t%d);"
+                      " sp_PolyArray_push(_t%d, sp_PolyArray_min(_t%d));"
+                      " sp_PolyArray_push(_t%d, sp_PolyArray_max(_t%d)); _t%d; })",
+                   t, o, o, o, t, o, t, o);
+        return 1;
+      }
       {
         const char *base = NULL;
         if      (sp_streq(name, "reverse!")) base = "reverse_bang";
@@ -2742,10 +2776,8 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
       }
       else if (sp_streq(name, "clamp") && argc == 2) { buf_printf(b, "sp_int_clamp_ck(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ", "); emit_expr(c, argv[1], b); buf_puts(b, ")"); }
       else if (sp_streq(name, "clamp") && argc == 1 && nt_type(c->nt, argv[0]) && sp_streq(nt_type(c->nt, argv[0]), "RangeNode")) {
-        int rn = argv[0]; int tcr = ++g_tmp;
-        buf_printf(b, "({ sp_Range _t%d = ", tcr); emit_expr(c, argv[0], b);
-        buf_printf(b, "; sp_int_clamp_ck(%s, _t%d.first, _t%d.last - _t%d.excl); })", r, tcr, tcr, tcr);
-        (void)rn;
+        /* the helper raises on an exclusive range with a real end (CRuby) */
+        buf_printf(b, "sp_int_clamp_range_ck(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")");
       }
       else if (sp_streq(name, "digits") && argc == 0) buf_printf(b, "sp_int_digits(%s, 10)", r);
       else if (sp_streq(name, "digits") && argc == 1) { buf_printf(b, "sp_int_digits(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ")"); }
@@ -2943,6 +2975,37 @@ int emit_object_call(Compiler *c, int id, Buf *b) {
         buf_printf(b, "sp_class_le(((sp_Class){%d}),_t%d); }))", cid, k);
       return 1;
     }
+  }
+
+  /* Comparable#clamp(lo, hi) on a user object: dispatch the user `<=>` through
+     sp_obj_clamp. The result is self or the APPLIED BOUND, so it keeps the
+     receiver's class only when both bounds are statically that class (the
+     inference arm matches); otherwise it stays boxed. */
+  if (recv >= 0 && ty_is_object(rt) && sp_streq(name, "clamp") && argc == 2 &&
+      comp_method_in_chain(c, ty_object_class(rt), "<=>", NULL) >= 0) {
+    TyKind clo = comp_ntype(c, argv[0]), chi = comp_ntype(c, argv[1]);
+    int same_cls = (clo == rt || clo == TY_NIL) && (chi == rt || chi == TY_NIL);
+    if (same_cls) { buf_puts(b, "(("); emit_ctype(c, rt, b); buf_puts(b, ")"); }
+    buf_puts(b, "sp_obj_clamp(");
+    emit_boxed(c, recv, b); buf_puts(b, ", ");
+    emit_boxed(c, argv[0], b); buf_puts(b, ", ");
+    emit_boxed(c, argv[1], b);
+    buf_puts(b, ")");
+    if (same_cls) buf_puts(b, ".v.p)");
+    return 1;
+  }
+  /* Comparable#clamp(range) on a user object: int endpoints become bounds fed
+     to the user `<=>`; beginless/endless clamp one-sided; an exclusive range
+     with a real end raises (CRuby). A clamped result IS the Integer endpoint
+     itself, so the value stays boxed (inference: TY_POLY). */
+  if (recv >= 0 && ty_is_object(rt) && sp_streq(name, "clamp") && argc == 1 &&
+      comp_ntype(c, argv[0]) == TY_RANGE &&
+      comp_method_in_chain(c, ty_object_class(rt), "<=>", NULL) >= 0) {
+    buf_puts(b, "sp_obj_clamp_range(");
+    emit_boxed(c, recv, b); buf_puts(b, ", ");
+    emit_expr(c, argv[0], b);
+    buf_puts(b, ")");
+    return 1;
   }
 
   /* Struct instance methods (to_h / to_a / values / members / dig). */
@@ -3871,10 +3934,10 @@ int emit_poly_call(Compiler *c, int id, Buf *b) {
   }
   if (recv >= 0 && rt == TY_POLY && sp_streq(name, "clamp") && argc == 1 &&
       nt_type(nt, argv[0]) && sp_streq(nt_type(nt, argv[0]), "RangeNode")) {
-    int tcr = ++g_tmp;
-    buf_printf(b, "({ sp_Range _t%d = ", tcr); emit_expr(c, argv[0], b);
-    buf_puts(b, "; sp_poly_clamp("); emit_boxed(c, recv, b);
-    buf_printf(b, ", sp_box_int(_t%d.first), sp_box_int(_t%d.last - _t%d.excl)); })", tcr, tcr, tcr);
+    /* raises on an exclusive range with a real end; routes a user-object
+       receiver through the `<=>` hook (sp_obj_clamp_range) */
+    buf_puts(b, "sp_poly_clamp_range("); emit_boxed(c, recv, b);
+    buf_puts(b, ", "); emit_expr(c, argv[0], b); buf_puts(b, ")");
     return 1;
   }
   /* poly receiver: replace(other) -> runtime dispatch (nullable array). */

--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -1561,7 +1561,7 @@ else {
     int t = ++g_tmp;
     buf_puts(b, "({ ");
     emit_ctype(c, rt, b);
-    buf_printf(b, " _t%d = %s; sp_exc_top++;\n", t, default_value(rt));
+    buf_printf(b, " _t%d = %s; int _gcb%d = sp_gc_nroots; (void)_gcb%d; sp_exc_top++;\n", t, default_value(rt), t, t);
     buf_puts(b, "if (setjmp(sp_exc_stack[sp_exc_top-1]) == 0) {\n");
     /* expression arm — assign result to temp (skip diverging exprs like raise) */
     TyKind et = e >= 0 ? comp_ntype(c, e) : TY_UNKNOWN;
@@ -1577,9 +1577,9 @@ else {
       /* diverging expression like raise: emit as stmt (no assignment) */
       emit_expr(c, e, b); buf_puts(b, ";");
     }
-    buf_puts(b, " sp_exc_top--;\n}\nelse {\n  sp_exc_top--;\n  "
+    buf_printf(b, " sp_exc_top--;\n}\nelse {\n  sp_exc_top--;\n  sp_gc_nroots = _gcb%d;\n  "
                 "if (sp_unwind_kind == SP_UNWIND_NONE) sp_proc_homes_unwind();\n  "
-                "if (sp_unwind_kind != SP_UNWIND_NONE) sp_unwind_resume();\n  ");
+                "if (sp_unwind_kind != SP_UNWIND_NONE) sp_unwind_resume();\n  ", t);
     /* rescue arm */
     if (r >= 0) {
       buf_printf(b, "_t%d = ", t);

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -213,6 +213,7 @@ extern int g_uses_regex;
 extern int g_uses_argv;
 extern int g_uses_random;
 extern int g_uses_threads;
+extern int g_has_user_cmp;
 extern int g_re_init_needed;
 
 const char *rename_local(const char *nm);

--- a/src/codegen_iter.c
+++ b/src/codegen_iter.c
@@ -579,6 +579,8 @@ int emit_iteration_stmt(Compiler *c, int id, Buf *b, int indent) {
     /* Kernel#loop rescues StopIteration to terminate normally (e.g. an external
        Enumerator's #next at the end). Wrap the loop in a setjmp handler; a
        StopIteration falls through, any other exception re-raises. */
+    int gcl = ++g_tmp;
+    emit_indent(b, indent); buf_printf(b, "int _gcb%d = sp_gc_nroots; (void)_gcb%d;\n", gcl, gcl);
     emit_indent(b, indent); buf_puts(b, "sp_exc_top++;\n");
     emit_indent(b, indent); buf_puts(b, "if (setjmp(sp_exc_stack[sp_exc_top-1]) == 0) {\n");
     emit_indent(b, indent + 1); buf_puts(b, "for (;;) {\n");
@@ -588,6 +590,7 @@ int emit_iteration_stmt(Compiler *c, int id, Buf *b, int indent) {
     emit_indent(b, indent); buf_puts(b, "}\n");
     emit_indent(b, indent); buf_puts(b, "else {\n");
     emit_indent(b, indent + 1); buf_puts(b, "sp_exc_top--;\n");
+    emit_indent(b, indent + 1); buf_printf(b, "sp_gc_nroots = _gcb%d;\n", gcl);
     emit_indent(b, indent + 1);
     buf_puts(b, "if (!sp_exc_cls_matches((const char *)sp_last_exc_cls, \"StopIteration\")) sp_raise_cls(sp_exc_cls[sp_exc_top], sp_exc_msg[sp_exc_top]);\n");
     emit_indent(b, indent); buf_puts(b, "}\n");

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -2838,6 +2838,12 @@ void emit_begin(Compiler *c, int id, Buf *b, int indent, const char *resultvar) 
   int else_stmts = else_c >= 0 ? nt_ref(nt, else_c, "statements") : -1;
   int ensure_stmts = ensure_c >= 0 ? nt_ref(nt, ensure_c, "statements") : -1;
   int fr = ++g_tmp;
+  /* GC root watermark for the protected region: a raise unwinds via longjmp,
+     which skips the __attribute__((cleanup)) pops of any SP_GC_ROOT locals in
+     the body (or in runtime helpers it called), leaving stale entries on the
+     root stack. Restore to this watermark on the exception landing, before the
+     rescue/ensure bodies allocate, so GC never marks a dead stack slot. */
+  int gcb = ++g_tmp;
 
   if (ensure_stmts >= 0 && g_ensure_depth < MAX_ENSURE_DEPTH) {
     /* Ensure clause present: use goto-based deferred-return mechanism so that
@@ -2857,6 +2863,7 @@ void emit_begin(Compiler *c, int id, Buf *b, int indent, const char *resultvar) 
     }
     g_ensure_stack[g_ensure_depth++] = (EnsureCtx){ eid, has_retval };
 
+    emit_indent(b, indent); buf_printf(b, "int _gcb%d = sp_gc_nroots; (void)_gcb%d;\n", gcb, gcb);
     emit_indent(b, indent); buf_puts(b, "sp_exc_top++;\n");
     emit_indent(b, indent); buf_puts(b, "if (setjmp(sp_exc_stack[sp_exc_top-1]) == 0) {\n");
     if (resultvar && else_stmts < 0) {
@@ -2879,6 +2886,7 @@ void emit_begin(Compiler *c, int id, Buf *b, int indent, const char *resultvar) 
     emit_indent(b, indent); buf_puts(b, "}\n");
     emit_indent(b, indent); buf_puts(b, "else {\n");
     emit_indent(b, indent + 1); buf_puts(b, "sp_exc_top--;\n");
+    emit_indent(b, indent + 1); buf_printf(b, "sp_gc_nroots = _gcb%d;\n", gcb);
     /* A non-local unwind (proc return / throw) only passes through here; it is
        not an exception, so skip rescue -- only the ensure (below) runs. */
     emit_indent(b, indent + 1); buf_puts(b, "if (sp_unwind_kind == SP_UNWIND_NONE) {\n");
@@ -2969,6 +2977,7 @@ void emit_begin(Compiler *c, int id, Buf *b, int indent, const char *resultvar) 
   const char *saved_retry = g_retry_label;
   if (has_retry) g_retry_label = retry_label;
 
+  emit_indent(b, indent); buf_printf(b, "int _gcb%d = sp_gc_nroots; (void)_gcb%d;\n", gcb, gcb);
   emit_indent(b, indent); buf_puts(b, "sp_exc_top++;\n");
   emit_indent(b, indent); buf_puts(b, "if (setjmp(sp_exc_stack[sp_exc_top-1]) == 0) {\n");
   /* body value is the begin value only when there is no else clause */
@@ -2995,6 +3004,7 @@ void emit_begin(Compiler *c, int id, Buf *b, int indent, const char *resultvar) 
   emit_indent(b, indent); buf_puts(b, "}\n");
   emit_indent(b, indent); buf_puts(b, "else {\n");
   emit_indent(b, indent + 1); buf_puts(b, "sp_exc_top--;\n");
+  emit_indent(b, indent + 1); buf_printf(b, "sp_gc_nroots = _gcb%d;\n", gcb);
   /* Drop home nodes a real exception unwound past (no-op for a throw/proc-return
      pass-through, where sp_unwind_kind is set); see the tail-position begin. */
   emit_indent(b, indent + 1); buf_puts(b, "if (sp_unwind_kind == SP_UNWIND_NONE) sp_proc_homes_unwind();\n");
@@ -4808,6 +4818,8 @@ else {
        fall through to the rescue expression on any exception. */
     int e = nt_ref(nt, id, "expression");
     int r = nt_ref(nt, id, "rescue_expression");
+    int gcm = ++g_tmp;
+    emit_indent(b, indent); buf_printf(b, "int _gcb%d = sp_gc_nroots; (void)_gcb%d;\n", gcm, gcm);
     emit_indent(b, indent); buf_puts(b, "sp_exc_top++;\n");
     emit_indent(b, indent); buf_puts(b, "if (setjmp(sp_exc_stack[sp_exc_top-1]) == 0) {\n");
     if (e >= 0) emit_stmt(c, e, b, indent + 1);
@@ -4815,6 +4827,7 @@ else {
     emit_indent(b, indent); buf_puts(b, "}\n");
     emit_indent(b, indent); buf_puts(b, "else {\n");
     emit_indent(b, indent + 1); buf_puts(b, "sp_exc_top--;\n");
+    emit_indent(b, indent + 1); buf_printf(b, "sp_gc_nroots = _gcb%d;\n", gcm);
     emit_indent(b, indent + 1); buf_puts(b, "if (sp_unwind_kind == SP_UNWIND_NONE) sp_proc_homes_unwind();\n");
     /* A non-local unwind only passes through (no ensure here): continue it. */
     emit_indent(b, indent + 1); buf_puts(b, "if (sp_unwind_kind != SP_UNWIND_NONE) sp_unwind_resume();\n");

--- a/src/codegen_util.c
+++ b/src/codegen_util.c
@@ -299,6 +299,7 @@ int g_uses_regex = 0;
 int g_uses_argv = 0;
 int g_uses_random = 0;
 int g_uses_threads = 0;
+int g_has_user_cmp = 0;
 int g_re_init_needed = 0;
 void emit_local_ref(Compiler *c, int scope_node, const char *name, Buf *b) {
   if (g_cap_struct && g_cap_names && nameset_has(g_cap_names, name)) {

--- a/test/comparable_clamp_parity.rb
+++ b/test/comparable_clamp_parity.rb
@@ -1,0 +1,70 @@
+# Comparable#clamp parity for user classes: reversed bounds raise, nil bounds
+# clamp one-sided, the range form accepts Integer endpoints (a clamped result
+# IS that endpoint), an exclusive range raises, and a poly receiver routes
+# through the user <=>. Receivers go through per-shape helper defs to defeat
+# constant folding.
+class Money
+  include Comparable
+  attr_reader :cents
+  def initialize(cents); @cents = cents; end
+  def <=>(other)
+    v = other.is_a?(Money) ? other.cents : (other.is_a?(Integer) ? other : nil)
+    v.nil? ? nil : (cents <=> v)
+  end
+end
+
+def money_id(x); x; end
+def poly_id(x); x; end
+def int_id(x); x; end
+
+# reversed bounds raise
+begin
+  money_id(Money.new(20)).clamp(Money.new(30), Money.new(10))
+rescue ArgumentError => e
+  puts e.message
+end
+
+# nil bounds clamp one-sided (the nil side is never returned, so the result
+# keeps the receiver's class)
+p money_id(Money.new(5)).clamp(Money.new(10), nil).cents
+p money_id(Money.new(5)).clamp(nil, Money.new(3)).cents
+p money_id(Money.new(5)).clamp(nil, Money.new(9)).cents
+
+# range form with Integer endpoints: the user <=> sees the Integer; a clamped
+# result is the Integer endpoint itself
+p money_id(Money.new(0)).clamp(1..5)
+p money_id(Money.new(9)).clamp(1..5)
+# in-range returns the receiver (not an endpoint); clamped returns the endpoint
+p money_id(Money.new(3)).clamp(1..5).is_a?(Integer)
+p money_id(Money.new(0)).clamp(1..5).is_a?(Integer)
+
+# beginless / endless ranges clamp one-sided
+p money_id(Money.new(9)).clamp(..5)
+p money_id(Money.new(0)).clamp(2..)
+
+# an exclusive range with a real end cannot clamp; exclusive endless can
+begin
+  money_id(Money.new(3)).clamp(1...5)
+rescue ArgumentError => e
+  puts e.message
+end
+p money_id(Money.new(0)).clamp(2...)
+
+# Integer receivers: exclusive range raises there too
+begin
+  int_id(7).clamp(1...5)
+rescue ArgumentError => e
+  puts e.message
+end
+p int_id(7).clamp(1..5)
+p int_id(7).clamp(1..)
+p int_id(0).clamp(..5)
+
+# a poly receiver holding a user object clamps via the user <=>
+p poly_id(Money.new(50)).clamp(Money.new(10), Money.new(30)).cents
+p (poly_id(Money.new(50)).clamp(10..30))
+begin
+  poly_id(Money.new(3)).clamp(1...5)
+rescue ArgumentError => e
+  puts e.message
+end

--- a/test/comparable_clamp_parity.rb.expected
+++ b/test/comparable_clamp_parity.rb.expected
@@ -1,0 +1,19 @@
+min argument must be less than or equal to max argument
+10
+3
+5
+1
+5
+false
+true
+5
+2
+cannot clamp with an exclusive range
+2
+cannot clamp with an exclusive range
+5
+7
+0
+30
+30
+cannot clamp with an exclusive range

--- a/test/comparable_no_block_cmp.rb
+++ b/test/comparable_no_block_cmp.rb
@@ -1,0 +1,68 @@
+# No-block sort/min/max/clamp over a user class that mixes in Comparable must
+# dispatch the user `<=>` (not the built-in poly comparator). A nil `<=>` result
+# (incomparable operands) raises ArgumentError, matching CRuby. Receivers are
+# routed through a method param so the calls hit the runtime comparator path.
+class Money
+  include Comparable
+  attr_reader :cents
+  def initialize(cents); @cents = cents; end
+  def <=>(other); cents <=> other.cents; end
+end
+
+# distinct monomorphic helpers per receiver shape (a shared one would go poly)
+def bag_id(x); x; end
+def money_id(x); x; end
+def wbag_id(x); x; end
+
+bag = bag_id([Money.new(30), Money.new(10), Money.new(20)])
+
+p bag.sort.map(&:cents)
+p bag.min.cents
+p bag.max.cents
+
+# clamp keeps the receiver's class (returns self or a bound)
+p money_id(Money.new(50)).clamp(Money.new(10), Money.new(30)).cents
+p money_id(Money.new(5)).clamp(Money.new(10), Money.new(30)).cents
+p money_id(Money.new(20)).clamp(Money.new(10), Money.new(30)).cents
+
+# a `<=>` that yields nil for foreign operands makes the comparison raise
+class Weight
+  include Comparable
+  attr_reader :g
+  def initialize(g); @g = g; end
+  def <=>(other); other.is_a?(Weight) ? (g <=> other.g) : nil; end
+end
+
+begin
+  wbag_id([Weight.new(3), "kg", Weight.new(1)]).sort
+  puts "no raise"
+rescue ArgumentError => e
+  puts e.message
+end
+
+# the recorded pair must be deterministic (libc-independent): exercise the
+# foreign operand at every position of 2- and 3-element arrays; the receiver
+# in the message is whichever operand the fixed merge schedule compares first
+def try_sort(a)
+  begin
+    a.sort
+    puts "no raise"
+  rescue ArgumentError => e
+    puts e.message
+  end
+end
+
+try_sort(["kg", Weight.new(1)])
+try_sort([Weight.new(1), "kg"])
+try_sort(["kg", Weight.new(1), Weight.new(2)])
+try_sort([Weight.new(1), Weight.new(2), "kg"])
+
+# minmax (no block) via the user <=>; min(n)/max(n) route through the sorted
+# order; Array#<=> compares object arrays elementwise
+p bag.minmax.map(&:cents)
+p bag.min(2).map(&:cents)
+p bag.max(2).map(&:cents)
+p (bag <=> bag_id([Money.new(30), Money.new(10), Money.new(20)]))
+p (bag <=> bag_id([Money.new(30), Money.new(99)]))
+empty = bag_id([])
+p empty.minmax

--- a/test/comparable_no_block_cmp.rb.expected
+++ b/test/comparable_no_block_cmp.rb.expected
@@ -1,0 +1,17 @@
+[10, 20, 30]
+10
+30
+30
+10
+20
+comparison of Weight with String failed
+comparison of String with Weight failed
+comparison of Weight with String failed
+comparison of String with Weight failed
+comparison of Weight with String failed
+[10, 30]
+[10, 20]
+[30, 20]
+0
+-1
+[nil, nil]

--- a/test/comparable_operator_nil_cmp.rb
+++ b/test/comparable_operator_nil_cmp.rb
@@ -1,0 +1,65 @@
+# Object <, <=, >, >=, ==, != and between? via a user <=> that can return nil:
+# an incomparable pair raises the Comparable ArgumentError for the operators
+# and between?, while == is false (and != true) without raising, and identity
+# is always equal -- matching CRuby compar.c. A <=> that always returns an
+# Integer keeps working (the fast inline path).
+class Weight
+  include Comparable
+  attr_reader :g
+  def initialize(g); @g = g; end
+  # nil for a negative operand: forces a runtime-nil <=> between same-class
+  # operands so the checked path is exercised
+  def <=>(other); other.g < 0 ? nil : (g <=> other.g); end
+end
+
+class Money
+  include Comparable
+  attr_reader :cents
+  def initialize(cents); @cents = cents; end
+  def <=>(other); cents <=> other.cents; end
+end
+
+def w_id(x); x; end
+def m_id(x); x; end
+
+w1 = w_id(Weight.new(1))
+w2 = w_id(Weight.new(2))
+bad = w_id(Weight.new(-5))
+
+# comparable pairs work
+p w1 < w2
+p w2 > w1
+p w1 <= w1
+p w2 >= w2
+p w1.between?(w1, w2)
+p w1 == w_id(Weight.new(1))
+p w1 != w2
+
+# incomparable operands raise for the operators...
+begin
+  w1 < bad
+rescue ArgumentError => e
+  puts e.message
+end
+begin
+  w1 >= bad
+rescue ArgumentError => e
+  puts e.message
+end
+begin
+  w2.between?(w1, bad)
+rescue ArgumentError => e
+  puts e.message
+end
+
+# ...but == is false (never raises), != is true, and identity always wins
+p w1 == bad
+p w1 != bad
+p bad == bad
+
+# an always-Integer <=> class keeps working
+m1 = m_id(Money.new(10))
+m2 = m_id(Money.new(20))
+p m1 < m2
+p m1.between?(m1, m2)
+p m1 == m_id(Money.new(10))

--- a/test/comparable_operator_nil_cmp.rb.expected
+++ b/test/comparable_operator_nil_cmp.rb.expected
@@ -1,0 +1,16 @@
+true
+true
+true
+true
+true
+true
+true
+comparison of Weight with Weight failed
+comparison of Weight with Weight failed
+comparison of Weight with Weight failed
+false
+true
+true
+true
+true
+true

--- a/test/obj_array_sort_typed.rb
+++ b/test/obj_array_sort_typed.rb
@@ -1,0 +1,57 @@
+# No-block sort/sort!/min/max over arrays of user objects. A local touched
+# only by modeled ops narrows to the typed object-array representation (the
+# runtime compares through the cmp hook); a component whose sort result
+# escapes into an unmodeled consumer stays on the boxed poly path -- the
+# behavior is identical either way. A class without <=> raises like CRuby.
+class Money
+  include Comparable
+  attr_reader :cents
+  def initialize(cents); @cents = cents; end
+  def <=>(other); cents <=> other.cents; end
+end
+
+# narrowed: only admitted ops touch this local and its sort alias
+bag = [Money.new(30), Money.new(10), Money.new(20)]
+sorted = bag.sort
+p sorted.first.cents
+p sorted.last.cents
+p bag.min.cents
+p bag.max.cents
+p bag.first.cents        # sort is a copy; the receiver is unchanged
+bag.sort!
+p bag.first.cents        # sort! reorders in place
+
+# escaping consumer: the component stays poly (boxed hook path)
+esc = [Money.new(3), Money.new(1), Money.new(2)]
+p esc.sort.length
+
+# empty array: min/max are nil
+none = [Money.new(1)]
+none.sort!
+p none.min.nil?
+
+# equal-comparing elements: the merge schedule is fixed (and matches CRuby's
+# small-array ordering), so tied elements land in a deterministic order on
+# every platform
+class Card
+  include Comparable
+  attr_reader :rank, :tag
+  def initialize(rank, tag); @rank = rank; @tag = tag; end
+  def <=>(other); rank <=> other.rank; end
+end
+deck = [Card.new(1, 0), Card.new(0, 1), Card.new(1, 2), Card.new(0, 3), Card.new(1, 4)]
+ordered = deck.sort
+p ordered.map(&:tag)
+
+# a class without <=> cannot compare, matching CRuby's error
+class NoCmp
+  attr_reader :v
+  def initialize(v); @v = v; end
+end
+plain = [NoCmp.new(2), NoCmp.new(1)]
+begin
+  plain.sort
+  puts "no raise"
+rescue ArgumentError => e
+  puts e.message
+end

--- a/test/obj_array_sort_typed.rb.expected
+++ b/test/obj_array_sort_typed.rb.expected
@@ -1,0 +1,10 @@
+10
+30
+10
+30
+30
+10
+3
+false
+[1, 3, 0, 2, 4]
+comparison of NoCmp with NoCmp failed


### PR DESCRIPTION
Sorting, `min`/`max`, and `clamp` over a user class that mixes in `Comparable` could not call the user `<=>` — the runtime comparator handled numbers, strings, symbols, and builtin arrays, but user objects fell through to not-comparable. The pieces that did exist were unsound at the edges: the inline object operator emitters produced invalid C when `<=>` can return nil, `clamp` never validated its bounds, and the range form silently computed `last - 1` where CRuby raises on an exclusive range.

**The hook.** Codegen emits `sp_obj_cmp_dispatch` — a `cls_id` switch calling each instantiated Comparable class's `<=>`, mapping a `nil` result to not-comparable — and installs it as `sp_obj_cmp_hook` at startup. `sp_poly_cmp` consults it whenever the **left** operand is a user object, so the right operand can be any boxed value and an Integer-aware user `<=>` works (`money.clamp(1..5)` feeds the Integer bound straight to the user method). The trigger scan walks each instantiated class's method chain, so a subclass inheriting `<=>` from a never-instantiated base class still installs the hook.

**clamp, exactly like `cmp_clamp`.** Reversed bounds raise `min argument must be less than or equal to max argument`; nil bounds clamp one-sided; the result keeps the receiver's class only when every bound is statically that class or nil — a clamped range form returns the Integer endpoint *itself*, so that result stays boxed. The range form works on object, int, and poly receivers and raises `cannot clamp with an exclusive range` exactly where CRuby does (exclusive endless is allowed). A poly receiver holding a user object routes through the object path instead of being reinterpreted as a float.

**Nil-safe operators.** `<`, `<=`, `>`, `>=`, `==`, `!=`, and `between?` on objects whose `<=>` can return nil route through `sp_poly_cmp_ck` (rb_cmpint semantics: incomparable raises `comparison of X with Y failed`) and `sp_poly_cmp_eq` (`Comparable#==`: identity is equal, nil-`<=>` is false, never an error). An always-Integer `<=>` keeps the zero-cost inline path — the switch is type-driven. `between?` on objects now infers boolean.

**Poly-array `minmax`** (no block) via the same comparator; empty arrays yield `[nil, nil]`. `min(n)`/`max(n)` and `Array#<=>` of object arrays already routed through it and are pinned by tests.

**Typed object arrays.** The narrowing pass admits no-block `sort`/`sort!`/`min`/`max` when the element class has `<=>`, and — for sort — only when the result lands in a modeled consumer (statement position or a slot alias). An escaping result (`arr.sort.length`) keeps the boxed poly path, so existing programs cannot regress into rejects. The runtime family (`sp_PtrArray_sort_obj`/`_bang`, `sp_PtrArray_minmax_obj`) boxes elements with the statically-known `cls_id` and reuses the PolyArray comparator machinery.

**Documented divergence** (docs/limitations.md): spinel keys the Comparable operators on `<=>` presence, where CRuby also requires `include Comparable`; plus the cmperr special-const inspect form, `sort_by`'s stable incomparable keys, and identity-based `include?`/`index`.

Tests cover sort/min/max/minmax through method params, clamp bounds and range forms on object/int/poly receivers, operator and `between?` raises with a runtime-nil `<=>`, `==`/`!=` never raising, and typed object-array sort/sort!/min/max with the escape and no-`<=>` fallbacks — exact CRuby classes and messages throughout. Full suite green; new tests verified under ASAN+UBSAN with GC stress.

**GC-root safety across exception unwinding.** A `raise` unwinds via `longjmp`, which skips the `__attribute__((cleanup))` pops of `SP_GC_ROOT` locals in the unwound frames, leaving stale entries on the root stack that a later allocation in the handler could mark. Every exception / `catch` / `Kernel#loop` / `Mutex#synchronize` landing now restores the GC-root watermark saved at the start of its protected region before the handler body runs. This is what makes the new no-block object-comparator sort — which raises on incomparable elements — clean under ASAN+UBSAN with GC stress.