### PR TITLE
runtime: skip frozen heap strings in GC object marking

### DIFF
--- a/lib/sp_gc.c
+++ b/lib/sp_gc.c
@@ -78,9 +78,9 @@ __attribute__((constructor)) static void sp_gc_debug_env(void){
   const char *v=getenv("SPINEL_GC_VERIFY"); sp_gc_verify=(v&&*v&&*v!='0');
 }
 
-/* Tag byte preceding `obj`: 0xfe heap-unmarked -> 0xfc; 0xfc/0xff/0xfd
+/* Tag byte preceding `obj`: 0xfe heap-unmarked -> 0xfc; 0xfc/0xff/0xfd/0xf1
  * skipped; else a real GC object reached through its scan hook. */
-void sp_gc_mark(void*obj){if(!obj)return;unsigned char pm=((unsigned char*)obj)[-1];if(pm==0xfe){((char*)obj)[-1]=(char)0xfc;return;}if(pm==0xfc||pm==0xff||pm==0xfd)return;sp_gc_hdr*h=(sp_gc_hdr*)((char*)obj-sizeof(sp_gc_hdr));if(sp_gc_verify&&!sp_gc_obj_registered(h))sp_gc_verify_fail(obj,h);if(h->marked)return;h->marked=1;if(h->scan){if(sp_gc_mark_stack&&sp_gc_mark_top<SP_GC_MARK_STACK_MAX){sp_gc_mark_stack[sp_gc_mark_top++]=obj;}else{h->scan(obj);}}}
+void sp_gc_mark(void*obj){if(!obj)return;unsigned char pm=((unsigned char*)obj)[-1];if(pm==0xfe){((char*)obj)[-1]=(char)0xfc;return;}if(pm==0xfc||pm==0xff||pm==0xfd||pm==0xf1)return;sp_gc_hdr*h=(sp_gc_hdr*)((char*)obj-sizeof(sp_gc_hdr));if(sp_gc_verify&&!sp_gc_obj_registered(h))sp_gc_verify_fail(obj,h);if(h->marked)return;h->marked=1;if(h->scan){if(sp_gc_mark_stack&&sp_gc_mark_top<SP_GC_MARK_STACK_MAX){sp_gc_mark_stack[sp_gc_mark_top++]=obj;}else{h->scan(obj);}}}
 
 void sp_gc_mark_all(void){if(!sp_gc_mark_stack)sp_gc_mark_stack=(void**)malloc(sizeof(void*)*SP_GC_MARK_STACK_MAX);sp_gc_mark_top=0;if(sp_gc_verify)sp_gc_verify_snapshot();int vd=sp_gc_verify;for(int i=0;i<sp_gc_nroots;i++){void**e=sp_gc_roots[i];if(vd){sp_gc_dbg_phase="root";sp_gc_dbg_ctx=(void*)e;}if((uintptr_t)e&(uintptr_t)3){sp_gc_mark_root_entry(e);}else{void*obj=*e;if(obj)sp_gc_mark(obj);}}if(vd)sp_gc_dbg_phase="fibers";if(sp_gc_mark_suspended_fibers_hook)sp_gc_mark_suspended_fibers_hook();if(vd)sp_gc_dbg_phase="globals";if(sp_gc_mark_globals_hook)sp_gc_mark_globals_hook();while(sp_gc_mark_top>0){void*obj=sp_gc_mark_stack[--sp_gc_mark_top];if(vd){sp_gc_dbg_phase="scan";sp_gc_dbg_ctx=obj;}sp_gc_hdr*h=(sp_gc_hdr*)((char*)obj-sizeof(sp_gc_hdr));if(h->scan)h->scan(obj);}if(vd){sp_gc_dbg_phase="?";sp_gc_dbg_ctx=NULL;}}
 

--- a/test/frozen_string_literal_gc_root.rb
+++ b/test/frozen_string_literal_gc_root.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+first = "first literal"
+second = "second literal"
+
+GC.start
+
+puts first
+puts second

--- a/test/frozen_string_literal_gc_root.rb.expected
+++ b/test/frozen_string_literal_gc_root.rb.expected
@@ -1,0 +1,2 @@
+first literal
+second literal


### PR DESCRIPTION
A rooted frozen string literal could crash during GC.

`sp_gc_mark` handles string-shaped pointers specially by checking the marker byte before falling back to the object-header path. It already skipped heap-marked strings and rodata literals, but missed the `0xf1` marker used for heap-frozen strings.

When a `# frozen_string_literal: true` literal was live in a normal GC root slot and a collection ran, the marker was not recognized, so the collector treated the string body as a regular GC object and tried to mark a bogus header. On macOS this surfaced as a SIGBUS / EXC_BAD_ACCESS when the bogus header address was in read-only memory.

Fix: treat `0xf1` like the other non-object string markers in `sp_gc_mark`, returning before the object-header mark path.

Minimal repro covered by `test/frozen_string_literal_gc_root.rb`:

```ruby
# frozen_string_literal: true

first = "first literal"
second = "second literal"

GC.start

puts first
puts second
```

Before the fix this crashed during GC.start; after the fix it prints both literals.