### PR TITLE
codegen: box a NULL reference-type object as nil, not a truthy wrapper

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1,5 +1,29 @@
 #include "codegen_internal.h"
 
+/* A reference-backed builtin (IO/Fiber/Thread/Queue/Mutex/ConditionVariable/
+   Enumerator/Exception/Proc/Method) is a genuinely nilable C pointer: an unset
+   ivar, a `return nil` method, or a cache miss yields NULL. It must box via
+   sp_box_nullable_obj so a NULL becomes SP_TAG_NIL rather than a "truthy"
+   SP_TAG_OBJ wrapping NULL v.p -- which passes `unless x`/`if x`, misreads as
+   non-nil (a wrong `nil?`), then segfaults on the first field/method read.
+   Value-type builtins (Range/Time/Complex/Rational, boxed as a by-value copy)
+   and non-pointer scalars are deliberately excluded -- they are never NULL. */
+const char *ty_nullable_builtin_id(TyKind t) {
+  switch (t) {
+    case TY_IO:         return "SP_BUILTIN_IO";
+    case TY_FIBER:      return "SP_BUILTIN_FIBER";
+    case TY_THREAD:     return "SP_BUILTIN_THREAD";
+    case TY_QUEUE:      return "SP_BUILTIN_QUEUE";
+    case TY_MUTEX:      return "SP_BUILTIN_MUTEX";
+    case TY_CONDVAR:    return "SP_BUILTIN_CONDVAR";
+    case TY_ENUMERATOR: return "SP_BUILTIN_ENUMERATOR";
+    case TY_EXCEPTION:  return "SP_BUILTIN_EXCEPTION";
+    case TY_PROC:       return "SP_BUILTIN_PROC";
+    case TY_METHOD:     return "SP_BUILTIN_METHOD";
+    default:            return NULL;
+  }
+}
+
 void emit_boxed_text(Compiler *c, TyKind t, const char *expr, Buf *b) {
   if (t == TY_POLY) { buf_puts(b, expr); return; }
   /* An untyped or void value is already emitted as a boxed sp_RbVal (a nil
@@ -8,14 +32,12 @@ void emit_boxed_text(Compiler *c, TyKind t, const char *expr, Buf *b) {
      this, the int-boxing fallback below produced sp_box_int(<sp_RbVal>) -- an
      mrb_int slot fed a boxed value (the recurring poly-box bug family). */
   if (t == TY_UNKNOWN || t == TY_VOID || t == TY_REGEX) { buf_printf(b, "(%s, sp_box_nil())", expr); return; }
-  if (t == TY_EXCEPTION) { buf_printf(b, "sp_box_obj(%s, SP_BUILTIN_EXCEPTION)", expr); return; }
-  if (t == TY_FIBER) { buf_printf(b, "sp_box_obj((void *)(%s), SP_BUILTIN_FIBER)", expr); return; }
-  if (t == TY_THREAD) { buf_printf(b, "sp_box_obj((void *)(%s), SP_BUILTIN_THREAD)", expr); return; }
-  if (t == TY_QUEUE) { buf_printf(b, "sp_box_obj((void *)(%s), SP_BUILTIN_QUEUE)", expr); return; }
-  if (t == TY_MUTEX) { buf_printf(b, "sp_box_obj((void *)(%s), SP_BUILTIN_MUTEX)", expr); return; }
-  if (t == TY_CONDVAR) { buf_printf(b, "sp_box_obj((void *)(%s), SP_BUILTIN_CONDVAR)", expr); return; }
-  if (t == TY_ENUMERATOR) { buf_printf(b, "sp_box_obj((void *)(%s), SP_BUILTIN_ENUMERATOR)", expr); return; }
-  if (t == TY_IO) { buf_printf(b, "sp_box_obj((void *)(%s), SP_BUILTIN_IO)", expr); return; }
+  /* Reference-backed builtins are nilable C pointers -- box NULL as nil (see
+     ty_nullable_builtin_id). This also covers TY_PROC/TY_METHOD, which used to
+     fall to the sp_box_proc/sp_box_method switch cases below (both wrapped NULL
+     as a truthy proc/method). */
+  { const char *nbid = ty_nullable_builtin_id(t);
+    if (nbid) { buf_printf(b, "sp_box_nullable_obj((void *)(%s), %s)", expr, nbid); return; } }
   if (ty_is_object(t)) {
     /* A reference-type object is a genuinely nilable C pointer (a hash/cache
        lookup or a method that can `return nil` -- e.g. doom's
@@ -38,8 +60,7 @@ void emit_boxed_text(Compiler *c, TyKind t, const char *expr, Buf *b) {
     case TY_SYMBOL: fn = "sp_box_sym"; break;     case TY_RANGE: fn = "sp_box_range"; break;
     case TY_TIME: fn = "sp_box_time"; break;
     case TY_COMPLEX: fn = "sp_box_complex"; break;  case TY_RATIONAL: fn = "sp_box_rational"; break;
-    case TY_PROC: fn = "sp_box_proc"; break;
-    case TY_METHOD: fn = "sp_box_method"; break;
+    /* TY_PROC / TY_METHOD are handled by the nullable-builtin box above. */
     case TY_CLASS: fn = "sp_box_class"; break;
     case TY_INT_ARRAY: fn = "sp_box_int_array"; break;
     case TY_FLOAT_ARRAY: fn = "sp_box_float_array"; break;
@@ -122,34 +143,15 @@ void emit_str_expr(Compiler *c, int node, Buf *b) {
 void emit_boxed(Compiler *c, int node, Buf *b) {
   TyKind t = comp_ntype(c, node);
   if (t == TY_POLY) { emit_expr(c, node, b); return; }
-  if (t == TY_FIBER) {
-    buf_puts(b, "sp_box_obj((void *)("); emit_expr(c, node, b); buf_puts(b, "), SP_BUILTIN_FIBER)");
-    return;
-  }
-  if (t == TY_THREAD) {
-    buf_puts(b, "sp_box_obj((void *)("); emit_expr(c, node, b); buf_puts(b, "), SP_BUILTIN_THREAD)");
-    return;
-  }
-  if (t == TY_QUEUE) {
-    buf_puts(b, "sp_box_obj((void *)("); emit_expr(c, node, b); buf_puts(b, "), SP_BUILTIN_QUEUE)");
-    return;
-  }
-  if (t == TY_MUTEX) {
-    buf_puts(b, "sp_box_obj((void *)("); emit_expr(c, node, b); buf_puts(b, "), SP_BUILTIN_MUTEX)");
-    return;
-  }
-  if (t == TY_CONDVAR) {
-    buf_puts(b, "sp_box_obj((void *)("); emit_expr(c, node, b); buf_puts(b, "), SP_BUILTIN_CONDVAR)");
-    return;
-  }
-  if (t == TY_IO) {
-    buf_puts(b, "sp_box_obj((void *)("); emit_expr(c, node, b); buf_puts(b, "), SP_BUILTIN_IO)");
-    return;
-  }
-  if (t == TY_EXCEPTION) {
-    buf_printf(b, "sp_box_obj("); emit_expr(c, node, b); buf_puts(b, ", SP_BUILTIN_EXCEPTION)");
-    return;
-  }
+  /* Reference-backed builtins (IO/Fiber/Thread/Queue/Mutex/ConditionVariable/
+     Enumerator/Exception/Proc/Method) are nilable C pointers -- box NULL as nil
+     via sp_box_nullable_obj, not a truthy SP_TAG_OBJ over NULL. */
+  { const char *nbid = ty_nullable_builtin_id(t);
+    if (nbid) {
+      buf_puts(b, "sp_box_nullable_obj((void *)("); emit_expr(c, node, b);
+      buf_printf(b, "), %s)", nbid);
+      return;
+    } }
   if (ty_is_object(t)) {
     /* A reference-type object is a nilable C pointer (a hash/cache lookup or a
        method that can `return nil`, e.g. doom's TextureManager#[] boxing
@@ -217,8 +219,7 @@ void emit_boxed(Compiler *c, int node, Buf *b) {
     case TY_TIME:   fn = "sp_box_time";  break;
     case TY_COMPLEX:  fn = "sp_box_complex";  break;
     case TY_RATIONAL: fn = "sp_box_rational"; break;
-    case TY_PROC:   fn = "sp_box_proc";  break;
-    case TY_METHOD: fn = "sp_box_method"; break;
+    /* TY_PROC / TY_METHOD are handled by the nullable-builtin box above. */
     case TY_INT_ARRAY:   fn = "sp_box_int_array";   break;
     case TY_FLOAT_ARRAY: fn = "sp_box_float_array"; break;
     case TY_STR_ARRAY:   fn = "sp_box_str_array";   break;

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -16,7 +16,19 @@ void emit_boxed_text(Compiler *c, TyKind t, const char *expr, Buf *b) {
   if (t == TY_CONDVAR) { buf_printf(b, "sp_box_obj((void *)(%s), SP_BUILTIN_CONDVAR)", expr); return; }
   if (t == TY_ENUMERATOR) { buf_printf(b, "sp_box_obj((void *)(%s), SP_BUILTIN_ENUMERATOR)", expr); return; }
   if (t == TY_IO) { buf_printf(b, "sp_box_obj((void *)(%s), SP_BUILTIN_IO)", expr); return; }
-  if (ty_is_object(t)) { buf_printf(b, "sp_box_obj(%s, %d)", expr, ty_object_class(t)); return; }
+  if (ty_is_object(t)) {
+    /* A reference-type object is a genuinely nilable C pointer (a hash/cache
+       lookup or a method that can `return nil` -- e.g. doom's
+       TextureManager#[] boxing build_composite's nullable result). Box via
+       sp_box_nullable_obj so a NULL pointer becomes a proper SP_TAG_NIL rather
+       than a "truthy" SP_TAG_OBJ wrapping NULL v.p, which passes `unless x` and
+       then segfaults on the first field/method read (renderer draw_wall_column
+       `texture.width`). A value-type object (a small Struct passed by value) is
+       never NULL and `expr` is not a pointer, so the plain box is correct. */
+    if (comp_ty_value_obj(c, t)) buf_printf(b, "sp_box_obj(%s, %d)", expr, ty_object_class(t));
+    else buf_printf(b, "sp_box_nullable_obj((void *)(%s), %d)", expr, ty_object_class(t));
+    return;
+  }
   if (ty_is_hash(t) && hash_box_cls(t)) { buf_printf(b, "sp_box_obj(%s, %s)", expr, hash_box_cls(t)); return; }
   const char *fn = NULL;
   switch (t) {
@@ -139,9 +151,16 @@ void emit_boxed(Compiler *c, int node, Buf *b) {
     return;
   }
   if (ty_is_object(t)) {
-    buf_printf(b, "sp_box_obj(");
+    /* A reference-type object is a nilable C pointer (a hash/cache lookup or a
+       method that can `return nil`, e.g. doom's TextureManager#[] boxing
+       build_composite's nullable result). Box via sp_box_nullable_obj so a
+       NULL pointer becomes SP_TAG_NIL rather than a truthy SP_TAG_OBJ over a
+       NULL v.p (which passes `unless x` then segfaults on the first field
+       read). A value-type object is never NULL and is not a pointer. */
+    int is_val = comp_ty_value_obj(c, t);
+    buf_printf(b, is_val ? "sp_box_obj(" : "sp_box_nullable_obj((void *)(");
     emit_expr(c, node, b);
-    buf_printf(b, ", %d)", ty_object_class(t));
+    buf_printf(b, is_val ? ", %d)" : "), %d)", ty_object_class(t));
     return;
   }
   if (ty_is_hash(t)) {

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -320,6 +320,10 @@ void emit_boxed(Compiler *c, int node, Buf *b);
 /* Emit a hash key, unboxing a poly value to the typed-hash's key type. */
 void emit_hash_key(Compiler *c, int key, TyKind kt, Buf *b);
 void emit_boxed_text(Compiler *c, TyKind t, const char *expr, Buf *b);
+/* For a reference-backed builtin type (a genuinely nilable C pointer that can
+   be NULL), return the name of its SP_BUILTIN_* class-id constant; else NULL.
+   Such a value must box via sp_box_nullable_obj so a NULL becomes SP_TAG_NIL. */
+const char *ty_nullable_builtin_id(TyKind t);
 void emit_unbox_text(Compiler *c, TyKind t, const char *expr, Buf *b);
 void emit_proc_literal(Compiler *c, int create, Buf *b);
 int proc_slot_is_direct(TyKind t);

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -3886,9 +3886,17 @@ else {
         buf_printf(g_pre, " _t%d = ", iatmp);
         emit_expr(c, ival, g_pre);
         buf_puts(g_pre, ";\n");
-        buf_printf(b, "%s = sp_box_obj(sp_%s_%s((sp_%s *)(%s).v.p, _t%d), %d);\n",
-                   ref, c->classes[poly_defcls].name, mc(pms->name),
-                   c->classes[poly_defcls].name, ref, iatmp, poly_defcls);
+        /* The operator method can `return nil` (a NULL reference); box a
+           reference-type result via sp_box_nullable_obj so NULL becomes nil, not
+           a truthy wrapper. A value-type class is never NULL, so keep sp_box_obj. */
+        const char *pbox = c->classes[poly_defcls].is_value_type
+                             ? "sp_box_obj(" : "sp_box_nullable_obj((void *)(";
+        const char *pboxc = c->classes[poly_defcls].is_value_type ? ", %d)" : "), %d)";
+        buf_printf(b, "%s = %ssp_%s_%s((sp_%s *)(%s).v.p, _t%d)", ref, pbox,
+                   c->classes[poly_defcls].name, mc(pms->name),
+                   c->classes[poly_defcls].name, ref, iatmp);
+        buf_printf(b, pboxc, poly_defcls);
+        buf_puts(b, ";\n");
       }
       else if ((sp_streq(op, "+") || sp_streq(op, "-") || sp_streq(op, "*") || sp_streq(op, "/"))) {
         /* numeric op on a poly slot: runtime poly arithmetic with a boxed rhs */

--- a/src/codegen_util.c
+++ b/src/codegen_util.c
@@ -703,13 +703,8 @@ void emit_box_open(Compiler *c, TyKind t, Buf *b) {
   else if (t == TY_CLASS) buf_puts(b, "sp_box_class(");
   else if (t == TY_COMPLEX)  buf_puts(b, "sp_box_complex(");
   else if (t == TY_RATIONAL) buf_puts(b, "sp_box_rational(");
-  else if (t == TY_FIBER) buf_puts(b, "sp_box_obj((void *)(");
-  else if (t == TY_THREAD) buf_puts(b, "sp_box_obj((void *)(");
-  else if (t == TY_QUEUE) buf_puts(b, "sp_box_obj((void *)(");
-  else if (t == TY_MUTEX) buf_puts(b, "sp_box_obj((void *)(");
-  else if (t == TY_CONDVAR) buf_puts(b, "sp_box_obj((void *)(");
-  else if (t == TY_ENUMERATOR) buf_puts(b, "sp_box_obj((void *)(");
-  else if (t == TY_IO)    buf_puts(b, "sp_box_obj((void *)(");
+  /* Reference-backed builtins are nilable C pointers: box NULL as nil. */
+  else if (ty_nullable_builtin_id(t)) buf_puts(b, "sp_box_nullable_obj((void *)(");
   else if (ty_is_object(t)) {
     int cid = ty_object_class(t);
     buf_printf(b, "sp_box_obj((%s *)( ", c->classes[cid].name);
@@ -719,13 +714,8 @@ void emit_box_open(Compiler *c, TyKind t, Buf *b) {
 void emit_box_close(Compiler *c, TyKind t, Buf *b) {
   (void)c;
   if (t == TY_POLY || t == TY_UNKNOWN) return; /* no-op: already sp_RbVal */
-  if (t == TY_FIBER) { buf_puts(b, "), SP_BUILTIN_FIBER)"); return; }
-  if (t == TY_THREAD) { buf_puts(b, "), SP_BUILTIN_THREAD)"); return; }
-  if (t == TY_QUEUE) { buf_puts(b, "), SP_BUILTIN_QUEUE)"); return; }
-  if (t == TY_MUTEX) { buf_puts(b, "), SP_BUILTIN_MUTEX)"); return; }
-  if (t == TY_CONDVAR) { buf_puts(b, "), SP_BUILTIN_CONDVAR)"); return; }
-  if (t == TY_ENUMERATOR) { buf_puts(b, "), SP_BUILTIN_ENUMERATOR)"); return; }
-  if (t == TY_IO)    { buf_puts(b, "), SP_BUILTIN_IO)"); return; }
+  { const char *nbid = ty_nullable_builtin_id(t);
+    if (nbid) { buf_printf(b, "), %s)", nbid); return; } }
   if (ty_is_object(t))        { buf_printf(b, "), %d)", ty_object_class(t)); return; }
   buf_puts(b, ")");
 }

--- a/test/box_nullable_builtin.rb
+++ b/test/box_nullable_builtin.rb
@@ -1,0 +1,23 @@
+# A reference-backed BUILTIN type (IO/Fiber/Thread/Exception/Proc/...) is a
+# nilable C pointer just like a user object: an unset ivar or a `return nil`
+# yields NULL. Boxing it into a poly slot must produce nil, not a "truthy"
+# wrapper over a NULL pointer -- otherwise `x.nil?` lies and `if x` / `unless x`
+# passes, then the first method/field read segfaults.
+class Sink
+  def open(p); @io = File.open(p, "w"); end
+  def io; @io; end   # @io is a NULL sp_File* until #open runs
+end
+
+s = Sink.new
+box = []
+box << s.io          # boxes a NULL IO into a poly array
+a = box[0]
+puts "unset nil? #{a.nil?}"
+puts "BUG: truthy NULL IO" if a        # without the fix, this wrongly prints
+
+s.open("/tmp/box_nullable_builtin_out.txt")
+box << s.io          # boxes a real IO into the poly array
+b = box[1]
+puts "open nil? #{b.nil?}"
+puts "have io" if b                     # this SHOULD print
+puts "done"

--- a/test/box_nullable_builtin.rb.expected
+++ b/test/box_nullable_builtin.rb.expected
@@ -1,0 +1,4 @@
+unset nil? true
+open nil? false
+have io
+done

--- a/test/box_nullable_obj.rb
+++ b/test/box_nullable_obj.rb
@@ -1,0 +1,21 @@
+# A method or hash lookup that can `return nil` yields a genuinely NULL object
+# pointer. Boxing it into a poly value must produce nil, not a "truthy" object
+# wrapping a NULL pointer -- otherwise `unless x` / `if x` passes and the first
+# field/method read segfaults (doom's TextureManager#[] -> build_composite ->
+# texture.width).
+Pt = Struct.new(:x, :y)
+class Cache
+  def initialize; @h = {}; end
+  def fetch(k); @h[k] ||= make(k); end
+  def make(k)
+    return nil if k < 0
+    Pt.new(k, k * 2)
+  end
+end
+c = Cache.new
+a = c.fetch(3)
+puts "a: #{a.x},#{a.y}"
+b = c.fetch(-1)
+puts "b nil? #{b.nil?}"
+puts "b.x=#{b.x}" if b   # must NOT run (b is nil); without the fix b is a truthy NULL -> segv
+puts "done"

--- a/test/box_nullable_obj.rb.expected
+++ b/test/box_nullable_obj.rb.expected
@@ -1,0 +1,3 @@
+a: 3,6
+b nil? true
+done


### PR DESCRIPTION
Part of the effort to run the unmodified Doom gem on spinel.

A method or hash lookup that can `return nil` yields a genuinely NULL object pointer (a nilable C reference). Boxing it into a poly value with `sp_box_obj` produced an `SP_TAG_OBJ` wrapping a NULL `v.p`, which `sp_poly_truthy` reports as **truthy** -- so an `unless x` / `if x` guard passes and the first field/method read off it dereferences NULL and segfaults.

Fix: box reference-type objects via `sp_box_nullable_obj` so a NULL becomes a proper `SP_TAG_NIL`. A value-type object (a small Struct passed by value) is never NULL and `expr` is not a pointer, so it keeps the plain unconditional box.

In doom this is `TextureManager#[]` boxing `build_composite`'s nullable result: the renderer then segfaulted on `texture.width` at renderer.rb:1228 after `return unless texture` wrongly passed a truthy NULL.

Regression test: test/box_nullable_obj.rb (segfaults without the fix, passes with it).