### PR TITLE
codegen: treat value constants in when-clauses as equality tests

### DIFF
--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -342,6 +342,7 @@ int emit_regex_pat_to_buf(Compiler *c, int nid, Buf *b);
 int nameset_has(NameSet *s, const char *nm);
 void nameset_add(NameSet *s, const char *nm);
 void emit_local_ref(Compiler *c, int scope_node, const char *name, Buf *b);
+const char *resolve_class_alias(Compiler *c, const char *cname);
 void emit_yblk_ref(Buf *b);
 void emit_tail_lead(Buf *b);
 const char *rename_local(const char *nm);

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -1993,6 +1993,11 @@ void emit_case(Compiler *c, int id, Buf *b, int indent) {
           const char *cty2 = nt_type(nt, conds[j]);
           const char *cn2 = cty2 && (sp_streq(cty2, "ConstantReadNode") || sp_streq(cty2, "ConstantPathNode"))
                            ? nt_str(nt, conds[j], "name") : NULL;
+          /* a VALUE constant (`STATE_TITLE = :title`; registered in
+             comp_const with a real type) in `when` is an equality test,
+             not Module#=== -- treating it as a class name folded every
+             arm of doom's Menu#render state dispatch to `if (0)`. */
+          if (cn2 && ({ LocalVar *_wv = comp_const(c, cn2); _wv && _wv->type != TY_UNKNOWN; })) cn2 = NULL;
           if (cn2 && pt == TY_POLY) {
             char tmp[32]; snprintf(tmp, sizeof tmp, "_t%d", t);
             if (!emit_poly_class_when(c, conds[j], tmp, b))
@@ -2142,6 +2147,8 @@ void emit_case_expr(Compiler *c, int id, Buf *b) {
         const char *cty2 = nt_type(nt, conds[j]);
         const char *cn2 = cty2 && (sp_streq(cty2, "ConstantReadNode") || sp_streq(cty2, "ConstantPathNode"))
                          ? nt_str(nt, conds[j], "name") : NULL;
+        /* value constant in `when`: equality, not a class test (see above) */
+        if (cn2 && ({ LocalVar *_wv = comp_const(c, cn2); _wv && _wv->type != TY_UNKNOWN; })) cn2 = NULL;
         if (cn2 && pt == TY_POLY) {
           char tmp[32]; snprintf(tmp, sizeof tmp, "_t%d", t);
           if (!emit_poly_class_when(c, conds[j], tmp, b)) buf_puts(b, "0");

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -1066,6 +1066,8 @@ int emit_poly_class_when(Compiler *c, int cond_id, const char *tmp, Buf *b) {
   if (!cty || (!sp_streq(cty, "ConstantReadNode") && !sp_streq(cty, "ConstantPathNode"))) return 0;
   const char *cn = nt_str(nt, cond_id, "name");
   if (!cn) return 0;
+  /* a class-aliasing constant (Alias = SomeClass) tests the aliased class */
+  { const char *_ra = resolve_class_alias(c, cn); if (_ra) cn = _ra; }
   if (sp_streq(cn, "Integer") || sp_streq(cn, "Fixnum"))
     buf_printf(b, "%s.tag == SP_TAG_INT", tmp);
   else if (sp_streq(cn, "String"))
@@ -1997,7 +1999,7 @@ void emit_case(Compiler *c, int id, Buf *b, int indent) {
              comp_const with a real type) in `when` is an equality test,
              not Module#=== -- treating it as a class name folded every
              arm of doom's Menu#render state dispatch to `if (0)`. */
-          if (cn2 && ({ LocalVar *_wv = comp_const(c, cn2); _wv && _wv->type != TY_UNKNOWN; })) cn2 = NULL;
+          if (cn2 && ({ LocalVar *_wv = comp_const(c, cn2); _wv && _wv->type != TY_UNKNOWN && _wv->type != TY_CLASS; })) cn2 = NULL;
           if (cn2 && pt == TY_POLY) {
             char tmp[32]; snprintf(tmp, sizeof tmp, "_t%d", t);
             if (!emit_poly_class_when(c, conds[j], tmp, b))
@@ -2148,7 +2150,7 @@ void emit_case_expr(Compiler *c, int id, Buf *b) {
         const char *cn2 = cty2 && (sp_streq(cty2, "ConstantReadNode") || sp_streq(cty2, "ConstantPathNode"))
                          ? nt_str(nt, conds[j], "name") : NULL;
         /* value constant in `when`: equality, not a class test (see above) */
-        if (cn2 && ({ LocalVar *_wv = comp_const(c, cn2); _wv && _wv->type != TY_UNKNOWN; })) cn2 = NULL;
+        if (cn2 && ({ LocalVar *_wv = comp_const(c, cn2); _wv && _wv->type != TY_UNKNOWN && _wv->type != TY_CLASS; })) cn2 = NULL;
         if (cn2 && pt == TY_POLY) {
           char tmp[32]; snprintf(tmp, sizeof tmp, "_t%d", t);
           if (!emit_poly_class_when(c, conds[j], tmp, b)) buf_puts(b, "0");

--- a/test/case_when_value_constant.rb
+++ b/test/case_when_value_constant.rb
@@ -51,3 +51,15 @@ puts kind(5)
 puts kind("s")
 puts kind(:title)
 puts kind(3.5)
+
+# a constant ALIASING a class must stay a Module#=== class test
+class Widget; end
+WidgetAlias = Widget
+def alias_kind(x)
+  case x
+  when WidgetAlias then "widget"
+  else "other"
+  end
+end
+puts alias_kind(Widget.new)
+puts alias_kind(7)

--- a/test/case_when_value_constant.rb
+++ b/test/case_when_value_constant.rb
@@ -1,0 +1,53 @@
+# A constant holding a VALUE (symbol/int/string) used in `when` is an
+# equality test, not a Module#=== class test. Treating it as a class name
+# made every arm compile to `if (0)`, so the whole case fell through.
+
+class Menu
+  STATE_TITLE = :title
+  STATE_OPTIONS = :options
+  STATE_SKILL = 2
+  LABEL = "quit"
+
+  def initialize
+    @state = STATE_TITLE
+  end
+
+  def advance(s)
+    @state = s
+  end
+
+  def render
+    case @state
+    when STATE_TITLE then "title screen"
+    when STATE_OPTIONS then "options screen"
+    when STATE_SKILL then "skill select"
+    when LABEL then "quitting"
+    else "unknown"
+    end
+  end
+end
+
+m = Menu.new
+puts m.render
+m.advance(Menu::STATE_OPTIONS)
+puts m.render
+m.advance(Menu::STATE_SKILL)
+puts m.render
+m.advance(Menu::LABEL)
+puts m.render
+m.advance(:bogus)
+puts m.render
+
+# classes in `when` still work as class tests alongside value constants
+def kind(x)
+  case x
+  when Integer then "int"
+  when String then "str"
+  when Menu::STATE_TITLE then "title-sym"
+  else "other"
+  end
+end
+puts kind(5)
+puts kind("s")
+puts kind(:title)
+puts kind(3.5)

--- a/test/case_when_value_constant.rb.expected
+++ b/test/case_when_value_constant.rb.expected
@@ -1,0 +1,9 @@
+title screen
+options screen
+skill select
+quitting
+unknown
+int
+str
+title-sym
+other

--- a/test/case_when_value_constant.rb.expected
+++ b/test/case_when_value_constant.rb.expected
@@ -7,3 +7,5 @@ int
 str
 title-sym
 other
+widget
+other


### PR DESCRIPTION
Part of the effort to run the unmodified Doom gem on spinel.

Both case emitters resolved any constant in a `when` clause as a class name for `Module#===`. A constant that holds a value (`STATE_TITLE = :title`) is an equality test; the class-test path found no class of that name and folded the arm to `if (0)`. Doom's menu dispatches on `case @state when STATE_TITLE ...`, so the whole menu rendered as a black screen.

Constants registered with a concrete value type now skip the class-test path in both the statement and expression case emitters. Real class names in `when` keep working as class tests, covered side by side in the test. Full suite green (1165 pass).