### PR TITLE
runtime,codegen: thread Exception#cause through raises and non-local exits

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -3973,11 +3973,36 @@ static SP_TLS volatile const char *sp_last_exc_cls = sp_str_empty;
    sp_pending_exc_obj is set by sp_raise_exc just before the longjmp and
    consumed into the per-frame slot by sp_raise_cls. */
 static SP_TLS void *sp_exc_obj[SP_EXC_STACK_MAX];
-/* $! -- the exception being handled by the innermost active rescue arm
-   (NULL outside one). The arm prologue saves/sets it; normal arm completion
-   restores the outer value. Rooted alongside the carried exc objects. */
-static SP_TLS struct sp_Exception_s *sp_bang_exc;
 static SP_TLS void *sp_pending_exc_obj = NULL;
+/* The exception currently being handled (set by a rescue body), and the cause
+   captured for the next raised exception -- Exception#cause threads the former
+   into a newly raised exception's `cause` field. */
+static SP_TLS void *sp_pending_cause = NULL;
+/* The exception handled at each active rescue-body depth (CRuby's per-rescue
+   errinfo). The "currently handled" exception -- what Exception#cause threads --
+   is the innermost: sp_rescue_sp>0 ? sp_exc_handling[sp_rescue_sp-1] : NULL. A
+   depth stack, NOT indexed by sp_exc_top: a rescue body runs with its begin frame
+   already popped, so nested rescue bodies share an sp_exc_top. Pushed on rescue
+   entry; popped on every exit -- fall-through, return/break/next/retry (codegen
+   pops sp_rescue_sp), and raise-out (the landing restores sp_rescue_mark). */
+static SP_TLS void *sp_exc_handling[SP_EXC_STACK_MAX];
+static SP_TLS int sp_rescue_sp = 0;
+/* sp_rescue_sp captured at each begin frame's arm, restored on that frame's
+   exception landing so a rescue body that exits by raising doesn't leak its push
+   (a side array beside the handler stack, mirroring sp_exc_rootmark). */
+static SP_TLS int sp_rescue_mark[SP_EXC_STACK_MAX];
+#define sp_cur_handled() (sp_rescue_sp > 0 ? sp_exc_handling[sp_rescue_sp-1] : NULL)
+/* Push a handled exception. sp_rescue_sp grows with recursion *through* rescue
+   bodies (the handler stays pushed across the recursive call it makes, unlike a
+   begin frame which is popped first), so a fixed SP_EXC_STACK_MAX can be reached;
+   fail loudly rather than write past sp_exc_handling. */
+static void sp_rescue_push(void *e) {
+  if (sp_rescue_sp >= SP_EXC_STACK_MAX) {
+    fprintf(stderr, "rescue nesting too deep (> %d)\n", SP_EXC_STACK_MAX);
+    exit(1);
+  }
+  sp_exc_handling[sp_rescue_sp++] = e;
+}
 /* ---- Native backtrace formatting (spinel --debug) ---------------------- */
 /* True for sp_<name> symbols that are runtime helpers, not user Ruby methods.
    A denylist of the lowercase runtime prefixes; user methods are sp_<rubyname>
@@ -4143,7 +4168,7 @@ SP_NORETURN SP_COLD void sp_raise_cls(const char *cls, const char *msg) {
      inside an `ensure` running during a proc-return / throw): clear the unwind so
      an outer handler treats this as an exception, not a continued unwind. */
   sp_unwind_kind = SP_UNWIND_NONE;
-  if (sp_exc_top > 0) { sp_exc_msg[sp_exc_top-1] = msg; sp_exc_cls[sp_exc_top-1] = cls; sp_exc_obj[sp_exc_top-1] = sp_pending_exc_obj; sp_pending_exc_obj = NULL; sp_last_exc_cls = cls; longjmp(sp_exc_stack[sp_exc_top-1], 1); } fprintf(stderr, "unhandled exception: %s\n", msg); exit(1); }
+  if (sp_exc_top > 0) { sp_exc_msg[sp_exc_top-1] = msg; sp_exc_cls[sp_exc_top-1] = cls; sp_exc_obj[sp_exc_top-1] = sp_pending_exc_obj; sp_pending_exc_obj = NULL; sp_pending_cause = sp_cur_handled(); sp_last_exc_cls = cls; longjmp(sp_exc_stack[sp_exc_top-1], 1); } fprintf(stderr, "unhandled exception: %s\n", msg); exit(1); }
 static void sp_raise(const char *msg) { sp_raise_cls("RuntimeError", msg); }
 
 /* Issue #781: bridge between the regex compile-error path (which lives
@@ -4179,6 +4204,9 @@ static void sp_mark_in_flight_exceptions(void) {
     if (sp_exc_obj[i]) sp_gc_mark(sp_exc_obj[i]);  /* carried subclass object + its ivars */
   }
   if (sp_pending_exc_obj) sp_gc_mark(sp_pending_exc_obj);
+  if (sp_pending_cause) sp_gc_mark(sp_pending_cause);
+  for (int i = 0; i < sp_rescue_sp; i++)
+    if (sp_exc_handling[i]) sp_gc_mark(sp_exc_handling[i]);  /* handled exceptions */
 }
 
 /* sp_Exception: first-class exception object. cls_name is a pointer
@@ -4189,12 +4217,14 @@ typedef struct sp_Exception_s {
   const char *cls_name;
   const char *parent_cls_name; /* builtin ancestor for user subclasses, or NULL */
   const char *msg;
+  struct sp_Exception_s *cause; /* the exception being handled when this was raised, or NULL */
 } sp_Exception;
 /* Registered by the generated program to provide user exception hierarchy. */
 static const char *(*sp_user_exc_parent_fn)(const char *) = NULL;
 static void sp_exc_gc_scan(void *p) {
   sp_Exception *e = (sp_Exception *)p;
   if (e->msg) sp_mark_string(e->msg);
+  if (e->cause) sp_gc_mark(e->cause);
   /* cls_name/parent_cls_name point into rodata -- not GC-managed strings */
 }
 static sp_Exception *sp_exc_new(const char *cls_name, const char *msg) {
@@ -4202,6 +4232,7 @@ static sp_Exception *sp_exc_new(const char *cls_name, const char *msg) {
   e->cls_name = cls_name ? cls_name : "RuntimeError";
   e->parent_cls_name = NULL;
   e->msg = (msg && msg[0]) ? msg : (cls_name ? cls_name : "RuntimeError");
+  e->cause = NULL;  /* set all fields explicitly; sp_exc_gc_scan reads cause */
   return e;
 }
 static sp_Exception *sp_exc_new_sub(const char *cls_name, const char *parent_cls, const char *msg) {
@@ -4253,6 +4284,11 @@ static sp_Exception *sp_exc_new_for_catch(const char *cls, const char *msg) {
     if (par) e->parent_cls_name = par;
   }
   return e;
+}
+/* Exception#cause: the exception active when this one was raised, or NULL. */
+static sp_Exception *sp_exc_cause(volatile sp_Exception *ve) {
+  sp_Exception *e = (sp_Exception *)ve;
+  return e ? e->cause : NULL;
 }
 /* Exception#is_a?(ClassName): checks class name and known hierarchy. */
 static mrb_int sp_exc_is_a(volatile sp_Exception *ve, const char *cn) {
@@ -4569,8 +4605,10 @@ static void sp_mark_proc_homes(void) {
    globals. Only in the threaded build (the single-threaded one never parks). */
 static void sp_publish_worker_roots(void) {
   for (int i = 0; i < sp_exc_top; i++) if (sp_exc_obj[i]) _sp_gc_root_push((void **)&sp_exc_obj[i]);
-  if (sp_bang_exc) _sp_gc_root_push((void **)&sp_bang_exc);
   if (sp_pending_exc_obj) _sp_gc_root_push((void **)&sp_pending_exc_obj);
+  if (sp_pending_cause) _sp_gc_root_push((void **)&sp_pending_cause);
+  for (int i = 0; i < sp_rescue_sp; i++)
+    if (sp_exc_handling[i]) _sp_gc_root_push((void **)&sp_exc_handling[i]);
   for (sp_proc_home *h = sp_proc_ret_head; h; h = h->prev)
     _sp_gc_root_push((void **)((uintptr_t)&h->val | (uintptr_t)1));   /* sp_RbVal root */
   for (int i = 0; i < sp_brk_top; i++)
@@ -4607,6 +4645,8 @@ typedef struct {
   jmp_buf *bs; sp_RbVal *bv; mrb_int *bser; int *bet;     int bn, bcap;  /* break scopes */
   sp_proc_home *prhead;  /* this fiber's proc-return chain head (nodes on its C stack) */
   int uk, ut, ue; sp_proc_home *uh;  /* transient unwind state (in flight only while running ensures) */
+  void **shand; int rn, rcap;        /* sp_exc_handling prefix [0..sp_rescue_sp) */
+  void *pcause;                      /* sp_pending_cause */
 } sp_exc_ctx_t;
 
 void *sp_exc_ctx_new(void) { return calloc(1, sizeof(sp_exc_ctx_t)); }
@@ -4615,7 +4655,7 @@ void sp_exc_ctx_free(void *p) {
   if (!x) return;
   free(x->es); free(x->em); free(x->ec); free(x->eo);
   free(x->cs); free(x->ct); free(x->cv); free(x->cet);
-  free(x->bs); free(x->bv); free(x->bser); free(x->bet); free(x);
+  free(x->bs); free(x->bv); free(x->bser); free(x->bet); free(x->shand); free(x);
 }
 void sp_exc_ctx_save(void *p) {            /* current globals -> ctx */
   sp_exc_ctx_t *x = (sp_exc_ctx_t *)p;
@@ -4649,6 +4689,12 @@ void sp_exc_ctx_save(void *p) {            /* current globals -> ctx */
   x->bn = bn;
   x->prhead = sp_proc_ret_head;
   x->uk = sp_unwind_kind; x->ut = sp_unwind_target; x->ue = sp_unwind_exc_top; x->uh = sp_unwind_home;
+  int rn = sp_rescue_sp;
+  if (rn > x->rcap) { x->rcap = rn;
+    x->shand = (void **)realloc(x->shand, sizeof(void *) * rn);
+    if (!x->shand) sp_oom_die(); }
+  for (int i = 0; i < rn; i++) x->shand[i] = sp_exc_handling[i];
+  x->rn = rn; x->pcause = sp_pending_cause;
 }
 void sp_exc_ctx_load(void *p) {            /* ctx -> current globals */
   sp_exc_ctx_t *x = (sp_exc_ctx_t *)p;
@@ -4663,6 +4709,8 @@ void sp_exc_ctx_load(void *p) {            /* ctx -> current globals */
   sp_brk_top = x->bn;
   sp_proc_ret_head = x->prhead;
   sp_unwind_kind = x->uk; sp_unwind_target = x->ut; sp_unwind_exc_top = x->ue; sp_unwind_home = x->uh;
+  for (int i = 0; i < x->rn; i++) sp_exc_handling[i] = x->shand[i];
+  sp_rescue_sp = x->rn; sp_pending_cause = x->pcause;
 }
 void sp_exc_ctx_mark(void *p) {            /* GC: mark a suspended fiber's carried exc objects */
   sp_exc_ctx_t *x = (sp_exc_ctx_t *)p;
@@ -4672,6 +4720,7 @@ void sp_exc_ctx_mark(void *p) {            /* GC: mark a suspended fiber's carri
      carry an in-flight return value; mark each so it survives a GC during yield. */
   for (sp_proc_home *h = x->prhead; h; h = h->prev) sp_mark_rbval(h->val);
   for (int i = 0; i < x->bn; i++) sp_mark_rbval(x->bv[i]);   /* carried break scopes */
+  for (int i = 0; i < x->rn; i++) if (x->shand[i]) sp_gc_mark(x->shand[i]);  /* handled excs */
 }
 /* Trampoline base handler (#1474): the fiber trampoline arms a copy of its own
    setjmp buffer as the fiber's lowest handler, so an otherwise-unhandled raise

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -2376,6 +2376,7 @@ else {
         sp_streq(name, "full_message") || sp_streq(name, "detailed_message") ||
         sp_streq(name, "class")) return TY_STRING;
     if (sp_streq(name, "backtrace")) return TY_STR_ARRAY;  /* empty: no frames captured */
+    if (sp_streq(name, "cause")) return TY_EXCEPTION;      /* the threaded cause, nil if none */
   }
 
   /* poly receiver / poly operand: result type of operations on sp_RbVal */

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -711,7 +711,7 @@ void emit_method(Compiler *c, Scope *s, Buf *b) {
   g_self_deref = (s->class_id >= 0 && !s->is_cmethod && c->classes[s->class_id].is_value_type &&
                   s->name && !sp_streq(s->name, "initialize")) ? "." : "->";
   g_ret_type = method_is_void(s) ? TY_VOID : s->ret;
-  g_exc_frame_depth = 0; g_method_pr_exc_depth = 0;
+  g_exc_frame_depth = 0; g_method_pr_exc_depth = 0; g_rescue_save_depth = 0;
   /* real-function funnel mirror: no proc-return frame yet (set below when
      one exists); block bodies spliced by yield-inlines restore from these. */
   g_fn_pr_label = NULL; g_fn_pr_var = NULL; g_fn_ret_type = g_ret_type;
@@ -1250,7 +1250,8 @@ void emit_fiber_new(Compiler *c, int id, Buf *b, int as_gen) {
   const char *sv_fbser = g_brk_ser_var; g_brk_ser_var = NULL;   /* fresh function context */
   int sv_fbskip = g_brk_skip_id; g_brk_skip_id = -1;
   int sv_fbexcd = g_exc_frame_depth, sv_fbprexcd = g_method_pr_exc_depth;
-  g_exc_frame_depth = 0; g_method_pr_exc_depth = 0;
+  int sv_fbrsd = g_rescue_save_depth;
+  g_exc_frame_depth = 0; g_method_pr_exc_depth = 0; g_rescue_save_depth = 0;
 
   /* Unpack capture struct */
   if (ncap > 0 || cap_self) {
@@ -1368,6 +1369,7 @@ void emit_fiber_new(Compiler *c, int id, Buf *b, int as_gen) {
   g_fn_pr_label = sv_fn_prl2; g_fn_pr_var = sv_fn_prv2; g_fn_ret_type = sv_fn_rt2;
   g_brk_ser_var = sv_fbser; g_brk_skip_id = sv_fbskip;
   g_exc_frame_depth = sv_fbexcd; g_method_pr_exc_depth = sv_fbprexcd;
+  g_rescue_save_depth = sv_fbrsd;
 
   /* Emit creation expression:
      If there are captures, allocate a GC-managed capture struct, fill it,
@@ -1782,7 +1784,8 @@ else if (orecv >= 0 && onm) {
   const char *sv_pr_label = g_method_pr_label, *sv_pr_var = g_method_pr_var, *sv_prh = g_proc_return_home;
   g_method_pr_label = NULL; g_method_pr_var = NULL;
   int sv_excd = g_exc_frame_depth, sv_prexcd = g_method_pr_exc_depth;
-  g_exc_frame_depth = 0; g_method_pr_exc_depth = 0;
+  int sv_rsd = g_rescue_save_depth;
+  g_exc_frame_depth = 0; g_method_pr_exc_depth = 0; g_rescue_save_depth = 0;
   const char *sv_fn_prl = g_fn_pr_label, *sv_fn_prv = g_fn_pr_var; TyKind sv_fn_rt = g_fn_ret_type;
   g_fn_pr_label = NULL; g_fn_pr_var = NULL; g_fn_ret_type = ret;
   char home_acc[48] = "";
@@ -2017,6 +2020,7 @@ else if (orecv >= 0 && onm) {
   g_result_poly = sv_rp;
   g_method_pr_label = sv_pr_label; g_method_pr_var = sv_pr_var; g_proc_return_home = sv_prh;
   g_exc_frame_depth = sv_excd; g_method_pr_exc_depth = sv_prexcd;
+  g_rescue_save_depth = sv_rsd;
   g_fn_pr_label = sv_fn_prl; g_fn_pr_var = sv_fn_prv; g_fn_ret_type = sv_fn_rt;
 
   if (ncap == 0 && !cap_self && !ret_proc) {
@@ -2149,14 +2153,17 @@ void emit_class_struct(Compiler *c, ClassInfo *ci, Buf *b) {
     /* An ivar-less exception subclass is forward-declared as
        `typedef sp_Exception` and needs no struct of its own. One with
        ivars gets a dedicated struct whose leading members mirror
-       sp_Exception (cls_name/parent_cls_name/msg) -- a common initial
+       sp_Exception (cls_name/parent_cls_name/msg/cause) -- a common initial
        sequence -- so every `(sp_Exception *)` cast in the raise/rescue
-       and message machinery stays valid, with the ivar fields after (#1415). */
+       and message machinery stays valid, with the ivar fields after (#1415).
+       cause must be mirrored too: the rescue machinery writes it through the
+       base cast, so omitting it would alias the first ivar. */
     if (ci->nivars == 0) return;
     buf_printf(b, "struct sp_%s_s {\n", ci->name);
     buf_puts(b, "  const char *cls_name;\n");
     buf_puts(b, "  const char *parent_cls_name;\n");
     buf_puts(b, "  const char *msg;\n");
+    buf_puts(b, "  struct sp_Exception_s *cause;\n");
     for (int i = 0; i < ci->nivars; i++) {
       TyKind t = ci->ivar_types[i];
       /* belt and suspenders: analyze widens void/nil ivar slots to poly

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -4542,6 +4542,10 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       buf_puts(b, "sp_exc_message("); emit_expr(c, recv, b); buf_puts(b, ")");
       return;
     }
+    if (sp_streq(name, "cause")) {
+      buf_puts(b, "sp_exc_cause("); emit_expr(c, recv, b); buf_puts(b, ")");
+      return;
+    }
     if (sp_streq(name, "full_message")) {
       int t = ++g_tmp;
       Buf rb = expr_buf(c, recv);
@@ -8409,9 +8413,10 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       }
       else {
         /* the deferred return leaves through every enclosing live begin
-           frame: pop them (see the begin..ensure epilogue in codegen_stmt.c) */
-        if (g_exc_frame_depth > 0)
-          buf_printf(b, "if (_retf%d) sp_exc_top -= %d; ", eid, g_exc_frame_depth);
+           frame: pop them (see the begin..ensure epilogue in codegen_stmt.c),
+           and pop the sp_rescue_sp handler for each rescue body it leaves */
+        { char g[24]; snprintf(g, sizeof g, "_retf%d", eid);
+          if (emit_frame_unwind(b, 0, g)) buf_puts(b, " "); }
         if (has_retval) buf_printf(b, "if (_retf%d) return _retv%d; ", eid, eid);
         else if (g_ret_type == TY_POLY) buf_printf(b, "if (_retf%d) return sp_box_nil(); ", eid);
         else if (g_ret_type == TY_UNKNOWN) buf_printf(b, "if (_retf%d) return 0; ", eid);

--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -1096,7 +1096,7 @@ void emit_expr(Compiler *c, int id, Buf *b) {
     if (nm && sp_streq(nm, "$/")) { emit_str_literal(b, "\n"); return; }
     if (nm && sp_streq(nm, "$?")) { buf_puts(b, "sp_last_status"); return; }
     if (nm && (sp_streq(nm, "$PROGRAM_NAME") || sp_streq(nm, "$0"))) { buf_puts(b, "sp_program_name"); return; }
-    if (nm && sp_streq(nm, "$!")) { buf_puts(b, "sp_bang_exc"); return; }
+    if (nm && sp_streq(nm, "$!")) { buf_puts(b, "((sp_Exception *)sp_cur_handled())"); return; }
     if (nm && (sp_streq(nm, "$;") || sp_streq(nm, "$,"))) { buf_puts(b, "0"); return; }
     /* regex match globals that Prism may emit as GlobalVariableReadNode */
     if (nm && (sp_streq(nm, "$~") || sp_streq(nm, "$&")))  { buf_puts(b, "sp_re_match_str");  return; }

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -171,6 +171,23 @@ typedef struct { int lid; int has_retval; int exc_base; } EnsureCtx;
 extern EnsureCtx g_ensure_stack[MAX_ENSURE_DEPTH];
 extern int       g_ensure_depth;
 
+/* One entry per rescue body currently being emitted. exc_base records
+   g_exc_frame_depth at that body's entry so a non-local exit can tell which
+   rescue bodies it crosses (those with exc_base >= the exit's frame base) and
+   pop their sp_exc_handling entries (sp_rescue_sp). */
+typedef struct { int exc_base; } RescueSave;
+extern RescueSave g_rescue_save_stack[MAX_ENSURE_DEPTH];
+extern int        g_rescue_save_depth;
+/* Emit the pop that leaves the exception frames above pop_base AND pops the
+   sp_rescue_sp handler for each rescue body crossed. Replaces the bare
+   `sp_exc_top -= N;` emission at every non-local-exit site. When guard != NULL
+   (deferred return), both are wrapped in `if (guard) { ... }`. Returns 1 if it
+   emitted anything. */
+int emit_frame_unwind(Buf *b, int pop_base, const char *guard);
+/* Pop the sp_rescue_sp handlers crossed (no frame pop), for the begin..ensure
+   deferred return whose frame-pop text is special. */
+void emit_cur_exc_restore(Buf *b, int pop_base);
+
 /* First-class Proc support: each `proc {}` / `lambda {}` / `->{}` literal
    lowers to a standalone `static mrb_int _proc_N(void *cap, mrb_int *args)`
    function (the ABI sp_proc_call expects). Definitions accumulate in g_procs

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -2956,8 +2956,7 @@ void emit_return(Compiler *c, int id, Buf *b, int indent) {
         if (!node_is_pure_literal(c->nt, vn)) { buf_puts(b, "(void)("); emit_expr(c, vn, b); buf_puts(b, "); "); }
       }
     }
-    if (g_exc_frame_depth > g_method_pr_exc_depth)
-      buf_printf(b, "sp_exc_top -= %d; ", g_exc_frame_depth - g_method_pr_exc_depth);
+    emit_frame_unwind(b, g_method_pr_exc_depth, NULL);
     buf_printf(b, "goto %s; }\n", g_method_pr_label);
     return;
   }
@@ -2988,6 +2987,9 @@ void emit_return(Compiler *c, int id, Buf *b, int indent) {
     {
       int pops = g_exc_frame_depth - ctx->exc_base;
       if (pops < 1) pops = 1;   /* at least the ensure frame itself */
+      /* pop the handlers for rescue bodies inside this ensure region we are
+         leaving; rescues outside it are popped at the ensure re-dispatch. */
+      emit_cur_exc_restore(b, ctx->exc_base);
       buf_printf(b, "_retf%d = 1; sp_exc_top -= %d; goto _ensure%d; }\n",
                  ctx->lid, pops, ctx->lid);
     }
@@ -2997,8 +2999,9 @@ void emit_return(Compiler *c, int id, Buf *b, int indent) {
   emit_indent(b, indent);
   /* leaving through live begin/rescue frames: pop them, or their jmp_bufs
      dangle into this soon-dead C frame and the next raise longjmps into
-     garbage (doom's SoundManager#[] early cache returns). */
-  if (g_exc_frame_depth > 0) buf_printf(b, "sp_exc_top -= %d; ", g_exc_frame_depth);
+     garbage (doom's SoundManager#[] early cache returns). Also restores
+     the sp_rescue_sp handler for every rescue body this return leaves. */
+  emit_frame_unwind(b, 0, NULL);
   if (n > 1) {
     int ta = ++g_tmp;
     buf_printf(b, "{ sp_PolyArray *_t%d = sp_PolyArray_new(); SP_GC_ROOT(_t%d);", ta, ta);
@@ -3139,48 +3142,53 @@ void emit_rescue(Compiler *c, int id, Buf *b, int indent, int fr, const char *re
   }
 
   g_rescue_cls = clsbuf; g_rescue_msg = msgbuf;
-  if (ref >= 0 && nt_type(nt, ref) && sp_streq(nt_type(nt, ref), "LocalVariableTargetNode")) {
-    /* If the analyzer specialized this binding to a user exception subclass
-       object (one arm, one class, no name collision -- see the rescue-var
-       typing in analyze_program), bind the original carried object so its
-       ivars survive the raise (#1415). The carried slot is at sp_exc_top (the
-       just-popped frame, same index _rmsg reads). A degenerate no-object raise
-       of that class falls back to a freshly built subclass struct so ivar
-       reads stay in-bounds rather than NULL-deref. */
-    int spec_cid = -1;
-    {
-      LocalVar *vlv = scope_local(comp_scope_of(c, ref), nt_str(nt, ref, "name"));
-      if (vlv && ty_is_object(vlv->type)) {
-        int xc = ty_object_class(vlv->type);
-        if (xc >= 0 && class_is_exc_subclass(c, xc)) spec_cid = xc;
-      }
+  /* If the analyzer specialized a `=> e` binding to a user exception subclass
+     object (one arm, one class, no name collision -- see the rescue-var typing
+     in analyze_program), the carried object must be kept so its ivars survive
+     the raise (#1415). The carried slot is at sp_exc_top (the just-popped frame,
+     same index _rmsg reads). A degenerate no-object raise of that class falls
+     back to a freshly built subclass struct so ivar reads stay in-bounds. */
+  int spec_cid = -1;
+  int has_bind = (ref >= 0 && nt_type(nt, ref) && sp_streq(nt_type(nt, ref), "LocalVariableTargetNode"));
+  if (has_bind) {
+    LocalVar *vlv = scope_local(comp_scope_of(c, ref), nt_str(nt, ref, "name"));
+    if (vlv && ty_is_object(vlv->type)) {
+      int xc = ty_object_class(vlv->type);
+      if (xc >= 0 && class_is_exc_subclass(c, xc)) spec_cid = xc;
     }
-    emit_indent(b, indent);
-    if (spec_cid >= 0) {
-      const char *xn = c->classes[spec_cid].name;
-      buf_printf(b, "lv_%s = sp_exc_obj[sp_exc_top] ? (sp_%s *)sp_exc_obj[sp_exc_top]"
-                    " : (sp_%s *)sp_exc_new_sub_sized(sizeof(sp_%s), _rcls_%d, _rmsg_%d);\n",
-                 nt_str(nt, ref, "name"), xn, xn, xn, rc, rc);
-    }
-    else
-      /* prefer the CARRIED object (raise <exception-object> / raise Cls.new):
-         the rescue variable, $!, and the raised object must be one identity;
-         synthesize only when nothing was carried (sp_raise_cls paths). */
-      buf_printf(b, "lv_%s = sp_exc_obj[sp_exc_top] ? (sp_Exception *)sp_exc_obj[sp_exc_top]"
-                    " : sp_exc_new_for_catch(_rcls_%d, _rmsg_%d);\n", nt_str(nt, ref, "name"), rc, rc);
   }
-  /* $! tracks the exception this arm is handling; save/restore so nesting
-     and normal completion behave like CRuby (raise-continuation leaves it
-     set, which the next arm overwrites anyway). */
-  int bangs = ++g_tmp;
+  /* Materialize the exception being handled exactly once -- the carried object
+     if any, else a freshly built one -- then thread the cause captured at raise
+     time onto it. Pushing the same object onto sp_exc_handling (so a re-raise in
+     the body threads it as #cause) and binding it to `=> e` keeps the cause chain
+     consistent, and covers an explicitly raised object too (it has a carried
+     object, so it flows through the same path). */
   emit_indent(b, indent);
-  buf_printf(b, "sp_Exception *volatile _svbang_%d = sp_bang_exc;\n", bangs);
-  emit_indent(b, indent);
-  if (ref >= 0 && nt_str(nt, ref, "name"))
-    buf_printf(b, "sp_bang_exc = (sp_Exception *)lv_%s;\n", nt_str(nt, ref, "name"));
+  if (spec_cid >= 0) {
+    const char *xn = c->classes[spec_cid].name;
+    buf_printf(b, "sp_Exception *_ce_%d = sp_exc_obj[sp_exc_top] ? (sp_Exception *)sp_exc_obj[sp_exc_top]"
+                  " : (sp_Exception *)sp_exc_new_sub_sized(sizeof(sp_%s), _rcls_%d, _rmsg_%d);\n",
+               rc, xn, rc, rc);
+  }
   else
-    buf_printf(b, "sp_bang_exc = sp_exc_obj[sp_exc_top] ? (sp_Exception *)sp_exc_obj[sp_exc_top]"
-                  " : sp_exc_new_for_catch(_rcls_%d, _rmsg_%d);\n", rc, rc);
+    buf_printf(b, "sp_Exception *_ce_%d = sp_exc_obj[sp_exc_top] ? (sp_Exception *)sp_exc_obj[sp_exc_top]"
+                  " : sp_exc_new_for_catch(_rcls_%d, _rmsg_%d);\n", rc, rc, rc);
+  emit_indent(b, indent);
+  buf_printf(b, "_ce_%d->cause = (sp_Exception *)sp_pending_cause; sp_pending_cause = NULL;\n", rc);
+  emit_indent(b, indent);
+  buf_printf(b, "sp_rescue_push((void *)_ce_%d);\n", rc);
+  g_rescue_save_stack[g_rescue_save_depth++] = (RescueSave){ g_exc_frame_depth };
+  if (has_bind) {
+    emit_indent(b, indent);
+    if (spec_cid >= 0)
+      buf_printf(b, "lv_%s = (sp_%s *)_ce_%d;\n", nt_str(nt, ref, "name"), c->classes[spec_cid].name, rc);
+    else
+      /* bind the materialized object (which already prefers the CARRIED object
+         from `raise <exception-object>` / `raise Cls.new`): the rescue variable,
+         $!, and the raised object are one identity, since $! reads the same
+         sp_exc_handling top this arm just pushed. */
+      buf_printf(b, "lv_%s = _ce_%d;\n", nt_str(nt, ref, "name"), rc);
+  }
   if (resultvar) {
     const char *sv = g_result_var; g_result_var = resultvar;
     emit_stmts_tail(c, stmts, b, indent);
@@ -3189,8 +3197,9 @@ void emit_rescue(Compiler *c, int id, Buf *b, int indent, int fr, const char *re
   else {
     emit_stmts(c, stmts, b, indent);
   }
+  g_rescue_save_depth--;
   emit_indent(b, indent);
-  buf_printf(b, "sp_bang_exc = _svbang_%d;\n", bangs);
+  buf_puts(b, "sp_rescue_sp--;\n");
   g_rescue_cls = save_cls; g_rescue_msg = save_msg;
 
   if (!catchall) {
@@ -3248,7 +3257,7 @@ void emit_begin(Compiler *c, int id, Buf *b, int indent, const char *resultvar) 
     }
     g_ensure_stack[g_ensure_depth++] = (EnsureCtx){ eid, has_retval, g_exc_frame_depth };
 
-    emit_indent(b, indent); buf_puts(b, "sp_exc_rootmark[sp_exc_top] = sp_gc_nroots;\n");
+    emit_indent(b, indent); buf_puts(b, "sp_exc_rootmark[sp_exc_top] = sp_gc_nroots; sp_rescue_mark[sp_exc_top] = sp_rescue_sp;\n");
     emit_indent(b, indent); buf_puts(b, "sp_exc_top++;\n");
     emit_indent(b, indent); buf_puts(b, "if (setjmp(sp_exc_stack[sp_exc_top-1]) == 0) {\n");
     g_exc_frame_depth++;
@@ -3273,7 +3282,7 @@ void emit_begin(Compiler *c, int id, Buf *b, int indent, const char *resultvar) 
     emit_indent(b, indent); buf_puts(b, "}\n");
     emit_indent(b, indent); buf_puts(b, "else {\n");
     emit_indent(b, indent + 1); buf_puts(b, "sp_exc_top--;\n");
-    emit_indent(b, indent + 1); buf_puts(b, "sp_gc_nroots = sp_exc_rootmark[sp_exc_top];\n");
+    emit_indent(b, indent + 1); buf_puts(b, "sp_gc_nroots = sp_exc_rootmark[sp_exc_top]; sp_rescue_sp = sp_rescue_mark[sp_exc_top];\n");
     /* A non-local unwind (proc return / throw) only passes through here; it is
        not an exception, so skip rescue -- only the ensure (below) runs. */
     emit_indent(b, indent + 1); buf_puts(b, "if (sp_unwind_kind == SP_UNWIND_NONE) {\n");
@@ -3344,9 +3353,9 @@ void emit_begin(Compiler *c, int id, Buf *b, int indent, const char *resultvar) 
     else {
       /* the deferred return leaves through every enclosing live begin frame:
          pop them or their jmp_bufs dangle into this soon-dead C frame */
-      if (g_exc_frame_depth > 0) {
-        buf_printf(b, "if (_retf%d) sp_exc_top -= %d;\n", eid, g_exc_frame_depth);
-        emit_indent(b, indent);
+      {
+        char g[24]; snprintf(g, sizeof g, "_retf%d", eid);
+        if (emit_frame_unwind(b, 0, g)) { buf_puts(b, "\n"); emit_indent(b, indent); }
       }
       /* inside a poly-slot proc body (g_result_var, e.g. a break-capable
          lambda) the deferred value returns through the slot ABI, not a raw
@@ -3377,7 +3386,7 @@ void emit_begin(Compiler *c, int id, Buf *b, int indent, const char *resultvar) 
   const char *saved_retry = g_retry_label;
   if (has_retry) g_retry_label = retry_label;
 
-  emit_indent(b, indent); buf_puts(b, "sp_exc_rootmark[sp_exc_top] = sp_gc_nroots;\n");
+  emit_indent(b, indent); buf_puts(b, "sp_exc_rootmark[sp_exc_top] = sp_gc_nroots; sp_rescue_mark[sp_exc_top] = sp_rescue_sp;\n");
   emit_indent(b, indent); buf_puts(b, "sp_exc_top++;\n");
   emit_indent(b, indent); buf_puts(b, "if (setjmp(sp_exc_stack[sp_exc_top-1]) == 0) {\n");
   g_exc_frame_depth++;
@@ -3406,7 +3415,7 @@ void emit_begin(Compiler *c, int id, Buf *b, int indent, const char *resultvar) 
   emit_indent(b, indent); buf_puts(b, "}\n");
   emit_indent(b, indent); buf_puts(b, "else {\n");
   emit_indent(b, indent + 1); buf_puts(b, "sp_exc_top--;\n");
-  emit_indent(b, indent + 1); buf_puts(b, "sp_gc_nroots = sp_exc_rootmark[sp_exc_top];\n");
+  emit_indent(b, indent + 1); buf_puts(b, "sp_gc_nroots = sp_exc_rootmark[sp_exc_top]; sp_rescue_sp = sp_rescue_mark[sp_exc_top];\n");
   /* Drop home nodes a real exception unwound past (no-op for a throw/proc-return
      pass-through, where sp_unwind_kind is set); see the tail-position begin. */
   emit_indent(b, indent + 1); buf_puts(b, "if (sp_unwind_kind == SP_UNWIND_NONE) sp_proc_homes_unwind();\n");
@@ -5558,6 +5567,9 @@ else {
                      strncmp(g_brk_ser_var, "_brkser", 7) == 0;
       const char *sfx = brk_goto ? g_brk_ser_var + 7 : NULL;   /* wrapper temp id */
       emit_indent(b, indent);
+      /* leaving the block pops the handler for every rescue body opened inside
+         it; the throw longjmps, so pop before it (the value persists). */
+      if (!brk_goto) emit_cur_exc_restore(b, g_brk_exc_base);
       if (brk_goto) buf_printf(b, "sp_brk_val[_brkslot%s - 1] = ", sfx);
       else buf_printf(b, "sp_brk_throw(%s, ", g_brk_ser_var);
       if (bvargc == 0) buf_puts(b, "sp_box_nil()");
@@ -5571,7 +5583,7 @@ else {
         }
         buf_printf(b, "sp_box_poly_array(_t%d); })", t);
       }
-      if (brk_goto) buf_printf(b, "; goto _brklbl%s;\n", sfx);
+      if (brk_goto) { buf_puts(b, "; "); emit_cur_exc_restore(b, g_brk_exc_base); buf_printf(b, "goto _brklbl%s;\n", sfx); }
       else buf_puts(b, ");\n");
       return;
     }
@@ -5632,8 +5644,7 @@ else {
     emit_indent(b, indent);
     /* leaving through live begin/rescue frames opened inside the loop body:
        pop them, or their jmp_bufs dangle (same accounting as emit_return) */
-    if (g_exc_frame_depth > g_loop_exc_base)
-      buf_printf(b, "sp_exc_top -= %d; ", g_exc_frame_depth - g_loop_exc_base);
+    emit_frame_unwind(b, g_loop_exc_base, NULL);
     buf_puts(b, "break;\n"); return;
   }
   if (sp_streq(ty, "NextNode")) {
@@ -5678,8 +5689,7 @@ else {
       }
     }
     emit_indent(b, indent);
-    if (g_exc_frame_depth > g_loop_exc_base)
-      buf_printf(b, "sp_exc_top -= %d; ", g_exc_frame_depth - g_loop_exc_base);
+    emit_frame_unwind(b, g_loop_exc_base, NULL);
     buf_puts(b, "continue;\n"); return;
   }
   if (sp_streq(ty, "RedoNode"))   {
@@ -5689,7 +5699,14 @@ else {
     return;
   }
   if (sp_streq(ty, "RetryNode")) {
-    if (g_retry_label) { emit_indent(b, indent); buf_printf(b, "goto %s;\n", g_retry_label); }
+    if (g_retry_label) {
+      emit_indent(b, indent);
+      /* leaving this rescue body back to its begin: pop its handler (exactly the
+         innermost rescue save). */
+      if (g_rescue_save_depth > 0)
+        buf_puts(b, "sp_rescue_sp--; ");
+      buf_printf(b, "goto %s;\n", g_retry_label);
+    }
     else unsupported(c, id, "retry (outside rescue)");
     return;
   }
@@ -5701,7 +5718,7 @@ else {
        fall through to the rescue expression on any exception. */
     int e = nt_ref(nt, id, "expression");
     int r = nt_ref(nt, id, "rescue_expression");
-    emit_indent(b, indent); buf_puts(b, "sp_exc_rootmark[sp_exc_top] = sp_gc_nroots;\n");
+    emit_indent(b, indent); buf_puts(b, "sp_exc_rootmark[sp_exc_top] = sp_gc_nroots; sp_rescue_mark[sp_exc_top] = sp_rescue_sp;\n");
     emit_indent(b, indent); buf_puts(b, "sp_exc_top++;\n");
     emit_indent(b, indent); buf_puts(b, "if (setjmp(sp_exc_stack[sp_exc_top-1]) == 0) {\n");
     if (e >= 0) emit_stmt(c, e, b, indent + 1);
@@ -5709,7 +5726,7 @@ else {
     emit_indent(b, indent); buf_puts(b, "}\n");
     emit_indent(b, indent); buf_puts(b, "else {\n");
     emit_indent(b, indent + 1); buf_puts(b, "sp_exc_top--;\n");
-    emit_indent(b, indent + 1); buf_puts(b, "sp_gc_nroots = sp_exc_rootmark[sp_exc_top];\n");
+    emit_indent(b, indent + 1); buf_puts(b, "sp_gc_nroots = sp_exc_rootmark[sp_exc_top]; sp_rescue_sp = sp_rescue_mark[sp_exc_top];\n");
     emit_indent(b, indent + 1); buf_puts(b, "if (sp_unwind_kind == SP_UNWIND_NONE) sp_proc_homes_unwind();\n");
     /* A non-local unwind only passes through (no ensure here): continue it. */
     emit_indent(b, indent + 1); buf_puts(b, "if (sp_unwind_kind != SP_UNWIND_NONE) sp_unwind_resume();\n");

--- a/src/codegen_util.c
+++ b/src/codegen_util.c
@@ -206,6 +206,33 @@ TyKind g_fn_ret_type = TY_UNKNOWN;
 int g_current_scope_is_lowered = 0;
 EnsureCtx g_ensure_stack[MAX_ENSURE_DEPTH];
 int       g_ensure_depth = 0;
+RescueSave g_rescue_save_stack[MAX_ENSURE_DEPTH];
+int        g_rescue_save_depth = 0;
+
+/* rescue bodies crossed by an exit to frame-depth pop_base: those entered at or
+   deeper than pop_base (their exc_base >= pop_base). */
+static int rescues_crossed(int pop_base) {
+  int k = 0;
+  for (int i = 0; i < g_rescue_save_depth; i++)
+    if (g_rescue_save_stack[i].exc_base >= pop_base) k++;
+  return k;
+}
+/* Pop the k crossed rescue-body handlers (no frame pop). Used at sites whose
+   frame-pop text is special (the begin..ensure deferred-return). */
+void emit_cur_exc_restore(Buf *b, int pop_base) {
+  int k = rescues_crossed(pop_base);
+  if (k > 0) buf_printf(b, "sp_rescue_sp -= %d; ", k);
+}
+int emit_frame_unwind(Buf *b, int pop_base, const char *guard) {
+  int pops = g_exc_frame_depth - pop_base;
+  int k = rescues_crossed(pop_base);
+  if (pops <= 0 && k == 0) return 0;
+  if (guard) buf_printf(b, "if (%s) { ", guard);
+  if (pops > 0) buf_printf(b, "sp_exc_top -= %d; ", pops);
+  if (k > 0) buf_printf(b, "sp_rescue_sp -= %d; ", k);
+  if (guard) buf_puts(b, "}");
+  return 1;
+}
 Buf g_procs;
 Buf g_proc_protos;
 int g_proc_counter = 0;

--- a/test/exception_cause.rb
+++ b/test/exception_cause.rb
@@ -1,0 +1,123 @@
+# Exception#cause threads the exception active when a new one is raised.
+begin
+  begin
+    raise "inner"
+  rescue
+    raise "outer"
+  end
+rescue => e
+  p e.cause.message
+  p e.message
+end
+# A three-deep chain threads cause through each level.
+begin
+  begin
+    begin
+      raise "a"
+    rescue
+      raise "b"
+    end
+  rescue
+    raise "c"
+  end
+rescue => e
+  p e.message
+  p e.cause.message
+  p e.cause.cause.message
+end
+# An explicitly raised exception object also threads the handled exception.
+begin
+  begin
+    raise "inner e"
+  rescue
+    raise RuntimeError.new("outer e")
+  end
+rescue => e
+  p e.cause.message
+  p e.message
+end
+# A `rescue => e` body that re-raises: the outer exception's cause chain still
+# reaches through the bound exception (which carries its own cause).
+begin
+  begin
+    begin
+      raise "a"
+    rescue
+      raise "b"
+    end
+  rescue => mid
+    raise "c"
+  end
+rescue => e
+  p e.message
+  p e.cause.message
+  p e.cause.cause.message
+end
+
+# A non-local exit from a rescue body must not leave the handled exception as a
+# stale "currently handled" state: a later unrelated raise has no cause.
+def cause_after_return
+  begin; raise "handled"; rescue; return 1; end
+end
+cause_after_return
+begin; raise "fresh"; rescue => e; puts(e.cause ? "cause" : "nocause"); end
+
+# break out of a rescue inside a loop, then an unrelated raise: no cause.
+[1].each do
+  begin; raise "handled"; rescue; break; end
+end
+begin; raise "fresh"; rescue => e; puts(e.cause ? "cause" : "nocause"); end
+
+# next out of a rescue inside a loop, then an unrelated raise: no cause.
+[1, 2].each do
+  begin; raise "handled"; rescue; next; end
+end
+begin; raise "fresh"; rescue => e; puts(e.cause ? "cause" : "nocause"); end
+
+# return crossing two nested rescue bodies restores the outermost saved state.
+def cause_after_nested_return
+  begin
+    raise "outer handled"
+  rescue
+    begin; raise "inner handled"; rescue; return 1; end
+  end
+end
+cause_after_nested_return
+begin; raise "fresh"; rescue => e; puts(e.cause ? "cause" : "nocause"); end
+
+# A callee that returns out of its own rescue while the caller is handling an
+# exception: the caller's next raise threads the CALLER's exception as cause.
+def callee_returns
+  begin; raise "callee"; rescue; return 1; end
+end
+begin
+  raise "caller"
+rescue
+  callee_returns
+  begin
+    raise "in caller"
+  rescue => e
+    p e.cause.message
+  end
+end
+
+# return from a rescue body nested in a begin/ensure, then an unrelated raise.
+def cause_after_ensure_return
+  begin
+    begin; raise "handled"; rescue; return 1; end
+  ensure
+    nil
+  end
+end
+cause_after_ensure_return
+begin; raise "fresh"; rescue => e; puts(e.cause ? "cause" : "nocause"); end
+
+# retry out of a rescue leaves no stale state for a later unrelated raise.
+$tries = 0
+begin
+  $tries = $tries + 1
+  raise "handled"
+rescue
+  retry if $tries < 2
+end
+begin; raise "fresh"; rescue => e; puts(e.cause ? "cause" : "nocause"); end

--- a/test/exception_cause.rb.expected
+++ b/test/exception_cause.rb.expected
@@ -1,0 +1,17 @@
+"inner"
+"outer"
+"c"
+"b"
+"a"
+"inner e"
+"outer e"
+"c"
+"b"
+"a"
+nocause
+nocause
+nocause
+nocause
+"caller"
+nocause
+nocause


### PR DESCRIPTION
`Exception#cause` links an exception to the one that was being handled when it was raised. It was unavailable, so a raise inside a `rescue` had no back-link to what it interrupted.

```ruby
begin
  begin
    raise "inner"
  rescue
    raise "outer"
  end
rescue => e
  p e.message        # "outer"
  p e.cause.message  # "inner"
end
```

## What this adds

- `Exception#cause`, returning the exception that was being handled when this one was raised (or `nil`).
- Correct tracking of the currently-handled exception through nested raises **and** through every non-local exit from a rescue body — `return`, `break`, `next`, `retry`, and re-raises — so an unrelated later raise never picks up a spurious cause.

## How it works

### The currently-handled exception

The exception handled at each rescue depth lives on a depth-indexed stack, `sp_exc_handling`, with one entry per active rescue body. The currently-handled exception is its top:

```c
sp_rescue_sp > 0 ? sp_exc_handling[sp_rescue_sp - 1] : NULL
```

This is the shape CRuby uses to derive `$!`/errinfo from its rescue frames rather than from a mutable global. A depth stack — not one indexed by the setjmp frame counter `sp_exc_top` — is required because a rescue body runs with its `begin` frame already popped, so two nested rescue bodies share an `sp_exc_top` and a per-frame-slot save would collide.

### Capturing the cause

`sp_raise_cls` reads that top into `sp_pending_cause` just before it longjmps. The matching rescue entry stores it onto the newly built exception's `cause` field and pushes the handled exception onto `sp_exc_handling`. An explicitly raised object flows through the same path, since it carries its object into the rescue.

### Leaving a rescue body

A rescue body pushes on entry and pops on every exit:

- **Fall-through** pops `sp_rescue_sp` directly.
- A non-local **`return` / `break` / `next` / `retry`** pops the handlers it crosses in the same place it already pops the exception frames it leaps — a single `emit_frame_unwind` co-locates `sp_exc_top -= N` with `sp_rescue_sp -= K`, both driven by the same frame base, so the two unwinds can never disagree.
- A rescue body that exits by **raising** longjmps past the pop, so `sp_rescue_sp` is restored on the exception landing from `sp_rescue_mark[sp_exc_top]`, captured at the `begin` frame's arm beside the existing GC-root watermark (`sp_exc_rootmark`). This keeps the handler stack balanced even when the re-raise originates in a called method whose exception lands at an outer `begin`.

The handled exceptions are GC-scanned and rooted while on the stack, and the per-fiber exception context swaps them so a fiber that yields mid-rescue stays isolated.

## Tests

`test/exception_cause.rb` (output baked from Ruby) covers:

- a raise inside a rescue threading the handled exception as its cause, and a three-deep cause chain;
- an explicitly raised object (`raise RuntimeError.new(...)`) and a re-raising `rescue => e` body;
- `return`, `break`, `next`, and `retry` out of a rescue followed by an unrelated raise — no spurious cause;
- a `return` crossing two nested rescue bodies (restores the outermost handled exception);
- a callee that returns out of its own rescue while the caller is still handling an exception — the caller's next raise threads the caller's exception;
- a `return` from a rescue body nested in `begin`/`ensure`.
