### PR TITLE
analyze: __method__ and __callee__ are nil at the top level

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -883,10 +883,14 @@ TyKind infer_call(Compiler *c, int id) {
                       sp_streq(name, "protected_instance_methods"))) return TY_POLY;
   }
 
-  /* __method__ / __callee__ -> the enclosing method's name (a symbol) */
+  /* __method__ / __callee__ -> the enclosing method's name (a symbol), or
+     nil at the top level, where the enclosing scope has no name (matching
+     the codegen, which emits sp_box_nil() there) */
   if (recv < 0 && argc == 0 &&
-      (sp_streq(name, "__method__") || sp_streq(name, "__callee__")))
-    return TY_SYMBOL;
+      (sp_streq(name, "__method__") || sp_streq(name, "__callee__"))) {
+    Scope *s = comp_scope_of(c, id);
+    return (s && s->name && s->name[0]) ? TY_SYMBOL : TY_NIL;
+  }
 
   /* identity methods: return the receiver unchanged */
   if (recv >= 0 && argc == 0 &&

--- a/test/method_at_toplevel.rb
+++ b/test/method_at_toplevel.rb
@@ -1,0 +1,6 @@
+# __method__ is nil at the top level; inside a method it is the method's name.
+p __method__
+def foo; __method__; end
+p foo
+def bar; __callee__; end
+p bar

--- a/test/method_at_toplevel.rb.expected
+++ b/test/method_at_toplevel.rb.expected
@@ -1,0 +1,3 @@
+nil
+:foo
+:bar


### PR DESCRIPTION
At the top level the enclosing scope has no name, and codegen already
emits sp_box_nil() there, but inference still typed __method__ and
__callee__ as a symbol. The p dispatch then routed the nil through the
symbol printer, whose argument type did not match. Type them as nil when
the enclosing scope is nameless, so the value and its printing agree.