### PR TITLE
codegen: box nullable hash/array lefts in the poly and/or value form

### DIFF
--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -1613,6 +1613,15 @@ else {
                else if (lt==TY_BOOL) buf_printf(b, "sp_box_bool(_t%d)", t); \
                else if (lt==TY_SYMBOL) buf_printf(b, "(_t%d != (sp_sym)-1 ? sp_box_sym(_t%d) : sp_box_nil())", t, t); \
                else if (ty_is_object(lt)) buf_printf(b, "sp_box_nullable_obj((void *)_t%d, %d)", t, ty_object_class(lt)); \
+               /* a nullable hash/array pointer boxes like an object: NULL is \
+                  nil (the AND kept-left arm only runs when the temp IS NULL). \
+                  Previously these fell to the raw pointer temp, yielding a \
+                  ternary with mismatched C operand types (sp_RbVal vs \
+                  sp_PolyPolyHash *, e.g. doom's `picked && picked[idx]`). */ \
+               else if (ty_is_hash(lt) && hash_box_cls(lt)) buf_printf(b, "sp_box_nullable_obj((void *)_t%d, %s)", t, hash_box_cls(lt)); \
+               else if (ty_is_array(lt)) buf_printf(b, "sp_box_nullable_obj((void *)_t%d, %s)", t, \
+                        lt==TY_INT_ARRAY ? "SP_BUILTIN_INT_ARRAY" : lt==TY_FLOAT_ARRAY ? "SP_BUILTIN_FLT_ARRAY" : \
+                        lt==TY_STR_ARRAY ? "SP_BUILTIN_STR_ARRAY" : "SP_BUILTIN_POLY_ARRAY"); \
                else buf_printf(b, "_t%d", t); } \
              else buf_printf(b, "_t%d", t); } \
     } while (0)

--- a/test/and_nullable_container_poly.rb
+++ b/test/and_nullable_container_poly.rb
@@ -1,0 +1,100 @@
+# The value form of `a && b` / `a || b` widens both arms to the unified
+# result type. When the left is a nullable container pointer (hash or
+# array) and the result is poly, the kept-left arm must box the temp;
+# it previously emitted the raw pointer, producing a C ternary with
+# mismatched operand types (sp_RbVal vs sp_PolyPolyHash *). A NULL
+# pointer boxes to nil so the widened value stays falsy. Shape from the
+# Doom gem's player_physics.rb: `picked && picked[idx]` where
+# `picked = @item_pickup&.picked_up` is a Hash or nil.
+
+class Pickup
+  attr_reader :picked_up
+
+  def initialize
+    @picked_up = {}
+  end
+
+  def mark(idx)
+    @picked_up[idx] = true
+  end
+end
+
+class Game
+  def initialize(pickup)
+    @item_pickup = pickup
+  end
+
+  def check(idx)
+    picked = @item_pickup&.picked_up
+    if picked && picked[idx]
+      puts "picked #{idx}"
+    else
+      puts "free #{idx}"
+    end
+  end
+
+  def value_of(idx)
+    picked = @item_pickup&.picked_up
+    picked && picked[idx]
+  end
+end
+
+pickup = Pickup.new
+pickup.mark(1)
+Game.new(pickup).check(1)
+Game.new(pickup).check(2)
+Game.new(nil).check(1)
+p Game.new(pickup).value_of(1)
+p Game.new(nil).value_of(1)
+
+# Same shape over a nullable poly array left.
+class Holder
+  attr_reader :items
+
+  def initialize
+    @items = []
+  end
+
+  def add(v)
+    @items << v
+  end
+end
+
+class User
+  def initialize(holder)
+    @holder = holder
+  end
+
+  def peek(idx)
+    items = @holder&.items
+    v = items && items[idx]
+    if v
+      puts "got #{v}"
+    else
+      puts "none"
+    end
+  end
+end
+
+h = Holder.new
+h.add("a")
+h.add(7)
+User.new(h).peek(0)
+User.new(h).peek(1)
+User.new(h).peek(5)
+User.new(nil).peek(0)
+
+# `||` keeps a truthy container left in a poly result.
+class Fallback
+  def initialize(holder)
+    @holder = holder
+  end
+
+  def items_or_flag
+    items = @holder&.items
+    items || :missing
+  end
+end
+
+p Fallback.new(h).items_or_flag
+p Fallback.new(nil).items_or_flag

--- a/test/and_nullable_container_poly.rb.expected
+++ b/test/and_nullable_container_poly.rb.expected
@@ -1,0 +1,11 @@
+picked 1
+free 2
+free 1
+true
+nil
+got a
+got 7
+none
+none
+["a", 7]
+:missing


### PR DESCRIPTION
Part of the effort to run the unmodified Doom gem on spinel.

Compiling the gem emitted invalid C in `player_physics.rb`:

```
error: incompatible operand types ('sp_RbVal' and 'sp_PolyPolyHash *')
  if (sp_poly_truthy(({ sp_PolyPolyHash * _t698 = lv_picked; (_t698 != 0) ? sp_PolyPolyHash_get(lv_picked, sp_box_int(lv_idx)) : _t698; }))) {
```

The value form of `a && b` / `a || b` widens both arms to the unified result type. The kept-left arm already boxed int, float, string, bool, symbol and object temps into a poly result, but hash and array pointers fell through to the raw temp, producing a C ternary with mismatched operand types. The Doom shape is `picked && picked[idx]` where `picked = @item_pickup&.picked_up` is a Hash or nil.

Fix: box nullable hash/array lefts with `sp_box_nullable_obj`, like the existing object arm. Nullable boxing matters for semantics too, not just for compiling: the AND kept-left arm only runs when the temp is NULL, and a plain `sp_box_obj(NULL, cls)` reads truthy under `sp_poly_truthy`, which would invert the condition. `sp_box_nullable_obj` boxes NULL to nil, keeping the widened value falsy.

Minimal repro that failed before and now compiles and matches CRuby:

```ruby
picked = @item_pickup&.picked_up
if picked && picked[idx]
```

Regression test: `test/and_nullable_container_poly.rb` covering the hash and array shapes for `&&` plus the `||` kept-left arm (expected output generated with CRuby).
