### PR TITLE
runtime: give PolyPolyHash Hash.new(default) support

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -3236,12 +3236,15 @@ static mrb_bool sp_rbval_eql_key(sp_RbVal a, sp_RbVal b) {
   }
   return FALSE;
 }
-typedef struct sp_PolyPolyHash{sp_RbVal*keys;sp_RbVal*vals;mrb_int*order;mrb_bool*occ;mrb_int len;mrb_int cap;mrb_int mask;}sp_PolyPolyHash;
+typedef struct sp_PolyPolyHash{sp_RbVal*keys;sp_RbVal*vals;mrb_int*order;mrb_bool*occ;mrb_int len;mrb_int cap;mrb_int mask;sp_RbVal default_v;}sp_PolyPolyHash;
 static void sp_PolyPolyHash_fin(void*p){sp_PolyPolyHash*h=(sp_PolyPolyHash*)p;free(h->keys);free(h->vals);free(h->order);free(h->occ);}
-static void sp_PolyPolyHash_scan(void*p){sp_PolyPolyHash*h=(sp_PolyPolyHash*)p;for(mrb_int i=0;i<h->cap;i++){if(h->occ[i]){sp_mark_rbval(h->keys[i]);sp_mark_rbval(h->vals[i]);}}}
-static sp_PolyPolyHash*sp_PolyPolyHash_new(void){sp_PolyPolyHash*h=(sp_PolyPolyHash*)sp_gc_alloc(sizeof(sp_PolyPolyHash),sp_PolyPolyHash_fin,sp_PolyPolyHash_scan);h->cap=16;h->mask=15;h->keys=(sp_RbVal*)calloc(h->cap,sizeof(sp_RbVal));h->vals=(sp_RbVal*)calloc(h->cap,sizeof(sp_RbVal));h->order=(mrb_int*)malloc(sizeof(mrb_int)*h->cap);h->occ=(mrb_bool*)calloc(h->cap,sizeof(mrb_bool));h->len=0;return h;}
+static void sp_PolyPolyHash_scan(void*p){sp_PolyPolyHash*h=(sp_PolyPolyHash*)p;for(mrb_int i=0;i<h->cap;i++){if(h->occ[i]){sp_mark_rbval(h->keys[i]);sp_mark_rbval(h->vals[i]);}}sp_mark_rbval(h->default_v);}
+static sp_PolyPolyHash*sp_PolyPolyHash_new(void){sp_PolyPolyHash*h=(sp_PolyPolyHash*)sp_gc_alloc(sizeof(sp_PolyPolyHash),sp_PolyPolyHash_fin,sp_PolyPolyHash_scan);h->cap=16;h->mask=15;h->keys=(sp_RbVal*)calloc(h->cap,sizeof(sp_RbVal));h->vals=(sp_RbVal*)calloc(h->cap,sizeof(sp_RbVal));h->order=(mrb_int*)malloc(sizeof(mrb_int)*h->cap);h->occ=(mrb_bool*)calloc(h->cap,sizeof(mrb_bool));h->len=0;h->default_v=sp_box_nil();return h;}
+static sp_PolyPolyHash*sp_PolyPolyHash_new_with_default(sp_RbVal d){sp_PolyPolyHash*h=sp_PolyPolyHash_new();h->default_v=d;return h;}
 static void sp_PolyPolyHash_grow(sp_PolyPolyHash*h){sp_RbVal*ok=h->keys;sp_RbVal*ov=h->vals;mrb_bool*oo=h->occ;mrb_int*oord=h->order;mrb_int olen=h->len;h->cap*=2;h->mask=h->cap-1;h->keys=(sp_RbVal*)calloc(h->cap,sizeof(sp_RbVal));h->vals=(sp_RbVal*)calloc(h->cap,sizeof(sp_RbVal));h->order=(mrb_int*)malloc(sizeof(mrb_int)*h->cap);h->occ=(mrb_bool*)calloc(h->cap,sizeof(mrb_bool));for(mrb_int i=0;i<olen;i++){mrb_int oi=oord[i];sp_RbVal k=ok[oi];mrb_int idx=(mrb_int)(sp_rbval_hash_key(k)&h->mask);while(h->occ[idx])idx=(idx+1)&h->mask;h->keys[idx]=k;h->vals[idx]=ov[oi];h->occ[idx]=TRUE;h->order[i]=idx;}free(ok);free(ov);free(oo);free(oord);}
-static sp_RbVal sp_PolyPolyHash_get(sp_PolyPolyHash*h,sp_RbVal k){if(!h)return sp_box_nil();mrb_int idx=(mrb_int)(sp_rbval_hash_key(k)&h->mask);while(h->occ[idx]){if(sp_rbval_eql_key(h->keys[idx],k))return h->vals[idx];idx=(idx+1)&h->mask;}return sp_box_nil();}
+/* Miss path returns default_v, which is nil unless set via Hash.new(d) /
+   Hash#default= -- so plain {} hashes keep surfacing Ruby nil (#801). */
+static sp_RbVal sp_PolyPolyHash_get(sp_PolyPolyHash*h,sp_RbVal k){if(!h)return sp_box_nil();mrb_int idx=(mrb_int)(sp_rbval_hash_key(k)&h->mask);while(h->occ[idx]){if(sp_rbval_eql_key(h->keys[idx],k))return h->vals[idx];idx=(idx+1)&h->mask;}return h->default_v;}
 static sp_RbVal sp_poly_get_sym(sp_RbVal v, sp_sym key) {
   if (v.tag != SP_TAG_OBJ) return sp_box_nil();
   switch (v.cls_id) {
@@ -3252,8 +3255,8 @@ static sp_RbVal sp_poly_get_sym(sp_RbVal v, sp_sym key) {
 }
 static void sp_PolyPolyHash_set(sp_PolyPolyHash*h,sp_RbVal k,sp_RbVal v){if(h->len*2>=h->cap)sp_PolyPolyHash_grow(h);mrb_int idx=(mrb_int)(sp_rbval_hash_key(k)&h->mask);while(h->occ[idx]){if(sp_rbval_eql_key(h->keys[idx],k)){h->vals[idx]=v;return;}idx=(idx+1)&h->mask;}h->keys[idx]=k;h->vals[idx]=v;h->occ[idx]=TRUE;h->order[h->len]=idx;h->len++;}
 /* order[] holds slot indices (not keys), so iterate keys/vals by the stored
-   index; this variant has no default_v. */
-static sp_PolyPolyHash*sp_PolyPolyHash_merge(sp_PolyPolyHash*a,sp_PolyPolyHash*b){sp_PolyPolyHash*r=sp_PolyPolyHash_new();if(a){for(mrb_int i=0;i<a->len;i++){mrb_int idx=a->order[i];sp_PolyPolyHash_set(r,a->keys[idx],a->vals[idx]);}}if(b){for(mrb_int i=0;i<b->len;i++){mrb_int idx=b->order[i];sp_PolyPolyHash_set(r,b->keys[idx],b->vals[idx]);}}return r;}
+   index; merge inherits the LEFT receiver's default per CRuby. */
+static sp_PolyPolyHash*sp_PolyPolyHash_merge(sp_PolyPolyHash*a,sp_PolyPolyHash*b){sp_PolyPolyHash*r=sp_PolyPolyHash_new();if(a){r->default_v=a->default_v;for(mrb_int i=0;i<a->len;i++){mrb_int idx=a->order[i];sp_PolyPolyHash_set(r,a->keys[idx],a->vals[idx]);}}if(b){for(mrb_int i=0;i<b->len;i++){mrb_int idx=b->order[i];sp_PolyPolyHash_set(r,b->keys[idx],b->vals[idx]);}}return r;}
 static mrb_bool sp_PolyPolyHash_has_key(sp_PolyPolyHash*h,sp_RbVal k){mrb_int idx=(mrb_int)(sp_rbval_hash_key(k)&h->mask);while(h->occ[idx]){if(sp_rbval_eql_key(h->keys[idx],k))return TRUE;idx=(idx+1)&h->mask;}return FALSE;}
 static mrb_int sp_PolyPolyHash_length(sp_PolyPolyHash*h){return h->len;}
 static void sp_PolyPolyHash_clear(sp_PolyPolyHash*h){if(!h)return;for(mrb_int i=0;i<h->cap;i++)h->occ[i]=0;h->len=0;}
@@ -3665,7 +3668,7 @@ static sp_PolyArray *sp_poly_values(sp_RbVal v) {
   sp_raise_cls("NoMethodError", "undefined method 'values'");
   return NULL;  /* unreachable: sp_raise_cls is noreturn */
 }
-static sp_PolyPolyHash*sp_PolyPolyHash_dup(sp_PolyPolyHash*h){sp_PolyPolyHash*r=sp_PolyPolyHash_new();for(mrb_int i=0;i<h->len;i++)sp_PolyPolyHash_set(r,h->keys[h->order[i]],h->vals[h->order[i]]);return r;}
+static sp_PolyPolyHash*sp_PolyPolyHash_dup(sp_PolyPolyHash*h){sp_PolyPolyHash*r=sp_PolyPolyHash_new();r->default_v=h->default_v;for(mrb_int i=0;i<h->len;i++)sp_PolyPolyHash_set(r,h->keys[h->order[i]],h->vals[h->order[i]]);return r;}
 /* Issue #738: poly_poly_hash inspect using sp_poly_inspect on each
    k,v. Output mirrors Ruby's `{k => v, ...}` for non-symbol keys and
    `{k: v, ...}` shorthand for symbol keys. */

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -586,7 +586,8 @@ void emit_assign(Compiler *c, int id, Buf *b, int indent) {
   }
   else if ((is_empty_hash || is_hash_new) && lv && ty_hash_cname(lv->type)) {
     const char *hcn = ty_hash_cname(lv->type);
-    int poly_val = (lv->type == TY_SYM_POLY_HASH || lv->type == TY_STR_POLY_HASH);
+    int poly_val = (lv->type == TY_SYM_POLY_HASH || lv->type == TY_STR_POLY_HASH ||
+                    lv->type == TY_POLY_POLY_HASH);
     if (is_hash_new && hash_new_default >= 0) {
       buf_printf(b, "sp_%sHash_new_with_default(", hcn);
       if (poly_val) emit_boxed(c, hash_new_default, b); else emit_expr(c, hash_new_default, b);

--- a/test/bundle_hash_b2.rb
+++ b/test/bundle_hash_b2.rb
@@ -7,8 +7,8 @@ def t_hash_new_default_value
   # `Hash.new(default_value)` per-instance default support.
   #
   # Each hash variant struct (StrIntHash / StrStrHash / IntStrHash /
-  # SymIntHash / SymStrHash / StrPolyHash / SymPolyHash) gains a
-  # `default_v` field. `_new` initializes it to the variant's
+  # SymIntHash / SymStrHash / StrPolyHash / SymPolyHash / PolyPolyHash)
+  # gains a `default_v` field. `_new` initializes it to the variant's
   # sentinel zero (so legacy `{}` literals unchanged); `_new_with_default`
   # is a new constructor that sets the field. `_get` returns
   # `default_v` on miss; `_dup` / `_merge` propagate (merge inherits
@@ -66,6 +66,23 @@ def t_hash_new_default_value
   counter["x"] = counter["x"] + 1
   puts counter["x"]       # 1
   puts counter["z"]       # 0
+
+  # Float default with int keys -- lands on the PolyPoly variant, which
+  # previously had no default_v / _new_with_default at all, so
+  # `Hash.new(0.0)` emitted `sp_PolyPolyHash_new_with_default(0.0)` and
+  # failed C compilation (int-to-pointer conversion).
+  f = Hash.new(0.0)
+  f[1] += 2.5
+  p f[1]                  # 2.5
+  p f[7]                  # 0.0 (default for a missing key)
+  p f.default             # 0.0
+  f.default = 1.5
+  p f[9]                  # 1.5
+  fd = f.dup
+  p fd[42]                # 1.5 (dup propagates default)
+  fm = f.merge({2 => 3.5})
+  p fm[2]                 # 3.5
+  p fm[99]                # 1.5 (merge inherits left default)
 end
 t_hash_new_default_value
 


### PR DESCRIPTION
Fixes #1673.

## Summary

`Hash.new(0.0)` failed to compile:

```
error: incompatible integer to pointer conversion assigning to 'sp_PolyPolyHash *'
       from 'int'  ...  lv_h = sp_PolyPolyHash_new_with_default(0.0);
```

**Root cause:** an int-keyed, float-valued hash has no dedicated typed variant, so the analyzer selects `sp_PolyPolyHash` — the only hash variant that never received `Hash.new(default)` support. It had no `default_v` field and no `_new_with_default` constructor, so codegen emitted a call to a function that does not exist (the "int to pointer" error is C's implicit-declaration rule at work). The construction site in `codegen_stmt.c` also didn't box the default for this variant, so even with the constructor present it would have passed a raw `double` where an `sp_RbVal` is expected.

## Changes

- `lib/sp_runtime.h`:
  - `sp_PolyPolyHash` gains a `default_v` field, nil-initialized in `_new` and marked by the GC scan.
  - New `sp_PolyPolyHash_new_with_default(sp_RbVal d)` constructor.
  - `_get` returns `default_v` on a missing key (still nil for `{}` hashes, preserving #801 semantics).
  - `_dup` copies the default; `_merge` inherits the LEFT receiver's default, per CRuby and matching the other variants.
- `src/codegen_stmt.c`: `TY_POLY_POLY_HASH` joins the poly-valued variants (`SymPoly`/`StrPoly`) so the `Hash.new` default argument is boxed at the construction site.
- `test/bundle_hash_b2.rb`: extended the existing `hash_new_default_value` test with the Float-default scenario, covering `[]` miss/hit, `default` / `default=`, and `dup` / `merge` default propagation. Output verified against CRuby.

## Test plan

- [x] Repro from #1673 now compiles and prints `2.5` / `0.0`, matching CRuby.
- [x] Extended repro (`default`, `default=`, `dup`, `merge`, `length`, `key?`) byte-identical to CRuby output.
- [x] `make test`: 1208 pass. The 5 failures on my machine (`array_pattern_match_basic`, `bundle_array_f`, `bundle_classd_49`, `dir_methods`, `string_slice_range`) also fail on the unmodified baseline — they have no `.rb.expected` snapshot and my system Ruby is too old to serve as the oracle for them.

Made with [Cursor](https://cursor.com)