### PR TITLE
poly: dispatch numeric/byte query builtins by runtime tag

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -1804,6 +1804,34 @@ static sp_RbVal sp_poly_mul(sp_RbVal a, sp_RbVal b) { if (a.tag == SP_TAG_BIGINT
 static mrb_int sp_poly_to_i(sp_RbVal v) { if (v.tag == SP_TAG_INT || v.tag == SP_TAG_SYM) return v.v.i; if (v.tag == SP_TAG_BIGINT) return (mrb_int)sp_bigint_to_int((sp_Bigint *)v.v.p); if (v.tag == SP_TAG_STR) return (mrb_int)strtoll(v.v.s ? v.v.s : sp_str_empty, NULL, 10); if (v.tag == SP_TAG_FLT) return (mrb_int)v.v.f; if (v.tag == SP_TAG_BOOL) return v.v.b ? 1 : 0; return 0; }
 static mrb_float sp_poly_to_f(sp_RbVal v) { if (v.tag == SP_TAG_FLT) return v.v.f; if (v.tag == SP_TAG_INT || v.tag == SP_TAG_SYM) return (mrb_float)v.v.i; if (v.tag == SP_TAG_BIGINT) return (mrb_float)sp_bigint_to_int((sp_Bigint *)v.v.p); if (v.tag == SP_TAG_BOOL) return v.v.b ? 1.0 : 0.0; return 0.0; }
 static mrb_bool sp_poly_numeric_p(sp_RbVal v) { return v.tag == SP_TAG_INT || v.tag == SP_TAG_FLT || v.tag == SP_TAG_BIGINT; }
+/* Numeric queries / rounding on a poly value: dispatch on the runtime tag the
+   way CRuby dispatches on the class. A tag whose class does not define the
+   method raises CRuby's NoMethodError (e.g. `1.nan?`, `"x".abs`). */
+SP_NORETURN SP_COLD static void sp_raise_poly_nomethod(const char *m, sp_RbVal v) {
+  static char buf[128];
+  snprintf(buf, sizeof buf, "undefined method '%s' for an instance of %s", m, sp_poly_class_name(v));
+  sp_raise_cls("NoMethodError", buf);
+}
+static mrb_bool sp_poly_nan_p(sp_RbVal v) { if (v.tag == SP_TAG_FLT) return isnan(v.v.f) != 0; sp_raise_poly_nomethod("nan?", v); }
+static mrb_bool sp_poly_finite_p(sp_RbVal v) { if (v.tag == SP_TAG_FLT) return isfinite(v.v.f) != 0; if (v.tag == SP_TAG_INT || v.tag == SP_TAG_BIGINT) return TRUE; sp_raise_poly_nomethod("finite?", v); }
+static sp_RbVal sp_poly_infinite(sp_RbVal v) { if (v.tag == SP_TAG_FLT) return isinf(v.v.f) ? sp_box_int(v.v.f > 0 ? 1 : -1) : sp_box_nil(); if (v.tag == SP_TAG_INT || v.tag == SP_TAG_BIGINT) return sp_box_nil(); sp_raise_poly_nomethod("infinite?", v); }
+static mrb_bool sp_poly_zero_p(sp_RbVal v) { if (v.tag == SP_TAG_INT) return v.v.i == 0; if (v.tag == SP_TAG_FLT) return v.v.f == 0.0; if (v.tag == SP_TAG_BIGINT) return sp_bigint_sign((sp_Bigint *)v.v.p) == 0; sp_raise_poly_nomethod("zero?", v); }
+static mrb_bool sp_poly_positive_p(sp_RbVal v) { if (v.tag == SP_TAG_INT) return v.v.i > 0; if (v.tag == SP_TAG_FLT) return v.v.f > 0.0; if (v.tag == SP_TAG_BIGINT) return sp_bigint_sign((sp_Bigint *)v.v.p) > 0; sp_raise_poly_nomethod("positive?", v); }
+static mrb_bool sp_poly_negative_p(sp_RbVal v) { if (v.tag == SP_TAG_INT) return v.v.i < 0; if (v.tag == SP_TAG_FLT) return v.v.f < 0.0; if (v.tag == SP_TAG_BIGINT) return sp_bigint_sign((sp_Bigint *)v.v.p) < 0; sp_raise_poly_nomethod("negative?", v); }
+static sp_RbVal sp_poly_abs(sp_RbVal v) { if (v.tag == SP_TAG_INT) return sp_box_int(v.v.i < 0 ? -v.v.i : v.v.i); if (v.tag == SP_TAG_FLT) return sp_box_float(v.v.f < 0 ? -v.v.f : v.v.f); if (v.tag == SP_TAG_BIGINT) { sp_Bigint *b = (sp_Bigint *)v.v.p; return sp_bigint_sign(b) < 0 ? sp_box_bigint(sp_bigint_sub(sp_bigint_new_int(0), b)) : v; } sp_raise_poly_nomethod("abs", v); }
+/* No-arg floor/ceil/round/truncate return Integer in Ruby: an int/bigint tag
+   is already its own floor (returned unchanged, lossless for bigints), a
+   float converts through the matching libm rounding. */
+static sp_RbVal sp_poly_floor(sp_RbVal v) { if (v.tag == SP_TAG_FLT) return sp_box_int((mrb_int)floor(v.v.f)); if (v.tag == SP_TAG_INT || v.tag == SP_TAG_BIGINT) return v; sp_raise_poly_nomethod("floor", v); }
+static mrb_int sp_poly_bytesize(sp_RbVal v) { if (v.tag == SP_TAG_STR) return sp_str_bytesize_m(v.v.s); sp_raise_poly_nomethod("bytesize", v); }
+static mrb_int sp_poly_ord(sp_RbVal v) { if (v.tag == SP_TAG_STR) return sp_str_ord(v.v.s); if (v.tag == SP_TAG_INT) return v.v.i; sp_raise_poly_nomethod("ord", v); }
+static mrb_int sp_poly_bit_length(sp_RbVal v) { if (v.tag == SP_TAG_INT) return sp_int_bit_length(v.v.i); sp_raise_poly_nomethod("bit_length", v); }
+/* String#getbyte on a poly value; nil (not 0) for an out-of-range index, per
+   CRuby, so the result is boxed. */
+static sp_RbVal sp_poly_getbyte(sp_RbVal v, mrb_int i) { if (v.tag != SP_TAG_STR) sp_raise_poly_nomethod("getbyte", v); const char *s = v.v.s; if (!s) return sp_box_nil(); mrb_int bl = (mrb_int)sp_str_byte_len(s); if (i < 0) i += bl; if (i < 0 || i >= bl) return sp_box_nil(); return sp_box_int((mrb_int)(unsigned char)s[i]); }
+static sp_RbVal sp_poly_ceil(sp_RbVal v) { if (v.tag == SP_TAG_FLT) return sp_box_int((mrb_int)ceil(v.v.f)); if (v.tag == SP_TAG_INT || v.tag == SP_TAG_BIGINT) return v; sp_raise_poly_nomethod("ceil", v); }
+static sp_RbVal sp_poly_round(sp_RbVal v) { if (v.tag == SP_TAG_FLT) return sp_box_int((mrb_int)round(v.v.f)); if (v.tag == SP_TAG_INT || v.tag == SP_TAG_BIGINT) return v; sp_raise_poly_nomethod("round", v); }
+static sp_RbVal sp_poly_truncate(sp_RbVal v) { if (v.tag == SP_TAG_FLT) return sp_box_int((mrb_int)trunc(v.v.f)); if (v.tag == SP_TAG_INT || v.tag == SP_TAG_BIGINT) return v; sp_raise_poly_nomethod("truncate", v); }
 static mrb_bool sp_poly_eq(sp_RbVal a, sp_RbVal b) { if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { sp_Bigint *ba = sp_poly_as_bigint(a), *bb = sp_poly_as_bigint(b); if (ba && bb) return sp_bigint_cmp(ba, bb) == 0; if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) return sp_poly_to_f(a) == sp_poly_to_f(b); return FALSE; } if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) return sp_poly_to_f(a) == sp_poly_to_f(b); if (a.tag != b.tag) return FALSE; switch (a.tag) { case SP_TAG_INT: return a.v.i == b.v.i; case SP_TAG_STR: return (a.v.s == NULL || b.v.s == NULL) ? (a.v.s == b.v.s) : (strcmp(a.v.s, b.v.s) == 0); case SP_TAG_FLT: return a.v.f == b.v.f; case SP_TAG_BOOL: return a.v.b == b.v.b; case SP_TAG_NIL: return TRUE; case SP_TAG_SYM: return a.v.i == b.v.i; case SP_TAG_ENCODING: return (a.v.s == NULL || b.v.s == NULL) ? (a.v.s == b.v.s) : (strcmp(a.v.s, b.v.s) == 0); case SP_TAG_OBJ: if (a.cls_id != b.cls_id) return FALSE; if (a.v.p == b.v.p) return TRUE; switch (a.cls_id) { case SP_BUILTIN_INT_ARRAY: return sp_IntArray_eq((sp_IntArray*)a.v.p,(sp_IntArray*)b.v.p); case SP_BUILTIN_STR_ARRAY: return sp_StrArray_eq((sp_StrArray*)a.v.p,(sp_StrArray*)b.v.p); case SP_BUILTIN_FLT_ARRAY: return sp_FloatArray_eq((sp_FloatArray*)a.v.p,(sp_FloatArray*)b.v.p); case SP_BUILTIN_POLY_ARRAY: return sp_PolyArray_eq((sp_PolyArray*)a.v.p,(sp_PolyArray*)b.v.p); default: return FALSE; } case SP_TAG_CLASS: return a.v.i == b.v.i; default: return FALSE; } }
 /* sp_sym_name_fn is now an extern hook (sp_gc.h / sp_gc.c) so cold lib readers
    like sp_json.c can resolve symbol names too; the generated TU still sets it. */

--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -1808,9 +1808,13 @@ static mrb_bool sp_poly_numeric_p(sp_RbVal v) { return v.tag == SP_TAG_INT || v.
    way CRuby dispatches on the class. A tag whose class does not define the
    method raises CRuby's NoMethodError (e.g. `1.nan?`, `"x".abs`). */
 SP_NORETURN SP_COLD static void sp_raise_poly_nomethod(const char *m, sp_RbVal v) {
-  static char buf[128];
-  snprintf(buf, sizeof buf, "undefined method '%s' for an instance of %s", m, sp_poly_class_name(v));
-  sp_raise_cls("NoMethodError", buf);
+  sp_raise_cls("NoMethodError",
+               sp_sprintf("undefined method '%s' for an instance of %s", m, sp_poly_class_name(v)));
+}
+/* floor/ceil/round/truncate on a non-finite Float: casting NaN/Inf to an
+   integer is C UB; CRuby raises FloatDomainError naming the value. */
+static inline void sp_poly_flo_domain_ck(mrb_float f) {
+  if (!isfinite(f)) sp_raise_cls("FloatDomainError", isnan(f) ? "NaN" : f > 0 ? "Infinity" : "-Infinity");
 }
 static mrb_bool sp_poly_nan_p(sp_RbVal v) { if (v.tag == SP_TAG_FLT) return isnan(v.v.f) != 0; sp_raise_poly_nomethod("nan?", v); }
 static mrb_bool sp_poly_finite_p(sp_RbVal v) { if (v.tag == SP_TAG_FLT) return isfinite(v.v.f) != 0; if (v.tag == SP_TAG_INT || v.tag == SP_TAG_BIGINT) return TRUE; sp_raise_poly_nomethod("finite?", v); }
@@ -1818,20 +1822,25 @@ static sp_RbVal sp_poly_infinite(sp_RbVal v) { if (v.tag == SP_TAG_FLT) return i
 static mrb_bool sp_poly_zero_p(sp_RbVal v) { if (v.tag == SP_TAG_INT) return v.v.i == 0; if (v.tag == SP_TAG_FLT) return v.v.f == 0.0; if (v.tag == SP_TAG_BIGINT) return sp_bigint_sign((sp_Bigint *)v.v.p) == 0; sp_raise_poly_nomethod("zero?", v); }
 static mrb_bool sp_poly_positive_p(sp_RbVal v) { if (v.tag == SP_TAG_INT) return v.v.i > 0; if (v.tag == SP_TAG_FLT) return v.v.f > 0.0; if (v.tag == SP_TAG_BIGINT) return sp_bigint_sign((sp_Bigint *)v.v.p) > 0; sp_raise_poly_nomethod("positive?", v); }
 static mrb_bool sp_poly_negative_p(sp_RbVal v) { if (v.tag == SP_TAG_INT) return v.v.i < 0; if (v.tag == SP_TAG_FLT) return v.v.f < 0.0; if (v.tag == SP_TAG_BIGINT) return sp_bigint_sign((sp_Bigint *)v.v.p) < 0; sp_raise_poly_nomethod("negative?", v); }
-static sp_RbVal sp_poly_abs(sp_RbVal v) { if (v.tag == SP_TAG_INT) return sp_box_int(v.v.i < 0 ? -v.v.i : v.v.i); if (v.tag == SP_TAG_FLT) return sp_box_float(v.v.f < 0 ? -v.v.f : v.v.f); if (v.tag == SP_TAG_BIGINT) { sp_Bigint *b = (sp_Bigint *)v.v.p; return sp_bigint_sign(b) < 0 ? sp_box_bigint(sp_bigint_sub(sp_bigint_new_int(0), b)) : v; } sp_raise_poly_nomethod("abs", v); }
+/* abs of a negative int goes through SP_POLY_INT_OP(sub, 0, x): plain -x is
+   UB for INT_MIN; promote mode boxes it as a bigint, wrap mode keeps the
+   documented wrapping C arithmetic. fabs covers -0.0 -> 0.0 too. */
+static sp_RbVal sp_poly_abs(sp_RbVal v) { if (v.tag == SP_TAG_INT) { if (v.v.i >= 0) return v; return SP_POLY_INT_OP(sub, (mrb_int)0, v.v.i); } if (v.tag == SP_TAG_FLT) return sp_box_float(fabs(v.v.f)); if (v.tag == SP_TAG_BIGINT) { sp_Bigint *b = (sp_Bigint *)v.v.p; return sp_bigint_sign(b) < 0 ? sp_box_bigint(sp_bigint_sub(sp_bigint_new_int(0), b)) : v; } sp_raise_poly_nomethod("abs", v); }
 /* No-arg floor/ceil/round/truncate return Integer in Ruby: an int/bigint tag
    is already its own floor (returned unchanged, lossless for bigints), a
    float converts through the matching libm rounding. */
-static sp_RbVal sp_poly_floor(sp_RbVal v) { if (v.tag == SP_TAG_FLT) return sp_box_int((mrb_int)floor(v.v.f)); if (v.tag == SP_TAG_INT || v.tag == SP_TAG_BIGINT) return v; sp_raise_poly_nomethod("floor", v); }
-static mrb_int sp_poly_bytesize(sp_RbVal v) { if (v.tag == SP_TAG_STR) return sp_str_bytesize_m(v.v.s); sp_raise_poly_nomethod("bytesize", v); }
-static mrb_int sp_poly_ord(sp_RbVal v) { if (v.tag == SP_TAG_STR) return sp_str_ord(v.v.s); if (v.tag == SP_TAG_INT) return v.v.i; sp_raise_poly_nomethod("ord", v); }
+static sp_RbVal sp_poly_floor(sp_RbVal v) { if (v.tag == SP_TAG_FLT) { sp_poly_flo_domain_ck(v.v.f); return sp_box_int((mrb_int)floor(v.v.f)); } if (v.tag == SP_TAG_INT || v.tag == SP_TAG_BIGINT) return v; sp_raise_poly_nomethod("floor", v); }
+/* a NULL char* carried under SP_TAG_STR is the empty string (as in
+   sp_poly_to_i / sp_poly_eq): bytesize 0, ord raises CRuby's ArgumentError. */
+static mrb_int sp_poly_bytesize(sp_RbVal v) { if (v.tag == SP_TAG_STR) return v.v.s ? sp_str_bytesize_m(v.v.s) : 0; sp_raise_poly_nomethod("bytesize", v); }
+static mrb_int sp_poly_ord(sp_RbVal v) { if (v.tag == SP_TAG_STR) { if (!v.v.s) sp_raise_cls("ArgumentError", "empty string"); return sp_str_ord(v.v.s); } if (v.tag == SP_TAG_INT) return v.v.i; sp_raise_poly_nomethod("ord", v); }
 static mrb_int sp_poly_bit_length(sp_RbVal v) { if (v.tag == SP_TAG_INT) return sp_int_bit_length(v.v.i); sp_raise_poly_nomethod("bit_length", v); }
 /* String#getbyte on a poly value; nil (not 0) for an out-of-range index, per
    CRuby, so the result is boxed. */
 static sp_RbVal sp_poly_getbyte(sp_RbVal v, mrb_int i) { if (v.tag != SP_TAG_STR) sp_raise_poly_nomethod("getbyte", v); const char *s = v.v.s; if (!s) return sp_box_nil(); mrb_int bl = (mrb_int)sp_str_byte_len(s); if (i < 0) i += bl; if (i < 0 || i >= bl) return sp_box_nil(); return sp_box_int((mrb_int)(unsigned char)s[i]); }
-static sp_RbVal sp_poly_ceil(sp_RbVal v) { if (v.tag == SP_TAG_FLT) return sp_box_int((mrb_int)ceil(v.v.f)); if (v.tag == SP_TAG_INT || v.tag == SP_TAG_BIGINT) return v; sp_raise_poly_nomethod("ceil", v); }
-static sp_RbVal sp_poly_round(sp_RbVal v) { if (v.tag == SP_TAG_FLT) return sp_box_int((mrb_int)round(v.v.f)); if (v.tag == SP_TAG_INT || v.tag == SP_TAG_BIGINT) return v; sp_raise_poly_nomethod("round", v); }
-static sp_RbVal sp_poly_truncate(sp_RbVal v) { if (v.tag == SP_TAG_FLT) return sp_box_int((mrb_int)trunc(v.v.f)); if (v.tag == SP_TAG_INT || v.tag == SP_TAG_BIGINT) return v; sp_raise_poly_nomethod("truncate", v); }
+static sp_RbVal sp_poly_ceil(sp_RbVal v) { if (v.tag == SP_TAG_FLT) { sp_poly_flo_domain_ck(v.v.f); return sp_box_int((mrb_int)ceil(v.v.f)); } if (v.tag == SP_TAG_INT || v.tag == SP_TAG_BIGINT) return v; sp_raise_poly_nomethod("ceil", v); }
+static sp_RbVal sp_poly_round(sp_RbVal v) { if (v.tag == SP_TAG_FLT) { sp_poly_flo_domain_ck(v.v.f); return sp_box_int((mrb_int)round(v.v.f)); } if (v.tag == SP_TAG_INT || v.tag == SP_TAG_BIGINT) return v; sp_raise_poly_nomethod("round", v); }
+static sp_RbVal sp_poly_truncate(sp_RbVal v) { if (v.tag == SP_TAG_FLT) { sp_poly_flo_domain_ck(v.v.f); return sp_box_int((mrb_int)trunc(v.v.f)); } if (v.tag == SP_TAG_INT || v.tag == SP_TAG_BIGINT) return v; sp_raise_poly_nomethod("truncate", v); }
 static mrb_bool sp_poly_eq(sp_RbVal a, sp_RbVal b) { if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { sp_Bigint *ba = sp_poly_as_bigint(a), *bb = sp_poly_as_bigint(b); if (ba && bb) return sp_bigint_cmp(ba, bb) == 0; if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) return sp_poly_to_f(a) == sp_poly_to_f(b); return FALSE; } if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) return sp_poly_to_f(a) == sp_poly_to_f(b); if (a.tag != b.tag) return FALSE; switch (a.tag) { case SP_TAG_INT: return a.v.i == b.v.i; case SP_TAG_STR: return (a.v.s == NULL || b.v.s == NULL) ? (a.v.s == b.v.s) : (strcmp(a.v.s, b.v.s) == 0); case SP_TAG_FLT: return a.v.f == b.v.f; case SP_TAG_BOOL: return a.v.b == b.v.b; case SP_TAG_NIL: return TRUE; case SP_TAG_SYM: return a.v.i == b.v.i; case SP_TAG_ENCODING: return (a.v.s == NULL || b.v.s == NULL) ? (a.v.s == b.v.s) : (strcmp(a.v.s, b.v.s) == 0); case SP_TAG_OBJ: if (a.cls_id != b.cls_id) return FALSE; if (a.v.p == b.v.p) return TRUE; switch (a.cls_id) { case SP_BUILTIN_INT_ARRAY: return sp_IntArray_eq((sp_IntArray*)a.v.p,(sp_IntArray*)b.v.p); case SP_BUILTIN_STR_ARRAY: return sp_StrArray_eq((sp_StrArray*)a.v.p,(sp_StrArray*)b.v.p); case SP_BUILTIN_FLT_ARRAY: return sp_FloatArray_eq((sp_FloatArray*)a.v.p,(sp_FloatArray*)b.v.p); case SP_BUILTIN_POLY_ARRAY: return sp_PolyArray_eq((sp_PolyArray*)a.v.p,(sp_PolyArray*)b.v.p); default: return FALSE; } case SP_TAG_CLASS: return a.v.i == b.v.i; default: return FALSE; } }
 /* sp_sym_name_fn is now an extern hook (sp_gc.h / sp_gc.c) so cold lib readers
    like sp_json.c can resolve symbol names too; the generated TU still sets it. */

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -2379,6 +2379,22 @@ else {
         }
       }
       if (found) return r;
+      /* Numeric queries / rounding on a boxed value: the sp_poly_* helpers
+         dispatch on the runtime tag (a non-numeric tag raises CRuby's
+         NoMethodError). abs keeps the receiver's class and floor/... can
+         return a bigint unchanged, so those stay boxed. */
+      if (argc == 0) {
+        if (sp_streq(name, "nan?") || sp_streq(name, "finite?") ||
+            sp_streq(name, "zero?") || sp_streq(name, "positive?") ||
+            sp_streq(name, "negative?")) return TY_BOOL;
+        if (sp_streq(name, "abs") || sp_streq(name, "infinite?") ||
+            sp_streq(name, "floor") || sp_streq(name, "ceil") ||
+            sp_streq(name, "round") || sp_streq(name, "truncate")) return TY_POLY;
+        if (sp_streq(name, "bytesize") || sp_streq(name, "ord") ||
+            sp_streq(name, "bit_length")) return TY_INT;
+      }
+      /* String#getbyte on a boxed value: int byte or nil on out-of-range. */
+      if (argc == 1 && sp_streq(name, "getbyte")) return TY_POLY;
       /* Array-reduction methods on a boxed array element (a run from
          chunk_while etc.): the concrete element type is erased to poly, so the
          result is a boxed poly value resolved at runtime by cls_id. */

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -3832,6 +3832,36 @@ int emit_poly_call(Compiler *c, int id, Buf *b) {
     }
     if (sp_streq(name, "to_i")) { buf_puts(b, "sp_poly_to_i("); emit_expr(c, recv, b); buf_puts(b, ")"); return 1; }
     if (sp_streq(name, "to_f")) { buf_puts(b, "sp_poly_to_f("); emit_expr(c, recv, b); buf_puts(b, ")"); return 1; }
+    /* Numeric queries / rounding: dispatch on the runtime tag (a non-numeric
+       tag raises CRuby's NoMethodError). A user method or attr reader with
+       the same name wins -- the poly method dispatch handles it instead. */
+    {
+      const char *pfn =
+        sp_streq(name, "nan?")      ? "sp_poly_nan_p" :
+        sp_streq(name, "finite?")   ? "sp_poly_finite_p" :
+        sp_streq(name, "infinite?") ? "sp_poly_infinite" :
+        sp_streq(name, "zero?")     ? "sp_poly_zero_p" :
+        sp_streq(name, "positive?") ? "sp_poly_positive_p" :
+        sp_streq(name, "negative?") ? "sp_poly_negative_p" :
+        sp_streq(name, "abs")       ? "sp_poly_abs" :
+        sp_streq(name, "floor")     ? "sp_poly_floor" :
+        sp_streq(name, "ceil")      ? "sp_poly_ceil" :
+        sp_streq(name, "round")     ? "sp_poly_round" :
+        sp_streq(name, "truncate")  ? "sp_poly_truncate" :
+        sp_streq(name, "bytesize")  ? "sp_poly_bytesize" :
+        sp_streq(name, "ord")       ? "sp_poly_ord" :
+        sp_streq(name, "bit_length") ? "sp_poly_bit_length" : NULL;
+      if (pfn) {
+        int has_user = 0;
+        for (int kk = 0; kk < c->nclasses && !has_user; kk++)
+          if (comp_method_in_chain(c, kk, name, NULL) >= 0 ||
+              comp_reader_in_chain(c, kk, name, NULL)) has_user = 1;
+        if (!has_user) {
+          buf_printf(b, "%s(", pfn); emit_expr(c, recv, b); buf_puts(b, ")");
+          return 1;
+        }
+      }
+    }
     if (sp_streq(name, "upcase"))     { buf_puts(b, "sp_box_str(sp_str_upcase(sp_poly_to_s("); emit_expr(c, recv, b); buf_puts(b, ")))"); return 1; }
     if (sp_streq(name, "downcase"))   { buf_puts(b, "sp_box_str(sp_str_downcase(sp_poly_to_s("); emit_expr(c, recv, b); buf_puts(b, ")))"); return 1; }
     if (sp_streq(name, "capitalize")) { buf_puts(b, "sp_box_str(sp_str_capitalize(sp_poly_to_s("); emit_expr(c, recv, b); buf_puts(b, ")))"); return 1; }
@@ -3842,6 +3872,19 @@ int emit_poly_call(Compiler *c, int id, Buf *b) {
     if (sp_streq(name, "chop"))       { buf_puts(b, "sp_box_str(sp_str_chop(sp_poly_to_s("); emit_expr(c, recv, b); buf_puts(b, ")))"); return 1; }
     if (sp_streq(name, "chr"))        { buf_puts(b, "sp_box_str(sp_str_chr(sp_poly_to_s("); emit_expr(c, recv, b); buf_puts(b, ")))"); return 1; }
     if (sp_streq(name, "freeze"))     { emit_expr(c, recv, b); return 1; }
+  }
+  /* poly receiver: String#getbyte (a non-string tag raises NoMethodError).
+     A user method or attr reader with the same name wins. */
+  if (recv >= 0 && rt == TY_POLY && argc == 1 && sp_streq(name, "getbyte")) {
+    int has_user = 0;
+    for (int kk = 0; kk < c->nclasses && !has_user; kk++)
+      if (comp_method_in_chain(c, kk, name, NULL) >= 0 ||
+          comp_reader_in_chain(c, kk, name, NULL)) has_user = 1;
+    if (!has_user) {
+      buf_puts(b, "sp_poly_getbyte("); emit_expr(c, recv, b); buf_puts(b, ", ");
+      emit_int_expr(c, argv[0], b); buf_puts(b, ")");
+      return 1;
+    }
   }
   /* poly receiver: arr[start, len] = src -- 3-arg splice assign
      Skip Fiber/Fiber.current storage receivers (handled later). */

--- a/test/poly_numeric_query_methods.rb
+++ b/test/poly_numeric_query_methods.rb
@@ -1,0 +1,61 @@
+# Numeric / byte query methods on a poly value (a boxed element of a
+# heterogeneous array): nan? / finite? / infinite? / abs / floor / ceil /
+# round / truncate / zero? / positive? / negative? / bytesize / ord /
+# bit_length / getbyte dispatch on the runtime tag like CRuby dispatches on
+# the class. Previously only to_i / to_f (and a few string transforms) were
+# in the poly table, so `v.nan?` raised "undefined method 'nan?' for poly"
+# at runtime and `v.floor` failed to compile.
+#
+# NOTE: no class in this file may define a colliding method/reader name --
+# a user definition shadows the builtin poly path program-wide (that
+# shadowing is covered by poly_attr_reader_shadows_builtin.rb).
+
+# Float carried in a poly slot
+v = [1.5, "x"][0]
+puts v.to_i        # 1 (already worked)
+puts v.nan?        # false
+puts v.abs         # 1.5
+puts v.floor       # 1
+puts v.ceil        # 2
+puts v.round       # 2
+puts v.truncate    # 1
+puts v.zero?       # false
+puts v.positive?   # true
+puts v.negative?   # false
+puts v.finite?     # true
+p v.infinite?      # nil
+
+# Negative float: round is half-away-from-zero, truncate goes toward zero
+w = [-2.5, "x"][0]
+puts w.abs         # 2.5
+puts w.floor       # -3
+puts w.ceil        # -2
+puts w.round       # -3
+puts w.truncate    # -2
+puts w.negative?   # true
+
+# Integer carried in a poly slot: floor/ceil/round return self
+n = [-3, "x"][0]
+puts n.abs         # 3
+puts n.floor       # -3
+puts n.round       # -3
+puts n.zero?       # false
+puts n.positive?   # false
+puts n.finite?     # true
+p n.infinite?      # nil
+
+z = [0, "x"][0]
+puts z.zero?       # true
+puts z.positive?   # false
+puts z.negative?   # false
+puts z.bit_length  # 0
+puts n.bit_length  # 2
+
+# String carried in a poly slot: byte/codepoint queries
+s = ["ab", 1][0]
+puts s.getbyte(0)  # 97
+puts s.getbyte(1)  # 98
+puts s.getbyte(-1) # 98
+p s.getbyte(5)     # nil (out of range)
+puts s.bytesize    # 2
+puts s.ord         # 97

--- a/test/poly_numeric_query_methods.rb
+++ b/test/poly_numeric_query_methods.rb
@@ -59,3 +59,29 @@ puts s.getbyte(-1) # 98
 p s.getbyte(5)     # nil (out of range)
 puts s.bytesize    # 2
 puts s.ord         # 97
+
+# Non-finite floats: rounding raises FloatDomainError (not C UB), abs works
+nan = [0.0 / 0.0, "x"][0]
+inf = [-1.0 / 0.0, "x"][0]
+begin
+  nan.floor
+rescue FloatDomainError => ex
+  puts "#{ex.class}: #{ex.message}"   # FloatDomainError: NaN
+end
+begin
+  inf.round
+rescue FloatDomainError => ex
+  puts "#{ex.class}: #{ex.message}"   # FloatDomainError: -Infinity
+end
+puts nan.abs.nan?  # true
+puts inf.finite?   # false
+p inf.infinite?    # -1
+
+# Empty string: bytesize 0; ord raises CRuby's ArgumentError
+es = ["", 1][0]
+puts es.bytesize   # 0
+begin
+  es.ord
+rescue ArgumentError => ex
+  puts "#{ex.class}: #{ex.message}"   # ArgumentError: empty string
+end

--- a/test/poly_numeric_query_methods.rb.expected
+++ b/test/poly_numeric_query_methods.rb.expected
@@ -1,0 +1,43 @@
+1
+false
+1.5
+1
+2
+2
+1
+false
+true
+false
+true
+nil
+2.5
+-3
+-2
+-3
+-2
+true
+3
+-3
+-3
+false
+false
+true
+nil
+true
+false
+false
+0
+2
+97
+98
+98
+nil
+2
+97
+FloatDomainError: NaN
+FloatDomainError: -Infinity
+true
+false
+-1
+0
+ArgumentError: empty string


### PR DESCRIPTION
Fixes #1684.

## Summary

A poly value that at runtime holds a Float/Integer/String could call `to_i`/`to_f` and a few string transforms, but common query/rounding builtins were missing from the poly table: `nan?`, `finite?`, `infinite?`, `abs`, `floor`, `ceil`, `round`, `truncate`, `zero?`, `positive?`, `negative?`, `bytesize`, `ord`, `bit_length`, `getbyte`. They raised `undefined method '...' for poly` at runtime — or failed to compile when the untyped result reached `puts` — while CRuby handles all of them.

## Changes

- `lib/sp_runtime.h`: new `sp_poly_*` helpers that dispatch on the runtime tag the way CRuby dispatches on the class. A tag whose class does not define the method raises CRuby's NoMethodError, naming the actual runtime class (`1.nan?` → `undefined method 'nan?' for an instance of Integer`). Semantics match the typed emitters: `round` is half-away-from-zero, `infinite?` returns nil/±1, `getbyte` returns nil out of range. `abs` keeps the receiver's class (Integer stays Integer, Float stays Float, negative bigints negate losslessly) and the no-arg rounding family returns an int/bigint receiver unchanged, so those return boxed values.
- `src/codegen_call_recv.c` (`emit_poly_call`): route the names to the helpers, gated on "no user class defines the name as a method **or attr reader**" — a colliding user definition wins and goes through the normal poly method dispatch (same collision rule as #1683).
- `src/analyze_infer.c`: type the calls **after** the user-class dispatch unification so user definitions keep their inferred return types; predicates are Bool, `bytesize`/`ord`/`bit_length` are Integer, `abs`/rounding/`getbyte`/`infinite?` are poly (class-preserving / nullable results).
- `test/poly_numeric_query_methods.rb`: regression test covering Float (incl. negative-value rounding directions), Integer, and String receivers plus the out-of-range `getbyte` nil; output byte-identical to CRuby.

## Test plan

- [x] Both repros from #1684 compile and match CRuby (`getbyte(0)` → 97, `nan?` → false, `floor` → 1).
- [x] New regression test byte-identical to CRuby.
- [x] NoMethodError path verified: `"x".nan?` through a poly slot raises `undefined method 'nan?' for an instance of String`.
- [x] User-shadowing verified: a class defining `abs` / an `attr_accessor :round` still dispatches to the user definition.
- [x] `make test`: 1209 pass; the 5 failures on my machine are the known pre-existing environment artifacts (no `.rb.expected` snapshot + system Ruby too old as oracle) and fail identically on the unmodified baseline.

Made with [Cursor](https://cursor.com)