### PR TITLE
runtime,codegen: Range indexing on poly arrays

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -2221,6 +2221,7 @@ static sp_PolyArray *sp_kernel_array(sp_RbVal x) {
 /* Issues #770, #789: NULL + bounds guard. Out-of-range set no-ops. */
 static void sp_PolyArray_set(sp_PolyArray *a, mrb_int i, sp_RbVal v) { if (!a) return; if (a->frozen) { sp_raise_frozen_array(); return; } mrb_int orig=i; if (i < 0) i += a->len; if (i < 0) sp_raise_cls("IndexError", sp_sprintf("index %lld too small for array; minimum: %lld",(long long)orig,(long long)-a->len)); if (i >= a->len) return; a->data[i] = v; }
 static sp_PolyArray *sp_PolyArray_slice(sp_PolyArray *a, mrb_int start, mrb_int len) { SP_GC_ROOT(a); if (start < 0) start += a->len; if (start < 0) start = 0; sp_PolyArray *b = sp_PolyArray_new(); if (start >= a->len || len <= 0) return b; if (start + len > a->len) len = a->len - start; for (mrb_int i = 0; i < len; i++) sp_PolyArray_push(b, a->data[start + i]); return b; }
+static sp_PolyArray *sp_PolyArray_slice_range(sp_PolyArray *a, mrb_int start, mrb_int end_, mrb_int excl) { if (end_ < 0) end_ += a->len; if (start < 0) start += a->len; mrb_int n = end_ - start + (excl ? 0 : 1); if (n < 0 || start < 0) n = 0; return sp_PolyArray_slice(a, start, n); }
 /* 2-arg slice on a poly receiver: dispatch to the typed slice functions. */
 typedef struct sp_BoundMethod { void *self; mrb_int fn; const char *name; } sp_BoundMethod;
 static sp_RbVal sp_poly_slice(sp_RbVal a, mrb_int start, mrb_int len) {

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -1243,6 +1243,18 @@ else {
     }
     /* poly (mixed-element) array methods: elements are boxed sp_RbVal */
     if (rt == TY_POLY_ARRAY) {
+      if (sp_streq(name, "[]") && argc == 1 && nt_type(nt, argv[0]) && sp_streq(nt_type(nt, argv[0]), "RangeNode")) {
+        /* arr[a..b] / arr[a...b] -> subarray */
+        int rn = argv[0];
+        int excl = (int)(nt_int(nt, rn, "flags", 0) & 4) ? 1 : 0;
+        int lo = nt_ref(nt, rn, "left"), hi = nt_ref(nt, rn, "right");
+        buf_puts(b, "sp_PolyArray_slice_range("); emit_expr(c, recv, b); buf_puts(b, ", ");
+        if (lo >= 0) emit_int_expr(c, lo, b); else buf_puts(b, "0");
+        buf_puts(b, ", ");
+        if (hi >= 0) emit_int_expr(c, hi, b); else buf_puts(b, "-1");
+        buf_printf(b, ", %d)", hi >= 0 ? excl : 0);
+        return 1;
+      }
       if (sp_streq(name, "[]") && argc == 1) {
         buf_puts(b, "sp_PolyArray_get("); emit_expr(c, recv, b); buf_puts(b, ", ");
         if (a0 == TY_POLY) { buf_puts(b, "sp_poly_to_i("); emit_expr(c, argv[0], b); buf_puts(b, ")"); }

--- a/test/poly_array_range_aref.rb
+++ b/test/poly_array_range_aref.rb
@@ -1,0 +1,21 @@
+# Range indexing on a poly (mixed-element) array: arr[a..b] / arr[a...b]
+# returns a subarray, like the typed-array receivers already did. Doom's WAD
+# reader slices its directory (a poly array of entries) between two markers:
+# `@directory[start_idx + 1...end_idx]`.
+arr = []
+arr << 1
+arr << "two"
+arr << :three
+arr << 4.5
+arr << [5]
+
+i = arr.index { |e| e == 1 }
+j = arr.index { |e| e == 4.5 }
+raise "missing marker" unless i && j
+
+p arr[i + 1...j]
+p arr[i..j]
+p arr[1..2]
+p arr[2..]
+p arr[1...1]
+p arr[-3..-2]

--- a/test/poly_array_range_aref.rb.expected
+++ b/test/poly_array_range_aref.rb.expected
@@ -1,0 +1,6 @@
+["two", :three]
+[1, "two", :three, 4.5]
+["two", :three]
+[:three, 4.5, [5]]
+[]
+[:three, 4.5]


### PR DESCRIPTION
Part of the effort to run the unmodified Doom gem on spinel.

`arr[a..b]` on a TY_POLY_ARRAY receiver fell through to the integer-index emit, passing an sp_Range to sp_PolyArray_get's mrb_int parameter, which is invalid C. The typed array kinds (Int/Str/Float) already route a literal RangeNode argument to their slice_range helpers; the poly receiver had no such branch and no runtime helper.

Doom hits this slicing the WAD directory between two lump markers: `@directory[start_idx + 1...end_idx]` in wad/reader.rb.

Fix: add `sp_PolyArray_slice_range` (same shape as `sp_IntArray_slice_range`) and mirror the typed receivers' RangeNode branch for TY_POLY_ARRAY, unboxing poly endpoints via emit_int_expr like the neighboring 2-arg slice.

Test: `test/poly_array_range_aref.rb` covers exclusive/inclusive, endless, empty, and negative ranges.

Suite: green apart from the known bundle_hash_b2 artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)