### PR TITLE
codegen: per-worker proc poly return/argument slots (data race)

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1640,7 +1640,7 @@ else if (orecv >= 0 && onm) {
       if (k < 16) {
         if (!g_needs_proc_poly_argslot) {
           g_needs_proc_poly_argslot = 1;
-          buf_puts(&g_proc_protos, "static sp_RbVal _sp_proc_poly_args[16];\n");
+          buf_puts(&g_proc_protos, "static SP_TLS sp_RbVal _sp_proc_poly_args[16];\n");
         }
         buf_printf(pb, "(argc > %d) ? _sp_proc_poly_args[%d] : sp_box_nil();\n", k, k);
       }
@@ -1689,10 +1689,14 @@ else if (orecv >= 0 && onm) {
   else if (ret_poly || ret_fbox) {
     /* Store the result in the file-static _sp_proc_poly_ret slot (boxed:
        a float tail becomes sp_box_float via g_result_poly); the call site
-       reads it back after sp_proc_call returns. */
+       reads it back after sp_proc_call returns. Per-worker (SP_TLS) in the
+       threaded build: concurrent Proc#call from several threads would race
+       on a shared slot and corrupt each other's return values. The slot is
+       safe per-worker because no safepoint poll (the only migration /
+       preemption point) lies between the store and the call-site read. */
     if (!g_needs_proc_poly_retslot) {
       g_needs_proc_poly_retslot = 1;
-      buf_puts(&g_proc_protos, "static sp_RbVal _sp_proc_poly_ret;\n");
+      buf_puts(&g_proc_protos, "static SP_TLS sp_RbVal _sp_proc_poly_ret;\n");
     }
     g_result_var = "_sp_proc_poly_ret"; g_result_poly = 1;
     if (tail_ret_arg >= 0) {

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -416,7 +416,7 @@ void emit_proc_call_args(Compiler *c, int argc, const int *argv, Buf *b, int for
   if (any_poly) {
     if (!g_needs_proc_poly_argslot) {
       g_needs_proc_poly_argslot = 1;
-      buf_puts(&g_proc_protos, "static sp_RbVal _sp_proc_poly_args[16];\n");
+      buf_puts(&g_proc_protos, "static SP_TLS sp_RbVal _sp_proc_poly_args[16];\n");
     }
     /* Each argument is evaluated once into a natural-typed temp so it can be
        published both unboxed (the mrb_int[] slot, for a concrete parameter)
@@ -3645,7 +3645,7 @@ void emit_call(Compiler *c, int id, Buf *b) {
        (e.g. ivar-stored proc whose proc_ret is TY_UNKNOWN → TY_POLY at analysis). */
     if ((unbox_poly || unbox_float) && !g_needs_proc_poly_retslot) {
       g_needs_proc_poly_retslot = 1;
-      buf_puts(&g_proc_protos, "static sp_RbVal _sp_proc_poly_ret;\n");
+      buf_puts(&g_proc_protos, "static SP_TLS sp_RbVal _sp_proc_poly_ret;\n");
     }
     if (unbox_ptr) { buf_puts(b, "("); emit_ctype(c, rty, b); buf_puts(b, ")(uintptr_t)("); }
     /* poly/float return: proc stores the boxed result in _sp_proc_poly_ret;

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -1876,7 +1876,7 @@ int emit_hash_call(Compiler *c, int id, Buf *b) {
         if (vt == TY_POLY) {
           if (!g_needs_proc_poly_retslot) {
             g_needs_proc_poly_retslot = 1;
-            buf_puts(&g_proc_protos, "static sp_RbVal _sp_proc_poly_ret;\n");
+            buf_puts(&g_proc_protos, "static SP_TLS sp_RbVal _sp_proc_poly_ret;\n");
           }
           buf_printf(&g_procs, "  _sp_proc_poly_ret = sp_%sHash_get(_h, %s);\n  return 0;\n}\n", hn, keyexpr);
         }

--- a/test/proc_concurrent_call_poly_ret.rb
+++ b/test/proc_concurrent_call_poly_ret.rb
@@ -1,0 +1,39 @@
+# Concurrent Proc#call return values are not corrupted across threads. A
+# poly-returning proc stashes its boxed result in the _sp_proc_poly_ret slot
+# (and poly arguments ride _sp_proc_poly_args); those slots were
+# process-global, so concurrent calls from several threads raced on them and
+# read each other's values -- intermittently wrong results, flagged
+# deterministically by ThreadSanitizer. The slots are per-worker (SP_TLS)
+# now, which is safe because no safepoint poll (the only migration /
+# preemption point) lies between the callee's store and the call-site read.
+# The loops stay allocation-free so the test exercises only the slots.
+
+# poly return: float for even, integer for odd -- a cross-thread mixup shows
+# up as a wrong value or a wrong type
+pr = ->(i) { i.even? ? i * 0.5 : i * 3 }
+
+nthreads = 4
+total_n = 80000
+threads = []
+t = 0
+while t < nthreads
+  threads << Thread.new(t) do |tid|
+    errs = 0
+    j = tid
+    while j < total_n
+      v = pr.call(j)
+      if j.even?
+        errs += 1 unless v == j * 0.5
+      else
+        errs += 1 unless v == j * 3
+      end
+      j += nthreads
+    end
+    errs
+  end
+  t += 1
+end
+
+total = 0
+threads.each { |th| total += th.value }
+puts total.zero? ? "poly ret ok" : "poly ret corrupted: #{total}"

--- a/test/proc_concurrent_call_poly_ret.rb.expected
+++ b/test/proc_concurrent_call_poly_ret.rb.expected
@@ -1,0 +1,1 @@
+poly ret ok


### PR DESCRIPTION
## Summary

A poly-returning Proc/lambda stashes its boxed result in a single process-global slot (`_sp_proc_poly_ret`), and poly arguments ride a global side-channel (`_sp_proc_poly_args[16]`). With the threaded runtime's real parallelism (no GVL), concurrent `Proc#call` from several threads races on those slots and reads another thread's value — intermittently wrong results. ThreadSanitizer makes it deterministic:

```
$ spinel --cc="clang -fsanitize=thread -fno-omit-frame-pointer -g" repro.rb -o t
$ SPINEL_WORKERS=4 ./t
WARNING: ThreadSanitizer: data race
  Location is global '_sp_proc_poly_ret'
SUMMARY: ThreadSanitizer: data race in _proc_1
```

This rules out e.g. a lambda-based parallel-map helper (`workers.each { Thread.new { ... pr.call(i) ... } }`).

## Fix

Declare both slots `SP_TLS` (per-worker), the same storage class the runtime already uses for the exception stack, proc-return homes, and regex match state; a no-op in the single-threaded build.

Per-worker is sufficient: no safepoint poll — the only migration/preemption point — lies between the callee's store and the call-site read (or between the argument publish and the callee's prologue read), so a green thread cannot move workers mid-handoff.

## Changes

- `src/codegen.c`, `src/codegen_call.c`, `src/codegen_call_recv.c`: the emitted declarations of `_sp_proc_poly_ret` / `_sp_proc_poly_args` gain `SP_TLS` (all emission sites of both slots).
- `test/proc_concurrent_call_poly_ret.rb` (+ committed `.expected`): hammers a poly-returning lambda (float/int by parity) from 4 threads, allocation-free, counting wrong values. Before the fix it reports corruption intermittently and TSan flags the race on every run; after, it is value-clean on every run and TSan-clean.

## Test plan

- Original repro is TSan-clean after the fix (was: deterministic `data race in _proc_1` on `_sp_proc_poly_ret`).
- New regression test verified through the harness against a committed CRuby snapshot; 10/10 clean runs at `SPINEL_WORKERS=4`.
- `make test`: 1254 pass, 0 fail, 0 error.
- `make optcarrot`: OK (369 fps, checksum 59662).


Made with [Cursor](https://cursor.com)