### PR TITLE
io: File#seek, #tell, #pos, and #rewind

### DIFF
--- a/lib/sp_io.c
+++ b/lib/sp_io.c
@@ -124,6 +124,25 @@ mrb_bool sp_File_eof_p(sp_File *f) {
   return FALSE;
 }
 
+mrb_int sp_File_seek(sp_File *f, mrb_int off, mrb_int whence) {
+  if (!f || !f->fp) return -1;
+  /* whence uses the Ruby IO::SEEK_* values (0/1/2), mapped explicitly so we
+     never depend on the platform's SEEK_SET/CUR/END numbering. */
+  int w = (whence == 1) ? SEEK_CUR : (whence == 2) ? SEEK_END : SEEK_SET;
+  return (mrb_int)fseek(f->fp, (long)off, w);
+}
+
+mrb_int sp_File_tell(sp_File *f) {
+  if (!f || !f->fp) return 0;
+  return (mrb_int)ftell(f->fp);
+}
+
+mrb_int sp_File_rewind(sp_File *f) {
+  if (!f || !f->fp) return -1;
+  rewind(f->fp);
+  return 0;
+}
+
 /* ---- File metadata predicates ----
    libc / WinAPI only, no spinel-string allocation and no shared mutable
    state, so they live here rather than inline in sp_runtime.h. */

--- a/lib/sp_io.c
+++ b/lib/sp_io.c
@@ -127,14 +127,16 @@ mrb_bool sp_File_eof_p(sp_File *f) {
 mrb_int sp_File_seek(sp_File *f, mrb_int off, mrb_int whence) {
   if (!f || !f->fp) return -1;
   /* whence uses the Ruby IO::SEEK_* values (0/1/2), mapped explicitly so we
-     never depend on the platform's SEEK_SET/CUR/END numbering. */
+     never depend on the platform's SEEK_SET/CUR/END numbering. fseeko/ftello
+     take off_t rather than fseek's long, so offsets past 2GB survive even
+     where long is 32-bit. */
   int w = (whence == 1) ? SEEK_CUR : (whence == 2) ? SEEK_END : SEEK_SET;
-  return (mrb_int)fseek(f->fp, (long)off, w);
+  return (mrb_int)fseeko(f->fp, (off_t)off, w);
 }
 
 mrb_int sp_File_tell(sp_File *f) {
-  if (!f || !f->fp) return 0;
-  return (mrb_int)ftell(f->fp);
+  if (!f || !f->fp) return -1;
+  return (mrb_int)ftello(f->fp);
 }
 
 mrb_int sp_File_rewind(sp_File *f) {

--- a/lib/sp_io.h
+++ b/lib/sp_io.h
@@ -29,7 +29,7 @@ void sp_File_print(sp_File *f, const char *s);
 mrb_int sp_File_flush(sp_File *f);
 mrb_bool sp_File_eof_p(sp_File *f);
 mrb_int sp_File_seek(sp_File *f, mrb_int off, mrb_int whence); /* #seek -- whence: 0=SET 1=CUR 2=END */
-mrb_int sp_File_tell(sp_File *f);       /* #tell / #pos -- ftell */
+mrb_int sp_File_tell(sp_File *f);       /* #tell / #pos -- ftello, -1 on closed */
 mrb_int sp_File_rewind(sp_File *f);     /* #rewind */
 mrb_bool sp_File_tty_p(sp_File *f);     /* #tty? / #isatty -- isatty(fileno) */
 mrb_int sp_File_fileno(sp_File *f);     /* #fileno */

--- a/lib/sp_io.h
+++ b/lib/sp_io.h
@@ -28,6 +28,9 @@ void sp_File_puts(sp_File *f, const char *s);
 void sp_File_print(sp_File *f, const char *s);
 mrb_int sp_File_flush(sp_File *f);
 mrb_bool sp_File_eof_p(sp_File *f);
+mrb_int sp_File_seek(sp_File *f, mrb_int off, mrb_int whence); /* #seek -- whence: 0=SET 1=CUR 2=END */
+mrb_int sp_File_tell(sp_File *f);       /* #tell / #pos -- ftell */
+mrb_int sp_File_rewind(sp_File *f);     /* #rewind */
 mrb_bool sp_File_tty_p(sp_File *f);     /* #tty? / #isatty -- isatty(fileno) */
 mrb_int sp_File_fileno(sp_File *f);     /* #fileno */
 sp_IntArray *sp_File_winsize(sp_File *f); /* #winsize -> [rows, cols] (ioctl, or [0,0]) */

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -3299,6 +3299,11 @@ TyKind infer_uncached(Compiler *c, int id) {
       if (nm && (sp_streq(nm, "SEPARATOR") || sp_streq(nm, "PATH_SEPARATOR") ||
                  sp_streq(nm, "ALT_SEPARATOR"))) return TY_STRING;
     }
+    if (par_nm && (sp_streq(par_nm, "IO") || sp_streq(par_nm, "File"))) {
+      /* IO#seek whence constants (File inherits them from IO) */
+      if (nm && (sp_streq(nm, "SEEK_SET") || sp_streq(nm, "SEEK_CUR") ||
+                 sp_streq(nm, "SEEK_END"))) return TY_INT;
+    }
     if (par_nm && sp_streq(par_nm, "Integer")) {
       if (nm && (sp_streq(nm, "MAX") || sp_streq(nm, "MIN"))) return TY_UNKNOWN; /* raises NameError */
     }

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -3765,6 +3765,23 @@ void emit_call(Compiler *c, int id, Buf *b) {
     if (sp_streq(name, "eof?") || sp_streq(name, "eof")) {
       buf_printf(b, "sp_File_eof_p(%s)", r); free(rb.p); return;
     }
+    if (sp_streq(name, "seek") && argc >= 1) {
+      /* offset plus optional whence (IO::SEEK_SET/CUR/END -> 0/1/2; absolute
+         when omitted, matching Ruby's SEEK_SET default) */
+      buf_printf(b, "sp_File_seek(%s, ", r);
+      emit_int_expr(c, argv[0], b);
+      buf_puts(b, ", ");
+      if (argc >= 2) emit_int_expr(c, argv[1], b);
+      else buf_puts(b, "0");
+      buf_puts(b, ")");
+      free(rb.p); return;
+    }
+    if (sp_streq(name, "tell") || sp_streq(name, "pos")) {
+      buf_printf(b, "sp_File_tell(%s)", r); free(rb.p); return;
+    }
+    if (sp_streq(name, "rewind")) {
+      buf_printf(b, "sp_File_rewind(%s)", r); free(rb.p); return;
+    }
     if (sp_streq(name, "path") || sp_streq(name, "to_path")) {
       buf_printf(b, "sp_File_path(%s)", r); free(rb.p); return;
     }

--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -1111,6 +1111,13 @@ void emit_expr(Compiler *c, int id, Buf *b) {
       if (sp_streq(nm, "PATH_SEPARATOR")) { buf_puts(b, "(&(\"\\xff\" \":\")[1])"); return; }
       if (sp_streq(nm, "ALT_SEPARATOR"))  { buf_puts(b, "(&(\"\\xff\")[1])"); return; }
     }
+    if (par_nmc && (sp_streq(par_nmc, "IO") || sp_streq(par_nmc, "File")) && nm) {
+      /* IO#seek whence constants (File inherits them from IO); the Ruby
+         values 0/1/2 are what sp_File_seek expects. */
+      if (sp_streq(nm, "SEEK_SET")) { buf_puts(b, "((mrb_int)0)"); return; }
+      if (sp_streq(nm, "SEEK_CUR")) { buf_puts(b, "((mrb_int)1)"); return; }
+      if (sp_streq(nm, "SEEK_END")) { buf_puts(b, "((mrb_int)2)"); return; }
+    }
     if (par_nmc && sp_streq(par_nmc, "Process") && nm) {
       if (sp_streq(nm, "CLOCK_MONOTONIC")) { buf_puts(b, "((mrb_int)1)"); return; }
       if (sp_streq(nm, "CLOCK_REALTIME"))  { buf_puts(b, "((mrb_int)0)"); return; }

--- a/test/file_seek_tell_rewind.rb
+++ b/test/file_seek_tell_rewind.rb
@@ -1,0 +1,25 @@
+path = "/tmp/spinel_file_seek_test.txt"
+File.open(path, "w") do |f|
+  f.write("HELLOWORLDABCDEF")
+end
+
+f = File.open(path, "r")
+puts f.read(4)
+puts f.tell
+puts f.pos
+f.seek(10)
+puts f.read(3)
+puts f.tell
+f.seek(2, IO::SEEK_CUR)
+puts f.read(1)
+f.seek(-6, IO::SEEK_END)
+puts f.read(6)
+f.seek(5, IO::SEEK_SET)
+puts f.read(5)
+f.rewind
+puts f.tell
+puts f.read(5)
+f.close
+
+File.delete(path)
+puts "done"

--- a/test/file_seek_tell_rewind.rb
+++ b/test/file_seek_tell_rewind.rb
@@ -1,4 +1,4 @@
-path = "/tmp/spinel_file_seek_test.txt"
+path = "spinel_file_seek_test_#{Process.pid}.txt"
 File.open(path, "w") do |f|
   f.write("HELLOWORLDABCDEF")
 end
@@ -21,5 +21,5 @@ puts f.tell
 puts f.read(5)
 f.close
 
-File.delete(path)
+File.delete(path) if File.exist?(path)
 puts "done"

--- a/test/file_seek_tell_rewind.rb.expected
+++ b/test/file_seek_tell_rewind.rb.expected
@@ -1,0 +1,11 @@
+HELL
+4
+4
+ABC
+13
+F
+ABCDEF
+WORLD
+0
+HELLO
+done


### PR DESCRIPTION
Part of the effort to run the unmodified Doom gem on spinel.

File/IO handles rejected `seek`/`tell`/`pos`/`rewind` as unsupported calls (4 occurrences block the Doom gem: its WAD reader seeks to lump offsets before reading each lump). This adds the runtime wrappers over `fseek`/`ftell`/`rewind`, the TY_IO codegen dispatch arms, and models `IO::SEEK_SET/CUR/END` (and the inherited `File::SEEK_*`) as int constants so the optional whence argument works; `seek` defaults to absolute. Return-type inference already mapped these methods to int.

Test covers read/tell/pos, absolute seek, SEEK_CUR, SEEK_END with a negative offset, and rewind. Suite green: 1228 pass, only the known system_argument_list flake and the bundle_hash_b2 artifact fail.