### PR TITLE
parse,codegen: fresh block-locals on every block invocation

### DIFF
--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -2184,6 +2184,9 @@ int emit_each_with_index_terminal(Compiler *c, int id, Buf *b) {
 
   int body = block >= 0 ? nt_ref(nt, block, "body") : -1;
   int bn = 0; const int *bb = body >= 0 ? nt_arr(nt, body, "body", &bn) : NULL;
+  /* fresh block-locals per iteration (this emitter walks the body itself
+     instead of going through emit_stmts, so reset explicitly) */
+  if (block >= 0) emit_block_locals_reset(c, block, g_pre, din);
   if (is_each) {
     for (int j = 0; j < bn; j++) emit_stmt(c, bb[j], g_pre, din);
   }
@@ -2605,6 +2608,8 @@ static void emit_block_value_into(Compiler *c, int block, const char *dest,
      value). Bodies without a next still run once -- the wrapper is free. */
   emit_indent(g_pre, indent); buf_puts(g_pre, "do {\n");
   int bi = indent + 1; g_indent = bi;
+  /* fresh block-locals on every invocation (this path bypasses emit_stmts) */
+  emit_block_locals_reset(c, block, g_pre, bi);
   for (int j = 0; j + 1 < bn; j++) emit_stmt(c, bb[j], g_pre, bi);
   if (bn > 0) {
     int tail = bb[bn - 1];

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -342,6 +342,7 @@ int emit_regex_pat_to_buf(Compiler *c, int nid, Buf *b);
 int nameset_has(NameSet *s, const char *nm);
 void nameset_add(NameSet *s, const char *nm);
 void emit_local_ref(Compiler *c, int scope_node, const char *name, Buf *b);
+void emit_block_locals_reset(Compiler *c, int blk, Buf *b, int indent);
 void emit_yblk_ref(Buf *b);
 void emit_tail_lead(Buf *b);
 const char *rename_local(const char *nm);

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -4882,6 +4882,32 @@ void emit_stmt_tail_inner(Compiler *c, int id, Buf *b, int indent) {
 }
 
 void emit_stmts(Compiler *c, int id, Buf *b, int indent) {
+  /* Ruby block-locals are FRESH on every block invocation. Find the
+     BlockNode whose body this is (memoized linear scan) and reset its
+     non-param locals at the top of each iteration -- without this a name
+     first assigned inside the block kept the previous iteration's value
+     (doom's render_sprites `sprite ||= ...` reused the first sprite for
+     every object on screen). */
+  {
+    static const NodeTable *blk_map_nt = NULL;
+    static int *blk_map = NULL;
+    if (blk_map_nt != c->nt) {
+      free(blk_map);
+      blk_map = malloc(sizeof(int) * (size_t)c->nt->count);
+      for (int i2 = 0; i2 < c->nt->count; i2++) blk_map[i2] = -1;
+      for (int i2 = 0; i2 < c->nt->count; i2++) {
+        const char *t2 = nt_type(c->nt, i2);
+        if (t2 && sp_streq(t2, "BlockNode")) {
+          int b2 = nt_ref(c->nt, i2, "body");
+          if (b2 >= 0 && b2 < c->nt->count) blk_map[b2] = i2;
+        }
+      }
+      blk_map_nt = c->nt;
+    }
+    if (id >= 0 && id < c->nt->count && blk_map[id] >= 0)
+      emit_block_locals_reset(c, blk_map[id], b, indent);
+  }
+
   if (id < 0) return;
   const NodeTable *nt = c->nt;
   const char *ty = nt_type(nt, id);

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -4883,29 +4883,26 @@ void emit_stmt_tail_inner(Compiler *c, int id, Buf *b, int indent) {
 
 void emit_stmts(Compiler *c, int id, Buf *b, int indent) {
   /* Ruby block-locals are FRESH on every block invocation. Find the
-     BlockNode whose body this is (memoized linear scan) and reset its
-     non-param locals at the top of each iteration -- without this a name
-     first assigned inside the block kept the previous iteration's value
-     (doom's render_sprites `sprite ||= ...` reused the first sprite for
-     every object on screen). */
+     BlockNode whose body this is (map built lazily on the compiler, so it
+     dies with it -- no static state to go stale across node tables) and
+     reset its non-param locals at the top of each iteration -- without
+     this a name first assigned inside the block kept the previous
+     iteration's value (doom's render_sprites `sprite ||= ...` reused the
+     first sprite for every object on screen). */
   {
-    static const NodeTable *blk_map_nt = NULL;
-    static int *blk_map = NULL;
-    if (blk_map_nt != c->nt) {
-      free(blk_map);
-      blk_map = malloc(sizeof(int) * (size_t)c->nt->count);
-      for (int i2 = 0; i2 < c->nt->count; i2++) blk_map[i2] = -1;
+    if (!c->blk_body_map) {
+      c->blk_body_map = malloc(sizeof(int) * (size_t)c->nt->count);
+      for (int i2 = 0; i2 < c->nt->count; i2++) c->blk_body_map[i2] = -1;
       for (int i2 = 0; i2 < c->nt->count; i2++) {
         const char *t2 = nt_type(c->nt, i2);
         if (t2 && sp_streq(t2, "BlockNode")) {
           int b2 = nt_ref(c->nt, i2, "body");
-          if (b2 >= 0 && b2 < c->nt->count) blk_map[b2] = i2;
+          if (b2 >= 0 && b2 < c->nt->count) c->blk_body_map[b2] = i2;
         }
       }
-      blk_map_nt = c->nt;
     }
-    if (id >= 0 && id < c->nt->count && blk_map[id] >= 0)
-      emit_block_locals_reset(c, blk_map[id], b, indent);
+    if (id >= 0 && id < c->nt->count && c->blk_body_map[id] >= 0)
+      emit_block_locals_reset(c, c->blk_body_map[id], b, indent);
   }
 
   if (id < 0) return;

--- a/src/codegen_util.c
+++ b/src/codegen_util.c
@@ -376,12 +376,16 @@ void emit_block_locals_reset(Compiler *c, int blk, Buf *b, int indent) {
   if (blk < 0) return;
   const char *locs = nt_str(c->nt, blk, "locals");
   if (!locs || !*locs) return;
-  char tmpn[128];
+  char tmpn_buf[128];
   const char *p = locs;
   while (*p) {
     const char *e = strchr(p, ',');
     size_t l = e ? (size_t)(e - p) : strlen(p);
-    if (l && l < sizeof tmpn) {
+    if (l) {
+      /* names longer than the stack buffer are legal Ruby; heap-fall back
+         rather than silently skipping the reset */
+      char *tmpn = l < sizeof tmpn_buf ? tmpn_buf : malloc(l + 1);
+      if (!tmpn) break;
       memcpy(tmpn, p, l); tmpn[l] = 0;
       /* Skip every name bound by the block's parameter list, including
          destructured, optional, rest, and shadow (`; x`) declarations --
@@ -399,6 +403,7 @@ void emit_block_locals_reset(Compiler *c, int blk, Buf *b, int indent) {
           buf_printf(b, "lv_%s = %s;\n", rename_local(tmpn), nv);
         }
       }
+      if (tmpn != tmpn_buf) free(tmpn);
     }
     if (!e) break;
     p = e + 1;

--- a/src/codegen_util.c
+++ b/src/codegen_util.c
@@ -326,6 +326,85 @@ void emit_tail_lead(Buf *b) {
   if (g_result_var) buf_printf(b, "%s = ", g_result_var);
   else buf_puts(b, "return ");
 }
+/* The C representation of Ruby `nil` for a concretely-typed slot (vs
+   default_value's zero-value): a fresh block-local starts nil, and several
+   types carry an in-band nil sentinel (NULL string, SP_INT_NIL, NaN float,
+   (sp_sym)-1). Types with no sentinel fall back to the zero value. */
+static const char *nil_value(TyKind t) {
+  switch (t) {
+    case TY_STRING: return "NULL";
+    case TY_INT:    return "SP_INT_NIL";
+    case TY_FLOAT:  return "sp_float_nil()";
+    case TY_POLY:   return "sp_box_nil()";
+    default:        return NULL;
+  }
+}
+
+static int subtree_has_param_named(const NodeTable *nt, int id, const char *nm) {
+  if (id < 0) return 0;
+  const char *ty = nt_type(nt, id);
+
+  /* numbered params (_1.._9): the NumberedParametersNode carries no child
+     parameter nodes, yet the block's locals list contains the names. */
+  if (ty && sp_streq(ty, "NumberedParametersNode") &&
+      nm[0] == '_' && nm[1] >= '1' && nm[1] <= '9' && !nm[2]) return 1;
+  if (ty && sp_streq(ty, "ItParametersNode") && sp_streq(nm, "it")) return 1;
+  if (ty && (strstr(ty, "ParameterNode") || sp_streq(ty, "LocalVariableTargetNode"))) {
+    const char *pn = nt_str(nt, id, "name");
+    /* shadow-renaming rewrites a param's node-table name to NAME__bpNN;
+       the parser's locals list keeps the raw NAME -- match both. */
+    if (pn) {
+      size_t nl = strlen(nm);
+      if (sp_streq(pn, nm)) return 1;
+      if (!strncmp(pn, nm, nl) && !strncmp(pn + nl, "__bp", 4)) return 1;
+    }
+  }
+  int nr = nt_num_refs(nt, id);
+  for (int i = 0; i < nr; i++)
+    if (subtree_has_param_named(nt, nt_ref_at(nt, id, i), nm)) return 1;
+  int na = nt_num_arrs(nt, id);
+  for (int i = 0; i < na; i++) {
+    int n = 0;
+    const int *ids = nt_arr_at(nt, id, i, &n);
+    for (int j = 0; j < n; j++)
+      if (subtree_has_param_named(nt, ids[j], nm)) return 1;
+  }
+  return 0;
+}
+
+void emit_block_locals_reset(Compiler *c, int blk, Buf *b, int indent) {
+  if (blk < 0) return;
+  const char *locs = nt_str(c->nt, blk, "locals");
+  if (!locs || !*locs) return;
+  char tmpn[128];
+  const char *p = locs;
+  while (*p) {
+    const char *e = strchr(p, ',');
+    size_t l = e ? (size_t)(e - p) : strlen(p);
+    if (l && l < sizeof tmpn) {
+      memcpy(tmpn, p, l); tmpn[l] = 0;
+      /* Skip every name bound by the block's parameter list, including
+         destructured, optional, rest, and shadow (`; x`) declarations --
+         collected straight from the parameters subtree, since
+         block_param_name only covers plain leading params. */
+      int is_param = subtree_has_param_named(c->nt, nt_ref(c->nt, blk, "parameters"), tmpn);
+
+      if (!is_param) {
+        Scope *sc = comp_scope_of(c, blk);
+        LocalVar *lv = sc ? scope_local(sc, tmpn) : NULL;
+        if (lv && lv->type != TY_UNKNOWN && !lv->is_cell) {
+          const char *nv = nil_value(lv->type);
+          if (!nv) nv = lv->type == TY_RANGE ? "(sp_Range){0}" : default_value(lv->type);
+          emit_indent(b, indent);
+          buf_printf(b, "lv_%s = %s;\n", rename_local(tmpn), nv);
+        }
+      }
+    }
+    if (!e) break;
+    p = e + 1;
+  }
+}
+
 const char *rename_local(const char *nm) {
   for (int i = 0; i < g_nren; i++)
     if (sp_streq(g_ren_from[i], nm)) return g_ren_to[i];

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -30,6 +30,8 @@ void comp_grow_node_arrays(Compiler *c) {
 
 void comp_free(Compiler *c) {
   if (!c) return;
+  free(c->blk_body_map);
+  c->blk_body_map = NULL;
   for (int s = 0; s < c->nscopes; s++) {
     Scope *sc = &c->scopes[s];
     free(sc->name);

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -219,6 +219,9 @@ typedef struct {
   /* FFI cflags per module (semicolon-separated) */
   FfiCflag *ffi_cflags;
   int n_ffi_cflags, c_ffi_cflags;
+  /* body-node id -> enclosing BlockNode id (lazy; emit_stmts block-local
+     resets). Sized nt->count; -1 = not a block body. */
+  int *blk_body_map;
 } Compiler;
 
 Compiler *comp_new(const NodeTable *nt);

--- a/src/spinel_parse.c
+++ b/src/spinel_parse.c
@@ -1008,22 +1008,29 @@ else {
        makes non-param locals FRESH on every block invocation; codegen needs
        the list to reset them per iteration in fused loops. */
     if (n->locals.size > 0) {
+      /* join the names in one pass (single cstr per name, no strcat rescans) */
       size_t total = 1;
-      for (size_t li = 0; li < n->locals.size; li++) {
-        char *nm2 = cstr(n->locals.ids[li]);
-        total += strlen(nm2) + 1;
-        free(nm2);
+      char **nms = malloc(n->locals.size * sizeof(char *));
+      if (nms) {
+        for (size_t li = 0; li < n->locals.size; li++) {
+          nms[li] = cstr(n->locals.ids[li]);
+          total += strlen(nms[li]) + 1;
+        }
+        char *joined = malloc(total);
+        if (joined) {
+          char *w = joined;
+          for (size_t li = 0; li < n->locals.size; li++) {
+            if (li) *w++ = ',';
+            size_t nl2 = strlen(nms[li]);
+            memcpy(w, nms[li], nl2); w += nl2;
+          }
+          *w = '\0';
+          out_add("S %d locals %s", id, joined);
+          free(joined);
+        }
+        for (size_t li = 0; li < n->locals.size; li++) free(nms[li]);
+        free(nms);
       }
-      char *joined = malloc(total);
-      joined[0] = '\0';
-      for (size_t li = 0; li < n->locals.size; li++) {
-        char *nm2 = cstr(n->locals.ids[li]);
-        if (li) strcat(joined, ",");
-        strcat(joined, nm2);
-        free(nm2);
-      }
-      out_add("S %d locals %s", id, joined);
-      free(joined);
     }
     /* Serialize block parameters */
     if (n->parameters) {

--- a/src/spinel_parse.c
+++ b/src/spinel_parse.c
@@ -1004,6 +1004,27 @@ else {
   case PM_BLOCK_NODE: {
     pm_block_node_t *n = (pm_block_node_t *)node;
     N("BlockNode");
+    /* Block-local variables (params + first-assigned-inside): Ruby scoping
+       makes non-param locals FRESH on every block invocation; codegen needs
+       the list to reset them per iteration in fused loops. */
+    if (n->locals.size > 0) {
+      size_t total = 1;
+      for (size_t li = 0; li < n->locals.size; li++) {
+        char *nm2 = cstr(n->locals.ids[li]);
+        total += strlen(nm2) + 1;
+        free(nm2);
+      }
+      char *joined = malloc(total);
+      joined[0] = '\0';
+      for (size_t li = 0; li < n->locals.size; li++) {
+        char *nm2 = cstr(n->locals.ids[li]);
+        if (li) strcat(joined, ",");
+        strcat(joined, nm2);
+        free(nm2);
+      }
+      out_add("S %d locals %s", id, joined);
+      free(joined);
+    }
     /* Serialize block parameters */
     if (n->parameters) {
       if (PM_NODE_TYPE(n->parameters) == PM_BLOCK_PARAMETERS_NODE) {

--- a/test/block_local_fresh_per_iteration.rb
+++ b/test/block_local_fresh_per_iteration.rb
@@ -1,0 +1,52 @@
+# Block-local variables are FRESH on every block invocation: a name first
+# assigned inside a block (not captured from the enclosing scope) must not
+# carry its value into the next iteration. The `keep ||=` pattern below
+# relied on that freshness; without the per-iteration reset every element
+# after the first truthy one reused the stale value.
+
+def widen(x); x; end
+
+# --- each_with_index over a poly array, `||=` fallback (the doom shape) ---
+items = widen([1, 60, 2, 70, 3])
+out = []
+items.each_with_index do |v, i|
+  keep = v if v > 50
+  keep ||= "none"
+  out << keep
+end
+p out
+# ["none", 60, "none", 70, "none"]
+
+# --- each over an int array, plain conditional first-assignment ---
+hits = []
+[5, 25, 8, 30].each do |n|
+  big = "big" if n > 20
+  hits << (big ? big : "small")
+end
+p hits
+# ["small", "big", "small", "big"]
+
+# --- times loop, block-local shadowless accumulator probe ---
+3.times do |t|
+  first_time = "yes" if t == 0
+  puts first_time.nil? ? "fresh" : first_time
+end
+# yes
+# fresh
+# fresh
+
+# --- map: block-local must not leak into the next element's value ---
+vals = [10, 1, 20, 2].map do |n|
+  label = "high" if n >= 10
+  label || "low"
+end
+p vals
+# ["high", "low", "high", "low"]
+
+# --- outer local of the same kind is NOT reset (captured, not block-local) ---
+count = 0
+[1, 2, 3].each do |n|
+  count += 1
+end
+puts count
+# 3

--- a/test/block_local_fresh_per_iteration.rb.expected
+++ b/test/block_local_fresh_per_iteration.rb.expected
@@ -1,0 +1,7 @@
+["none", 60, "none", 70, "none"]
+["small", "big", "small", "big"]
+yes
+fresh
+fresh
+["high", "low", "high", "low"]
+3


### PR DESCRIPTION
Part of the effort to run the unmodified Doom gem on spinel.

In Ruby, a variable first assigned inside a block is block-local and starts nil on every invocation. Spinel emitted it as one function-level C local, so it kept its value across loop iterations. Doom's sprite selection does `sprite ||= get_rotated(...)` per visible object, and the leak made every object on screen reuse the first loaded sprite.

What this does:
- the parser serializes each BlockNode's `locals` list (Prism already tracks it),
- codegen resets the non-parameter locals to their nil representation (NULL string, SP_INT_NIL, NaN float, boxed nil) at the top of every block invocation,
- wired into `emit_stmts` plus the two fold paths that walk block bodies directly,
- parameter names are recognized through shadow renames (`name__bpN`), numbered params (`_1`), and `it`.

Adds a regression test covering `||=` fallbacks, conditional first assignment, and map/each/times shapes. Full suite green (1165 pass).