### PR TITLE
runtime,codegen: make exception values real objects ($! and #class)

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -1573,8 +1573,15 @@ sp_Bigint *sp_bigint_from_le_bytes(int negative, const unsigned char *bytes, siz
    than a boxed INT_MIN. Used when an int? value (hash miss, rindex, nonzero?,
    ...) flows into a poly slot. */
 static sp_RbVal sp_box_int_or_nil(mrb_int v) { return v == SP_INT_NIL ? sp_box_nil() : sp_box_int(v); }
-/* box a sp_Class into a poly slot. */
-static sp_RbVal sp_box_class(sp_Class c) { sp_RbVal r; r.tag = SP_TAG_CLASS; r.cls_id = (int)c.cls_id; r.v.i = c.cls_id; return r; }
+/* A class known only by name (an exception's cls_name -- the id table covers
+   only a few exception classes, but the name is complete for all of them,
+   including the open-ended Errno:: family). Marked with a sentinel cls_id so
+   the SP_TAG_CLASS arms read the name from v.s instead of resolving v.i. The
+   name points into rodata (see sp_exc_gc_scan), so no GC marking is needed. */
+#define SP_CLASS_BY_NAME 0x7F000000
+static sp_RbVal sp_box_class_name(const char *name) { sp_RbVal r; r.tag = SP_TAG_CLASS; r.cls_id = SP_CLASS_BY_NAME; r.v.s = name; return r; }
+/* box a sp_Class into a poly slot (a name-backed class boxes by name). */
+static sp_RbVal sp_box_class(sp_Class c) { if (c.name) return sp_box_class_name(c.name); sp_RbVal r; r.tag = SP_TAG_CLASS; r.cls_id = (int)c.cls_id; r.v.i = c.cls_id; return r; }
 /* box a sp_Bigint* into a poly slot (heterogeneous container element, or a
    promote-mode overflow result). */
 static sp_RbVal sp_box_bigint(sp_Bigint *b) { sp_RbVal r; r.tag = SP_TAG_BIGINT; r.cls_id = 0; r.v.p = b; return r; }
@@ -1712,6 +1719,20 @@ static sp_RbVal sp_box_time(sp_Time v) {
 }
 /* sp_Time_inspect moved to lib/sp_format.c (cold). */
 static const char *sp_class_to_s(sp_Class c); /* fwd decl: sp_poly_puts' SP_TAG_CLASS arm */
+/* Name of a boxed SP_TAG_CLASS value: a name-backed box carries it in v.s,
+   otherwise resolve the cls_id through the generated id->name table. */
+static inline const char *sp_class_val_name(sp_RbVal v) {
+  if (v.cls_id == SP_CLASS_BY_NAME) return v.v.s ? v.v.s : "";
+  sp_Class _c = {v.v.i, NULL};
+  return sp_class_to_s(_c);
+}
+/* Class identity: a name-backed class compares by its (complete) name, so it
+   equals the id-backed class of the same name. */
+static inline mrb_bool sp_class_eq(sp_Class a, sp_Class b) {
+  if (!a.name && !b.name) return a.cls_id == b.cls_id;
+  const char *an = sp_class_to_s(a), *bn = sp_class_to_s(b);
+  return (an && bn) ? strcmp(an, bn) == 0 : an == bn;
+}
 static inline void sp_poly_puts(sp_RbVal v) {
   switch (v.tag) {
     case SP_TAG_INT: printf("%lld\n", (long long)v.v.i); break;
@@ -1721,7 +1742,7 @@ static inline void sp_poly_puts(sp_RbVal v) {
     case SP_TAG_NIL: putchar('\n'); break;
     case SP_TAG_SYM: { const char *_ss = sp_sym_to_s((sp_sym)v.v.i); fputs(_ss, stdout); putchar('\n'); break; }
     case SP_TAG_ENCODING: { const char *_es = v.v.s ? v.v.s : sp_str_empty; fputs(_es, stdout); putchar('\n'); break; }
-    case SP_TAG_CLASS: { sp_Class _c = {v.v.i}; fputs(sp_class_to_s(_c), stdout); putchar('\n'); break; }
+    case SP_TAG_CLASS: { fputs(sp_class_val_name(v), stdout); putchar('\n'); break; }
     case SP_TAG_BIGINT: { fputs(sp_bigint_to_s((sp_Bigint *)v.v.p), stdout); putchar('\n'); break; }
     case SP_TAG_OBJ: {
       /* MRI's `puts arr` iterates an Array, printing one element per
@@ -1786,7 +1807,7 @@ static inline const char *sp_poly_to_s(sp_RbVal v) {
     case SP_TAG_BOOL: return v.v.b ? SPL("true") : SPL("false");
     case SP_TAG_NIL: return sp_str_empty;
     case SP_TAG_SYM: return sp_sym_to_s((sp_sym)v.v.i);
-    case SP_TAG_CLASS: { sp_Class c = {v.v.i}; return sp_class_to_s(c); }
+    case SP_TAG_CLASS: return sp_class_val_name(v);
     case SP_TAG_ENCODING: return v.v.s ? v.v.s : sp_str_empty;
     case SP_TAG_BIGINT: return sp_bigint_to_s((sp_Bigint *)v.v.p);
     case SP_TAG_OBJ:
@@ -1916,7 +1937,7 @@ static inline int sp_poly_is_array_kind(int cls_id) {
 }
 static mrb_bool sp_poly_eq(sp_RbVal a, sp_RbVal b) { if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { sp_Bigint *ba = sp_poly_as_bigint(a), *bb = sp_poly_as_bigint(b); if (ba && bb) return sp_bigint_cmp(ba, bb) == 0; if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) return sp_poly_to_f(a) == sp_poly_to_f(b); return FALSE; } if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) return sp_poly_to_f(a) == sp_poly_to_f(b); if (a.tag != b.tag) return FALSE; switch (a.tag) { case SP_TAG_INT: return a.v.i == b.v.i; case SP_TAG_STR: return (a.v.s == NULL || b.v.s == NULL) ? (a.v.s == b.v.s) : (strcmp(a.v.s, b.v.s) == 0); case SP_TAG_FLT: return a.v.f == b.v.f; case SP_TAG_BOOL: return a.v.b == b.v.b; case SP_TAG_NIL: return TRUE; case SP_TAG_SYM: return a.v.i == b.v.i; case SP_TAG_ENCODING: return (a.v.s == NULL || b.v.s == NULL) ? (a.v.s == b.v.s) : (strcmp(a.v.s, b.v.s) == 0); case SP_TAG_OBJ: /* Arrays compare by VALUE across storage kinds: [1,2] boxed as an IntArray equals the same numbers rebuilt as a PolyArray (a splat-rest, a mapped run). Ruby has one Array; the kinds are a storage optimization and must not leak into ==. */ if (sp_poly_is_array_kind(a.cls_id) && sp_poly_is_array_kind(b.cls_id)) { if (a.cls_id == b.cls_id && a.v.p == b.v.p) return TRUE; { mrb_int __n = sp_poly_length(a); if (__n != sp_poly_length(b)) return FALSE; for (mrb_int __i = 0; __i < __n; __i++) if (!sp_poly_eq(sp_poly_arr_get(a, __i), sp_poly_arr_get(b, __i))) return FALSE; return TRUE; } } if (a.cls_id != b.cls_id) return FALSE; if (a.v.p == b.v.p) return TRUE; switch (a.cls_id) { case SP_BUILTIN_INT_ARRAY: return sp_IntArray_eq((sp_IntArray*)a.v.p,(sp_IntArray*)b.v.p); case SP_BUILTIN_STR_ARRAY: return sp_StrArray_eq((sp_StrArray*)a.v.p,(sp_StrArray*)b.v.p); case SP_BUILTIN_FLT_ARRAY: return sp_FloatArray_eq((sp_FloatArray*)a.v.p,(sp_FloatArray*)b.v.p); case SP_BUILTIN_POLY_ARRAY: return sp_PolyArray_eq((sp_PolyArray*)a.v.p,(sp_PolyArray*)b.v.p); /* boxed hashes of the same variant compare by value like every other
      container -- the arm was simply missing, so [h] == [h-literal] was
-     pointer identity and always false. */ case SP_BUILTIN_STR_INT_HASH: return sp_StrIntHash_eq((sp_StrIntHash*)a.v.p,(sp_StrIntHash*)b.v.p); case SP_BUILTIN_STR_STR_HASH: return sp_StrStrHash_eq((sp_StrStrHash*)a.v.p,(sp_StrStrHash*)b.v.p); case SP_BUILTIN_INT_STR_HASH: return sp_IntStrHash_eq((sp_IntStrHash*)a.v.p,(sp_IntStrHash*)b.v.p); case SP_BUILTIN_STR_POLY_HASH: return sp_StrPolyHash_eq((sp_StrPolyHash*)a.v.p,(sp_StrPolyHash*)b.v.p); case SP_BUILTIN_SYM_POLY_HASH: return sp_SymPolyHash_eq((sp_SymPolyHash*)a.v.p,(sp_SymPolyHash*)b.v.p); case SP_BUILTIN_POLY_POLY_HASH: return sp_PolyPolyHash_eq((sp_PolyPolyHash*)a.v.p,(sp_PolyPolyHash*)b.v.p); default: return FALSE; } case SP_TAG_CLASS: return a.v.i == b.v.i; default: return FALSE; } }
+     pointer identity and always false. */ case SP_BUILTIN_STR_INT_HASH: return sp_StrIntHash_eq((sp_StrIntHash*)a.v.p,(sp_StrIntHash*)b.v.p); case SP_BUILTIN_STR_STR_HASH: return sp_StrStrHash_eq((sp_StrStrHash*)a.v.p,(sp_StrStrHash*)b.v.p); case SP_BUILTIN_INT_STR_HASH: return sp_IntStrHash_eq((sp_IntStrHash*)a.v.p,(sp_IntStrHash*)b.v.p); case SP_BUILTIN_STR_POLY_HASH: return sp_StrPolyHash_eq((sp_StrPolyHash*)a.v.p,(sp_StrPolyHash*)b.v.p); case SP_BUILTIN_SYM_POLY_HASH: return sp_SymPolyHash_eq((sp_SymPolyHash*)a.v.p,(sp_SymPolyHash*)b.v.p); case SP_BUILTIN_POLY_POLY_HASH: return sp_PolyPolyHash_eq((sp_PolyPolyHash*)a.v.p,(sp_PolyPolyHash*)b.v.p); default: return FALSE; } case SP_TAG_CLASS: { const char *an = sp_class_val_name(a), *bn = sp_class_val_name(b); return (an && bn) ? strcmp(an, bn) == 0 : an == bn; } default: return FALSE; } }
 /* sp_sym_name_fn is now an extern hook (sp_gc.h / sp_gc.c) so cold lib readers
    like sp_json.c can resolve symbol names too; the generated TU still sets it. */
 static mrb_int sp_poly_arr_cmp(sp_RbVal a, sp_RbVal b, mrb_bool *comparable);
@@ -3093,7 +3114,7 @@ static inline const char *sp_poly_inspect(sp_RbVal v) {
     case SP_TAG_NIL:  return SPL("nil");
     case SP_TAG_SYM:  return sp_sym_inspect((sp_sym)v.v.i);
     case SP_TAG_ENCODING: return sp_sprintf("#<Encoding:%s>", v.v.s ? v.v.s : "");
-    case SP_TAG_CLASS: { sp_Class c = {v.v.i}; return sp_class_to_s(c); }
+    case SP_TAG_CLASS: return sp_class_val_name(v);
     case SP_TAG_BIGINT: return sp_bigint_to_s((sp_Bigint *)v.v.p);
     case SP_TAG_OBJ:
  /* Built-in container / value-type tags get their typed inspect
@@ -4131,6 +4152,13 @@ enum { SP_UNWIND_NONE, SP_UNWIND_PROCRET, SP_UNWIND_THROW, SP_UNWIND_BREAK };
 struct sp_proc_home;
 static SP_TLS int sp_unwind_kind = SP_UNWIND_NONE, sp_unwind_target = -1, sp_unwind_exc_top = 0;  /* per-worker (see sp_exc_stack) */
 static SP_TLS struct sp_proc_home *sp_unwind_home = NULL;  /* PROCRET target (THROW uses sp_unwind_target) */
+/* forward: materialize the exception object for a raise that carried none
+   (a bare `raise "msg"` / `raise Cls, msg` / builtin runtime raise), so `$!`
+   and `rescue => e` bind one real object with a stable identity. The struct
+   tag is used because the sp_Exception typedef is defined further down; the
+   result is stored as a void* in sp_exc_obj[]. */
+struct sp_Exception_s;
+static struct sp_Exception_s *sp_exc_new_for_catch(const char *cls, const char *msg);
 SP_NORETURN SP_COLD void sp_raise_cls(const char *cls, const char *msg) {
 #if SP_BT_AVAILABLE
   if (sp_bt_enabled) sp_bt_n = backtrace(sp_bt_buf, 256);
@@ -4139,7 +4167,7 @@ SP_NORETURN SP_COLD void sp_raise_cls(const char *cls, const char *msg) {
      inside an `ensure` running during a proc-return / throw): clear the unwind so
      an outer handler treats this as an exception, not a continued unwind. */
   sp_unwind_kind = SP_UNWIND_NONE;
-  if (sp_exc_top > 0) { sp_exc_msg[sp_exc_top-1] = msg; sp_exc_cls[sp_exc_top-1] = cls; sp_exc_obj[sp_exc_top-1] = sp_pending_exc_obj; sp_pending_exc_obj = NULL; sp_last_exc_cls = cls; longjmp(sp_exc_stack[sp_exc_top-1], 1); } fprintf(stderr, "unhandled exception: %s\n", msg); exit(1); }
+  if (sp_exc_top > 0) { sp_exc_msg[sp_exc_top-1] = msg; sp_exc_cls[sp_exc_top-1] = cls; sp_exc_obj[sp_exc_top-1] = sp_pending_exc_obj ? sp_pending_exc_obj : (void *)sp_exc_new_for_catch(cls, msg); sp_pending_exc_obj = NULL; sp_last_exc_cls = cls; longjmp(sp_exc_stack[sp_exc_top-1], 1); } fprintf(stderr, "unhandled exception: %s\n", msg); exit(1); }
 static void sp_raise(const char *msg) { sp_raise_cls("RuntimeError", msg); }
 
 /* Issue #781: bridge between the regex compile-error path (which lives

--- a/lib/sp_types.h
+++ b/lib/sp_types.h
@@ -129,7 +129,11 @@ typedef mrb_int sp_sym;
 
 /* ---- Leaf value structs ---- */
 typedef struct{mrb_int first;mrb_int last;mrb_int excl;}sp_Range;
-typedef struct{mrb_int cls_id;}sp_Class;
+/* A class value. `name`, when non-NULL, is a rodata class name carried by a
+   class whose cls_id table entry may not exist (an exception's class -- the
+   Errno:: family and many builtin error classes have no assigned cls_id). It
+   takes precedence over cls_id for to_s / boxing / equality. */
+typedef struct{mrb_int cls_id;const char *name;}sp_Class;
 typedef struct{mrb_float re;mrb_float im;}sp_Complex;
 typedef struct{mrb_int num;mrb_int den;}sp_Rational;
 typedef struct{const char *name;}sp_Encoding;

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -2371,8 +2371,9 @@ else {
   if (recv >= 0 && exc_shaped) {
     if (sp_streq(name, "message") || sp_streq(name, "to_s") ||
         sp_streq(name, "to_str") || sp_streq(name, "inspect") ||
-        sp_streq(name, "full_message") || sp_streq(name, "detailed_message") ||
-        sp_streq(name, "class")) return TY_STRING;
+        sp_streq(name, "full_message") || sp_streq(name, "detailed_message"))
+      return TY_STRING;
+    if (sp_streq(name, "class")) return TY_CLASS;  /* a Class object, carried by name */
     if (sp_streq(name, "backtrace")) return TY_STR_ARRAY;  /* empty: no frames captured */
   }
 
@@ -3344,7 +3345,8 @@ TyKind infer_uncached(Compiler *c, int id) {
     if (nm && sp_streq(nm, "$/")) return TY_STRING;
     if (nm && sp_streq(nm, "$?")) return TY_INT;  /* last child exit status */
     if (nm && (sp_streq(nm, "$PROGRAM_NAME") || sp_streq(nm, "$0"))) return TY_STRING;
-    if (nm && (sp_streq(nm, "$!") || sp_streq(nm, "$;") || sp_streq(nm, "$,"))) return TY_NIL;
+    if (nm && sp_streq(nm, "$!")) return TY_EXCEPTION;  /* the exception being handled, or nil (NULL) outside a rescue */
+    if (nm && (sp_streq(nm, "$;") || sp_streq(nm, "$,"))) return TY_NIL;
     /* regex match globals: nullable strings ($~ == $&, $`, $', $+) */
     if (nm && (sp_streq(nm, "$~") || sp_streq(nm, "$&") || sp_streq(nm, "$`") ||
                sp_streq(nm, "$'") || sp_streq(nm, "$+"))) return TY_STRING;

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -3740,7 +3740,7 @@ char *codegen_program(const NodeTable *nt) {
      sp_poly_to_s SP_TAG_CLASS arms), so it is always emitted, independent of
      the gated introspection bank below. */
   {
-    buf_puts(&b, "static const char *sp_class_to_s(sp_Class c){switch(c.cls_id){");
+    buf_puts(&b, "static const char *sp_class_to_s(sp_Class c){if(c.name)return c.name;switch(c.cls_id){");
     for (int i = 0; i < c->nclasses; i++) {
       if (!is_builtin_reopen(c->classes[i].name)) {
         const char *qname = class_ruby_name(c, i);

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -4496,7 +4496,13 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
   /* exception object methods */
   if (recv >= 0 && comp_ntype(c, recv) == TY_EXCEPTION) {
     if (sp_streq(name, "message") || sp_streq(name, "to_s") || sp_streq(name, "to_str")) {
-      buf_puts(b, "sp_exc_message("); emit_expr(c, recv, b); buf_puts(b, ")");
+      /* NULL-guard: a nil $! (outside any rescue) has no message. */
+      int t = ++g_tmp;
+      Buf rb = expr_buf(c, recv);
+      emit_indent(g_pre, g_indent);
+      buf_printf(g_pre, "sp_Exception *_t%d = ", t);
+      buf_puts(g_pre, rb.p ? rb.p : ""); buf_puts(g_pre, ";\n"); free(rb.p);
+      buf_printf(b, "(_t%d ? sp_exc_message(_t%d) : \"\")", t, t);
       return;
     }
     if (sp_streq(name, "full_message")) {
@@ -4519,17 +4525,43 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       return;
     }
     if (sp_streq(name, "inspect")) {
-      /* #<ClassName: message> */
+      /* #<ClassName: message>, or "nil" for a nil $! (outside any rescue). */
       int t = ++g_tmp;
       Buf rb = expr_buf(c, recv);
       emit_indent(g_pre, g_indent);
       buf_printf(g_pre, "sp_Exception *_t%d = ", t);
       buf_puts(g_pre, rb.p ? rb.p : ""); buf_puts(g_pre, ";\n"); free(rb.p);
-      buf_printf(b, "sp_sprintf(\"#<%%s: %%s>\", sp_exc_class_name(_t%d), sp_exc_message(_t%d))", t, t);
+      buf_printf(b, "(_t%d ? sp_sprintf(\"#<%%s: %%s>\", sp_exc_class_name(_t%d), sp_exc_message(_t%d)) : \"nil\")", t, t, t);
       return;
     }
-    if (sp_streq(name, "class")) {  /* used as .class.to_s / .class.name */
-      buf_puts(b, "sp_exc_class_name("); emit_expr(c, recv, b); buf_puts(b, ")");
+    if (sp_streq(name, "class")) {  /* a Class carried by name (complete for every exception class) */
+      /* a nil $! (outside any rescue) is NilClass, matching the sibling nil-guards. */
+      int t = ++g_tmp;
+      Buf rb = expr_buf(c, recv);
+      emit_indent(g_pre, g_indent);
+      buf_printf(g_pre, "sp_Exception *_t%d = ", t);
+      buf_puts(g_pre, rb.p ? rb.p : ""); buf_puts(g_pre, ";\n"); free(rb.p);
+      buf_printf(b, "((sp_Class){0, _t%d ? sp_exc_class_name(_t%d) : \"NilClass\"})", t, t);
+      return;
+    }
+    /* object identity: the same raised object compares equal to $! / a `=> e`
+       binding, since both now point at the one materialized exception. */
+    if (argc == 1 && sp_streq(name, "equal?")) {
+      /* Only an exception arg can share identity with the receiver; nil compares
+         against a NULL pointer. Any other type is a struct or scalar that can't
+         be cast to void* (a -Werror break) and can never be the same object. */
+      TyKind at = comp_ntype(c, argv[0]);
+      if (at == TY_EXCEPTION) {
+        Buf rb = expr_buf(c, recv), ab = expr_buf(c, argv[0]);
+        buf_printf(b, "((void *)(%s) == (void *)(%s))", rb.p ? rb.p : "0", ab.p ? ab.p : "0");
+        free(rb.p); free(ab.p);
+      } else if (at == TY_NIL) {
+        Buf rb = expr_buf(c, recv);
+        buf_printf(b, "((void *)(%s) == NULL)", rb.p ? rb.p : "0");
+        free(rb.p);
+      } else {
+        buf_puts(b, "0");
+      }
       return;
     }
     if (sp_streq(name, "backtrace")) {
@@ -5056,7 +5088,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       if (at == TY_CLASS) {
         buf_printf(b, "({ sp_Class _cl%d = ", _clt); emit_expr(c, recv, b);
         buf_printf(b, "; sp_Class _cl%da = ", _clt); emit_expr(c, argv[0], b);
-        buf_printf(b, "; _cl%d.cls_id == _cl%da.cls_id; })", _clt, _clt);
+        buf_printf(b, "; sp_class_eq(_cl%d, _cl%da); })", _clt, _clt);
         return;
       }
     }
@@ -5065,7 +5097,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       if (at == TY_CLASS) {
         buf_printf(b, "({ sp_Class _cl%d = ", _clt); emit_expr(c, recv, b);
         buf_printf(b, "; sp_Class _cl%da = ", _clt); emit_expr(c, argv[0], b);
-        buf_printf(b, "; _cl%d.cls_id != _cl%da.cls_id; })", _clt, _clt);
+        buf_printf(b, "; !sp_class_eq(_cl%d, _cl%da); })", _clt, _clt);
         return;
       }
     }

--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -1096,7 +1096,14 @@ void emit_expr(Compiler *c, int id, Buf *b) {
     if (nm && sp_streq(nm, "$/")) { emit_str_literal(b, "\n"); return; }
     if (nm && sp_streq(nm, "$?")) { buf_puts(b, "sp_last_status"); return; }
     if (nm && (sp_streq(nm, "$PROGRAM_NAME") || sp_streq(nm, "$0"))) { buf_puts(b, "sp_program_name"); return; }
-    if (nm && (sp_streq(nm, "$!") || sp_streq(nm, "$;") || sp_streq(nm, "$,"))) { buf_puts(b, "0"); return; }
+    /* $! is the exception currently being handled -- the same real object the
+       enclosing `rescue` binds (sp_exc_obj[sp_exc_top] once the handler frame is
+       popped) -- or nil (a NULL sp_Exception*) outside any rescue body. */
+    if (nm && sp_streq(nm, "$!")) {
+      buf_puts(b, g_rescue_cls ? "((sp_Exception *)sp_exc_obj[sp_exc_top])" : "((sp_Exception *)0)");
+      return;
+    }
+    if (nm && (sp_streq(nm, "$;") || sp_streq(nm, "$,"))) { buf_puts(b, "0"); return; }
     /* regex match globals that Prism may emit as GlobalVariableReadNode */
     if (nm && (sp_streq(nm, "$~") || sp_streq(nm, "$&")))  { buf_puts(b, "sp_re_match_str");  return; }
     if (nm && sp_streq(nm, "$`"))                          { buf_puts(b, "sp_re_match_pre");  return; }

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -243,6 +243,13 @@ void emit_p_one(Compiler *c, int arg, Buf *b, int indent) {
     emit_expr(c, arg, b);
     buf_puts(b, "), stdout); putchar('\\n');\n");
   }
+  else if (t == TY_EXCEPTION) {
+    /* p of an exception inspects as #<ClassName: message>; a NULL receiver
+       (nil $! outside a rescue) prints "nil". */
+    int tv = ++g_tmp;
+    buf_printf(b, "{ sp_Exception *_t%d = ", tv); emit_expr(c, arg, b);
+    buf_printf(b, "; fputs(_t%d ? sp_sprintf(\"#<%%s: %%s>\", sp_exc_class_name(_t%d), sp_exc_message(_t%d)) : \"nil\", stdout); putchar('\\n'); }\n", tv, tv, tv);
+  }
   else if (ty_is_array(t) && array_kind(t)) {
     buf_printf(b, "fputs(sp_%sArray_inspect(", array_kind(t));
     emit_expr(c, arg, b);
@@ -3123,7 +3130,12 @@ void emit_rescue(Compiler *c, int id, Buf *b, int indent, int fr, const char *re
                  nt_str(nt, ref, "name"), xn, xn, xn, rc, rc);
     }
     else
-      buf_printf(b, "lv_%s = sp_exc_new_for_catch(_rcls_%d, _rmsg_%d);\n", nt_str(nt, ref, "name"), rc, rc);
+      /* bind the actual raised object (materialized at the raise), so
+         `rescue => e` and `$!` share one identity; fall back to a fresh
+         reconstruction only if none was carried. */
+      buf_printf(b, "lv_%s = sp_exc_obj[sp_exc_top] ? (sp_Exception *)sp_exc_obj[sp_exc_top]"
+                    " : sp_exc_new_for_catch(_rcls_%d, _rmsg_%d);\n",
+                 nt_str(nt, ref, "name"), rc, rc);
   }
   if (resultvar) {
     const char *sv = g_result_var; g_result_var = resultvar;

--- a/test/exception_class_array_inspect.rb
+++ b/test/exception_class_array_inspect.rb
@@ -1,0 +1,37 @@
+# An exception's #class is a real Class object: it inspects bare (not quoted)
+# inside a container, renders as its name via to_s/name, and compares by identity.
+begin
+  raise ArgumentError, "x"
+rescue => e
+  p [e.class, e.message]       # [ArgumentError, "x"]
+  p e.class                    # ArgumentError
+  puts e.class.to_s            # ArgumentError
+  puts e.class.name            # ArgumentError
+  p e.class == ArgumentError   # true
+  p e.class == RuntimeError    # false
+end
+
+# a builtin default-message exception
+begin
+  raise "boom"
+rescue => e
+  p [e.class, e.message]       # [RuntimeError, "boom"]
+end
+
+# a user-defined exception subclass reifies to its own Class
+class MyErr < StandardError; end
+begin
+  raise MyErr, "oops"
+rescue => e
+  p [e.class, e.message]       # [MyErr, "oops"]
+  p e.class == MyErr           # true
+  puts e.class.name            # MyErr
+end
+
+# the class survives flowing through a method and boxing alongside other kinds
+def id(v); v; end
+begin
+  raise TypeError, "nope"
+rescue => e
+  p [1, id(e).class, :ok]      # [1, TypeError, :ok]
+end

--- a/test/exception_class_array_inspect.rb.expected
+++ b/test/exception_class_array_inspect.rb.expected
@@ -1,0 +1,11 @@
+[ArgumentError, "x"]
+ArgumentError
+ArgumentError
+ArgumentError
+true
+false
+[RuntimeError, "boom"]
+[MyErr, "oops"]
+true
+MyErr
+[1, TypeError, :ok]

--- a/test/exception_real_objects.rb
+++ b/test/exception_real_objects.rb
@@ -1,0 +1,67 @@
+# An exception is a real object: $! and `rescue => e` bind the same object, its
+# #class is a real Class (usable in ==, case, printing), and `p` inspects it.
+
+# $! is the actual rescued object (identity), and its class/message read through
+begin
+  raise "boom"
+rescue => e
+  p $!.equal?(e)              # true
+  p $!.class                  # RuntimeError
+  p $!.class == RuntimeError  # true
+  p $!.message                # "boom"
+  p $!                        # #<RuntimeError: boom>
+end
+
+# outside any rescue, $! is nil
+p $!                          # nil
+
+# a typed exception class flows through == and drives a case
+begin
+  raise ArgumentError, "bad arg"
+rescue => e
+  p e.class                   # ArgumentError
+  p e.class == ArgumentError  # true
+  label = case e.class.to_s
+          when "ArgumentError" then "arg"
+          else "other"
+          end
+  p label                     # "arg"
+end
+
+# nested rescue: $! is the innermost handled exception and is identical to its
+# `=> e` binding
+begin
+  raise TypeError, "outer"
+rescue => outer
+  p outer.class               # TypeError
+  begin
+    raise IndexError, "inner"
+  rescue => inner
+    p $!.class                # IndexError
+    p $!.equal?(inner)        # true
+  end
+end
+
+# a user exception subclass keeps its class and custom message through => e
+class MyErr < StandardError
+  def initialize(code)
+    super("code #{code}")
+  end
+end
+begin
+  raise MyErr.new(42)
+rescue => e
+  p e.class                   # MyErr
+  p e.message                 # "code 42"
+  p $!.equal?(e)              # true
+end
+
+# a nil $! (outside any rescue) reports NilClass; equal? against a non-exception
+# value is always false, since neither can be the one raised object
+p $!.class                    # NilClass
+begin
+  raise "again"
+rescue => e
+  p e.equal?(42)              # false
+  p e.equal?("again")         # false
+end

--- a/test/exception_real_objects.rb.expected
+++ b/test/exception_real_objects.rb.expected
@@ -1,0 +1,18 @@
+true
+RuntimeError
+true
+"boom"
+#<RuntimeError: boom>
+nil
+ArgumentError
+true
+"arg"
+TypeError
+IndexError
+true
+MyErr
+"code 42"
+true
+NilClass
+false
+false


### PR DESCRIPTION
## What this solves

An exception value now behaves like a real object: the exception currently being
handled is available through `$!`, it is the *same* object bound by `rescue => e`,
and its `#class` is a real `Class` rather than a string.

```ruby
begin
  raise "boom"
rescue => e
  $!.equal?(e)          # => true   (one object)
  $!.class              # => RuntimeError
  $!.class == RuntimeError  # => true
  $!.message            # => "boom"
  p $!                  # #<RuntimeError: boom>
end
$!                      # => nil    (outside any rescue)
```

## How it works

### One materialized object per raise

Every raise now produces one real exception object. When the raise already
carries an object (`raise SomeError.new(...)`), that object is used. When it does
not — a bare `raise "msg"`, a `raise Class, msg`, or a runtime raise from a
builtin — `sp_raise_cls` materializes an exception and stores it on the active
handler frame.

Because the object exists at the moment of the raise, both `$!` and the
`rescue => e` binding read that same slot, so they are guaranteed to be the same
object (`$!.equal?(e)` holds) and `#message` reads through it.

### `#class` as a real Class

`#class` returns a `Class` value carried by name. `sp_Class` gains an optional
name field; when present it takes precedence over the numeric class id, which
makes this work for **every** exception class — including the `Errno::` family
that has no dedicated id. Class values compare by name, so:

```ruby
e.class == ArgumentError          # works
case e.class ; when ... ; end     # works
```

### Inspection and identity

- Exception `#inspect`, `#message`/`#to_s`, and `p` render `#<Class: message>`.
- `#equal?` compares object identity (the underlying exception pointers).
- A nil `$!` (read outside any rescue) is handled as `nil` — `#inspect` gives
  `"nil"` and `#message` is empty rather than dereferencing a null exception.

## Tests

- `test/exception_real_objects.rb` — `$!`/`rescue => e` identity, `#class` in
  `==` and `case`, `#message`, `p`, nested rescue, a user subclass with a custom
  message, and nil `$!` outside a rescue.
- `test/exception_class_array_inspect.rb` — an exception's `#class` boxed into a
  poly array and inspected as a Class.

Expected output is baked from Ruby, and the raise-path allocation is verified
under GC stress.