### PR TITLE
codegen: loud-reject send with a genuinely runtime-computed name

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -3539,6 +3539,40 @@ static void scan_prologue_features(Compiler *c) {
    turn the opaque downstream reject (or silent nil-stub) into one actionable
    diagnostic anchored to the call site. Skipped entirely if the program defines
    its own method by that name, since then the call resolves normally. */
+/* A method result (`.to_sym`, `.join`, ...) or a string/symbol interpolation
+   produces a fresh value that need not appear anywhere as a source literal. */
+static int node_is_computed_name(const NodeTable *nt, int n) {
+  const char *ty = n >= 0 ? nt_type(nt, n) : NULL;
+  if (!ty) return 0;
+  return sp_streq(ty, "CallNode") || sp_streq(ty, "InterpolatedStringNode") ||
+         sp_streq(ty, "InterpolatedSymbolNode");
+}
+
+/* A dynamic-send name is genuinely runtime-computed -- and so cannot be covered
+   by desugar_dynamic_send's literal-derived arm set -- when it is a computed
+   expression directly, or a local assigned such a computation. A bare variable
+   or block parameter whose values are the program's symbol/string literals
+   (`m = :upcase; x.send(m)`, `%w[a b].each { |k| x.send(k) }`) is NOT computed:
+   its runtime value is one of those literals, which the arm set already covers.
+   Only a computed name is rejected, so it fails loudly at build time rather than
+   silently raising the wrong NoMethodError for a method the arms never built. */
+static int send_name_is_computed(Compiler *c, int arg) {
+  const NodeTable *nt = c->nt;
+  if (node_is_computed_name(nt, arg)) return 1;
+  const char *aty = arg >= 0 ? nt_type(nt, arg) : NULL;
+  if (!aty || !sp_streq(aty, "LocalVariableReadNode")) return 0;
+  const char *vn = nt_str(nt, arg, "name");
+  int scope = (arg >= 0 && arg < nt->count) ? c->nscope[arg] : -1;
+  if (!vn) return 0;
+  NT_FOREACH_KIND(nt, NK_LocalVariableWriteNode, id) {
+    if (c->nscope[id] != scope) continue;
+    const char *wn = nt_str(nt, id, "name");
+    if (!wn || !sp_streq(wn, vn)) continue;
+    if (node_is_computed_name(nt, nt_ref(nt, id, "value"))) return 1;
+  }
+  return 0;
+}
+
 static void reject_runtime_send(Compiler *c) {
   const NodeTable *nt = c->nt;
   static const char *const names[] = { "send", "__send__", "public_send", NULL };
@@ -3564,8 +3598,11 @@ static void reject_runtime_send(Compiler *c) {
     /* a literal name should have been rewritten already; only a runtime name
        (a variable, a method result, an interpolated string, ...) reaches here */
     if (a0 && (sp_streq(a0, "SymbolNode") || sp_streq(a0, "StringNode"))) continue;
-    /* lowered to a static name-dispatch (desugar_dynamic_send): handled, not rejected */
-    { int dn = 0; nt_arr(nt, id, "dyn_send_arms", &dn); if (dn > 0) continue; }
+    /* lowered to a static name-dispatch (desugar_dynamic_send): the arm set can
+       only cover a name that is provably one of the program's literals; a
+       genuinely runtime-computed name falls through to the loud reject below. */
+    { int dn = 0; nt_arr(nt, id, "dyn_send_arms", &dn);
+      if (dn > 0 && !send_name_is_computed(c, av[0])) continue; }
     /* Only diagnose a send that codegen will actually emit. A send in a dead
        (unreachable) method is pruned before emission, so rejecting it would
        fail otherwise-valid programs that merely contain an unused method.

--- a/test/send_traceable_name.rb
+++ b/test/send_traceable_name.rb
@@ -1,0 +1,34 @@
+# The statically-traceable send names must keep compiling and running after the
+# genuinely-computed names are loud-rejected. A name is traceable when it is a
+# literal, a variable assigned only literals, or a block parameter bound to
+# program literals -- all of which the static arm set covers.
+
+# a literal name
+p "hi".send(:upcase)
+
+# a variable assigned a symbol literal
+m = :upcase
+p "hi".send(m)
+
+# a variable reassigned among symbol literals
+sel = :reverse
+p [1, 2, 3].send(sel)
+sel = :first
+p [1, 2, 3].send(sel)
+
+# a block parameter bound to string literals
+%w[upcase reverse].each { |k| p "abc".send(k) }
+
+# __send__ / public_send aliases with a traceable name
+op = :max
+p [3, 1, 2].__send__(op)
+q = :min
+p [3, 1, 2].public_send(q)
+
+# a traceable name that isn't a method on the receiver still raises NoMethodError
+bad = :no_such_method
+begin
+  "hi".send(bad)
+rescue NoMethodError
+  puts "NoMethodError"
+end

--- a/test/send_traceable_name.rb.expected
+++ b/test/send_traceable_name.rb.expected
@@ -1,0 +1,9 @@
+"HI"
+"HI"
+[3, 2, 1]
+1
+"ABC"
+"cba"
+3
+1
+NoMethodError


### PR DESCRIPTION
## Problem

A `send` with a genuinely runtime-computed method name silently raises the wrong error:

```ruby
name = ["up", "case"].join   # "upcase", built at runtime
p "hi".send(name.to_sym)     # NoMethodError — even though String#upcase exists
```

The dynamic-send lowering builds dispatch arms from the symbol/string **literals** in the program. `"upcase"` never appears as a literal (only `"up"` and `"case"` do), so no arm matched and the send raised `NoMethodError` at runtime rather than being caught at build time. The reject gate unconditionally skipped any send already lowered to arms.

## Fix

Reject a dynamic send whose name is genuinely **computed** — a method result (`.to_sym`, `.join`), a string/symbol interpolation, or a local assigned such a computation — because the literal-derived arm set cannot cover a value that need not appear as a source literal. The existing loud diagnostic (`send with a runtime method name`) now fires for these instead of a silent wrong answer at runtime.

Statically-decidable names keep working unchanged — a literal, a variable assigned only literals, or a block parameter bound to program literals:

```ruby
m = :upcase;                "hi".send(m)          # ok
%w[upcase reverse].each { |k| "abc".send(k) }     # ok
"hi".send(:upcase)                                # ok
```

## Tests

`test/send_traceable_name.rb` (oracle from `ruby`) guards the positive boundary: literal / variable / reassigned-variable / block-parameter names, `__send__` and `public_send`, and a traceable name that still raises `NoMethodError`. The computed case is now a clean compile-time reject (verified manually — a rejecting program can't be an output-diff test). Full suite green.

