### PR TITLE
analyze,codegen: FFI foundation -- canonical spec table + registration hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,8 +130,9 @@ build/rbs/%.o: $(RBS_DIR)/src/%.c
 # `spinel` is the single binary: it emits C and then drives cc to link it.
 # (SPINEL itself is defined above, just before the `all` target.)
 
-SPINEL_HDRS = src/node_table.h src/codegen.h src/codegen_internal.h src/types.h src/compiler.h src/analyze.h src/analyze_internal.h
+SPINEL_HDRS = src/node_table.h src/codegen.h src/codegen_internal.h src/types.h src/compiler.h src/analyze.h src/analyze_internal.h src/ffi_spec.h
 SPINEL_OBJ  = build/csrc/node_table.o build/csrc/types.o build/csrc/compiler.o \
+               build/csrc/ffi_spec.o \
                build/csrc/analyze.o build/csrc/analyze_util.o build/csrc/analyze_infer.o \
                build/csrc/analyze_scope.o build/csrc/analyze_pass.o build/csrc/codegen.o build/csrc/codegen_util.o \
                build/csrc/codegen_fold.o build/csrc/codegen_call.o build/csrc/codegen_call_recv.o build/csrc/codegen_iter.o \

--- a/src/analyze_internal.h
+++ b/src/analyze_internal.h
@@ -4,6 +4,7 @@
 #ifndef SPINEL_ANALYZE_INTERNAL_H
 #define SPINEL_ANALYZE_INTERNAL_H
 #include "analyze.h"
+#include "ffi_spec.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -11,15 +12,6 @@
 
 /* The receiver class for a node inside an instance_eval/exec block, or -1. */
 int ie_class_of(Compiler *c, int node);
-
-/* Forward declarations for FFI helpers defined later in this file. */
-const char *ffi_arg_str(const NodeTable *nt, int nid);
-int ffi_arg_int(const NodeTable *nt, int nid);
-TyKind ffi_spec_to_ty(const char *spec);
-int ffi_find_func(Compiler *c, const char *mod, const char *name);
-int ffi_find_buf(Compiler *c, const char *mod, const char *name);
-int ffi_find_reader(Compiler *c, const char *mod, const char *name);
-
 
 
 /* Returns 1 if user class ci (or any ancestor in user chain) has a builtin

--- a/src/analyze_scope.c
+++ b/src/analyze_scope.c
@@ -1435,19 +1435,8 @@ int ffi_arg_int(const NodeTable *nt, int nid) {
 
 /* Map an FFI spec string to the Spinel TyKind used for return types. */
 TyKind ffi_spec_to_ty(const char *spec) {
-  if (!spec) return TY_UNKNOWN;
-  if (sp_streq(spec,"int")||sp_streq(spec,"uint32")||sp_streq(spec,"int32")||
-      sp_streq(spec,"uint16")||sp_streq(spec,"int16")||sp_streq(spec,"uint8")||
-      sp_streq(spec,"size_t")||sp_streq(spec,"long")||sp_streq(spec,"int64"))
-    return TY_INT;
-  if (sp_streq(spec,"float")||sp_streq(spec,"double")) return TY_FLOAT;
-  if (sp_streq(spec,"str")||sp_streq(spec,"binstr")) return TY_STRING;
-  if (sp_streq(spec,"bool")) return TY_BOOL;
-  if (sp_streq(spec,"ptr")) return TY_POLY;
-  if (sp_streq(spec,"void")) return TY_NIL;
-  if (sp_streq(spec,"float_array")) return TY_FLOAT_ARRAY;
-  if (sp_streq(spec,"int_array")) return TY_INT_ARRAY;
-  return TY_UNKNOWN;
+  const FfiSpecInfo *info = ffi_spec_lookup(spec);
+  return info ? info->ty : TY_UNKNOWN;
 }
 
 /* Register a ffi_func / ffi_const / ffi_buffer / ffi_read_* declared in

--- a/src/analyze_scope.c
+++ b/src/analyze_scope.c
@@ -1450,6 +1450,36 @@ TyKind ffi_spec_to_ty(const char *spec) {
   return TY_UNKNOWN;
 }
 
+/* Loud reject of an FFI declaration called with too few arguments. Arity is
+   purely syntactic, so unlike a non-literal argument (which the DSL may fold
+   from a compile-time string/int form -- see test/i1011.rb) a missing argument
+   is always an author error: report it against its source line and stop,
+   instead of silently dropping the decl and surfacing an opaque `unsupported`
+   at the eventual call site. This is an analyze-phase error -- `unsupported`
+   is a codegen primitive whose recovery context is not armed here. */
+__attribute__((noreturn)) static void ffi_decl_error(Compiler *c, int node, const char *msg) {
+  const NodeTable *nt = c->nt;
+  int ln  = (int)nt_int(nt, node, "node_line", 0);
+  int fid = (int)nt_int(nt, node, "node_file", 0);
+  const char *file = nt_file_path(nt, fid);
+  if (!file || !*file) file = nt->source_file;
+  if (!file || !*file) file = "source.rb";
+  fprintf(stderr, "spinel: %s:%d: %s\n", file, ln, msg);
+  exit(1);
+}
+
+/* Append `add` to a semicolon-joined per-module list, allocating the string or
+   growing it in place. The ffi_lib and ffi_cflags merges share this. */
+static void ffi_semi_append(char **slot, const char *add) {
+  if (!*slot) { *slot = strdup(add); if (!*slot) { perror("strdup"); exit(1); } return; }
+  size_t n = strlen(*slot) + 1 + strlen(add) + 1;
+  char *merged = malloc(n);
+  if (!merged) { perror("malloc"); exit(1); }
+  snprintf(merged, n, "%s;%s", *slot, add);
+  free(*slot);
+  *slot = merged;
+}
+
 /* Register a ffi_func / ffi_const / ffi_buffer / ffi_read_* declared in
    module bodies. Called during analyze_program before fixpoint. */
 void register_ffi_decls(Compiler *c) {
@@ -1607,66 +1637,56 @@ void register_ffi_decls(Compiler *c) {
       }
 
       if (sp_streq(dname, "ffi_lib")) {
-        if (an < 1) continue;
+        if (an < 1) ffi_decl_error(c, s, "`ffi_lib` needs a library name");
         const char *libname = ffi_arg_str(nt, args[0]);
-        if (!libname) continue;
-        /* find or create lib entry */
+        if (!libname) continue;  /* non-literal (e.g. a compile-time fold): tolerate */
+        /* find or create the per-module lib entry, then semicolon-merge */
         int mi = -1;
         for (int li = 0; li < c->n_ffi_libs; li++)
           if (sp_streq(c->ffi_libs[li].mod, mname)) { mi = li; break; }
         if (mi < 0) {
           if (c->n_ffi_libs >= c->c_ffi_libs) {
             c->c_ffi_libs = c->c_ffi_libs ? c->c_ffi_libs * 2 : 8;
-            c->ffi_libs = realloc(c->ffi_libs, sizeof(FfiLib) * (size_t)c->c_ffi_libs);
+            FfiLib *tmp = realloc(c->ffi_libs, sizeof(FfiLib) * (size_t)c->c_ffi_libs);
+            if (!tmp) { perror("realloc"); exit(1); }
+            c->ffi_libs = tmp;
           }
-          c->ffi_libs[c->n_ffi_libs].mod  = strdup(mname);
+          c->ffi_libs[c->n_ffi_libs].mod   = strdup(mname);
           c->ffi_libs[c->n_ffi_libs].names = strdup(libname);
-          mi = c->n_ffi_libs++;
+          c->n_ffi_libs++;
         }
-        else {
-          /* append with semicolon */
-          size_t old_len = strlen(c->ffi_libs[mi].names);
-          size_t new_len = old_len + 1 + strlen(libname) + 1;
-          char *merged = malloc(new_len);
-          snprintf(merged, new_len, "%s;%s", c->ffi_libs[mi].names, libname);
-          free(c->ffi_libs[mi].names);
-          c->ffi_libs[mi].names = merged;
-        }
+        else ffi_semi_append(&c->ffi_libs[mi].names, libname);
         continue;
       }
 
       if (sp_streq(dname, "ffi_cflags")) {
-        if (an < 1) continue;
+        if (an < 1) ffi_decl_error(c, s, "`ffi_cflags` needs a flag string");
         const char *cflag = ffi_arg_str(nt, args[0]);
-        if (!cflag) continue;
-        /* find or create cflag entry, semicolon-merged per module */
+        if (!cflag) continue;  /* non-literal (e.g. "-I" + File.expand_path): tolerate */
+        /* find or create the per-module cflag entry, then semicolon-merge */
         int mi = -1;
         for (int ci = 0; ci < c->n_ffi_cflags; ci++)
           if (sp_streq(c->ffi_cflags[ci].mod, mname)) { mi = ci; break; }
         if (mi < 0) {
           if (c->n_ffi_cflags >= c->c_ffi_cflags) {
             c->c_ffi_cflags = c->c_ffi_cflags ? c->c_ffi_cflags * 2 : 8;
-            c->ffi_cflags = realloc(c->ffi_cflags, sizeof(FfiCflag) * (size_t)c->c_ffi_cflags);
+            FfiCflag *tmp = realloc(c->ffi_cflags, sizeof(FfiCflag) * (size_t)c->c_ffi_cflags);
+            if (!tmp) { perror("realloc"); exit(1); }
+            c->ffi_cflags = tmp;
           }
           c->ffi_cflags[c->n_ffi_cflags].mod = strdup(mname);
           c->ffi_cflags[c->n_ffi_cflags].val = strdup(cflag);
-          mi = c->n_ffi_cflags++;
+          c->n_ffi_cflags++;
         }
-        else {
-          size_t old_len = strlen(c->ffi_cflags[mi].val);
-          size_t new_len = old_len + 1 + strlen(cflag) + 1;
-          char *merged = malloc(new_len);
-          snprintf(merged, new_len, "%s;%s", c->ffi_cflags[mi].val, cflag);
-          free(c->ffi_cflags[mi].val);
-          c->ffi_cflags[mi].val = merged;
-        }
+        else ffi_semi_append(&c->ffi_cflags[mi].val, cflag);
         continue;
       }
 
       if (sp_streq(dname, "ffi_func")) {
-        if (an < 3) continue;
+        if (an < 3)
+          ffi_decl_error(c, s, "`ffi_func` needs a name, an argument-type array, and a return type");
         const char *fname = ffi_arg_str(nt, args[0]);
-        if (!fname) continue;
+        if (!fname) continue;  /* non-literal name: tolerate */
         /* arg type array */
         int arr_id = args[1];
         const char *arr_ty = nt_type(nt, arr_id);
@@ -1674,6 +1694,7 @@ void register_ffi_decls(Compiler *c) {
         int en = 0;
         const int *elems = nt_arr(nt, arr_id, "elements", &en);
         char **arg_specs = malloc(sizeof(char*) * (size_t)(en + 1));
+        if (!arg_specs) { perror("malloc"); exit(1); }
         for (int ei = 0; ei < en; ei++) {
           const char *spec = ffi_arg_str(nt, elems[ei]);
           arg_specs[ei] = strdup(spec ? spec : "");
@@ -1683,7 +1704,9 @@ void register_ffi_decls(Compiler *c) {
         /* grow array */
         if (c->n_ffi_funcs >= c->c_ffi_funcs) {
           c->c_ffi_funcs = c->c_ffi_funcs ? c->c_ffi_funcs * 2 : 16;
-          c->ffi_funcs = realloc(c->ffi_funcs, sizeof(FfiFunc) * (size_t)c->c_ffi_funcs);
+          FfiFunc *tmp = realloc(c->ffi_funcs, sizeof(FfiFunc) * (size_t)c->c_ffi_funcs);
+          if (!tmp) { perror("realloc"); exit(1); }
+          c->ffi_funcs = tmp;
         }
         int fi = c->n_ffi_funcs++;
         c->ffi_funcs[fi].mod  = strdup(mname);
@@ -1695,13 +1718,15 @@ void register_ffi_decls(Compiler *c) {
       }
 
       if (sp_streq(dname, "ffi_const")) {
-        if (an < 2) continue;
+        if (an < 2) ffi_decl_error(c, s, "`ffi_const` needs a name and an integer value");
         const char *kname = ffi_arg_str(nt, args[0]);
-        if (!kname) continue;
+        if (!kname) continue;  /* non-literal name: tolerate */
         int val = ffi_arg_int(nt, args[1]);
         if (c->n_ffi_consts >= c->c_ffi_consts) {
           c->c_ffi_consts = c->c_ffi_consts ? c->c_ffi_consts * 2 : 16;
-          c->ffi_consts = realloc(c->ffi_consts, sizeof(FfiConst) * (size_t)c->c_ffi_consts);
+          FfiConst *tmp = realloc(c->ffi_consts, sizeof(FfiConst) * (size_t)c->c_ffi_consts);
+          if (!tmp) { perror("realloc"); exit(1); }
+          c->ffi_consts = tmp;
         }
         int ci2 = c->n_ffi_consts++;
         c->ffi_consts[ci2].mod  = strdup(mname);
@@ -1711,14 +1736,16 @@ void register_ffi_decls(Compiler *c) {
       }
 
       if (sp_streq(dname, "ffi_buffer")) {
-        if (an < 2) continue;
+        if (an < 2) ffi_decl_error(c, s, "`ffi_buffer` needs a name and a byte size");
         const char *bname = ffi_arg_str(nt, args[0]);
-        if (!bname) continue;
+        if (!bname) continue;  /* non-literal name: tolerate */
         int bsize = ffi_arg_int(nt, args[1]);
-        if (bsize <= 0) continue;
+        if (bsize <= 0) continue;  /* non-literal or non-positive size: tolerate */
         if (c->n_ffi_bufs >= c->c_ffi_bufs) {
           c->c_ffi_bufs = c->c_ffi_bufs ? c->c_ffi_bufs * 2 : 8;
-          c->ffi_bufs = realloc(c->ffi_bufs, sizeof(FfiBuf) * (size_t)c->c_ffi_bufs);
+          FfiBuf *tmp = realloc(c->ffi_bufs, sizeof(FfiBuf) * (size_t)c->c_ffi_bufs);
+          if (!tmp) { perror("realloc"); exit(1); }
+          c->ffi_bufs = tmp;
         }
         int bi = c->n_ffi_bufs++;
         c->ffi_bufs[bi].mod  = strdup(mname);
@@ -1728,15 +1755,17 @@ void register_ffi_decls(Compiler *c) {
       }
 
       if (!strncmp(dname, "ffi_read_", 9)) {
-        if (an < 2) continue;
+        if (an < 2) ffi_decl_error(c, s, "`ffi_read_*` needs a name and a byte offset");
         const char *rname = ffi_arg_str(nt, args[0]);
-        if (!rname) continue;
+        if (!rname) continue;  /* non-literal name: tolerate */
         int roff = ffi_arg_int(nt, args[1]);
-        if (roff < 0) roff = 0;
+        if (roff < 0) roff = 0;  /* non-literal or negative offset: clamp (pre-existing) */
         const char *kind = dname + 9;  /* "u32", "i32", "ptr" */
         if (c->n_ffi_readers >= c->c_ffi_readers) {
           c->c_ffi_readers = c->c_ffi_readers ? c->c_ffi_readers * 2 : 8;
-          c->ffi_readers = realloc(c->ffi_readers, sizeof(FfiReader) * (size_t)c->c_ffi_readers);
+          FfiReader *tmp = realloc(c->ffi_readers, sizeof(FfiReader) * (size_t)c->c_ffi_readers);
+          if (!tmp) { perror("realloc"); exit(1); }
+          c->ffi_readers = tmp;
         }
         int ri = c->n_ffi_readers++;
         c->ffi_readers[ri].mod    = strdup(mname);

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -4,6 +4,7 @@
  * file-static in the single file and is shared between the parts. */
 #ifndef SPINEL_CODEGEN_INTERNAL_H
 #define SPINEL_CODEGEN_INTERNAL_H
+#include "ffi_spec.h"
 /* M2 code generator: the M1 scalar/control-flow subset plus user-defined
  * methods (required params, inferred param/return types, recursion, tail-
  * position implicit returns). Emits the same runtime ABI as the legacy

--- a/src/codegen_util.c
+++ b/src/codegen_util.c
@@ -678,27 +678,8 @@ const char *native_c_type(const char *spec) {
 }
 
 const char *ffi_c_type(const char *spec) {
-  if (!spec) return "void";
-  if (sp_streq(spec, "int"))    return "int";
-  if (sp_streq(spec, "uint32")) return "uint32_t";
-  if (sp_streq(spec, "int32"))  return "int32_t";
-  if (sp_streq(spec, "uint16")) return "uint16_t";
-  if (sp_streq(spec, "int16"))  return "int16_t";
-  if (sp_streq(spec, "uint8"))  return "uint8_t";
-  if (sp_streq(spec, "int8"))   return "int8_t";
-  if (sp_streq(spec, "size_t")) return "size_t";
-  if (sp_streq(spec, "long"))   return "long";
-  if (sp_streq(spec, "int64"))  return "int64_t";
-  if (sp_streq(spec, "float"))  return "float";
-  if (sp_streq(spec, "double")) return "double";
-  if (sp_streq(spec, "bool"))   return "int";
-  if (sp_streq(spec, "str"))    return "const char *";
-  if (sp_streq(spec, "binstr")) return "const char *";  /* bytes + sp_net_bin_len */
-  if (sp_streq(spec, "ptr"))    return "void *";
-  if (sp_streq(spec, "float_array")) return "const double *";
-  if (sp_streq(spec, "int_array"))   return "const int64_t *";
-  if (sp_streq(spec, "void"))   return "void";
-  return "void";
+  const FfiSpecInfo *info = ffi_spec_lookup(spec);
+  return info ? info->c_type : "void";
 }
 const char *default_value(TyKind t) {
   switch (t) {

--- a/src/ffi_spec.c
+++ b/src/ffi_spec.c
@@ -1,0 +1,35 @@
+#include <stddef.h>
+
+#include "ffi_spec.h"
+
+/* The single source of truth for the FFI type-spec vocabulary. Each row pairs a
+ * spec token with its inferred Ruby type and its C type at the ABI boundary;
+ * ffi_spec_to_ty and ffi_c_type are thin lookups into it. LP64 target. */
+static const FfiSpecInfo FFI_SPECS[] = {
+  { "int",         TY_INT,         "int"             },
+  { "uint32",      TY_INT,         "uint32_t"        },
+  { "int32",       TY_INT,         "int32_t"         },
+  { "uint16",      TY_INT,         "uint16_t"        },
+  { "int16",       TY_INT,         "int16_t"         },
+  { "uint8",       TY_INT,         "uint8_t"         },
+  { "int8",        TY_INT,         "int8_t"          },
+  { "size_t",      TY_INT,         "size_t"          },
+  { "long",        TY_INT,         "long"            },
+  { "int64",       TY_INT,         "int64_t"         },
+  { "float",       TY_FLOAT,       "float"           },
+  { "double",      TY_FLOAT,       "double"          },
+  { "bool",        TY_BOOL,        "int"             },
+  { "str",         TY_STRING,      "const char *"    },
+  { "binstr",      TY_STRING,      "const char *"    },  /* bytes + sp_net_bin_len */
+  { "ptr",         TY_POLY,        "void *"          },
+  { "float_array", TY_FLOAT_ARRAY, "const double *"  },
+  { "int_array",   TY_INT_ARRAY,   "const int64_t *" },
+  { "void",        TY_NIL,         "void"            },
+};
+
+const FfiSpecInfo *ffi_spec_lookup(const char *spec) {
+  if (!spec) return NULL;
+  for (unsigned i = 0; i < sizeof(FFI_SPECS) / sizeof(FFI_SPECS[0]); i++)
+    if (sp_streq(FFI_SPECS[i].spec, spec)) return &FFI_SPECS[i];
+  return NULL;
+}

--- a/src/ffi_spec.h
+++ b/src/ffi_spec.h
@@ -1,0 +1,24 @@
+#ifndef FFI_SPEC_H
+#define FFI_SPEC_H
+
+#include "types.h"   /* TyKind */
+
+/* The FFI type-spec vocabulary in one place.
+ *
+ * An FFI declaration (`ffi_func :abs, [:int], :int`, and the forms layered on
+ * top of it) describes each value by a spec token -- "int", "long", "ptr",
+ * "str", "double", .... Every place that needs to know something about a spec
+ * -- its inferred Ruby type (ffi_spec_to_ty) and its C type at the ABI boundary
+ * (ffi_c_type) -- resolves it through this single table, so the two can never
+ * disagree. Adding a type is one row here; there is no second table to keep in
+ * sync. LP64 target (arm64-darwin / x86_64-linux). */
+typedef struct {
+  const char *spec;    /* the spec token */
+  TyKind      ty;      /* inferred Ruby type of a value of this spec */
+  const char *c_type;  /* C type at the ABI boundary */
+} FfiSpecInfo;
+
+/* The row for `spec`, or NULL if the token is not part of the vocabulary. */
+const FfiSpecInfo *ffi_spec_lookup(const char *spec);
+
+#endif /* FFI_SPEC_H */


### PR DESCRIPTION
The shared foundation the FFI DSL capabilities build on. Two behavior-preserving pieces (apart from one latent-bug fix):

**Canonical type-spec table.** The FFI type vocabulary was described by two independent hand-rolled `sp_streq` tables — `ffi_spec_to_ty` (spec → inferred Ruby type) and `ffi_c_type` (spec → C type) — kept in agreement by hand, and already drifted: `int8` was handled by `ffi_c_type` but missing from `ffi_spec_to_ty`, so an `int8` return/field inferred `TY_UNKNOWN` and lost its typed-integer path. This introduces one descriptor table, `FfiSpecInfo` (`src/ffi_spec.{c,h}`), that both functions become thin lookups into; adding a type is a single row and the two mappings can no longer disagree. The duplicated FFI helper declarations in `analyze_internal.h` are dropped.

**Registration hardening.** `register_ffi_decls` now rejects a wrong-arity FFI declaration loudly (source-anchored, via the analyze-phase error idiom) instead of silently dropping it — arity is purely syntactic, so this never collides with the DSL's compile-time folding of non-literal string/int arguments. Every array growth in the pass is checked (temp pointer + NULL guard + exit), and the identical semicolon-merge in the `ffi_lib`/`ffi_cflags` arms folds into one `ffi_semi_append` helper.

Full suite green; generated C clean under clang and gcc with `-Werror`.