### PR TITLE
codegen: Array#index and #to_h on a poly array

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -2084,6 +2084,29 @@ else {
            a scalar block return behaves like map (each wrapped element). */
         return ty_is_array(bret) ? bret : ty_array_of(bret);
       }
+      if (sp_streq(name, "to_h") && argc == 0) {
+        /* array.to_h { |x| [k, v] } -> a boxed-value hash, keyed by the
+           block's [k, v] tail-pair key type (string/symbol get their own
+           hash kind; anything else falls back to a fully boxed hash). */
+        int body = nt_ref(nt, block, "body");
+        int bn = 0;
+        const int *bb = body >= 0 ? nt_arr(nt, body, "body", &bn) : NULL;
+        int tail = bn > 0 ? bb[bn - 1] : -1;
+        const char *tty = tail >= 0 ? nt_type(nt, tail) : NULL;
+        if (tty && sp_streq(tty, "ArrayNode")) {
+          int en = 0; const int *el = nt_arr(nt, tail, "elements", &en);
+          if (en == 2) {
+            TyKind kt = infer_type(c, el[0]);
+            if (kt == TY_SYMBOL) return TY_SYM_POLY_HASH;
+            if (kt == TY_STRING) return TY_STR_POLY_HASH;
+            /* the key's type hasn't settled yet (mid-fixpoint) -- stay
+               unknown rather than locking in poly_poly_hash prematurely,
+               which would then never narrow once kt resolves. */
+            if (kt == TY_UNKNOWN) return TY_UNKNOWN;
+          }
+        }
+        return TY_POLY_POLY_HASH;
+      }
       if (sp_streq(name, "select") || sp_streq(name, "reject") ||
           sp_streq(name, "filter") || sp_streq(name, "sort_by") ||
           sp_streq(name, "sort_by!") ||

--- a/src/analyze_pass.c
+++ b/src/analyze_pass.c
@@ -3630,7 +3630,8 @@ int infer_block_params(Compiler *c) {
               sp_streq(name, "filter_map") || sp_streq(name, "count_by") ||
               sp_streq(name, "partition") || sp_streq(name, "each_slice") ||
               sp_streq(name, "minmax_by") || sp_streq(name, "bsearch_index") ||
-              sp_streq(name, "each_cons") || sp_streq(name, "cycle")) &&
+              sp_streq(name, "each_cons") || sp_streq(name, "cycle") ||
+              sp_streq(name, "to_h")) &&
              ty_is_array(rt))
       pt = ty_array_elem(rt);
     /* each_index { |i| } binds the index, not the element: always int. */

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -400,8 +400,11 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
         argc == 1 && nt_ref(nt, id, "block") < 0) {
       int trecv = ++g_tmp, ta = ++g_tmp, tres = ++g_tmp, ti = ++g_tmp;
       Buf ra = expr_buf(c, recv);
-      buf_printf(b, "({ sp_PolyArray *_t%d = %s;", trecv, ra.p ? ra.p : "NULL"); free(ra.p);
-      buf_printf(b, " sp_RbVal _t%d = ", ta); emit_boxed(c, argv[0], b); buf_puts(b, ";");
+      /* Root the receiver and the boxed needle: sp_poly_eq can allocate
+         (bigint promotion), so a collection may run mid-loop. */
+      buf_printf(b, "({ sp_PolyArray *_t%d = %s; SP_GC_ROOT(_t%d);", trecv, ra.p ? ra.p : "NULL", trecv); free(ra.p);
+      buf_printf(b, " sp_RbVal _t%d = ", ta); emit_boxed(c, argv[0], b);
+      buf_printf(b, "; SP_GC_ROOT_RBVAL(_t%d);", ta);
       buf_printf(b, " mrb_int _t%d = SP_INT_NIL;", tres);
       buf_printf(b, " for (mrb_int _t%d = 0; _t%d < sp_PolyArray_length(_t%d); _t%d++)", ti, ti, trecv, ti);
       buf_printf(b, " if (sp_poly_eq(sp_PolyArray_get(_t%d, _t%d), _t%d)) { _t%d = _t%d; break; }",
@@ -1688,7 +1691,15 @@ else {
           for (int j = 0; j < bn - 1; j++) emit_stmt(c, bb[j], g_pre, g_indent + 1);
           int sv = g_indent; g_indent++;
           Buf kb; memset(&kb, 0, sizeof kb);
-          if (kt == TY_STRING) { buf_puts(&kb, "sp_str_dup("); emit_expr(c, pair[0], &kb); buf_puts(&kb, ")"); }
+          if (kt == TY_STRING) {
+            /* A TY_STRING slot can carry nil (NULL); a Str-keyed hash can't
+               store it (NULL marks an empty bucket and sp_str_hash reads
+               k[-1]), so raise instead of segfaulting on a nil key. */
+            int tk = ++g_tmp;
+            buf_printf(&kb, "({ const char *_t%d = sp_str_dup(", tk);
+            emit_expr(c, pair[0], &kb);
+            buf_printf(&kb, "); if (!_t%d) sp_raise_cls(\"TypeError\", \"nil key in a string-keyed Hash\"); _t%d; })", tk, tk);
+          }
           else if (kt == TY_SYMBOL) emit_expr(c, pair[0], &kb);
           else emit_boxed(c, pair[0], &kb);
           Buf vb; memset(&vb, 0, sizeof vb); emit_boxed(c, pair[1], &vb);

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -358,6 +358,57 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
         }
       }
     }
+    /* find_index / index { |x| cond } on a poly array -> the index or nil.
+       The typed-array form lives inside the `if (k)` block below; array_kind
+       is NULL for a poly array, so handle it here. Unlike the int/str-array
+       forms (which infer TY_POLY and box), index/find_index on a poly array
+       infer as a plain nullable mrb_int -- return the bare SP_INT_NIL
+       sentinel, don't box. */
+    if (rt == TY_POLY_ARRAY && (sp_streq(name, "find_index") || sp_streq(name, "index")) &&
+        nt_ref(nt, id, "block") >= 0) {
+      int fblock = nt_ref(nt, id, "block");
+      const char *bp = block_param_name(c, fblock, 0); if (bp) bp = rename_local(bp);
+      int body = nt_ref(nt, fblock, "body");
+      int bn = 0; const int *bb = body >= 0 ? nt_arr(nt, body, "body", &bn) : NULL;
+      if (bn >= 1) {
+        int trecv = ++g_tmp, ti = ++g_tmp, tres = ++g_tmp;
+        Buf rb = expr_buf(c, recv);
+        emit_indent(g_pre, g_indent);
+        buf_printf(g_pre, "sp_PolyArray *_t%d = %s; SP_GC_ROOT(_t%d);\n", trecv, rb.p ? rb.p : "NULL", trecv); free(rb.p);
+        emit_indent(g_pre, g_indent); buf_printf(g_pre, "mrb_int _t%d = SP_INT_NIL;\n", tres);
+        emit_indent(g_pre, g_indent);
+        buf_printf(g_pre, "for (mrb_int _t%d = 0; _t%d < sp_PolyArray_length(_t%d); _t%d++) {\n",
+                   ti, ti, trecv, ti);
+        /* Declare the block param in the loop body so the form is self-contained
+           (same rationale as find/detect above). */
+        if (bp) { emit_indent(g_pre, g_indent + 1); buf_printf(g_pre, "sp_RbVal lv_%s = sp_PolyArray_get(_t%d, _t%d);\n", bp, trecv, ti); }
+        for (int j = 0; j < bn - 1; j++) emit_stmt(c, bb[j], g_pre, g_indent + 1);
+        int sv = g_indent; g_indent++;
+        Buf cb; memset(&cb, 0, sizeof cb); emit_cond(c, bb[bn - 1], &cb); g_indent = sv;
+        emit_indent(g_pre, g_indent + 1);
+        buf_printf(g_pre, "if (%s) { _t%d = _t%d; break; }\n", cb.p ? cb.p : "0", tres, ti);
+        free(cb.p);
+        emit_indent(g_pre, g_indent); buf_puts(g_pre, "}\n");
+        buf_printf(b, "_t%d", tres);
+        return 1;
+      }
+    }
+    /* index(v) / find_index(v) on a poly array (no block) -> the first
+       position whose element == v (sp_poly_eq), or nil (SP_INT_NIL),
+       mirroring the count(v)/any?(v) idiom (doom: @map.sectors.index(sector)). */
+    if (rt == TY_POLY_ARRAY && (sp_streq(name, "index") || sp_streq(name, "find_index")) &&
+        argc == 1 && nt_ref(nt, id, "block") < 0) {
+      int trecv = ++g_tmp, ta = ++g_tmp, tres = ++g_tmp, ti = ++g_tmp;
+      Buf ra = expr_buf(c, recv);
+      buf_printf(b, "({ sp_PolyArray *_t%d = %s;", trecv, ra.p ? ra.p : "NULL"); free(ra.p);
+      buf_printf(b, " sp_RbVal _t%d = ", ta); emit_boxed(c, argv[0], b); buf_puts(b, ";");
+      buf_printf(b, " mrb_int _t%d = SP_INT_NIL;", tres);
+      buf_printf(b, " for (mrb_int _t%d = 0; _t%d < sp_PolyArray_length(_t%d); _t%d++)", ti, ti, trecv, ti);
+      buf_printf(b, " if (sp_poly_eq(sp_PolyArray_get(_t%d, _t%d), _t%d)) { _t%d = _t%d; break; }",
+                 trecv, ti, ta, tres, ti);
+      buf_printf(b, " _t%d; })", tres);
+      return 1;
+    }
     if (k) {
       if ((sp_streq(name, "to_a") || sp_streq(name, "to_ary") || sp_streq(name, "entries") ||
            sp_streq(name, "flatten") || sp_streq(name, "compact")) && argc == 0) {
@@ -1607,6 +1658,48 @@ else {
         else                       buf_printf(b, "sp_poly_arr_get(_t%d, 1)", tp);
         buf_printf(b, "); } _t%d; })", th);
         return 1;
+      }
+      /* to_h { |x| [k, v] } on a poly array -> a hash keyed by the block's
+         literal [k, v] tail pair (the only shape analyze_infer types):
+         string/symbol keys get their own hash kind, anything else a fully
+         boxed hash (doom: flats.to_h { |f| [f.name, f] }). */
+      if (sp_streq(name, "to_h") && argc == 0 && nt_ref(nt, id, "block") >= 0) {
+        int blk = nt_ref(nt, id, "block");
+        const char *bp = block_param_name(c, blk, 0); if (bp) bp = rename_local(bp);
+        int body = nt_ref(nt, blk, "body");
+        int bn = 0; const int *bb = body >= 0 ? nt_arr(nt, body, "body", &bn) : NULL;
+        int tail = bn > 0 ? bb[bn - 1] : -1;
+        const char *tty = tail >= 0 ? nt_type(nt, tail) : NULL;
+        int pairn = 0;
+        const int *pair = (tty && sp_streq(tty, "ArrayNode")) ? nt_arr(nt, tail, "elements", &pairn) : NULL;
+        const char *hn = pair && pairn == 2 ? ty_hash_cname(res) : NULL;
+        if (hn) {
+          TyKind kt = comp_ntype(c, pair[0]);
+          int trecv = ++g_tmp, ti = ++g_tmp, th = ++g_tmp;
+          Buf rb = expr_buf(c, recv);
+          emit_indent(g_pre, g_indent);
+          buf_printf(g_pre, "sp_PolyArray *_t%d = %s; SP_GC_ROOT(_t%d);\n", trecv, rb.p ? rb.p : "NULL", trecv); free(rb.p);
+          emit_indent(g_pre, g_indent);
+          buf_printf(g_pre, "sp_%sHash *_t%d = sp_%sHash_new(); SP_GC_ROOT(_t%d);\n", hn, th, hn, th);
+          emit_indent(g_pre, g_indent);
+          buf_printf(g_pre, "for (mrb_int _t%d = 0; _t%d < sp_PolyArray_length(_t%d); _t%d++) {\n",
+                     ti, ti, trecv, ti);
+          if (bp) { emit_indent(g_pre, g_indent + 1); buf_printf(g_pre, "sp_RbVal lv_%s = sp_PolyArray_get(_t%d, _t%d);\n", bp, trecv, ti); }
+          for (int j = 0; j < bn - 1; j++) emit_stmt(c, bb[j], g_pre, g_indent + 1);
+          int sv = g_indent; g_indent++;
+          Buf kb; memset(&kb, 0, sizeof kb);
+          if (kt == TY_STRING) { buf_puts(&kb, "sp_str_dup("); emit_expr(c, pair[0], &kb); buf_puts(&kb, ")"); }
+          else if (kt == TY_SYMBOL) emit_expr(c, pair[0], &kb);
+          else emit_boxed(c, pair[0], &kb);
+          Buf vb; memset(&vb, 0, sizeof vb); emit_boxed(c, pair[1], &vb);
+          g_indent = sv;
+          emit_indent(g_pre, g_indent + 1);
+          buf_printf(g_pre, "sp_%sHash_set(_t%d, %s, %s);\n", hn, th, kb.p ? kb.p : "", vb.p ? vb.p : "");
+          free(kb.p); free(vb.p);
+          emit_indent(g_pre, g_indent); buf_puts(g_pre, "}\n");
+          buf_printf(b, "_t%d", th);
+          return 1;
+        }
       }
     }
   }

--- a/test/poly_array_index_to_h.rb
+++ b/test/poly_array_index_to_h.rb
@@ -1,0 +1,50 @@
+class Sector
+  attr_reader :name
+
+  def initialize(name)
+    @name = name
+  end
+end
+
+class Flat
+  attr_reader :name
+
+  def initialize(name)
+    @name = name
+  end
+end
+
+# --- index(value) on a poly array of objects (Doom: @map.sectors.index(sector)) ---
+a = Sector.new("a")
+b = Sector.new("b")
+c = Sector.new("c")
+sectors = [a, b, c]
+puts sectors.index(b)
+puts sectors.index(a)
+puts sectors.index(Sector.new("z")).inspect
+
+# --- index(value) on a mixed poly array of strings and ints ---
+mixed = [1, "two", 3, "four"]
+puts mixed.index("two")
+puts mixed.index(3)
+puts mixed.index("missing").inspect
+
+# --- index { |x| cond } on a poly array ---
+puts sectors.index { |s| s.name == "c" }
+puts sectors.index { |s| s.name == "nope" }.inspect
+puts mixed.index { |x| x == "four" }
+
+# --- to_h { |f| [f.name, f] } producing string keys (Doom: flats.to_h) ---
+flats = [Flat.new("floor"), Flat.new("ceil"), Flat.new("sky")]
+by_name = flats.to_h { |f| [f.name, f] }
+puts by_name.size
+puts by_name["floor"].name
+puts by_name["ceil"].name
+puts by_name["sky"].name
+
+# --- to_h with symbol keys over a poly array ---
+things = [1, "two"]
+sym_h = things.to_h { |t| [t.class.to_s.downcase.to_sym, t.to_s] }
+puts sym_h.size
+puts sym_h[:integer]
+puts sym_h[:string]

--- a/test/poly_array_index_to_h.rb.expected
+++ b/test/poly_array_index_to_h.rb.expected
@@ -1,0 +1,16 @@
+1
+0
+nil
+1
+2
+nil
+2
+nil
+3
+3
+floor
+ceil
+sky
+2
+1
+two


### PR DESCRIPTION
Part of the effort to run the unmodified Doom gem on spinel.

On a poly-array receiver, `index` (both `arr.index(v)` and `arr.index { |x| cond }`, plus `find_index`) and the block form of `to_h` were rejected as unsupported calls. Doom hits both: `@map.sectors.index(sector)` (value form over poly object elements, compared via `sp_poly_eq`) and `flats.to_h { |f| [f.name, f] }` (string-keyed hash from a literal `[k, v]` block pair).

- `index(v)`: element-wise `sp_poly_eq` scan returning the position or the `SP_INT_NIL` sentinel, mirroring the existing `count(v)`/`any?(v)` idiom.
- `index/find_index { }`: loop with block truthiness, next to the existing poly `find`/`detect` arm.
- `to_h { |x| [k, v] }`: builds the hash kind matching the block's pair key type (string/symbol/poly -> StrPoly/SymPoly/PolyPoly), boxing values; inference and block-param typing added alongside.

Test: `test/poly_array_index_to_h.rb` covers object/mixed arrays, hit and miss, and string- and symbol-keyed `to_h`. Suite is green (1229 pass; the one remaining failure, `bundle_hash_b2`, is a pre-existing expected-file artifact unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)