### PR TITLE
codegen: honor the nil sentinel in symbol truthiness

### DIFF
--- a/lib/sp_alloc.h
+++ b/lib/sp_alloc.h
@@ -251,7 +251,7 @@ static inline sp_RbVal sp_box_float(mrb_float v){ sp_RbVal r; r.tag = SP_TAG_FLT
 static inline sp_RbVal sp_box_bool(mrb_bool v)  { sp_RbVal r; r.tag = SP_TAG_BOOL; r.cls_id = 0; r.v.b = v; return r; }
 static inline sp_RbVal sp_box_nil(void)         { sp_RbVal r; r.tag = SP_TAG_NIL;  r.cls_id = 0; r.v.i = 0; return r; }
 static inline sp_RbVal sp_box_obj(void *p, int cls_id) { sp_RbVal r; r.tag = SP_TAG_OBJ; r.cls_id = cls_id; r.v.p = p; return r; }
-static inline sp_RbVal sp_box_sym(sp_sym v)     { sp_RbVal r; r.tag = SP_TAG_SYM;  r.cls_id = 0; r.v.i = (mrb_int)v; return r; }
+static inline sp_RbVal sp_box_sym(sp_sym v)     { if (v == (sp_sym)-1) { sp_RbVal n; n.tag = SP_TAG_NIL; n.cls_id = 0; n.v.i = 0; return n; } sp_RbVal r; r.tag = SP_TAG_SYM;  r.cls_id = 0; r.v.i = (mrb_int)v; return r; }  /* (sp_sym)-1 is the nilable-symbol sentinel: box it as nil, never as :"" */
 static inline sp_RbVal sp_box_poly_array(void *p) { return sp_box_obj(p, SP_BUILTIN_POLY_ARRAY); }
 
 /* GC object allocator. The threshold/stress state is extern (defined in

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -831,7 +831,7 @@ static inline mrb_int sp_int_clamp_range_ck(mrb_int v, sp_Range r) {
 }
 /* `:name`, or `:"name"` when the name needs quoting -- shares the
    name-string predicates in lib/sp_str.c with the hash-key short form. */
-static const char *sp_sym_inspect(sp_sym id) { return sp_sym_inspect_name(sp_sym_to_s(id)); }
+static const char *sp_sym_inspect(sp_sym id) { if (id == (sp_sym)-1) return "nil"; /* nilable-symbol sentinel */ return sp_sym_inspect_name(sp_sym_to_s(id)); }
 static const char*sp_gets(void){char buf[4096];if(!fgets(buf,sizeof(buf),stdin))return NULL;size_t l=strlen(buf);char*r=sp_str_alloc_raw(l+1);memcpy(r,buf,l+1);return r;}
 static sp_StrArray*sp_readlines(void){sp_StrArray*a=sp_StrArray_new();char buf[4096];while(fgets(buf,sizeof(buf),stdin)){size_t l=strlen(buf);char*r=sp_str_alloc_raw(l+1);memcpy(r,buf,l+1);sp_StrArray_push(a,r);}return a;}
 const char*sp_sprintf(const char*fmt,...){char _sp_tmp[4096];va_list ap;va_start(ap,fmt);int _sp_n=vsnprintf(_sp_tmp,sizeof(_sp_tmp),fmt,ap);va_end(ap);if(_sp_n<0)_sp_n=0;char*b=sp_str_alloc((size_t)_sp_n);if(_sp_n<(int)sizeof(_sp_tmp)){memcpy(b,_sp_tmp,(size_t)_sp_n);}else{/* result didn't fit the stack temp; re-render at full width (sp_str_alloc gives _sp_n bytes + NUL) so long string interpolations aren't truncated. re-arm the va_list rather than va_copy so the common fast path pays nothing */va_start(ap,fmt);vsnprintf(b,(size_t)_sp_n+1,fmt,ap);va_end(ap);}return b;}

--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -1574,6 +1574,7 @@ else {
     else if (lt == TY_STRING || ty_is_array(lt) || ty_is_hash(lt) || ty_is_object(lt) ||
              lt == TY_PROC || lt == TY_STRINGIO || lt == TY_STRINGSCANNER || lt == TY_MATCHDATA || lt == TY_EXCEPTION)
       buf_printf(b, "(_t%d != 0)", t);  /* nullable pointer: NULL reads falsy */
+    else if (lt == TY_SYMBOL) buf_printf(b, "(_t%d != (sp_sym)-1)", t);  /* nilable symbol sentinel */
     else                    buf_puts(b, "1");  /* concrete value: always truthy */
     buf_puts(b, " ? ");
     /* the "kept-left" arm and the "right" arm, each widened to res */
@@ -1586,7 +1587,7 @@ else {
                else if (lt==TY_STRING) buf_printf(b, "sp_box_nullable_str(_t%d)", t); \
                else if (lt==TY_FLOAT) buf_printf(b, "sp_box_float(_t%d)", t); \
                else if (lt==TY_BOOL) buf_printf(b, "sp_box_bool(_t%d)", t); \
-               else if (lt==TY_SYMBOL) buf_printf(b, "sp_box_sym(_t%d)", t); \
+               else if (lt==TY_SYMBOL) buf_printf(b, "(_t%d != (sp_sym)-1 ? sp_box_sym(_t%d) : sp_box_nil())", t, t); \
                else if (ty_is_object(lt)) buf_printf(b, "sp_box_nullable_obj((void *)_t%d, %d)", t, ty_object_class(lt)); \
                else buf_printf(b, "_t%d", t); free(_vb.p); } \
              else buf_printf(b, "_t%d", t); } \

--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -681,6 +681,12 @@ void emit_expr(Compiler *c, int id, Buf *b) {
         buf_printf(b, "; %s; })", ref3);
       }
     }
+    else if (ivt3 == TY_SYMBOL) {
+      /* nilable symbol: (sp_sym)-1 is the nil sentinel */
+      buf_printf(b, "({ if (%s %s= (sp_sym)-1) %s = ", ref3, is_or ? "=" : "!", ref3);
+      emit_expr(c, v, b);
+      buf_printf(b, "; %s; })", ref3);
+    }
     else if (ivt3 == TY_STRING) {
       if (is_or) {
         buf_printf(b, "({ if (!%s) %s = ", ref3, ref3);
@@ -727,6 +733,12 @@ void emit_expr(Compiler *c, int id, Buf *b) {
     }
     else if (t == TY_BOOL) {
       buf_printf(b, "({ if (%slv_%s) lv_%s = ", is_or ? "!" : "", en, en);
+      emit_expr(c, v, b);
+      buf_printf(b, "; lv_%s; })", en);
+    }
+    else if (t == TY_SYMBOL) {
+      /* nilable symbol: (sp_sym)-1 is the nil sentinel */
+      buf_printf(b, "({ if (lv_%s %s= (sp_sym)-1) lv_%s = ", en, is_or ? "=" : "!", en);
       emit_expr(c, v, b);
       buf_printf(b, "; lv_%s; })", en);
     }
@@ -1580,16 +1592,14 @@ else {
     /* the "kept-left" arm and the "right" arm, each widened to res */
     #define EMIT_ARM(IS_RIGHT) do { \
       if (IS_RIGHT) { if (res == TY_POLY && comp_ntype(c, right) != TY_POLY) emit_boxed(c, right, b); else emit_expr(c, right, b); } \
-      else { if (res == TY_POLY && lt != TY_POLY) { /* box temp */ \
-               Buf _vb; memset(&_vb,0,sizeof _vb); buf_printf(&_vb, "_t%d", t); \
-               /* reuse emit_boxed by faking: just box by left type */ \
+      else { if (res == TY_POLY && lt != TY_POLY) { /* box the temp by left type */ \
                if (lt==TY_INT) buf_printf(b, "sp_box_int(_t%d)", t); \
                else if (lt==TY_STRING) buf_printf(b, "sp_box_nullable_str(_t%d)", t); \
                else if (lt==TY_FLOAT) buf_printf(b, "sp_box_float(_t%d)", t); \
                else if (lt==TY_BOOL) buf_printf(b, "sp_box_bool(_t%d)", t); \
                else if (lt==TY_SYMBOL) buf_printf(b, "(_t%d != (sp_sym)-1 ? sp_box_sym(_t%d) : sp_box_nil())", t, t); \
                else if (ty_is_object(lt)) buf_printf(b, "sp_box_nullable_obj((void *)_t%d, %d)", t, ty_object_class(lt)); \
-               else buf_printf(b, "_t%d", t); free(_vb.p); } \
+               else buf_printf(b, "_t%d", t); } \
              else buf_printf(b, "_t%d", t); } \
     } while (0)
     if (is_and) { EMIT_ARM(1); buf_puts(b, " : "); EMIT_ARM(0); }

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -3452,6 +3452,12 @@ else {
       buf_printf(b, "if (%slv_%s) lv_%s = ", is_or ? "!" : "", en, en);
       emit_expr(c, v, b); buf_puts(b, ";\n");
     }
+    else if (t == TY_SYMBOL) {
+      emit_indent(b, indent);
+      /* nilable symbol: (sp_sym)-1 is the nil sentinel */
+      buf_printf(b, "if (lv_%s %s= (sp_sym)-1) lv_%s = ", en, is_or ? "=" : "!", en);
+      emit_expr(c, v, b); buf_puts(b, ";\n");
+    }
     else if (!is_or) {  /* a &&= v on an always-truthy var: always assign */
       emit_indent(b, indent);
       buf_printf(b, "lv_%s = ", en); emit_expr(c, v, b); buf_puts(b, ";\n");
@@ -3486,6 +3492,13 @@ else {
       emit_indent(b, indent);
       if (is_or) buf_printf(b, "if (%s == SP_INT_NIL) %s = ", ref2, ref2);
       else       buf_printf(b, "if (%s != SP_INT_NIL) %s = ", ref2, ref2);
+      emit_expr(c, v, b); buf_puts(b, ";\n");
+    }
+    else if (ivt2 == TY_SYMBOL) {
+      emit_indent(b, indent);
+      /* nilable symbol: (sp_sym)-1 is the nil sentinel */
+      if (is_or) buf_printf(b, "if (%s == (sp_sym)-1) %s = ", ref2, ref2);
+      else       buf_printf(b, "if (%s != (sp_sym)-1) %s = ", ref2, ref2);
       emit_expr(c, v, b); buf_puts(b, ";\n");
     }
     else if (ivt2 == TY_STRING) {

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -882,7 +882,11 @@ void emit_cond(Compiler *c, int id, Buf *b) {
   }
   if (t == TY_INT)   { buf_puts(b, "(("); emit_expr(c, id, b); buf_puts(b, ") != SP_INT_NIL)"); return; }
   if (t == TY_FLOAT) { buf_puts(b, "(!sp_float_is_nil("); emit_expr(c, id, b); buf_puts(b, "))"); return; }
-  if (t == TY_SYMBOL) { buf_puts(b, "(("); emit_expr(c, id, b); buf_puts(b, "), 1)"); return; }
+  /* a nilable symbol slot holds (sp_sym)-1 for nil (default_value), so
+     truthiness must test the sentinel -- `if @exit_triggered` with
+     `@exit_triggered = nil` read always-true and ended doom's level on
+     the first tic. */
+  if (t == TY_SYMBOL) { buf_puts(b, "(("); emit_expr(c, id, b); buf_puts(b, ") != (sp_sym)-1)"); return; }
   /* Always-truthy concrete value types: a Range / Class / Complex / Rational /
      Time value is never nil or false, so it is truthy in condition position.
      Evaluate it for side effects and yield 1. */

--- a/test/symbol_nil_truthiness.rb
+++ b/test/symbol_nil_truthiness.rb
@@ -1,0 +1,40 @@
+# A nilable symbol slot stores (sp_sym)-1 as its nil sentinel. Truthiness
+# in conditions and in the value form of && / || must test the sentinel;
+# it used to read always-true, so `if @exit_triggered` fired on nil.
+
+class Level
+  def initialize
+    @exit_triggered = nil
+  end
+
+  def trigger(kind)
+    @exit_triggered = kind
+  end
+
+  def check
+    if @exit_triggered
+      "exit:#{@exit_triggered}"
+    else
+      "playing"
+    end
+  end
+
+  def check_and(intermission)
+    # value-form && with a symbol left arm
+    (@exit_triggered && !intermission) ? "finish" : "continue"
+  end
+
+  def sym_or_default
+    @exit_triggered || :none
+  end
+end
+
+lvl = Level.new
+puts lvl.check
+puts lvl.check_and(false)
+p lvl.sym_or_default
+lvl.trigger(:normal)
+puts lvl.check
+puts lvl.check_and(false)
+puts lvl.check_and(true)
+p lvl.sym_or_default

--- a/test/symbol_nil_truthiness.rb
+++ b/test/symbol_nil_truthiness.rb
@@ -38,3 +38,36 @@ puts lvl.check
 puts lvl.check_and(false)
 puts lvl.check_and(true)
 p lvl.sym_or_default
+
+# ||= / &&= on nilable symbol slots (ivar and local, statement and value form)
+class Cache
+  def initialize
+    @mode = nil
+  end
+  def mode_or_default
+    @mode ||= :easy
+  end
+  def try_upgrade
+    @mode &&= :hard
+    @mode
+  end
+  def reset
+    @mode = nil
+  end
+end
+
+c = Cache.new
+p c.mode_or_default
+p c.mode_or_default
+p c.try_upgrade
+c.reset
+p c.try_upgrade
+
+def lsym(start)
+  s = start ? :given : nil
+  s ||= :fallback
+  got = (s &&= :promoted)
+  [s, got]
+end
+p lsym(true)
+p lsym(false)

--- a/test/symbol_nil_truthiness.rb.expected
+++ b/test/symbol_nil_truthiness.rb.expected
@@ -5,3 +5,9 @@ exit:normal
 finish
 continue
 :normal
+:easy
+:easy
+:hard
+nil
+[:promoted, :promoted]
+[:promoted, :promoted]

--- a/test/symbol_nil_truthiness.rb.expected
+++ b/test/symbol_nil_truthiness.rb.expected
@@ -1,0 +1,7 @@
+playing
+continue
+:none
+exit:normal
+finish
+continue
+:normal


### PR DESCRIPTION
Part of the effort to run the unmodified Doom gem on spinel.

A nilable symbol slot stores `(sp_sym)-1` as its nil sentinel, but truthiness treated every symbol value as always-true. Doom keeps `@exit_triggered = nil` and sets it to a symbol on level exit; the always-true read ended the level on the first tic (instant intermission screen).

Fixes both readers:
- `emit_cond`: symbol condition now compares against the sentinel,
- value-form `&&` / `||`: symbol left arm tests the sentinel, and when the kept arm widens to poly the sentinel boxes as nil instead of a bogus symbol.

Test covers if/&&/|| over a nil-then-set symbol ivar. Full suite green (1165 pass).