### PR TITLE
codegen: coerce poly File.join components with sp_poly_to_s

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -91,8 +91,20 @@ void emit_float_expr(Compiler *c, int node, Buf *b) {
 void emit_str_expr(Compiler *c, int node, Buf *b) {
   if (comp_ntype(c, node) == TY_POLY) {
     buf_puts(b, "sp_poly_to_s("); emit_expr(c, node, b); buf_puts(b, ")");
+    return;
   }
-  else emit_expr(c, node, b);
+  /* The unresolved-call gate's sp_raise_nomethod(...) is a side-effecting poly
+     value (it raises): coerce it to the const char* slot, keeping the call,
+     rather than passing the sp_RbVal through raw (doom's
+     `File.join(Dir.tmpdir, ...)`). A text match on the gate's own token is
+     reliable where comp_ntype is not (the node stays TY_UNKNOWN). */
+  Buf tmp; memset(&tmp, 0, sizeof tmp);
+  emit_expr(c, node, &tmp);
+  const char *txt = tmp.p ? tmp.p : "";
+  if (strncmp(txt, "sp_raise_nomethod(", 18) == 0)
+    buf_printf(b, "sp_poly_to_s(%s)", txt);
+  else buf_puts(b, txt);
+  free(tmp.p);
 }
 
 void emit_boxed(Compiler *c, int node, Buf *b) {

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -5857,8 +5857,11 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       buf_puts(b, ")"); return;
     }
     if (sp_streq(name, "join")) {
+      /* each component initializes a `const char *` slot, so a poly arg (e.g.
+         doom's `File.join(Dir.tmpdir, ...)` where the first component stays
+         poly) must be unboxed via sp_poly_to_s, not land its sp_RbVal raw. */
       buf_printf(b, "sp_file_join((const char*[]){");
-      for (int k = 0; k < argc; k++) { if (k) buf_puts(b, ", "); emit_expr(c, argv[k], b); }
+      for (int k = 0; k < argc; k++) { if (k) buf_puts(b, ", "); emit_str_expr(c, argv[k], b); }
       if (argc == 0) buf_puts(b, "(const char*)0");
       buf_printf(b, "}, %d)", argc); return;
     }

--- a/test/file_join_poly_component.rb
+++ b/test/file_join_poly_component.rb
@@ -1,0 +1,9 @@
+# A poly component of File.join (here: an element read from a heterogeneous
+# array) initializes a `const char *` slot in the sp_file_join argument list,
+# so it must be coerced with sp_poly_to_s rather than land its sp_RbVal raw
+# (doom's SoundManager builds its temp dir from a poly Dir.tmpdir value).
+parts = ["sounds", 7]
+dir = parts[0]
+path = File.join(dir, "doom_rb")
+puts path
+puts File.join("a", "b", "c")

--- a/test/file_join_poly_component.rb.expected
+++ b/test/file_join_poly_component.rb.expected
@@ -1,0 +1,2 @@
+sounds/doom_rb
+a/b/c


### PR DESCRIPTION
Part of the effort to run the unmodified Doom gem on spinel.

`File.join` emitted each argument with plain `emit_expr`, so a poly component landed its raw `sp_RbVal` in the `const char *[]` argument array, a C type error. Doom hits this in `Doom::Wad::SoundManager#initialize`:

```ruby
@temp_dir = File.join(Dir.tmpdir, "doom_rb_sounds_#{Process.pid}")
```

`Dir.tmpdir` is unresolved (the `tmpdir` require is ignored), so the gate emits `sp_raise_nomethod(...)`, which is `sp_RbVal`-valued:

```
lib/doom/wad/sound.rb:14:52: error: initializing 'const char *' with an expression of incompatible type 'sp_RbVal'
```

Two changes:

- `File.join` args now go through `emit_str_expr`, which coerces a poly component with `sp_poly_to_s`.
- `emit_str_expr` also recognizes the unresolved-call gate's `sp_raise_nomethod(...)` token (whose node type stays `TY_UNKNOWN`, so the `TY_POLY` check misses it) and wraps it the same way, following the existing token-match convention in `emit_scalar_call` (string receivers) and `emit_tail_value`. The raise still diverges at runtime before the value is read.

Regression test: `test/file_join_poly_component.rb` (poly array element as a `File.join` component).
