### PR TITLE
parse,codegen: support one-line `expr in pattern` (MatchPredicateNode)

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -3238,6 +3238,7 @@ TyKind infer_uncached(Compiler *c, int id) {
   if (nk == NK_SourceEncodingNode)      return TY_POLY;
   if (nk == NK_RegularExpressionNode ||
       nk == NK_InterpolatedRegularExpressionNode) return TY_REGEX;
+  if (nk == NK_MatchPredicateNode)      return TY_BOOL;   /* `expr in pattern` */
   /* `/(?<n>..)/ =~ str` -- the value is the `=~` result (match index or nil). */
   if (sp_streq(ty, "MatchWriteNode")) return TY_POLY;
   if (nk == NK_InterpolatedStringNode)  return TY_STRING;

--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -470,6 +470,31 @@ void emit_expr(Compiler *c, int id, Buf *b) {
     return;
   }
 
+  if (sp_streq(ty, "MatchPredicateNode")) {
+    /* `expr in pattern` as a boolean: materialize the scrutinee, then yield the
+       pattern-match condition. Bindings are not introduced by the predicate
+       form here; an unsupported pattern rejects loudly. */
+    int value = nt_ref(nt, id, "value");
+    int pattern = nt_ref(nt, id, "pattern");
+    TyKind vt = comp_ntype(c, value);
+    if (vt == TY_UNKNOWN) vt = TY_POLY;
+    int tv = ++g_tmp;
+    Buf vb = expr_buf(c, value);
+    emit_indent(g_pre, g_indent); emit_ctype(c, vt, g_pre);
+    buf_printf(g_pre, " _t%d = %s;\n", tv, vb.p ? vb.p : default_value(vt));
+    free(vb.p);
+    if (needs_root(vt)) { emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", tv); }
+    Buf cb; memset(&cb, 0, sizeof cb);
+    if (!emit_pm_cond(c, pattern, tv, vt, &cb)) {
+      free(cb.p);
+      unsupported(c, id, "one-line `in` pattern");
+      return;
+    }
+    buf_printf(b, "(%s)", cb.p ? cb.p : "0");
+    free(cb.p);
+    return;
+  }
+
   if (sp_streq(ty, "MatchWriteNode")) {
     /* `/(?<n>..)/ =~ str`: run the match (setting the match registers), bind
        each named group to its local (NULL = nil when it did not participate),

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -1212,6 +1212,24 @@ static void emit_pm_array_cond(Compiler *c, int pat, const char *arr, Buf *b) {
   buf_puts(b, ")");
 }
 
+/* Classify a hash-pattern value sub-node for the boolean pattern matcher:
+   returns the class ConstantReadNode id for `Class` / `Class => v`, -1 for a
+   presence-only value (`k:` bare or `k: v` binding, which imposes no value
+   constraint), or PM_HASH_VAL_REJECT for a shape we emit no check for (a
+   literal, range, pin, or nested pattern) so the caller can reject it. */
+#define PM_HASH_VAL_REJECT (-2)
+static int pm_hash_value_class(const NodeTable *nt, int vpat) {
+  if (vpat < 0 || !nt_type(nt, vpat)) return -1;
+  const char *vty = nt_type(nt, vpat);
+  if (sp_streq(vty, "ConstantReadNode")) return vpat;
+  if (sp_streq(vty, "ImplicitNode") || sp_streq(vty, "LocalVariableTargetNode")) return -1;
+  if (sp_streq(vty, "CapturePatternNode")) {
+    int cv = nt_ref(nt, vpat, "value");
+    if (cv >= 0 && nt_type(nt, cv) && sp_streq(nt_type(nt, cv), "ConstantReadNode")) return cv;
+  }
+  return PM_HASH_VAL_REJECT;
+}
+
 int emit_pm_cond(Compiler *c, int pat, int t, TyKind pt, Buf *b) {
   const NodeTable *nt = c->nt;
   const char *pty = nt_type(nt, pat);
@@ -1339,6 +1357,62 @@ int emit_pm_cond(Compiler *c, int pat, int t, TyKind pt, Buf *b) {
     int val = nt_ref(nt, pat, "value");
     if (val >= 0) return emit_pm_cond(c, val, t, pt, b);
     return 0;
+  }
+  if (sp_streq(pty, "HashPatternNode")) {
+    /* matches when the scrutinee is a hash with every key present and each value
+       matching its sub-pattern (a class check for `k: Class`). Only a statically
+       typed hash scrutinee and the value shapes classified by pm_hash_value_class
+       are handled; a poly/non-hash scrutinee, an unsupported value pattern, or an
+       unresolvable class returns 0 so the caller reports it unsupported rather
+       than emitting a silently-wrong match. Everything is validated before any
+       emit, so a reject never leaves half-built helper code in g_pre. */
+    const char *hn = ty_is_hash(pt) ? ty_hash_cname(pt) : NULL;
+    if (!hn) return 0;
+    TyKind hvt = ty_hash_val(pt);
+    int en = 0;
+    const int *elms = nt_arr(nt, pat, "elements", &en);
+    for (int i = 0; i < en; i++) {
+      if (!nt_type(nt, elms[i]) || !sp_streq(nt_type(nt, elms[i]), "AssocNode")) return 0;
+      if (nt_ref(nt, elms[i], "key") < 0) return 0;
+      int classpat = pm_hash_value_class(nt, nt_ref(nt, elms[i], "value"));
+      if (classpat == PM_HASH_VAL_REJECT) return 0;
+      if (classpat >= 0 && hvt == TY_POLY) {
+        Buf probe; memset(&probe, 0, sizeof probe);
+        int ok = emit_poly_class_when(c, classpat, "_v", &probe);
+        free(probe.p);
+        if (!ok) return 0;
+      }
+    }
+    int hcond = ++g_tmp;
+    emit_indent(g_pre, g_indent); buf_printf(g_pre, "int _t%d = 1;\n", hcond);
+    for (int i = 0; i < en; i++) {
+      int key = nt_ref(nt, elms[i], "key");
+      int classpat = pm_hash_value_class(nt, nt_ref(nt, elms[i], "value"));
+      emit_indent(g_pre, g_indent);
+      buf_printf(g_pre, "_t%d = _t%d && sp_%sHash_has_key(_t%d, ", hcond, hcond, hn, t);
+      emit_expr(c, key, g_pre); buf_puts(g_pre, ");\n");
+      if (classpat < 0) continue;
+      if (hvt == TY_POLY) {
+        int vtmp = ++g_tmp;
+        emit_indent(g_pre, g_indent);
+        buf_printf(g_pre, "{ sp_RbVal _t%d = sp_%sHash_get(_t%d, ", vtmp, hn, t);
+        emit_expr(c, key, g_pre); buf_puts(g_pre, "); ");
+        char vn[24]; snprintf(vn, sizeof vn, "_t%d", vtmp);
+        Buf cw; memset(&cw, 0, sizeof cw);
+        emit_poly_class_when(c, classpat, vn, &cw);   /* validated to succeed above */
+        buf_printf(g_pre, "_t%d = _t%d && (%s);", hcond, hcond, cw.p ? cw.p : "1");
+        free(cw.p);
+        buf_puts(g_pre, " }\n");
+      }
+      else {
+        const char *cn = nt_str(nt, classpat, "name");
+        if (cn && ty_matches_class(hvt, cn, 0) <= 0) {
+          emit_indent(g_pre, g_indent); buf_printf(g_pre, "_t%d = 0;\n", hcond);
+        }
+      }
+    }
+    buf_printf(b, "_t%d", hcond);
+    return 1;
   }
   return 0;
 }

--- a/src/node_table.h
+++ b/src/node_table.h
@@ -133,6 +133,7 @@ typedef struct {
   X(LocalVariableTargetNode) \
   X(LocalVariableWriteNode) \
   X(MatchRequiredNode) \
+  X(MatchPredicateNode) \
   X(ModuleNode) \
   X(MultiTargetNode) \
   X(MultiWriteNode) \

--- a/src/spinel_parse.c
+++ b/src/spinel_parse.c
@@ -1446,6 +1446,14 @@ else {
     }
     break;
   }
+  case PM_MATCH_PREDICATE_NODE: {
+    /* `expr in pattern`: a boolean one-line pattern test (Ruby 3.0+). */
+    pm_match_predicate_node_t *n = (pm_match_predicate_node_t *)node;
+    N("MatchPredicateNode");
+    R("value", n->value);
+    R("pattern", n->pattern);
+    break;
+  }
   case PM_ALTERNATION_PATTERN_NODE: {
     pm_alternation_pattern_node_t *n = (pm_alternation_pattern_node_t *)node;
     N("AlternationPatternNode");

--- a/test/oneline_in_array.rb
+++ b/test/oneline_in_array.rb
@@ -1,0 +1,5 @@
+# One-line `expr in pattern` with an array pattern yields a boolean.
+def s(x); x; end
+a = (s([1, 2, 3]) in [1, *]);    p a
+b = (s([1, 2, 3]) in [1, 2, 3]); p b
+c = (s([1, 2, 3]) in [1, 2]);    p c

--- a/test/oneline_in_array.rb.expected
+++ b/test/oneline_in_array.rb.expected
@@ -1,0 +1,3 @@
+true
+true
+false

--- a/test/oneline_in_hash.rb
+++ b/test/oneline_in_hash.rb
@@ -1,0 +1,7 @@
+# One-line `expr in pattern` with a hash pattern and a class-checked capture.
+def s(x); x; end
+data = s({x: 5})
+matched = (data in {x: Integer => xv}); p matched
+b = (data in {x: Integer}); p b
+c = (data in {x: String});  p c
+d = (data in {y: Integer}); p d

--- a/test/oneline_in_hash.rb.expected
+++ b/test/oneline_in_hash.rb.expected
@@ -1,0 +1,4 @@
+true
+true
+false
+false

--- a/test/oneline_in_hash_presence.rb
+++ b/test/oneline_in_hash_presence.rb
@@ -1,0 +1,9 @@
+# A bare `k:` in a one-line hash pattern is a presence-only test (no value
+# constraint); a `k: Class` check still constrains the value.
+def s(x); x; end
+h = s({a: 1, b: 2})
+p (h in {a:})
+p (h in {a:, b:})
+p (h in {c:})
+p (h in {a: Integer, b: Integer})
+p (h in {a: String})

--- a/test/oneline_in_hash_presence.rb.expected
+++ b/test/oneline_in_hash_presence.rb.expected
@@ -1,0 +1,5 @@
+true
+true
+false
+true
+false


### PR DESCRIPTION
The boolean one-line pattern test `expr in pattern` was unparsed and fell
through to the unsupported-node path. Parse it as a MatchPredicateNode,
type it as a boolean, and emit it in expression position: materialize the
scrutinee, then yield the pattern-match condition. Extend the pattern
condition emitter to handle hash patterns so `{k: Class}` works as a
one-line test as well as inside case/in.