### PR TITLE
codegen: pop live exception frames on early return

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -640,6 +640,7 @@ void emit_method(Compiler *c, Scope *s, Buf *b) {
   g_self_deref = (s->class_id >= 0 && !s->is_cmethod && c->classes[s->class_id].is_value_type &&
                   s->name && !sp_streq(s->name, "initialize")) ? "." : "->";
   g_ret_type = method_is_void(s) ? TY_VOID : s->ret;
+  g_exc_frame_depth = 0; g_method_pr_exc_depth = 0;
   int is_void = method_is_void(s);
   /* A method that creates a non-lambda proc with a `return` owns a proc-return
      frame: a setjmp target the proc longjmps to. All returns funnel through a
@@ -677,6 +678,7 @@ void emit_method(Compiler *c, Scope *s, Buf *b) {
     }
     buf_puts(b, "    {\n");
     g_method_pr_label = "_pr_done"; g_method_pr_var = is_void ? NULL : "_prret";
+    g_method_pr_exc_depth = 0;   /* _pr_done sits outside every begin frame */
   }
   const char *sv_rv2 = g_result_var; int sv_rp2 = g_result_poly;
   if (pr_frame && !is_void) { g_result_var = "_prret"; g_result_poly = (s->ret == TY_POLY); }
@@ -1108,6 +1110,8 @@ void emit_fiber_new(Compiler *c, int id, Buf *b, int as_gen) {
   g_ret_type = TY_POLY; g_result_poly = 0; g_result_var = NULL;
   const char *sv_fbser = g_brk_ser_var; g_brk_ser_var = NULL;   /* fresh function context */
   int sv_fbskip = g_brk_skip_id; g_brk_skip_id = -1;
+  int sv_fbexcd = g_exc_frame_depth, sv_fbprexcd = g_method_pr_exc_depth;
+  g_exc_frame_depth = 0; g_method_pr_exc_depth = 0;
 
   /* Unpack capture struct */
   if (ncap > 0 || cap_self) {
@@ -1223,6 +1227,7 @@ void emit_fiber_new(Compiler *c, int id, Buf *b, int as_gen) {
   g_block_param_name = sv_bpn; g_self = sv_self; g_ret_type = sv_rt;
   g_result_poly = sv_rp; g_result_var = sv_rv; g_yielder_name = sv_yld;
   g_brk_ser_var = sv_fbser; g_brk_skip_id = sv_fbskip;
+  g_exc_frame_depth = sv_fbexcd; g_method_pr_exc_depth = sv_fbprexcd;
 
   /* Emit creation expression:
      If there are captures, allocate a GC-managed capture struct, fill it,
@@ -1584,6 +1589,8 @@ else if (orecv >= 0 && onm) {
      capture. Save/clear the method funnel and set the proc-return home accessor. */
   const char *sv_pr_label = g_method_pr_label, *sv_pr_var = g_method_pr_var, *sv_prh = g_proc_return_home;
   g_method_pr_label = NULL; g_method_pr_var = NULL;
+  int sv_excd = g_exc_frame_depth, sv_prexcd = g_method_pr_exc_depth;
+  g_exc_frame_depth = 0; g_method_pr_exc_depth = 0;
   char home_acc[48] = "";
   if (ret_proc) { snprintf(home_acc, sizeof home_acc, "((_proc_cap_%d *)_cap)->_home", pid); g_proc_return_home = home_acc; }
   else g_proc_return_home = NULL;
@@ -1728,6 +1735,7 @@ else if (orecv >= 0 && onm) {
   g_proc_body_kind = sv_pbk; g_proc_brk_home = sv_pbh;
   g_result_poly = sv_rp;
   g_method_pr_label = sv_pr_label; g_method_pr_var = sv_pr_var; g_proc_return_home = sv_prh;
+  g_exc_frame_depth = sv_excd; g_method_pr_exc_depth = sv_prexcd;
 
   if (ncap == 0 && !cap_self && !ret_proc) {
     buf_printf(b, "sp_proc_new_meta((void *)_proc_%d, NULL, NULL, %d, %s, %d, %s)",

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -7961,9 +7961,10 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       buf_printf(b, "int _retf%d = 0; int _excf%d = 0; const char *_excmsg%d = NULL, *_exccls%d = NULL; ",
                  eid, eid, eid, eid);
       if (has_retval) { emit_ctype(c, g_ret_type, b); buf_printf(b, " _retv%d = %s; ", eid, default_value(g_ret_type)); }
-      g_ensure_stack[g_ensure_depth++] = (EnsureCtx){ eid, has_retval };
+      g_ensure_stack[g_ensure_depth++] = (EnsureCtx){ eid, has_retval, g_exc_frame_depth };
       buf_puts(b, "sp_exc_rootmark[sp_exc_top] = sp_gc_nroots; ");
       buf_puts(b, "sp_exc_top++; if (setjmp(sp_exc_stack[sp_exc_top-1]) == 0) { ");
+      g_exc_frame_depth++;
     }
     for (int k = 0; k < bbn - 1; k++) emit_stmt(c, bbb[k], b, 0);
     if (bbn > 0) {
@@ -7983,6 +7984,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     }
     if (is_mx) {
       g_ensure_depth--;
+      g_exc_frame_depth--;
       buf_printf(b, "sp_exc_top--; } else { sp_exc_top--; sp_gc_nroots = sp_exc_rootmark[sp_exc_top]; if (sp_unwind_kind == SP_UNWIND_NONE) { sp_proc_homes_unwind(); _excf%d = 1; _excmsg%d = sp_exc_msg[sp_exc_top]; _exccls%d = sp_exc_cls[sp_exc_top]; } } ",
                  eid, eid, eid);
       buf_printf(b, "_ensure%d: ; sp_Mutex_unlock(_t%d); ", eid, mtmp);
@@ -8000,6 +8002,10 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
                    eid, outer->lid, outer->lid, eid, outer->lid, eid, outer->lid);
       }
       else {
+        /* the deferred return leaves through every enclosing live begin
+           frame: pop them (see the begin..ensure epilogue in codegen_stmt.c) */
+        if (g_exc_frame_depth > 0)
+          buf_printf(b, "if (_retf%d) sp_exc_top -= %d; ", eid, g_exc_frame_depth);
         if (has_retval) buf_printf(b, "if (_retf%d) return _retv%d; ", eid, eid);
         else if (g_ret_type == TY_POLY) buf_printf(b, "if (_retf%d) return sp_box_nil(); ", eid);
         else if (g_ret_type == TY_UNKNOWN) buf_printf(b, "if (_retf%d) return 0; ", eid);

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -130,6 +130,8 @@ extern int g_result_poly;
 extern const char *g_method_pr_label;
 extern const char *g_method_pr_var;
 extern const char *g_proc_return_home;
+extern int g_exc_frame_depth;      /* live begin/rescue setjmp frames (see codegen_util.c) */
+extern int g_method_pr_exc_depth;
 /* Return type of the method currently being emitted, so a tail/return value
    can be boxed when the method returns poly but the value is concrete. */
 extern TyKind g_ret_type;
@@ -154,7 +156,7 @@ void emit_line_directive(Compiler *c, int id, Buf *b);
    pushes a context on this stack; emit_return uses the top to emit a
    deferred goto instead of a bare C `return`. */
 #define MAX_ENSURE_DEPTH 32
-typedef struct { int lid; int has_retval; } EnsureCtx;
+typedef struct { int lid; int has_retval; int exc_base; } EnsureCtx;
 extern EnsureCtx g_ensure_stack[MAX_ENSURE_DEPTH];
 extern int       g_ensure_depth;
 

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -2644,6 +2644,8 @@ void emit_return(Compiler *c, int id, Buf *b, int indent) {
         buf_printf(b, "%s = %s; ", g_method_pr_var, nilv);
       }
     }
+    if (g_exc_frame_depth > g_method_pr_exc_depth)
+      buf_printf(b, "sp_exc_top -= %d; ", g_exc_frame_depth - g_method_pr_exc_depth);
     buf_printf(b, "goto %s; }\n", g_method_pr_label);
     return;
   }
@@ -2671,12 +2673,20 @@ void emit_return(Compiler *c, int id, Buf *b, int indent) {
         buf_puts(b, "; ");
       }
     }
-    buf_printf(b, "_retf%d = 1; sp_exc_top--; goto _ensure%d; }\n",
-               ctx->lid, ctx->lid);
+    {
+      int pops = g_exc_frame_depth - ctx->exc_base;
+      if (pops < 1) pops = 1;   /* at least the ensure frame itself */
+      buf_printf(b, "_retf%d = 1; sp_exc_top -= %d; goto _ensure%d; }\n",
+                 ctx->lid, pops, ctx->lid);
+    }
     return;
   }
 
   emit_indent(b, indent);
+  /* leaving through live begin/rescue frames: pop them, or their jmp_bufs
+     dangle into this soon-dead C frame and the next raise longjmps into
+     garbage (doom's SoundManager#[] early cache returns). */
+  if (g_exc_frame_depth > 0) buf_printf(b, "sp_exc_top -= %d; ", g_exc_frame_depth);
   if (n > 1) {
     int ta = ++g_tmp;
     buf_printf(b, "{ sp_PolyArray *_t%d = sp_PolyArray_new(); SP_GC_ROOT(_t%d);", ta, ta);
@@ -2906,11 +2916,12 @@ void emit_begin(Compiler *c, int id, Buf *b, int indent, const char *resultvar) 
       emit_indent(b, indent); emit_ctype(c, g_ret_type, b);
       buf_printf(b, " _retv%d = %s;\n", eid, default_value(g_ret_type));
     }
-    g_ensure_stack[g_ensure_depth++] = (EnsureCtx){ eid, has_retval };
+    g_ensure_stack[g_ensure_depth++] = (EnsureCtx){ eid, has_retval, g_exc_frame_depth };
 
     emit_indent(b, indent); buf_puts(b, "sp_exc_rootmark[sp_exc_top] = sp_gc_nroots;\n");
     emit_indent(b, indent); buf_puts(b, "sp_exc_top++;\n");
     emit_indent(b, indent); buf_puts(b, "if (setjmp(sp_exc_stack[sp_exc_top-1]) == 0) {\n");
+    g_exc_frame_depth++;
     if (resultvar && else_stmts < 0) {
       const char *sv = g_result_var; g_result_var = resultvar;
       emit_stmts_tail(c, body, b, indent + 1);
@@ -2919,6 +2930,7 @@ void emit_begin(Compiler *c, int id, Buf *b, int indent, const char *resultvar) 
     else {
       emit_stmts(c, body, b, indent + 1);
     }
+    g_exc_frame_depth--;
     emit_indent(b, indent + 1); buf_puts(b, "sp_exc_top--;\n");
     if (else_stmts >= 0) {
       if (resultvar) {
@@ -3000,6 +3012,12 @@ void emit_begin(Compiler *c, int id, Buf *b, int indent, const char *resultvar) 
                  eid, outer->lid, outer->lid, eid, outer->lid, eid, outer->lid);
     }
     else {
+      /* the deferred return leaves through every enclosing live begin frame:
+         pop them or their jmp_bufs dangle into this soon-dead C frame */
+      if (g_exc_frame_depth > 0) {
+        buf_printf(b, "if (_retf%d) sp_exc_top -= %d;\n", eid, g_exc_frame_depth);
+        emit_indent(b, indent);
+      }
       /* inside a poly-slot proc body (g_result_var, e.g. a break-capable
          lambda) the deferred value returns through the slot ABI, not a raw
          C return of an sp_RbVal from an mrb_int function */
@@ -3032,6 +3050,7 @@ void emit_begin(Compiler *c, int id, Buf *b, int indent, const char *resultvar) 
   emit_indent(b, indent); buf_puts(b, "sp_exc_rootmark[sp_exc_top] = sp_gc_nroots;\n");
   emit_indent(b, indent); buf_puts(b, "sp_exc_top++;\n");
   emit_indent(b, indent); buf_puts(b, "if (setjmp(sp_exc_stack[sp_exc_top-1]) == 0) {\n");
+  g_exc_frame_depth++;
   /* body value is the begin value only when there is no else clause */
   if (resultvar && else_stmts < 0) {
     const char *sv = g_result_var; g_result_var = resultvar;
@@ -3041,6 +3060,7 @@ void emit_begin(Compiler *c, int id, Buf *b, int indent, const char *resultvar) 
   else {
     emit_stmts(c, body, b, indent + 1);
   }
+  g_exc_frame_depth--;
   emit_indent(b, indent + 1); buf_puts(b, "sp_exc_top--;\n");
   if (else_stmts >= 0) {  /* else runs only on success; its value is the begin value */
     if (resultvar) {

--- a/src/codegen_util.c
+++ b/src/codegen_util.c
@@ -148,6 +148,15 @@ int g_result_poly = 0;
 const char *g_method_pr_label = NULL;
 const char *g_method_pr_var = NULL;
 const char *g_proc_return_home = NULL;
+/* Number of live setjmp exception frames (begin/rescue) enclosing the
+   current emission point. A `return` from inside a try body must pop them
+   (sp_exc_top -= N) before leaving -- a stale frame's jmp_buf points into
+   a dead C stack frame, and the next raise longjmps into it (doom's
+   SoundManager#[] early returns corrupted the stack this way).
+   g_method_pr_exc_depth snapshots the depth at the return-funnel target so
+   funnel gotos pop only the frames they actually exit. */
+int g_exc_frame_depth = 0;
+int g_method_pr_exc_depth = 0;
 /* Loop-invariant string-length hoisting: while a loop whose receiver string is
    not mutated in its body is being emitted, g_hoist_len_recv holds that
    receiver's AST local name and g_hoist_len_var the C temp caching its length;

--- a/test/exc_frame_early_return_pops.rb
+++ b/test/exc_frame_early_return_pops.rb
@@ -1,0 +1,111 @@
+# An early `return` from inside begin/rescue must pop the live setjmp
+# exception frames it exits. If codegen emits a bare C `return`, the frame
+# stays on sp_exc_stack with a jmp_buf pointing into a dead C stack frame;
+# the next raise longjmps into garbage (Doom's SoundManager#[] crashed this
+# way), and repeated calls overflow the exception stack.
+
+class SoundCache
+  def initialize
+    @cache = {}
+  end
+
+  def [](key)
+    begin
+      return @cache[key] if @cache.key?(key)
+      value = key * 2
+      @cache[key] = value
+      value
+    rescue
+      -1
+    end
+  end
+end
+
+sc = SoundCache.new
+sc[7]  # populate: the non-early path pops its frame correctly
+
+# Each early-return hit leaked one frame (capacity is far below 200).
+total = 0
+1.upto(200) { |i| total += sc[7] }
+puts total
+
+# A raise must land in this fresh handler, not a stale leaked frame.
+begin
+  sc[7]
+  raise "boom"
+rescue => e
+  puts "caught #{e.message}"
+end
+
+# Early return through two nested begin frames pops both.
+def double_nested(flag)
+  begin
+    begin
+      return "inner-out" if flag
+      "no"
+    rescue
+      "r1"
+    end
+    "outer"
+  rescue
+    "r2"
+  end
+end
+
+200.times { double_nested(true) }
+puts double_nested(true)
+begin
+  raise "deep"
+rescue => e
+  puts "caught #{e.message}"
+end
+
+# Return from a begin/rescue nested inside begin..ensure: the deferred
+# return must pop down to the frame depth at ensure entry (both the rescue
+# frame and the ensure frame), then run the ensure.
+def rescue_in_ensure(flag)
+  begin
+    begin
+      return "early" if flag
+      "body"
+    rescue
+      "rescued"
+    end
+  ensure
+    $ensure_runs += 1
+  end
+end
+
+$ensure_runs = 0
+200.times { rescue_in_ensure(true) }
+puts $ensure_runs
+begin
+  raise "after ensure"
+rescue => e
+  puts "caught #{e.message}"
+end
+
+# Return from a begin..ensure nested inside begin/rescue: after the ensure
+# runs, the deferred return must also pop the enclosing rescue frame.
+def ensure_in_rescue(flag)
+  begin
+    begin
+      return "early2" if flag
+      "body"
+    ensure
+      $ensure_runs2 += 1
+    end
+  rescue
+    "rescued"
+  end
+end
+
+$ensure_runs2 = 0
+200.times { ensure_in_rescue(true) }
+puts $ensure_runs2
+begin
+  raise "after ensure 2"
+rescue => e
+  puts "caught #{e.message}"
+end
+puts "done"

--- a/test/exc_frame_early_return_pops.rb.expected
+++ b/test/exc_frame_early_return_pops.rb.expected
@@ -1,0 +1,9 @@
+2800
+caught boom
+inner-out
+caught deep
+200
+caught after ensure
+200
+caught after ensure 2
+done


### PR DESCRIPTION
Part of the effort to run the unmodified Doom gem on spinel.

spinel lowers begin/rescue to a setjmp frame pushed onto sp_exc_stack. A Ruby `return` from inside the try body emitted a plain C `return` without popping the frame, so the stale jmp_buf kept pointing into a dead C stack frame. The next raise longjmped into garbage, and repeated calls overflowed the 64-slot exception stack. In the Doom port this showed up as a stack smash (`__stack_chk_fail`) on the first key press, in `SoundManager#[]` which does `return @cache[key] if @cache.key?(key)` inside begin/rescue.

The fix tracks the number of live setjmp frames enclosing the emission point (`g_exc_frame_depth`) and pops them on every return path: plain returns pop all live frames, proc-return funnel gotos pop only the delta above the funnel target (`g_method_pr_exc_depth`), and deferred returns through begin..ensure pop down to the depth at ensure entry (`EnsureCtx.exc_base`), with the ensure epilogue popping the frames enclosing the construct. The method, proc and fiber body emitters save/reset the counters so nesting does not leak counts.

The new test crashes (SIGSEGV) before the fix and passes after. Suite is green apart from the known `system_argument_list` failure.