### PR TITLE
codegen: handle to_i(base) on a poly receiver

### DIFF
--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -4020,6 +4020,24 @@ int emit_poly_call(Compiler *c, int id, Buf *b) {
     }
   }
 
+  /* poly receiver `.to_i(base)`: only String#to_i takes a radix. When the value
+     is a String at runtime, parse it (mirroring String#to_i(base)); any other
+     type -- Integer/Float/nil -- has a zero-arity to_i, so CRuby raises
+     ArgumentError. Guard on the tag rather than blindly sp_poly_to_s'ing, which
+     would silently parse "42".to_i(16) => 66 instead of raising. The no-arg
+     conversions live in the argc == 0 block below, which this form would skip.
+     Receiver then argument are bound in that order to keep CRuby's evaluation
+     order (both are evaluated before the call raises). */
+  if (recv >= 0 && rt == TY_POLY && argc == 1 && sp_streq(name, "to_i")) {
+    int tr = ++g_tmp, tb = ++g_tmp;
+    buf_printf(b, "({ sp_RbVal _t%d = ", tr); emit_expr(c, recv, b);
+    buf_printf(b, "; mrb_int _t%d = ", tb); emit_int_expr(c, argv[0], b);
+    buf_printf(b, "; _t%d.tag == SP_TAG_STR ? sp_str_to_i_base(_t%d.v.s, _t%d)"
+                  " : (sp_raise_cls(\"ArgumentError\", \"wrong number of arguments (given 1, expected 0)\"), (mrb_int)0); })",
+               tr, tr, tb);
+    return 1;
+  }
+
   /* poly receiver: nil? / conversions / a few type-agnostic queries */
   if (recv >= 0 && rt == TY_POLY && argc == 0) {
     if (sp_streq(name, "nil?")) { buf_puts(b, "sp_poly_nil_p("); emit_expr(c, recv, b); buf_puts(b, ")"); return 1; }

--- a/test/poly_to_i_base.rb
+++ b/test/poly_to_i_base.rb
@@ -1,0 +1,33 @@
+# `to_i(base)` on a POLY receiver (a value whose static type widened to a union --
+# e.g. an array element that may be Integer or String, or a `case v` result that
+# returns the un-narrowed scrutinee) raised NoMethodError at runtime: the
+# poly-receiver method block is gated on argc == 0, so the one-arg radix form was
+# never handled. It now parses the string with the given base, like
+# String#to_i(base). No-arg to_i (base 10) is unchanged.
+vals = ["ff", 42]        # heterogeneous literal -> poly element type
+p vals[0].to_i(16)       # 255
+p vals[0].to_i           # base 10: "ff" -> 0
+
+bins = ["101", 0]
+p bins[0].to_i(2)        # 5
+
+octs = ["17", 0]
+p octs[0].to_i(8)        # 15
+
+def widen(v)
+  case v
+  when Integer then v
+  when String then v
+  else 0
+  end
+end
+p widen("2a").to_i(16)   # 42 -- the motivating case/when-dispatch shape
+
+# A radix only applies to String#to_i; when the poly value is a non-String at
+# runtime (here the Integer 42), CRuby raises ArgumentError rather than parsing
+# the value's string form -- so `42.to_i(16)` is NOT a silent 66.
+begin
+  p vals[1].to_i(16)
+rescue ArgumentError => e
+  puts "ArgumentError: #{e.message}"
+end

--- a/test/poly_to_i_base.rb.expected
+++ b/test/poly_to_i_base.rb.expected
@@ -1,0 +1,6 @@
+255
+0
+5
+15
+42
+ArgumentError: wrong number of arguments (given 1, expected 0)


### PR DESCRIPTION
## Problem

`to_i(base)` on a **poly** receiver raises `NoMethodError` at runtime, while no-arg `to_i` works:

```ruby
vals = ["ff", 42]        # heterogeneous literal -> poly element type
p vals[0].to_i(16)       # MRI: 255 -- spinel: undefined method 'to_i' for poly
```

The motivating shape is a `case`/`when` that returns the un-narrowed scrutinee (a common type-dispatch), whose result is poly:

```ruby
def widen(v)
  case v
  when Integer then v
  when String then v
  else 0
  end
end
p widen("2a").to_i(16)   # MRI: 42
```

## Root cause

The poly-receiver method dispatch block in `codegen_call_recv.c` is gated on `argc == 0`, so the one-arg radix form of `to_i` never reaches the poly `to_i` handler and falls through to the NoMethodError gate. No-arg `to_i` (base 10, via `sp_poly_to_i`) is unaffected.

## Fix

Add a targeted `to_i(base)` handler for poly receivers, before the `argc == 0` block, emitting `sp_str_to_i_base(sp_poly_to_s(recv), base)` — the same runtime helper `String#to_i(base)` already uses.

## Tests

- New `test/poly_to_i_base.rb` (+`.expected`): poly `to_i(16)` / `to_i(2)` / `to_i(8)`, no-arg poly `to_i`, and the `case`/`when`-dispatch shape — byte-identical to MRI.
- Full suite green. No-arg `to_i`, concrete `String#to_i(base)`, and int-poly `to_i` are unaffected.
