### PR TITLE
codegen: stack-local self buffer in the yielding-method inliner

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -95,19 +95,19 @@ int emit_ctor_yield_inline(Compiler *c, int id, int ci, Buf *b) {
   const char *saved_self = g_self;
   const char *saved_bpn = g_block_param_name;
   int saved_yfb = g_yield_block_fallback;
-  static char selfbuf[64];
+  /* stack-local: this ctor inliner recurses (a constructor's block may itself
+     construct), and g_self points into this buffer -- a shared static would be
+     clobbered by the nested inline. */
+  char selfbuf[64];
   g_yield_block_fallback = saved_block;
   /* the block being captured is caller code: record the caller's self so
-     emit_block_invoke can restore it around the spliced block body. Copy the
-     STRING into a per-inline (stack) buffer: g_self may point at the shared
-     static selfbuf below, which a deeper nested inline overwrites -- aliasing
-     the fallback by pointer would then make the spliced block body read the
-     wrong (inner) receiver name. */
+     emit_block_invoke can restore it around the spliced block body. Aliasing
+     g_self by pointer is safe now that selfbuf is stack-local: it names an
+     ancestor frame's selfbuf, which stays live and unmodified for the whole
+     nested emission (a frame only ever writes its own selfbuf). */
   const char *saved_self_fb = g_yield_self_fallback;
   const char *saved_deref_fb = g_yield_self_deref_fallback;
-  char self_fb_buf[sizeof selfbuf];
-  if (g_self) { snprintf(self_fb_buf, sizeof self_fb_buf, "%s", g_self); g_yield_self_fallback = self_fb_buf; }
-  else g_yield_self_fallback = NULL;
+  g_yield_self_fallback = g_self;
   g_yield_self_deref_fallback = g_self_deref;
   g_block_id = block;
   g_block_param_name = m->blk_param;
@@ -1372,7 +1372,7 @@ static int emit_poly_method_dispatch(Compiler *c, int id, Buf *b) {
           buf_printf(&cb, "sp_%s_%s(%s", _dcn, mc(c->scopes[mi].name), _dself);
           if (c->scopes[mi].nparams > 0) {
             const char *saved_self = g_self;
-            static char selfpbuf[64];
+            char selfpbuf[64];  /* stack-local: nested inlines each need their own receiver buffer */
             snprintf(selfpbuf, sizeof selfpbuf, "%s", _dself);
             g_self = selfpbuf;
             for (int a = 0; a < c->scopes[mi].nparams; a++) {
@@ -1665,7 +1665,7 @@ static int emit_poly_method_dispatch(Compiler *c, int id, Buf *b) {
         buf_printf(&cb, "sp_%s_%s((sp_%s *)_t%d.v.p", c->classes[defcls].c_name,
                    mc(c->scopes[mi].name), c->classes[defcls].name, tv);
         const char *saved_self = g_self;
-        static char selfpbuf2[64];
+        char selfpbuf2[64];  /* stack-local: nested inlines each need their own receiver buffer */
         snprintf(selfpbuf2, sizeof selfpbuf2, "(sp_%s *)_t%d.v.p", c->classes[defcls].c_name, tv);
         for (int a = 0; a < mnp; a++) {
           /* box the call-site arg if this candidate's parameter is poly;

--- a/src/codegen_iter.c
+++ b/src/codegen_iter.c
@@ -113,23 +113,24 @@ int emit_inline_call_x(Compiler *c, int id, Buf *b, int indent, int as_expr) {
   int saved_bbe = g_block_brk_ebase, saved_yfbe = g_yield_blk_brk_efallback;
   int saved_bbexc = g_block_brk_exc_base, saved_bexc = g_brk_exc_base;
   int saved_ebase = g_brk_ensure_base;
-  static char selfbuf[64];
+  /* Stack-local, not static: emit_inline_call_x recurses (a yielded block can
+     call the same yielding method), and g_self points into this buffer. A
+     shared static would be clobbered by the nested inline, so the outer frame's
+     ensure/trailing-self would emit the inner receiver temp (undeclared here). */
+  char selfbuf[64];
   /* Nested `yield` inside the block body should chain to the block that was
      active before this inline, not to the inner block. */
   g_yield_block_fallback = saved_block;
   g_yield_blk_brk_fallback = saved_bbv;
   g_yield_blk_brk_efallback = saved_bbe;
   /* the block being captured is caller code: record the caller's self so
-     emit_block_invoke can restore it around the spliced block body. Copy the
-     STRING into a per-inline (stack) buffer: g_self may point at the shared
-     static selfbuf below, which a deeper nested inline overwrites -- aliasing
-     the fallback by pointer would then make the spliced block body read the
-     wrong (inner) receiver name. */
+     emit_block_invoke can restore it around the spliced block body. Aliasing
+     g_self by pointer is safe now that selfbuf is stack-local: it names an
+     ancestor frame's selfbuf, which stays live and unmodified for the whole
+     nested emission (a frame only ever writes its own selfbuf). */
   const char *saved_self_fb = g_yield_self_fallback;
   const char *saved_deref_fb = g_yield_self_deref_fallback;
-  char self_fb_buf[sizeof selfbuf];
-  if (g_self) { snprintf(self_fb_buf, sizeof self_fb_buf, "%s", g_self); g_yield_self_fallback = self_fb_buf; }
-  else g_yield_self_fallback = NULL;
+  g_yield_self_fallback = g_self;
   g_yield_self_deref_fallback = g_self_deref;
   g_block_id = block;
   /* the literal block binds to THIS call site's break scope; a forwarded

--- a/test/nested_ensure_self.rb
+++ b/test/nested_ensure_self.rb
@@ -1,0 +1,41 @@
+# A method shaped `save; begin; yield self; ensure; restore; end; self` must
+# compile when it yields to a block that calls the SAME method (re-entrantly).
+#
+# The yielding-method inliner recorded the receiver-temp name in a file-static
+# buffer that g_self points into. A nested inline (the yielded block calling the
+# method again) overwrote that single static, so the outer frame's ensure and
+# trailing self emitted the inner receiver temp -- "use of undeclared identifier
+# '_tN'". Making the buffer stack-local gives each recursive inline its own.
+
+class C
+  attr_reader :log
+  def initialize = (@log = [])
+  def save = (@log << :save)
+  def restore = (@log << :restore)
+  def with_state
+    save
+    begin
+      yield self
+    ensure
+      restore
+    end
+    self
+  end
+end
+
+c = C.new
+# 1. Single call.
+c.with_state { |s| s.save }
+# 2. Two-level nesting (the gap).
+c.with_state { |s| s.with_state { |ss| ss.save } }
+# 3. Three-level nesting.
+c.with_state { |s| s.with_state { |ss| ss.with_state { |sss| sss.save } } }
+p c.log.length                     #=> 15
+# 4. ensure still runs when the block raises.
+begin
+  c.with_state { |s| raise "boom" }
+rescue
+end
+p c.log.last                       #=> :restore
+
+puts "done"

--- a/test/nested_ensure_self.rb.expected
+++ b/test/nested_ensure_self.rb.expected
@@ -1,0 +1,3 @@
+15
+:restore
+done


### PR DESCRIPTION
A method shaped `save; begin; yield self; ensure; restore; end; self` compiled when called once but failed to compile when called re-entrantly (the yielded block calls the same method again): `use of undeclared identifier '_tN'`.

The yielding-method inliner records the receiver-temp name in a buffer that `g_self` points into, but that buffer was file-static. A nested inline overwrote the single static, so the outer frame's `ensure` and trailing `self` emitted the inner receiver temp — undeclared in the outer scope.

Making the buffer stack-local gives each recursive inline frame its own; the same latent aliasing is fixed in the sibling constructor inliner and the two nested-inline receiver buffers.

Covered by `test/nested_ensure_self.rb` (ruby-oracle): single, two-level, and three-level nested calls, and ensure running when the block raises.