### PR TITLE
codegen: implement Array#eql? as element-wise structural equality

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -2068,8 +2068,11 @@ static int emit_case_eq_call(Compiler *c, int id, Buf *b) {
     }
   }
 
-  if (argc == 1 && (sp_streq(name, "==") || sp_streq(name, "!="))) {
-    int eq = sp_streq(name, "==");
+  if (argc == 1 && (sp_streq(name, "==") || sp_streq(name, "!=") ||
+                    (sp_streq(name, "eql?") && ty_is_array(rt)))) {
+    /* Array#eql? is structural, the same element-wise comparison as ==;
+       only != negates. Scalar eql? is handled by the per-type emitters. */
+    int eq = !sp_streq(name, "!=");
     /* `x == nil` / `x != nil` for any receiver */
     int a_nil = nt_type(nt, argv[0]) && sp_streq(nt_type(nt, argv[0]), "NilNode");
     int r_nil = nt_type(nt, recv) && sp_streq(nt_type(nt, recv), "NilNode");

--- a/test/eql_on_chain_result.rb
+++ b/test/eql_on_chain_result.rb
@@ -1,0 +1,8 @@
+# Array#eql? compares element-wise, like ==, including on a method-chain result.
+def s(x); x; end
+p s([2, 1]).sort.eql?([1, 2])
+p [1, 2].eql?([1, 2])
+p [1, 2].eql?([1, 3])
+p [1, 2].eql?([1, 2, 3])
+p s([1, 2]).eql?([1, 2])
+p s([1, 2]).eql?([9, 9])

--- a/test/eql_on_chain_result.rb.expected
+++ b/test/eql_on_chain_result.rb.expected
@@ -1,0 +1,6 @@
+true
+true
+false
+false
+true
+false


### PR DESCRIPTION
Array#eql? had no emitter, so it fell through to the NoMethodError gate
and rejected at compile time, including on a method-chain result such as
`ary.sort.eql?(other)`. Route an array receiver's eql? through the same
element-wise comparison used for ==, which already covers same-kind typed
arrays and the poly-versus-typed array case; only != stays negated.