### PR TITLE
codegen: index $~[N] as the Nth regexp group, 0 the whole match

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -3211,6 +3211,17 @@ void emit_call(Compiler *c, int id, Buf *b) {
   const int *argv = call_args(nt, id, &argc);
   if (!name) unsupported(c, id, "call (no name)");
 
+  /* $~[N]: the Nth regexp group of the last match (0 = the whole match), read
+     from the match registers. $~ is a special regexp accessor rather than
+     stored MatchData, so index it directly instead of char-indexing a string. */
+  if (recv >= 0 && sp_streq(name, "[]") && argc == 1 &&
+      nt_type(nt, recv) && sp_streq(nt_type(nt, recv), "GlobalVariableReadNode") &&
+      nt_str(nt, recv, "name") && sp_streq(nt_str(nt, recv, "name"), "$~")) {
+    buf_puts(b, "({ mrb_int _mi = "); emit_int_expr(c, argv[0], b);
+    buf_puts(b, "; _mi == 0 ? sp_re_match_str : (_mi >= 1 && _mi <= 9 ? sp_re_captures[_mi] : (const char *)0); })");
+    return;
+  }
+
   /* `@nested[i]` inferred as an int array (poly array of int arrays): unbox
      the poly element to sp_IntArray* so the surrounding code stays typed. */
   if (recv >= 0 && sp_streq(name, "[]") && argc == 1 &&

--- a/test/matchdata_whole_match.rb
+++ b/test/matchdata_whole_match.rb
@@ -1,0 +1,5 @@
+# $~[0] is the whole match even when capture groups are present; $~[n] are groups.
+"hello world" =~ /(\w+) (\w+)/
+p $~[0]
+p $~[1]
+p $~[2]

--- a/test/matchdata_whole_match.rb.expected
+++ b/test/matchdata_whole_match.rb.expected
@@ -1,0 +1,3 @@
+"hello world"
+"hello"
+"world"


### PR DESCRIPTION
`$~[0]` char-indexed the whole-match string, returning its first character
instead of the whole match. Index the match registers directly: 0 yields
the whole match, 1..9 the corresponding capture group, matching the
special-accessor model `$~` already uses.