### PR TITLE
codegen: give nil, true and false their fixed object_ids

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -7389,11 +7389,13 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
   }
 
   /* object_id: a stable integer id. Int uses MRI's 2n+1; pointer-backed
-     values use the pointer bit pattern; a symbol uses its interned id. */
+     values use the pointer bit pattern; a symbol uses its interned id.
+     The immediates have fixed ids: nil is 4, false is 0, true is 20. */
   if (sp_streq(name, "object_id") && recv >= 0 && argc == 0) {
     if (rt == TY_INT) { buf_puts(b, "(2*("); emit_expr(c, recv, b); buf_puts(b, ")+1)"); }
     else if (rt == TY_SYMBOL) { buf_puts(b, "((mrb_int)("); emit_expr(c, recv, b); buf_puts(b, ")*2)"); }
-    else if (rt == TY_BOOL || rt == TY_NIL) { buf_puts(b, "((void)("); emit_expr(c, recv, b); buf_puts(b, "), 0)"); }
+    else if (rt == TY_NIL) { buf_puts(b, "((void)("); emit_expr(c, recv, b); buf_puts(b, "), 4)"); }
+    else if (rt == TY_BOOL) { buf_puts(b, "(("); emit_expr(c, recv, b); buf_puts(b, ") ? 20 : 0)"); }
     /* a boxed value: its identity is the boxed payload (heap pointer / int) */
     else if (rt == TY_POLY) { buf_puts(b, "((mrb_int)(uintptr_t)("); emit_expr(c, recv, b); buf_puts(b, ").v.p)"); }
     else { buf_puts(b, "((mrb_int)(uintptr_t)("); emit_expr(c, recv, b); buf_puts(b, "))"); }

--- a/test/object_id_nil_true.rb
+++ b/test/object_id_nil_true.rb
@@ -1,0 +1,8 @@
+# The immediate values nil, false and true have fixed, distinct object_ids.
+p nil.object_id
+p false.object_id
+p true.object_id
+p [nil.object_id, true.object_id]
+p(nil.object_id == false.object_id)
+p(false.object_id == true.object_id)
+p(nil.object_id == true.object_id)

--- a/test/object_id_nil_true.rb.expected
+++ b/test/object_id_nil_true.rb.expected
@@ -1,0 +1,7 @@
+4
+0
+20
+[4, 20]
+false
+false
+false


### PR DESCRIPTION
object_id on a nil, true or false receiver folded to a single 0, so all
three shared an id and none matched CRuby. Emit the fixed immediate ids
instead: nil is 4, false is 0, true is 20, evaluating the receiver for
its side effects and selecting on its runtime truth for the boolean case.