### PR TITLE
codegen: initialize constants assigned inside a Struct.new block

### DIFF
--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -4111,8 +4111,31 @@ else {
     const char *raw_key = isg ? nm + 1 : nm;
     const char *key = isg ? comp_resolve_gvar(c, raw_key) : raw_key;
     LocalVar *lv = isg ? comp_gvar(c, key) : comp_const(c, key);
-    if (!lv || (!isg && lv->type == TY_UNKNOWN)) { /* untyped -> skip */ return; }
     int v = nt_ref(nt, id, "value");
+    if (!lv || (!isg && lv->type == TY_UNKNOWN)) {
+      /* The struct-def constant itself (`Foo = Struct.new(...) do ... end`) has
+         no C runtime value and is skipped -- but any top-level constant writes
+         INSIDE that block still need init code emitted. register_structs only
+         consumes the block for class/ivar/method registration, never as
+         executable statements, so without this such constants stay NULL/default
+         despite being declared and typed (a method reading them, e.g. a Linedef
+         FLAGS[:TWOSIDED] flag helper, silently sees an empty constant). Mirrors
+         fix_struct_block_scopes, which does the analogous fixup for DefNodes. */
+      if (!isg && v >= 0 && is_struct_call(c, v)) {
+        int blk = nt_ref(nt, v, "block");
+        int bbody = blk >= 0 ? nt_ref(nt, blk, "body") : -1;
+        if (bbody >= 0) {
+          int bn = 0;
+          const int *stmts = nt_arr(nt, bbody, "body", &bn);
+          for (int k = 0; k < bn; k++) {
+            const char *sty = nt_type(nt, stmts[k]);
+            if (sty && sp_streq(sty, "ConstantWriteNode"))
+              emit_stmt(c, stmts[k], b, indent);
+          }
+        }
+      }
+      return;
+    }
     if (!isg && lv->init_guarded) {
       /* flag the const as in-progress while its Class.new runs, so a
          self-referential read inside initialize raises NameError */

--- a/test/struct_block_constant_init.rb
+++ b/test/struct_block_constant_init.rb
@@ -1,0 +1,24 @@
+# A constant assigned inside a `Struct.new(...) do ... end` block body must be
+# initialized. register_structs consumes the block only for class/ivar/method
+# registration, never as executable statements, so such a constant stayed
+# NULL/default -- a method reading it saw an empty value (doom's Linedef
+# FLAGS[:TWOSIDED] came back nil, so every linedef read as one-sided and the
+# two-sided portal walls never rendered).
+Line = Struct.new(:flags) do
+  FLAGS = {
+    BLOCKING: 0x0001,
+    TWOSIDED: 0x0004,
+    SECRET: 0x0020
+  }.freeze
+  def two_sided?
+    (flags & FLAGS[:TWOSIDED]) != 0
+  end
+  def flag(name)
+    FLAGS[name]
+  end
+end
+puts Line::FLAGS[:TWOSIDED]
+l = Line.new(0x0004)
+puts l.two_sided?
+puts Line.new(0x0001).two_sided?
+puts l.flag(:SECRET)

--- a/test/struct_block_constant_init.rb.expected
+++ b/test/struct_block_constant_init.rb.expected
@@ -1,0 +1,4 @@
+4
+true
+false
+32


### PR DESCRIPTION
Part of the effort to run the unmodified Doom gem on spinel.

A constant assigned inside a `Struct.new(...) do ... end` block body (for example `FLAGS = { ... }.freeze`) was declared and typed but never initialized. register_structs consumes the block only for class / ivar / method registration, never as executable statements, and the enclosing `Name = Struct.new ...` constant write is itself skipped (a struct-name constant has no C runtime value) - so the block's own constant writes were dropped. The constant stayed NULL/default, and any method reading it saw an empty value.

Fix: when skipping a struct-def constant write, walk its block body and emit each `ConstantWriteNode`'s initializer. This mirrors `fix_struct_block_scopes`, which does the analogous fixup for `DefNode`s in the same block.

In doom this is `Linedef`'s `FLAGS[:TWOSIDED]`: it read back nil, so `two_sided?` was always false, `back_sector` was never resolved, and the two-sided portal (upper/lower) walls never drew - about 570 wall columns missing per frame. With this fix doom's first frame renders byte-identical to CRuby (a single pixel differs, an off-by-one palette index from float rounding at a texture boundary).

Regression test: test/struct_block_constant_init.rb (the constant reads back nil without the fix, correct with it).
