### PR TITLE
String#length/size: count bytes for binary (non-UTF-8) content

### DIFF
--- a/lib/sp_str.c
+++ b/lib/sp_str.c
@@ -304,13 +304,45 @@ mrb_int sp_str_count_chars(const char *s, size_t bl) {
   }
   return n;
 }
+/* Byte-length-bounded UTF-8 validity check. Used to decide char-count vs
+   byte-count semantics for String#length/size: a string with any invalid UTF-8
+   byte (near-certain for genuine binary data, e.g. a binary-mode File.read of a
+   WAD lump) is counted byte-for-byte instead of decoded, matching Ruby's
+   ASCII-8BIT semantics for binary I/O without a separate per-string encoding
+   tag. Valid UTF-8 (the common text case) still counts codepoints. */
+static mrb_bool sp_str_valid_utf8_bytes(const char *s, size_t bl) {
+  const unsigned char *p = (const unsigned char *)s, *end = p + bl;
+  while (p < end) {
+    unsigned c = *p;
+    if (c < 0x80) { p++; continue; }
+    int extra; unsigned cp, min;
+    if ((c & 0xE0) == 0xC0) { extra = 1; cp = c & 0x1F; min = 0x80; }
+    else if ((c & 0xF0) == 0xE0) { extra = 2; cp = c & 0x0F; min = 0x800; }
+    else if ((c & 0xF8) == 0xF0) { extra = 3; cp = c & 0x07; min = 0x10000; }
+    else return FALSE;
+    p++;
+    if (p + extra > end) return FALSE;
+    for (int i = 0; i < extra; i++) {
+      if ((*p & 0xC0) != 0x80) return FALSE;
+      cp = (cp << 6) | (*p & 0x3F);
+      p++;
+    }
+    if (cp < min) return FALSE;
+    if (cp >= 0xD800 && cp <= 0xDFFF) return FALSE;
+    if (cp > 0x10FFFF) return FALSE;
+  }
+  return TRUE;
+}
+static mrb_int sp_str_count_units(const char *s, size_t bl) {
+  return sp_str_valid_utf8_bytes(s, bl) ? sp_str_count_chars(s, bl) : (mrb_int)bl;
+}
 mrb_int sp_str_length(const char*s){
   if (!s) return 0;
-  if (!sp_str_cacheable(s)) return sp_str_count_chars(s, sp_str_byte_len(s));
+  if (!sp_str_cacheable(s)) return sp_str_count_units(s, sp_str_byte_len(s));
   unsigned h = sp_str_lcache_hash(s);
   if (sp_str_lcache[h].s == s) return sp_str_lcache[h].char_len;
   size_t bl = sp_str_byte_len(s);
-  mrb_int n = sp_str_count_chars(s, bl);
+  mrb_int n = sp_str_count_units(s, bl);
   sp_str_lcache[h].s = s;
   sp_str_lcache[h].byte_len = bl;
   sp_str_lcache[h].char_len = n;

--- a/lib/sp_str.c
+++ b/lib/sp_str.c
@@ -304,37 +304,43 @@ mrb_int sp_str_count_chars(const char *s, size_t bl) {
   }
   return n;
 }
-/* Byte-length-bounded UTF-8 validity check. Used to decide char-count vs
-   byte-count semantics for String#length/size: a string with any invalid UTF-8
-   byte (near-certain for genuine binary data, e.g. a binary-mode File.read of a
-   WAD lump) is counted byte-for-byte instead of decoded, matching Ruby's
-   ASCII-8BIT semantics for binary I/O without a separate per-string encoding
-   tag. Valid UTF-8 (the common text case) still counts codepoints. */
-static mrb_bool sp_str_valid_utf8_bytes(const char *s, size_t bl) {
+/* Length in "units" for String#length/size, validating and counting in a
+   single walk: count UTF-8 codepoints while the bytes stay valid UTF-8, but
+   fall back to the raw byte count the moment an invalid byte appears
+   (near-certain for genuine binary data, e.g. a binary-mode File.read of a WAD
+   lump) -- matching Ruby's ASCII-8BIT semantics for binary I/O without a
+   separate per-string encoding tag. Folding validation into the count keeps
+   String#length off a two-pass hot path; valid text still costs one walk. */
+static mrb_int sp_str_count_units(const char *s, size_t bl) {
   const unsigned char *p = (const unsigned char *)s, *end = p + bl;
-  while (p < end) {
+  mrb_int n = 0;
+  for (;;) {
+    /* ASCII fast path: 8 bytes at a time, each a valid single-unit codepoint */
+    while (p + 8 <= end) {
+      uint64_t w;
+      memcpy(&w, p, sizeof(w));
+      if (w & 0x8080808080808080ULL) break;
+      p += 8; n += 8;
+    }
+    if (p >= end) break;
     unsigned c = *p;
-    if (c < 0x80) { p++; continue; }
+    if (c < 0x80) { p++; n++; continue; }
     int extra; unsigned cp, min;
     if ((c & 0xE0) == 0xC0) { extra = 1; cp = c & 0x1F; min = 0x80; }
     else if ((c & 0xF0) == 0xE0) { extra = 2; cp = c & 0x0F; min = 0x800; }
     else if ((c & 0xF8) == 0xF0) { extra = 3; cp = c & 0x07; min = 0x10000; }
-    else return FALSE;
+    else return (mrb_int)bl;   /* invalid lead byte -> count bytes */
     p++;
-    if (p + extra > end) return FALSE;
+    if (p + extra > end) return (mrb_int)bl;
     for (int i = 0; i < extra; i++) {
-      if ((*p & 0xC0) != 0x80) return FALSE;
+      if ((*p & 0xC0) != 0x80) return (mrb_int)bl;
       cp = (cp << 6) | (*p & 0x3F);
       p++;
     }
-    if (cp < min) return FALSE;
-    if (cp >= 0xD800 && cp <= 0xDFFF) return FALSE;
-    if (cp > 0x10FFFF) return FALSE;
+    if (cp < min || (cp >= 0xD800 && cp <= 0xDFFF) || cp > 0x10FFFF) return (mrb_int)bl;
+    n++;
   }
-  return TRUE;
-}
-static mrb_int sp_str_count_units(const char *s, size_t bl) {
-  return sp_str_valid_utf8_bytes(s, bl) ? sp_str_count_chars(s, bl) : (mrb_int)bl;
+  return n;
 }
 mrb_int sp_str_length(const char*s){
   if (!s) return 0;

--- a/test/binary_string_length_bytes.rb
+++ b/test/binary_string_length_bytes.rb
@@ -1,0 +1,10 @@
+# A binary string (invalid UTF-8, e.g. a binary-mode read) counts its length in
+# bytes (Ruby ASCII-8BIT semantics), matching bytesize -- not UTF-8 codepoints.
+bin = [0x00, 0x80, 0xC0, 0xFF, 0x41, 0xFE].pack('C*')
+puts "size=#{bin.size} bytesize=#{bin.bytesize}"
+# valid UTF-8 text still counts codepoints
+txt = "abc"
+puts "txt size=#{txt.size} bytesize=#{txt.bytesize}"
+# a longer binary blob
+blob = ([0xAA] * 100).pack('C*')
+puts "blob size=#{blob.size}"

--- a/test/binary_string_length_bytes.rb
+++ b/test/binary_string_length_bytes.rb
@@ -5,6 +5,15 @@ puts "size=#{bin.size} bytesize=#{bin.bytesize}"
 # valid UTF-8 text still counts codepoints
 txt = "abc"
 puts "txt size=#{txt.size} bytesize=#{txt.bytesize}"
+# valid *multibyte* UTF-8: size counts codepoints while bytesize counts bytes,
+# so the two must differ -- this exercises the char-count path (unlike ASCII,
+# where size == bytesize would pass either way).
+snow = "☃"          # snowman, one codepoint, three UTF-8 bytes
+puts "snow size=#{snow.size} bytesize=#{snow.bytesize}"
+acc = "café"        # "cafe" with an accent: four codepoints, five bytes
+puts "acc size=#{acc.size} bytesize=#{acc.bytesize}"
+mix = "aé☃z"   # ascii + 2-byte + 3-byte + ascii = 4 chars, 7 bytes
+puts "mix size=#{mix.size} bytesize=#{mix.bytesize}"
 # a longer binary blob
 blob = ([0xAA] * 100).pack('C*')
 puts "blob size=#{blob.size}"

--- a/test/binary_string_length_bytes.rb.expected
+++ b/test/binary_string_length_bytes.rb.expected
@@ -1,3 +1,6 @@
 size=6 bytesize=6
 txt size=3 bytesize=3
+snow size=1 bytesize=3
+acc size=4 bytesize=5
+mix size=4 bytesize=7
 blob size=100

--- a/test/binary_string_length_bytes.rb.expected
+++ b/test/binary_string_length_bytes.rb.expected
@@ -1,0 +1,3 @@
+size=6 bytesize=6
+txt size=3 bytesize=3
+blob size=100


### PR DESCRIPTION
Part of the effort to run the unmodified Doom gem on spinel.

`sp_str_length` always counted UTF-8 codepoints, so a binary string (a binary-mode `File.read` of a WAD lump, full of bytes >= 0x80) reported a character count below its byte count. Ruby's ASCII-8BIT strings, produced by binary I/O, count bytes -- `size == bytesize`.

In doom this made `data.size / 28` under-count the NODES lump (6237 vs 6608), so the BSP tree was parsed from misaligned records and rendering recursed into wild node indices.

Fix: decide char-count vs byte-count by UTF-8 validity. Any invalid byte (near-certain for genuine binary data) counts byte-for-byte, matching ASCII-8BIT; valid UTF-8 text still counts codepoints. This avoids adding a per-string encoding tag.

Regression test: test/binary_string_length_bytes.rb.