### PR TITLE
runtime: fix out-of-bounds read inspecting a Symbol via sp_sym_inspect_name

### DIFF
--- a/lib/sp_str.c
+++ b/lib/sp_str.c
@@ -75,8 +75,18 @@ mrb_bool sp_sym_simple_p(const char *n) {
   return FALSE;
 }
 const char *sp_sym_inspect_name(const char *name) {
-  if (sp_sym_simple_p(name)) return sp_str_concat(":", name);
-  return sp_str_concat(":", sp_str_inspect(name));
+  /* Build ":" + body directly rather than sp_str_concat(":", body): a bare
+     literal like ":" has no length-marker byte, so sp_str_byte_len would read
+     one byte before it (out of bounds of the .rodata constant). `body` is a
+     real spinel string (the symbol's name, or its inspected form), so measuring
+     it is safe. */
+  const char *body = sp_sym_simple_p(name) ? name : sp_str_inspect(name);
+  SP_GC_ROOT(body);   /* the non-simple branch just allocated body; keep it live across sp_str_alloc's GC */
+  size_t bl = sp_str_byte_len(body);
+  char *r = sp_str_alloc(1 + bl);
+  r[0] = ':';
+  memcpy(r + 1, body, bl);
+  return r;
 }
 /* A symbol hash key in the `key: value` short form: a simple name is bare, a
    name needing quotes is string-quoted (`"k space": ...`) -- no leading colon. */


### PR DESCRIPTION
`Symbol#inspect` built its `:name` result with `sp_str_concat(":", name)`, passing the bare string literal `":"`. `sp_str_concat` measures each operand with `sp_str_byte_len`, which reads the length-marker byte at `s[-1]` — valid for a spinel-managed string (allocated with a `0xfe`/`0xfc`/`0xfd` marker, or an `SPL(...)` `\xff`-prefixed constant) but out of bounds for a bare `.rodata` literal, which has no marker.

In practice the byte preceding the literal is readable and not a marker, so `sp_str_byte_len` falls through to `strlen` and the result is correct — but it is an out-of-bounds read (ASAN reports a global-buffer-overflow) and would misbehave outright if that adjacent byte ever happened to be a marker value.

Build the `:`-prefixed result directly instead: the symbol's name (or its inspected form for a non-simple symbol) is a real spinel string, so measuring *that* is safe, and the leading `:` is written without measuring a literal.

Surfaced while inspecting an external `Enumerator#next` value that yields a symbol. Full suite green; verified clean under ASAN+UBSAN with GC stress.