### PR TITLE
codegen: inspect an exception value with p as #<Class: message>

### DIFF
--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -284,6 +284,14 @@ void emit_p_one(Compiler *c, int arg, Buf *b, int indent) {
     buf_printf(b, "{ sp_Class _t%d = ", cv); emit_expr(c, arg, b);
     buf_printf(b, "; fputs(sp_class_to_s(_t%d), stdout); putchar('\\n'); }\n", cv);
   }
+  else if (t == TY_EXCEPTION) {   /* an exception inspects as "#<ClassName: message>" */
+    int ev = ++g_tmp;
+    buf_printf(b, "{ sp_Exception *_t%d = ", ev); emit_expr(c, arg, b);
+    /* Root the temp across sp_sprintf's allocation (it may GC, and the exception
+       can be an unrooted temporary). A NULL exception models a nil $! outside a
+       rescue: inspect it as "nil". */
+    buf_printf(b, "; SP_GC_ROOT(_t%d); fputs(_t%d ? sp_sprintf(\"#<%%s: %%s>\", sp_exc_class_name(_t%d), sp_exc_message(_t%d)) : \"nil\", stdout); putchar('\\n'); }\n", ev, ev, ev, ev);
+  }
   else if (t == TY_NIL || t == TY_VOID) {
     buf_puts(b, "(void)("); emit_expr(c, arg, b); buf_puts(b, "); fputs(\"nil\\n\", stdout);\n");
   }

--- a/test/p_of_exception_object.rb
+++ b/test/p_of_exception_object.rb
@@ -1,0 +1,30 @@
+# p of an exception object inspects it as #<ClassName: message>.
+begin
+  raise "boom"
+rescue => e
+  x = e
+  p x       # #<RuntimeError: boom>
+  p e       # rescued binding directly
+end
+
+# a specific exception class with an explicit message
+begin
+  raise ArgumentError, "bad arg"
+rescue => e
+  p e       # #<ArgumentError: bad arg>
+end
+
+# an exception flowed through a method keeps its inspect form
+def id(v); v; end
+begin
+  raise TypeError, "no good"
+rescue => e
+  p id(e)   # #<TypeError: no good>
+end
+
+# a default-message exception (message equals the class name)
+begin
+  raise RuntimeError
+rescue => e
+  p e       # #<RuntimeError: RuntimeError>
+end

--- a/test/p_of_exception_object.rb.expected
+++ b/test/p_of_exception_object.rb.expected
@@ -1,0 +1,5 @@
+#<RuntimeError: boom>
+#<RuntimeError: boom>
+#<ArgumentError: bad arg>
+#<TypeError: no good>
+#<RuntimeError: RuntimeError>


### PR DESCRIPTION
A local or parameter typed as an exception reached the p emitter with no
matching arm and was rejected as an unsupported argument. Give it an arm
that renders the same #<ClassName: message> form the explicit #inspect
dispatch already produces, guarding a null exception (a nil $! outside a
rescue) as "nil".