### PR TITLE
set: add Set.[] constructor

### DIFF
--- a/packages/set/set.rb
+++ b/packages/set/set.rb
@@ -7,6 +7,11 @@
 # is only as precise as Array#include?'s element comparison.
 
 class Set
+  # Set[1, 2, 3] builds a Set from the given elements (CRuby's Set.[]).
+  def self.[](*args)
+    new(args)
+  end
+
   def initialize(enum = nil)
     @data = []
     enum.each { |x| add(x) } if enum

--- a/test/set_bracket_ctor.rb
+++ b/test/set_bracket_ctor.rb
@@ -1,0 +1,15 @@
+# Set[...] class-method constructor (CRuby's Set.[]).
+require "set"
+
+s = Set[1, 2, 3, 2, 1]
+puts s.size
+puts s.include?(2)
+puts s.include?(9)
+
+empty = Set[]
+puts empty.empty?
+
+t = Set["a", "b", "a"]
+puts t.size
+t << "c"
+puts t.size

--- a/test/set_bracket_ctor.rb.expected
+++ b/test/set_bracket_ctor.rb.expected
@@ -1,0 +1,6 @@
+3
+true
+false
+true
+2
+3


### PR DESCRIPTION
`Set[1, 2, 3]` (the `Set.[]` constructor) raised an unsupported-call
error because the bundled `set` package defined no `self.[]`. Add it as
a class method that builds a Set from its arguments.

Covered by `test/set_bracket_ctor.rb`.