### PR TITLE
codegen: receiverless respond_to? and related dispatch gaps

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -210,6 +210,18 @@ void compute_instantiated(Compiler *c) {
         disable = 1; break;
       }
     }
+    /* bare `new(...)` (no receiver) inside a class/singleton method (`def
+       self.foo; ...; new(...); end`) is implicit `self.new(...)`, i.e. the
+       enclosing class -- e.g. doom's `Texture.parse_texture` builds each
+       Texture via a bare `new(name, ...)`. Missing this meant such a
+       class's `instantiated` flag never got set unless some other call
+       site also did `Texture.new` explicitly -- so a poly-array element
+       member-read dispatch silently dropped its case arm, reading back
+       nil/0 for every field of an otherwise fully-constructed object. */
+    if (recv < 0 && sp_streq(name, "new")) {
+      Scope *encl = comp_scope_of(c, id);
+      if (encl && encl->class_id >= 0) c->classes[encl->class_id].instantiated = 1;
+    }
     /* raise Cls / raise Cls, msg : constructs an instance of Cls */
     if (recv < 0 && sp_streq(name, "raise")) {
       int rargs = nt_ref(nt, id, "arguments");

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -217,10 +217,14 @@ void compute_instantiated(Compiler *c) {
        class's `instantiated` flag never got set unless some other call
        site also did `Texture.new` explicitly -- so a poly-array element
        member-read dispatch silently dropped its case arm, reading back
-       nil/0 for every field of an otherwise fully-constructed object. */
+       nil/0 for every field of an otherwise fully-constructed object.
+       Class methods only: inside an *instance* method bare `new` is not
+       Class#new (Ruby raises NameError unless a method `new` is in
+       scope), so it must not mark the class instantiated. */
     if (recv < 0 && sp_streq(name, "new")) {
       Scope *encl = comp_scope_of(c, id);
-      if (encl && encl->class_id >= 0) c->classes[encl->class_id].instantiated = 1;
+      if (encl && encl->class_id >= 0 && encl->is_cmethod)
+        c->classes[encl->class_id].instantiated = 1;
     }
     /* raise Cls / raise Cls, msg : constructs an instance of Cls */
     if (recv < 0 && sp_streq(name, "raise")) {

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -2376,6 +2376,19 @@ else {
         if (!has_user) return TY_POLY_ARRAY;
       }
       if (sp_streq(name, "clamp")) return TY_POLY;  /* boxed numeric clamp -> poly */
+      /* poly.delete(chars): String#delete on a value that widened to poly
+         (`data[offset, 8].delete("\x00").upcase` stripping NUL padding off a
+         fixed-width WAD name field in doom's texture parser). Resolve it here
+         so the poly method-dispatch below does not bind `delete` to whatever
+         user class happens to define one; always a concrete TY_STRING, like
+         the rt==TY_STRING rule. Skipped when a user class defines `delete`
+         (the class-dispatch unification then wins). */
+      if (sp_streq(name, "delete") && argc == 1) {
+        int has_user = 0;
+        for (int k = 0; k < c->nclasses && !has_user; k++)
+          if (comp_method_in_chain(c, k, name, NULL) >= 0) has_user = 1;
+        if (!has_user) return TY_STRING;
+      }
       if (sp_streq(name, "[]") && argc == 1) return TY_POLY;  /* boxed array element access */
       if (sp_streq(name, "[]") && argc == 2) return TY_POLY;  /* 2-arg poly slice */
       /* []= on a poly receiver yields the assigned value, emitted boxed */

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -2858,6 +2858,45 @@ void emit_brk_wrapped_call(Compiler *c, int id, Buf *b) {
   else { emit_indent(g_pre, g_indent); buf_printf(g_pre, "(void)_t%d;\n", tR); }
 }
 
+/* Would the class/module *object* with class id `ci` answer
+   respond_to?(:qm)? Consults user class (singleton) methods, singleton
+   attr readers/writers via `class << self`, a module's def'd
+   (module_function) methods, then the builtin Class/Module methods every
+   class object inherits (`new` answered by classes, not modules). Shared
+   by the explicit `Const.respond_to?(:m)` fold and the receiverless form
+   inside a `def self.x` method (implicit self = the class object). */
+static int class_responds_to(Compiler *c, int ci, const char *qm) {
+  const NodeTable *nt = c->nt;
+  if (comp_cmethod_in_chain(c, ci, qm, NULL) >= 0) return 1;
+  /* singleton attr_accessor/reader/writer via class << self */
+  size_t ql = strlen(qm);
+  int is_wr = ql > 0 && qm[ql - 1] == '=';
+  if (is_wr) {
+    char base[256];
+    if (ql - 1 < sizeof base) {
+      memcpy(base, qm, ql - 1); base[ql - 1] = '\0';
+      if (comp_is_sg_writer(&c->classes[ci], base)) return 1;
+    }
+  }
+  else if (comp_is_sg_reader(&c->classes[ci], qm)) return 1;
+  int dn = c->classes[ci].def_node;
+  const char *dt = dn >= 0 ? nt_type(nt, dn) : NULL;
+  int is_module = dt && sp_streq(dt, "ModuleNode");
+  /* a module also responds to its def'd (module_function) methods */
+  if (is_module && comp_method_in_chain(c, ci, qm, NULL) >= 0) return 1;
+  /* builtin Class/Module methods every class object inherits */
+  static const char *const cls_uni[] = {
+    "name", "instance_methods", "public_instance_methods",
+    "private_instance_methods", "protected_instance_methods",
+    "instance_method", "method_defined?", "superclass", "ancestors",
+    "include?", "const_get", "const_set", "const_defined?",
+    "define_method", "allocate", "<", "<=", ">", ">=", NULL };
+  for (int u = 0; cls_uni[u]; u++) if (sp_streq(qm, cls_uni[u])) return 1;
+  /* `new`: a class responds, a module does not */
+  if (sp_streq(qm, "new")) return !is_module;
+  return 0;
+}
+
 void emit_call(Compiler *c, int id, Buf *b) {
   const NodeTable *nt = c->nt;
   if (emit_dynamic_send(c, id, b)) return;   /* recv.send(runtime_name, args) static dispatch */
@@ -6555,45 +6594,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
         const char *rty = nt_type(nt, recv);
         if (rty && sp_streq(rty, "ConstantReadNode")) {
           int ci = comp_class_index(c, nt_str(nt, recv, "name"));
-          if (ci >= 0) {
-            resolved = 1;
-            yes = comp_cmethod_in_chain(c, ci, qm, NULL) >= 0;
-            /* singleton attr_accessor/reader/writer via class << self */
-            if (!yes) {
-              size_t ql = strlen(qm);
-              int is_wr = ql > 0 && qm[ql - 1] == '=';
-              if (is_wr) {
-                char base[256];
-                if (ql - 1 < sizeof base) { memcpy(base, qm, ql - 1); base[ql - 1] = '\0'; }
-                yes = comp_is_sg_writer(&c->classes[ci], base);
-              }
-              else {
-                yes = comp_is_sg_reader(&c->classes[ci], qm);
-              }
-            }
-            /* a module also responds to its def'd (module_function) methods */
-            if (!yes) {
-              int dn = c->classes[ci].def_node;
-              const char *dt = dn >= 0 ? nt_type(nt, dn) : NULL;
-              if (dt && sp_streq(dt, "ModuleNode")) yes = comp_method_in_chain(c, ci, qm, NULL) >= 0;
-            }
-            /* builtin Class/Module methods every class object inherits */
-            if (!yes) {
-              static const char *const cls_uni[] = {
-                "name", "instance_methods", "public_instance_methods",
-                "private_instance_methods", "protected_instance_methods",
-                "instance_method", "method_defined?", "superclass", "ancestors",
-                "include?", "const_get", "const_set", "const_defined?",
-                "define_method", "allocate", "<", "<=", ">", ">=", NULL };
-              for (int u = 0; cls_uni[u]; u++) if (sp_streq(qm, cls_uni[u])) { yes = 1; break; }
-              /* `new`: a class responds, a module does not */
-              if (!yes && sp_streq(qm, "new")) {
-                int dn = c->classes[ci].def_node;
-                const char *dt = dn >= 0 ? nt_type(nt, dn) : NULL;
-                yes = !(dt && sp_streq(dt, "ModuleNode"));
-              }
-            }
-          }
+          if (ci >= 0) { resolved = 1; yes = class_responds_to(c, ci, qm); }
         }
         else if (recv >= 0 && ty_is_object(rt)) {
           int cid = ty_object_class(rt);
@@ -6628,13 +6629,11 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
             char wbase[256]; wbase[0] = '\0';
             if (is_wr && ql - 1 < sizeof wbase) { memcpy(wbase, qm, ql - 1); wbase[ql - 1] = '\0'; }
             if (ss->is_cmethod) {
+              /* implicit self is the class object itself: same answer as
+                 the explicit `Const.respond_to?` fold, including the
+                 builtin Class/Module capabilities (:new, :name, ...). */
               resolved = 1;
-              yes = comp_cmethod_in_chain(c, cid, qm, NULL) >= 0;
-              /* singleton attr_accessor/reader/writer via class << self */
-              if (!yes) {
-                if (is_wr) yes = comp_is_sg_writer(&c->classes[cid], wbase);
-                else yes = comp_is_sg_reader(&c->classes[cid], qm);
-              }
+              yes = class_responds_to(c, cid, qm);
             }
             else {
               int found = comp_method_in_chain(c, cid, qm, NULL) >= 0 ||

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -6523,8 +6523,11 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
 
   /* respond_to?(:m): compile-time approximation. A universal method set is
      always true; otherwise consult the receiver's class / class-method chain.
-     Unknown primitive methods answer conservatively false. */
-  if (sp_streq(name, "respond_to?") && recv >= 0 && argc >= 1) {
+     Unknown primitive methods answer conservatively false. Also fires for
+     the receiverless (implicit-self) form, resolved against the enclosing
+     class -- `self.fullscreen = v if respond_to?(:fullscreen=)` (doom's
+     gosu_window.rb). */
+  if (sp_streq(name, "respond_to?") && argc >= 1) {
     const char *aty = nt_type(nt, argv[0]);
     const char *qm = NULL;
     if (aty && sp_streq(aty, "SymbolNode")) qm = nt_str(nt, argv[0], "value");
@@ -6592,7 +6595,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
             }
           }
         }
-        else if (ty_is_object(rt)) {
+        else if (recv >= 0 && ty_is_object(rt)) {
           int cid = ty_object_class(rt);
           /* a writer query (`m=`) consults the writer table under its base name */
           size_t ql = strlen(qm);
@@ -6608,6 +6611,45 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
             if (v == SP_VIS_PUBLIC) { resolved = 1; yes = 1; }       /* public: always */
             else if (foldable) { resolved = 1; yes = include_all; }  /* private/protected */
             /* else: private/protected + runtime include_all -> unresolved */
+          }
+        }
+        else if (recv < 0) {
+          /* implicit self: resolve against the enclosing scope's class. An
+             instance method consults the instance chain (methods + attr
+             readers/writers, a `m=` query matching the writer table under
+             its base name); a class (`def self.x`) method consults the
+             class-method chain and singleton attrs. Toplevel (class_id < 0)
+             stays unresolved and takes the normal fall-through. */
+          Scope *ss = comp_scope_of(c, id);
+          if (ss && ss->class_id >= 0) {
+            int cid = ss->class_id;
+            size_t ql = strlen(qm);
+            int is_wr = ql > 0 && qm[ql - 1] == '=';
+            char wbase[256]; wbase[0] = '\0';
+            if (is_wr && ql - 1 < sizeof wbase) { memcpy(wbase, qm, ql - 1); wbase[ql - 1] = '\0'; }
+            if (ss->is_cmethod) {
+              resolved = 1;
+              yes = comp_cmethod_in_chain(c, cid, qm, NULL) >= 0;
+              /* singleton attr_accessor/reader/writer via class << self */
+              if (!yes) {
+                if (is_wr) yes = comp_is_sg_writer(&c->classes[cid], wbase);
+                else yes = comp_is_sg_reader(&c->classes[cid], qm);
+              }
+            }
+            else {
+              int found = comp_method_in_chain(c, cid, qm, NULL) >= 0 ||
+                          comp_reader_in_chain(c, cid, qm, NULL) ||
+                          (is_wr && comp_writer_in_chain(c, cid, wbase, NULL));
+              if (!found) { resolved = 1; yes = 0; }
+              else {
+                /* receiverless respond_to? still answers false for a private
+                   or protected match unless include_all folded true. */
+                int v = comp_method_vis_in_chain(c, cid, qm);
+                if (v == SP_VIS_PUBLIC) { resolved = 1; yes = 1; }
+                else if (foldable) { resolved = 1; yes = include_all; }
+                /* else: private/protected + runtime include_all -> unresolved */
+              }
+            }
           }
         }
         /* a primitive/poly/unknown receiver with a non-universal method: we

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -4146,6 +4146,23 @@ int emit_poly_call(Compiler *c, int id, Buf *b) {
     buf_puts(b, ", "); emit_expr(c, argv[0], b); buf_puts(b, ")");
     return 1;
   }
+  /* poly receiver: delete(chars) -> String#delete on the unboxed payload.
+     Mirrors the analyzer's poly rule (result is a concrete TY_STRING): a
+     string that widened to poly -- `data[offset, 8].delete("\x00")` stripping
+     NUL padding off a fixed-width WAD name field in doom's texture parser.
+     Like the analyzer rule, skipped when a user class defines `delete` (the
+     per-class poly dispatch below then generates the proper arms). */
+  if (recv >= 0 && rt == TY_POLY && sp_streq(name, "delete") && argc == 1 &&
+      comp_ntype(c, id) == TY_STRING) {
+    int has_user_delete = 0;
+    for (int k = 0; k < c->nclasses; k++)
+      if (comp_method_in_chain(c, k, "delete", NULL) >= 0) { has_user_delete = 1; break; }
+    if (!has_user_delete) {
+      buf_puts(b, "sp_str_delete(sp_poly_to_s("); emit_expr(c, recv, b);
+      buf_puts(b, "), "); emit_expr(c, argv[0], b); buf_puts(b, ")");
+      return 1;
+    }
+  }
 
   /* poly receiver: gsub/sub with a regex literal -- extract the string
      payload (poly values reaching here are strings) and route to the

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -2096,6 +2096,17 @@ void emit_case_branch_value(Compiler *c, int stmts, TyKind rt, int cr, Buf *b) {
   int n = 0;
   const int *bb = stmts >= 0 ? nt_arr(nt, stmts, "body", &n) : NULL;
   for (int k = 0; k < n - 1; k++) emit_stmt(c, bb[k], b, 0);
+  /* a value-less tail (nil/void/unknown -- e.g. an arm ending in `puts`,
+     doom's debug-toggle arms in GosuWindow#button_down): run it as a
+     statement and leave the arm value at the slot default, mirroring the
+     if-as-value emitter. Assigning it would route `puts` through
+     emit_expr, which has no expression form for it. */
+  TyKind lt = n > 0 ? comp_ntype(c, bb[n - 1]) : TY_NIL;
+  if (n > 0 && (lt == TY_NIL || lt == TY_VOID || lt == TY_UNKNOWN)) {
+    emit_stmt(c, bb[n - 1], b, 0);
+    buf_printf(b, "_cr%d = %s; ", cr, rt == TY_POLY ? "sp_box_nil()" : default_value(rt));
+    return;
+  }
   buf_printf(b, "_cr%d = ", cr);
   if (n > 0) { if (rt == TY_POLY) emit_boxed(c, bb[n - 1], b); else emit_expr(c, bb[n - 1], b); }
   else buf_puts(b, rt == TY_POLY ? "sp_box_nil()" : default_value(rt));

--- a/test/poly_str_delete_chain.rb
+++ b/test/poly_str_delete_chain.rb
@@ -1,0 +1,38 @@
+class Wad
+  def initialize(blob)
+    @blob = blob
+  end
+
+  def read_lump(name)
+    return nil unless name == "PNAMES"
+
+    @blob
+  end
+end
+
+class Texture
+  attr_reader :name
+
+  def initialize(name)
+    @name = name
+  end
+
+  def self.parse_texture(data, offset)
+    name = data[offset, 8].delete("\x00").upcase
+    new(name)
+  end
+
+  def self.load_all(wad)
+    data = wad.read_lump("PNAMES")
+    return [] unless data
+
+    [parse_texture(data, 0), parse_texture(data, 8)]
+  end
+end
+
+w = Wad.new("abcd\x00\x00\x00\x00tail\x00\x00\x00\x00rest")
+Texture.load_all(w).each { |t| puts t.name }
+
+# the plain string form keeps working
+puts "hi\x00\x00\x00".delete("\x00")
+puts Texture.load_all(Wad.new("x\x00\x00\x00\x00\x00\x00\x00")).map(&:name).inspect

--- a/test/poly_str_delete_chain.rb.expected
+++ b/test/poly_str_delete_chain.rb.expected
@@ -1,0 +1,4 @@
+ABCD
+TAIL
+hi
+["X", ""]

--- a/test/puts_in_case_value_arm.rb
+++ b/test/puts_in_case_value_arm.rb
@@ -1,0 +1,31 @@
+class Renderer
+  attr_accessor :skip_background_fill
+
+  def initialize
+    @skip_background_fill = false
+  end
+end
+
+class Window
+  def initialize
+    @renderer = Renderer.new
+    @show_debug = false
+  end
+
+  def button_down(id)
+    case id
+    when 1
+      @show_debug = !@show_debug
+    when 2
+      @renderer.skip_background_fill = !@renderer.skip_background_fill
+      puts "Background fill: #{@renderer.skip_background_fill ? 'OFF' : 'ON'}"
+    end
+  end
+end
+
+w = Window.new
+w.button_down(2)
+w.button_down(1)
+w.button_down(2)
+w.button_down(3)
+puts "done"

--- a/test/puts_in_case_value_arm.rb.expected
+++ b/test/puts_in_case_value_arm.rb.expected
@@ -1,0 +1,3 @@
+Background fill: OFF
+Background fill: ON
+done

--- a/test/respond_to_implicit_self.rb
+++ b/test/respond_to_implicit_self.rb
@@ -1,0 +1,53 @@
+class Screen
+  attr_accessor :width
+  attr_writer :depth
+  attr_reader :label
+
+  def initialize
+    @width = 320
+    @depth = 8
+    @label = "screen"
+    @fullscreen = false
+  end
+
+  def fullscreen=(v)
+    @fullscreen = v
+  end
+
+  def resize
+    42
+  end
+
+  def apply(key, value)
+    case key
+    when :fullscreen
+      self.fullscreen = value if respond_to?(:fullscreen=)
+      puts "fullscreen set"
+    when :width
+      self.width = value if respond_to?(:width=)
+      puts "width set"
+    end
+  end
+
+  def probe
+    puts respond_to?(:resize)
+    puts respond_to?(:width)
+    puts respond_to?(:width=)
+    puts respond_to?(:depth=)
+    puts respond_to?(:label)
+    puts respond_to?(:label=)
+    puts respond_to?(:missing_method)
+    puts respond_to?(:to_s)
+  end
+
+  def self.build
+    puts respond_to?(:build)
+    puts respond_to?(:nope)
+    new
+  end
+end
+
+s = Screen.build
+s.apply(:fullscreen, true)
+s.apply(:width, 640)
+s.probe

--- a/test/respond_to_implicit_self.rb
+++ b/test/respond_to_implicit_self.rb
@@ -43,11 +43,23 @@ class Screen
   def self.build
     puts respond_to?(:build)
     puts respond_to?(:nope)
+    # builtin Class capabilities on the implicit class object
+    puts respond_to?(:new)
+    puts respond_to?(:allocate)
+    puts respond_to?(:name)
     new
   end
 end
 
+module Palette
+  def self.probe
+    puts respond_to?(:probe)
+    puts respond_to?(:new)  # a module does not respond to new
+  end
+end
+
 s = Screen.build
+Palette.probe
 s.apply(:fullscreen, true)
 s.apply(:width, 640)
 s.probe

--- a/test/respond_to_implicit_self.rb.expected
+++ b/test/respond_to_implicit_self.rb.expected
@@ -1,0 +1,12 @@
+true
+false
+fullscreen set
+width set
+true
+true
+true
+true
+true
+false
+false
+true

--- a/test/respond_to_implicit_self.rb.expected
+++ b/test/respond_to_implicit_self.rb.expected
@@ -1,5 +1,10 @@
 true
 false
+true
+true
+true
+true
+false
 fullscreen set
 width set
 true


### PR DESCRIPTION
Part of the effort to run the unmodified Doom gem on spinel.

Four small gaps, each with a test:

- `respond_to?(:m)` with no receiver (implicit self) inside a method was rejected (doom's `gosu_window.rb`: `self.fullscreen = value if respond_to?(:fullscreen=)`). Resolve it against the enclosing scope's class: instance methods consult the method chain and attr readers/writers (a `:m=` query matches the writer table under its base name), `def self.x` methods consult the class-method chain and singleton attrs. Toplevel keeps the existing fall-through.
- A `case` in value position with an arm ending in `puts` routed the tail through `emit_expr`, which has no expression form for it (doom's `GosuWindow#button_down` debug-toggle arms). A nil/void/unknown-typed tail now runs as a statement and the arm value stays at the slot default, mirroring the if-as-value emitter.
- `String#delete` on a receiver widened to poly had no inference or codegen rule, so `data[offset, 8].delete("\x00").upcase` in doom's WAD texture parser collapsed into an unresolved-call raise. Added the poly rule (concrete `TY_STRING`) plus the matching `sp_str_delete(sp_poly_to_s(..))` emission, both skipped when a user class defines `delete`.
- Bare `new(...)` inside a class method (implicit `self.new`) never marked the enclosing class instantiated, so poly-element member reads dispatched with a missing case arm and read back nil for every field of a valid object (doom's `Texture.parse_texture`).

Suite: 1230 pass; the only failures are the known-flaky `system_argument_list` (passes standalone) and the `bundle_hash_b2` artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)