### PR TITLE
codegen: destructure a poly multi-assign RHS at runtime

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -3048,6 +3048,20 @@ static sp_RbVal sp_poly_each_elem(sp_RbVal a, mrb_int i) {
   }
 }
 /* poly_arr_get/set for PolyPolyHash with integer index key. */
+/* multi-assign element read: `a, b = v` destructures only when the boxed
+   value is an Array (Ruby's to_ary semantics); any other runtime kind is a
+   scalar -- the first target takes the whole value, the rest nil-fill.
+   sp_poly_arr_get_hash is NOT that (Integer#[i] reads a bit, String#[i] a
+   char, Hash#[i] a lookup). */
+static sp_RbVal sp_poly_massign_get(sp_RbVal v, mrb_int i) {
+  if (v.tag == SP_TAG_OBJ) switch (v.cls_id) {
+    case SP_BUILTIN_POLY_ARRAY: case SP_BUILTIN_INT_ARRAY: case SP_BUILTIN_SYM_ARRAY:
+    case SP_BUILTIN_STR_ARRAY: case SP_BUILTIN_FLT_ARRAY:
+      return sp_poly_arr_get(v, i);
+    default: break;
+  }
+  return i == 0 ? v : sp_box_nil();
+}
 static sp_RbVal sp_poly_arr_get_hash(sp_RbVal a, mrb_int i) {
   if (a.tag == SP_TAG_INT) return sp_box_int((a.v.i >> i) & 1);
   if (a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_POLY_POLY_HASH)

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -2408,13 +2408,13 @@ void emit_for(Compiler *c, int id, Buf *b, int indent) {
                     scope_local(comp_scope_of(c, idx), lnm)->type : TY_POLY;
         emit_indent(b, indent + 2);
         if (vt == TY_INT || vt == TY_UNKNOWN)
-          buf_printf(b, "lv_%s = sp_unbox_int(sp_poly_arr_get_hash(_t%d, %d));\n", lnm, tv, i);
+          buf_printf(b, "lv_%s = sp_unbox_int(sp_poly_massign_get(_t%d, %d));\n", lnm, tv, i);
         else if (vt == TY_FLOAT)
-          buf_printf(b, "lv_%s = sp_unbox_float(sp_poly_arr_get_hash(_t%d, %d));\n", lnm, tv, i);
+          buf_printf(b, "lv_%s = sp_unbox_float(sp_poly_massign_get(_t%d, %d));\n", lnm, tv, i);
         else if (vt == TY_STRING)
-          buf_printf(b, "lv_%s = sp_unbox_str(sp_poly_arr_get_hash(_t%d, %d));\n", lnm, tv, i);
+          buf_printf(b, "lv_%s = sp_unbox_str(sp_poly_massign_get(_t%d, %d));\n", lnm, tv, i);
         else
-          buf_printf(b, "lv_%s = sp_poly_arr_get_hash(_t%d, %d);\n", lnm, tv, i);
+          buf_printf(b, "lv_%s = sp_poly_massign_get(_t%d, %d);\n", lnm, tv, i);
       }
       emit_loop_body(c, body, b, indent + 2);
       emit_indent(b, indent + 1); buf_puts(b, "}\n");
@@ -4255,7 +4255,7 @@ else {
           if (sp_streq(lty, "LocalVariableTargetNode")) {
             const char *lnm = nt_str(nt, lefts[i], "name");
             emit_indent(b, indent);
-            buf_printf(b, "lv_%s = sp_poly_arr_get_hash(_t%d, %dLL);\n", lnm, tarr, i);
+            buf_printf(b, "lv_%s = sp_poly_massign_get(_t%d, %dLL);\n", lnm, tarr, i);
           }
           else if (sp_streq(lty, "InstanceVariableTargetNode") &&
                    rt_scope_p && rt_scope_p->class_id >= 0) {
@@ -4265,7 +4265,7 @@ else {
             if (iv_rt < 0) continue;
             TyKind ivt = c->classes[rt_scope_p->class_id].ivar_types[iv_rt];
             emit_indent(b, indent);
-            char get_expr[64]; snprintf(get_expr, sizeof get_expr, "sp_poly_arr_get_hash(_t%d, %dLL)", tarr, i);
+            char get_expr[64]; snprintf(get_expr, sizeof get_expr, "sp_poly_massign_get(_t%d, %dLL)", tarr, i);
             if (rt_scope_p->is_cmethod)
               buf_printf(b, "civ_%s_%s = ", c->classes[rt_scope_p->class_id].name, ivnm + 1);
             else

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -4065,7 +4065,11 @@ else {
       TyKind st = comp_ntype(c, value);
       int multi_src = vty && (sp_streq(vty, "CallNode") || sp_streq(vty, "SuperNode") ||
                               sp_streq(vty, "ForwardingSuperNode") || sp_streq(vty, "YieldNode"));
-      if (vty && !multi_src && !ty_is_array(st) && !ty_is_hash(st) && st != TY_UNKNOWN) {
+      /* a TY_POLY value can hold an array at runtime (doom's
+         `lump_name, mirrored = @sprite_index[key]` read through a local),
+         so it must take the runtime-destructure path below, not the
+         scalar fill -- which handed the whole array to the first target. */
+      if (vty && !multi_src && !ty_is_array(st) && !ty_is_hash(st) && st != TY_UNKNOWN && st != TY_POLY) {
         for (int i = 0; i < ln; i++) {
           const char *lty = nt_type(nt, lefts[i]);
           if (!lty || !sp_streq(lty, "LocalVariableTargetNode")) continue;

--- a/test/multi_assign_poly_rhs.rb
+++ b/test/multi_assign_poly_rhs.rb
@@ -28,3 +28,18 @@ puts c.nil?
 # 1
 # 2
 # true
+
+# a poly SCALAR RHS keeps Ruby semantics: first target takes the whole
+# value, the rest nil-fill (no Integer#[] bit reads / String#[] chars)
+x = widen(42)
+a2, b2 = x
+puts a2
+puts b2.nil?
+s2 = widen("hi")
+c2, d2 = s2
+puts c2
+puts d2.nil?
+h2 = widen({ k: 1 })
+e2, f2 = h2
+puts e2 == h2
+puts f2.nil?

--- a/test/multi_assign_poly_rhs.rb
+++ b/test/multi_assign_poly_rhs.rb
@@ -1,0 +1,30 @@
+# Multi-assign with a TY_POLY right-hand side: the boxed value can hold an
+# array at runtime, so it must be destructured element-by-element. The
+# scalar fast path used to hand the whole array to the first target and
+# nil-fill the rest.
+
+def widen(x); x; end
+
+pair = widen(["TROOA1", true])
+name, mirrored = pair
+puts name
+puts mirrored
+# TROOA1
+# true
+
+# through a poly hash read (the doom sprite-index shape)
+index = widen({ "k" => ["POSSB2", false] })
+lump, mir = index["k"]
+puts lump
+puts mir.inspect
+# POSSB2
+# false
+
+# more targets than elements: trailing targets nil-fill
+a, b, c = widen([1, 2])
+puts a
+puts b
+puts c.nil?
+# 1
+# 2
+# true

--- a/test/multi_assign_poly_rhs.rb.expected
+++ b/test/multi_assign_poly_rhs.rb.expected
@@ -5,3 +5,9 @@ false
 1
 2
 true
+42
+true
+hi
+true
+true
+true

--- a/test/multi_assign_poly_rhs.rb.expected
+++ b/test/multi_assign_poly_rhs.rb.expected
@@ -1,0 +1,7 @@
+TROOA1
+true
+POSSB2
+false
+1
+2
+true


### PR DESCRIPTION
Part of the effort to run the unmodified Doom gem on spinel.

`lump_name, mirrored = @sprite_index[key]` reads the pair through a poly-typed value. The scalar fast path in multi-assign saw a non-array static type and handed the whole boxed array to the first target, nil-filling the rest, so Doom's sprite index lookups returned garbage.

A TY_POLY value can hold an array at runtime, so it now takes the runtime destructure path (element-by-element with nil-fill for surplus targets). Test covers a poly array pair, a poly hash read, and surplus targets. Full suite green (1165 pass).