### PR TITLE
analyze,set: fold false defined?-guarded branches; Set#delete

### DIFF
--- a/packages/set/set.rb
+++ b/packages/set/set.rb
@@ -26,6 +26,11 @@ class Set
   end
   alias member? include?
 
+  def delete(x)
+    @data.delete(x)
+    self
+  end
+
   def each
     @data.each { |x| yield x }
     self

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -28,13 +28,13 @@ void compute_reachable(Compiler *c) {
   int   *sc_cap      = calloc((size_t)c->nscopes, sizeof(int));
   for (int s = 0; s < c->nscopes; s++) {
     if (c->scopes[s].body >= 0)
-      cr_collect_calls(c->nt, c->scopes[s].body, &scope_calls[s], &sc_n[s], &sc_cap[s]);
+      cr_collect_calls(c, c->nt, c->scopes[s].body, &scope_calls[s], &sc_n[s], &sc_cap[s]);
     /* Also scan parameter defaults (e.g. def foo(opt = bar)) — these emit calls
        within the method scope but live in the DefNode parameters subtree. */
     if (c->scopes[s].def_node >= 0) {
       int pn = nt_ref(c->nt, c->scopes[s].def_node, "parameters");
       if (pn >= 0)
-        cr_collect_calls(c->nt, pn, &scope_calls[s], &sc_n[s], &sc_cap[s]);
+        cr_collect_calls(c, c->nt, pn, &scope_calls[s], &sc_n[s], &sc_cap[s]);
     }
   }
 

--- a/src/analyze_internal.h
+++ b/src/analyze_internal.h
@@ -204,7 +204,7 @@ TyKind return_node_type(Compiler *c, int id);
 int infer_return_types(Compiler *c);
 int backprop_hash_return_types(Compiler *c);
 int backprop_call_target(Compiler *c, int call_id);
-void cr_collect_calls(const NodeTable *nt, int id, char ***out, int *n, int *cap);
+void cr_collect_calls(Compiler *c, const NodeTable *nt, int id, char ***out, int *n, int *cap);
 void compute_reachable(Compiler *c);
 void compute_instantiated(Compiler *c);
 int aname_has(ANameSet *s, const char *nm);

--- a/src/analyze_pass.c
+++ b/src/analyze_pass.c
@@ -4551,12 +4551,23 @@ int infer_return_types(Compiler *c) {
 /* Collect CallNode names in the subtree rooted at `id`, stopping at nested
    DefNodes (which are separate method scopes). `out` / `n` / `cap` are
    the dynamic string array to append to. */
-void cr_collect_calls(const NodeTable *nt, int id,
+void cr_collect_calls(Compiler *c, const NodeTable *nt, int id,
                               char ***out, int *n, int *cap) {
   if (id < 0) return;
   const char *ty = nt_type(nt, id);
   if (!ty) return;
   if (sp_streq(ty, "DefNode")) return;          /* don't enter nested methods */
+  /* `if defined?(UnknownConst) ... end`: the then-branch is compile-time dead
+     (and never emitted -- see emit_if), so collecting its calls would mark
+     genuinely unemittable methods live. Only walk the live side. */
+  if (sp_streq(ty, "IfNode") && comp_defined_guard_false(c, nt_ref(nt, id, "predicate"))) {
+    cr_collect_calls(c, nt, nt_ref(nt, id, "subsequent"), out, n, cap);
+    return;
+  }
+  if (sp_streq(ty, "UnlessNode") && comp_defined_guard_false(c, nt_ref(nt, id, "predicate"))) {
+    cr_collect_calls(c, nt, nt_ref(nt, id, "statements"), out, n, cap);
+    return;
+  }
   /* Collect method name from CallNode, or operator name from op-assign nodes
      (e.g. `a += 1` → InstanceVariableOperatorWriteNode with binary_operator "+"). */
   const char *nm = NULL;
@@ -4597,9 +4608,9 @@ void cr_collect_calls(const NodeTable *nt, int id,
     }
   }
   int nr = nt_num_refs(nt, id);
-  for (int i = 0; i < nr; i++) { int ch = nt_ref_at(nt, id, i); if (ch >= 0) cr_collect_calls(nt, ch, out, n, cap); }
+  for (int i = 0; i < nr; i++) { int ch = nt_ref_at(nt, id, i); if (ch >= 0) cr_collect_calls(c, nt, ch, out, n, cap); }
   int na = nt_num_arrs(nt, id);
-  for (int i = 0; i < na; i++) { int nn = 0; const int *ids = nt_arr_at(nt, id, i, &nn); for (int k = 0; k < nn; k++) if (ids[k] >= 0) cr_collect_calls(nt, ids[k], out, n, cap); }
+  for (int i = 0; i < na; i++) { int nn = 0; const int *ids = nt_arr_at(nt, id, i, &nn); for (int k = 0; k < nn; k++) if (ids[k] >= 0) cr_collect_calls(c, nt, ids[k], out, n, cap); }
 }
 
 /* Mark each method scope reachable via transitive call-graph BFS.

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -1003,6 +1003,11 @@ void emit_if(Compiler *c, int id, Buf *b, int indent, int is_unless, int tail) {
     int sc = static_isa_cond(c, pred);
     if (sc < 0) sc = static_nil_ivar_cond(c, pred);
     if (sc < 0) sc = static_nil_reader_cond(c, pred);
+    /* `if defined?(UnknownConst) [&& ...]`: nil guard, the branch is dead.
+       Must be dropped (not just emitted under `if (NULL)`): its body may call
+       methods reachability already skipped for the same reason, or lean on
+       the missing constant in ways that have no C translation. */
+    if (sc < 0 && comp_defined_guard_false(c, pred)) sc = 0;
     int eff = (sc < 0) ? -1 : (is_unless ? !sc : sc);
     if (eff == 1) {
       /* condition always true: emit only the then-branch */

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -562,6 +562,43 @@ int comp_sg_reader_candidates(Compiler *c, int call_id, int *out, int max) {
   return comp_sg_const_candidates(c, ci, nm, out, max);
 }
 
+/* Statically-false `defined?(Const)` guard: the predicate is a DefinedNode
+   (or a `defined?(Const) && ...` AndNode, whose left arm short-circuits the
+   whole conjunction to nil) over a constant / constant path that resolves to
+   nothing at compile time: not a registered class/module, not a value
+   constant, and not a well-known builtin the DefinedNode emit answers
+   "constant" for. Such an if-branch is compile-time dead -- doom's
+   `if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?` MRI hack -- so call
+   reachability must not walk it and codegen must not emit it. Deliberately
+   narrow: only constants/constant paths, no dynamic defined? forms. */
+int comp_defined_guard_false(Compiler *c, int pred) {
+  const NodeTable *nt = c->nt;
+  if (pred < 0) return 0;
+  const char *pt = nt_type(nt, pred);
+  if (!pt) return 0;
+  /* `defined?(X) && rest`: falseness of the left arm decides the whole
+     predicate (recurses to cover chained `&&`s, which nest leftward). */
+  if (sp_streq(pt, "AndNode"))
+    return comp_defined_guard_false(c, nt_ref(nt, pred, "left"));
+  if (!sp_streq(pt, "DefinedNode")) return 0;
+  int v = nt_ref(nt, pred, "value");
+  if (v < 0) return 0;
+  const char *vt = nt_type(nt, v);
+  if (!vt || (!sp_streq(vt, "ConstantReadNode") && !sp_streq(vt, "ConstantPathNode"))) return 0;
+  const char *cn = nt_str(nt, v, "name");
+  if (!cn) return 0;
+  if (comp_const(c, cn) || comp_class_index(c, cn) >= 0) return 0;
+  /* keep in sync with the DefinedNode ConstantReadNode emit (codegen_expr.c) */
+  static const char *const builtins[] = {
+    "Object", "BasicObject", "Kernel", "Module", "Class", "Array", "Hash",
+    "String", "Integer", "Float", "Symbol", "Regexp", "Range", "NilClass",
+    "TrueClass", "FalseClass", "Numeric", "Comparable", "Enumerable",
+    "IO", "File", "Dir", "Math", "GC", "Process", "ENV", "ARGV",
+    "STDOUT", "STDERR", "STDIN", NULL };
+  for (int bi = 0; builtins[bi]; bi++) if (sp_streq(cn, builtins[bi])) return 0;
+  return 1;
+}
+
 /* A literal ArrayNode whose elements are all integer literals (or empty). */
 static int is_int_array_literal(Compiler *c, int node) {
   const NodeTable *nt = c->nt;

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -562,12 +562,31 @@ int comp_sg_reader_candidates(Compiler *c, int call_id, int *out, int max) {
   return comp_sg_const_candidates(c, ci, nm, out, max);
 }
 
+/* A constant name that resolves to something at compile time: a value
+   constant, a registered class/module, or a well-known builtin the
+   DefinedNode emit answers "constant" for (keep the list in sync with the
+   ConstantReadNode arm in codegen_expr.c). */
+static int const_name_resolves(Compiler *c, const char *cn) {
+  if (!cn) return 0;
+  if (comp_const(c, cn) || comp_class_index(c, cn) >= 0) return 1;
+  static const char *const builtins[] = {
+    "Object", "BasicObject", "Kernel", "Module", "Class", "Array", "Hash",
+    "String", "Integer", "Float", "Symbol", "Regexp", "Range", "NilClass",
+    "TrueClass", "FalseClass", "Numeric", "Comparable", "Enumerable",
+    "IO", "File", "Dir", "Math", "GC", "Process", "ENV", "ARGV",
+    "STDOUT", "STDERR", "STDIN", NULL };
+  for (int bi = 0; builtins[bi]; bi++) if (sp_streq(cn, builtins[bi])) return 1;
+  return 0;
+}
+
 /* Statically-false `defined?(Const)` guard: the predicate is a DefinedNode
    (or a `defined?(Const) && ...` AndNode, whose left arm short-circuits the
    whole conjunction to nil) over a constant / constant path that resolves to
-   nothing at compile time: not a registered class/module, not a value
-   constant, and not a well-known builtin the DefinedNode emit answers
-   "constant" for. Such an if-branch is compile-time dead -- doom's
+   nothing at compile time. A constant path (A::B::C) needs every segment to
+   resolve for the path to possibly exist; one unresolved segment makes the
+   whole path -- and the guard -- statically false (`RubyVM::YJIT` folds on
+   RubyVM, and `MissingParent::String` folds on MissingParent despite its
+   builtin tail). Such an if-branch is compile-time dead -- doom's
    `if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?` MRI hack -- so call
    reachability must not walk it and codegen must not emit it. Deliberately
    narrow: only constants/constant paths, no dynamic defined? forms. */
@@ -584,19 +603,22 @@ int comp_defined_guard_false(Compiler *c, int pred) {
   int v = nt_ref(nt, pred, "value");
   if (v < 0) return 0;
   const char *vt = nt_type(nt, v);
-  if (!vt || (!sp_streq(vt, "ConstantReadNode") && !sp_streq(vt, "ConstantPathNode"))) return 0;
-  const char *cn = nt_str(nt, v, "name");
-  if (!cn) return 0;
-  if (comp_const(c, cn) || comp_class_index(c, cn) >= 0) return 0;
-  /* keep in sync with the DefinedNode ConstantReadNode emit (codegen_expr.c) */
-  static const char *const builtins[] = {
-    "Object", "BasicObject", "Kernel", "Module", "Class", "Array", "Hash",
-    "String", "Integer", "Float", "Symbol", "Regexp", "Range", "NilClass",
-    "TrueClass", "FalseClass", "Numeric", "Comparable", "Enumerable",
-    "IO", "File", "Dir", "Math", "GC", "Process", "ENV", "ARGV",
-    "STDOUT", "STDERR", "STDIN", NULL };
-  for (int bi = 0; builtins[bi]; bi++) if (sp_streq(cn, builtins[bi])) return 0;
-  return 1;
+  if (vt && sp_streq(vt, "ConstantReadNode"))
+    return !const_name_resolves(c, nt_str(nt, v, "name"));
+  if (vt && sp_streq(vt, "ConstantPathNode")) {
+    /* Walk tail-to-root; any unresolved segment kills the whole path. */
+    for (int seg = v; ; ) {
+      if (!const_name_resolves(c, nt_str(nt, seg, "name"))) return 1;
+      int par = nt_ref(nt, seg, "parent");
+      if (par < 0) return 0;                     /* ::Root form, all resolved */
+      const char *pty = nt_type(nt, par);
+      if (pty && sp_streq(pty, "ConstantPathNode")) { seg = par; continue; }
+      if (pty && sp_streq(pty, "ConstantReadNode"))
+        return !const_name_resolves(c, nt_str(nt, par, "name"));
+      return 0;                                  /* dynamic parent: no fold */
+    }
+  }
+  return 0;
 }
 
 /* A literal ArrayNode whose elements are all integer literals (or empty). */

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -274,6 +274,10 @@ const char *comp_resolve_gvar(Compiler *c, const char *name); /* alias resolutio
 void comp_add_gvar_alias(Compiler *c, const char *from, const char *to);
 LocalVar *comp_const(Compiler *c, const char *name);
 LocalVar *comp_const_intern(Compiler *c, const char *name);
+/* 1 when `pred` is a statically-false `defined?(Const)` if-guard (optionally
+   the left arm of an `&&` chain) over a constant that resolves to nothing;
+   the guarded branch is compile-time dead. */
+int comp_defined_guard_false(Compiler *c, int pred);
 
 /* Classes. */
 ClassInfo *comp_class_new(Compiler *c, const char *name, int def_node);

--- a/test/defined_guard_dead_branch.rb
+++ b/test/defined_guard_dead_branch.rb
@@ -1,0 +1,63 @@
+# A statically-false defined?(Const) guard must fold the whole branch away:
+# the constant resolves to nothing at compile time, so the branch is dead code.
+# Shape from doom's gosu_window YJIT toggle:
+#   if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
+#     ... RubyVM::YJIT.enable ...
+#   end
+# The dead branch must neither pull its callees into emission (reachability)
+# nor be emitted itself (its body may be uncompilable, like an MRI-only hack).
+
+class YjitShim
+end
+
+# Only ever called from dead branches; `frobnicate` does not exist on
+# YjitShim, so emitting this body is a hard compile error.
+def setup_yjit_toggle
+  shim = YjitShim.new
+  shim.frobnicate
+  puts "toggled"
+end
+
+def yjit_toggle
+  if defined?(SomeMissingConst) && SomeMissingConst.enabled?
+    SomeMissingConst.enable
+    setup_yjit_toggle
+    puts "on"
+  end
+  puts "after"
+end
+
+def elsif_variant(n)
+  if n > 10
+    puts "big"
+  elsif defined?(AnotherMissingConst)
+    setup_yjit_toggle
+    puts "activated"
+  else
+    puts "small"
+  end
+end
+
+def plain_guard
+  if defined?(MissingToo::Nested)
+    shim = YjitShim.new
+    shim.enable_nested
+    puts "unreachable"
+  end
+  puts "done"
+end
+
+# Control: a truthy defined? over a real builtin keeps its branch.
+def known_guard
+  if defined?(String)
+    puts "string exists"
+  else
+    puts "no string"
+  end
+end
+
+yjit_toggle
+elsif_variant(3)
+elsif_variant(42)
+plain_guard
+known_guard

--- a/test/defined_guard_dead_branch.rb
+++ b/test/defined_guard_dead_branch.rb
@@ -47,6 +47,25 @@ def plain_guard
   puts "done"
 end
 
+# A builtin tail must not mask an unresolved parent: MissingParent does not
+# exist, so the whole path is statically false (CRuby agrees: nil).
+def qualified_tail_builtin
+  if defined?(MissingParent::String)
+    shim = YjitShim.new
+    shim.frobnicate_qualified
+    puts "unreachable"
+  end
+  puts "qualified done"
+end
+
+def nested_missing_root
+  if defined?(MissingRoot::Sub::Thing) && MissingRoot::Sub::Thing.on?
+    setup_yjit_toggle
+    puts "nested on"
+  end
+  puts "nested done"
+end
+
 # Control: a truthy defined? over a real builtin keeps its branch.
 def known_guard
   if defined?(String)
@@ -60,4 +79,6 @@ yjit_toggle
 elsif_variant(3)
 elsif_variant(42)
 plain_guard
+qualified_tail_builtin
+nested_missing_root
 known_guard

--- a/test/defined_guard_dead_branch.rb.expected
+++ b/test/defined_guard_dead_branch.rb.expected
@@ -1,0 +1,5 @@
+after
+small
+big
+done
+string exists

--- a/test/defined_guard_dead_branch.rb.expected
+++ b/test/defined_guard_dead_branch.rb.expected
@@ -2,4 +2,6 @@ after
 small
 big
 done
+qualified done
+nested done
 string exists

--- a/test/set_delete.rb
+++ b/test/set_delete.rb
@@ -1,0 +1,20 @@
+require 'set'
+
+s = Set.new
+s.add(1)
+s.add(2)
+s << 3
+s.add(2)
+puts s.size
+puts s.include?(2)
+
+s.delete(2)
+puts s.include?(2)
+puts s.size
+
+# deleting a missing key is a no-op and still returns the set (chainable)
+s.delete(99).add(4)
+puts s.size
+puts s.include?(4)
+puts s.member?(1)
+puts s.empty?

--- a/test/set_delete.rb.expected
+++ b/test/set_delete.rb.expected
@@ -1,0 +1,8 @@
+3
+true
+false
+2
+3
+true
+true
+false


### PR DESCRIPTION
Part of the effort to run the unmodified Doom gem on spinel.

Doom's gosu_window wraps an MRI-only YJIT toggle in `if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?`. RubyVM resolves to nothing in spinel, so the guard is statically false, yet the compiler still walked the branch: call collection marked the unemittable toggle helper reachable and codegen rejected the branch body (4 errors).

This adds a shared `comp_defined_guard_false` check and applies it in two places: `cr_collect_calls` skips the dead branch during reachability, and statement-form `emit_if` drops it via the existing static-guard fold chain. The scope is deliberately narrow: only `defined?` over constants/constant paths (optionally as the left arm of an `&&` chain) that resolve to no class, module, value constant, or known builtin. Dynamic `defined?` forms are untouched.

Also adds `Set#delete` (remove and return self) to the bundled set package, which doom's sector_actions.rb needs.

Tests: `test/defined_guard_dead_branch.rb` (dead if/elsif branches plus a truthy `defined?(String)` control) and `test/set_delete.rb`; both fail before this change. Full suite green (1229 pass; the flaky system_argument_list passes when rerun individually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)