### PR TITLE
codegen: respond_to? on a poly checks the runtime class for a user method

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -3195,6 +3195,21 @@ void emit_brk_wrapped_call(Compiler *c, int id, Buf *b) {
    class object inherits (`new` answered by classes, not modules). Shared
    by the explicit `Const.respond_to?(:m)` fold and the receiverless form
    inside a `def self.x` method (implicit self = the class object). */
+/* Does any user class's chain define qm (instance method, attr reader, or a
+   `m=` attr writer)? Lets a poly respond_to?(:qm) decide whether a runtime
+   cls_id check is needed instead of the union-wide static probe answer. */
+static int any_class_defines(Compiler *c, const char *qm) {
+  size_t ql = strlen(qm);
+  char wbase[256]; wbase[0] = '\0';
+  int is_wr = ql > 0 && qm[ql - 1] == '=' && ql - 1 < sizeof wbase;
+  if (is_wr) { memcpy(wbase, qm, ql - 1); wbase[ql - 1] = '\0'; }
+  for (int k = 0; k < c->nclasses; k++)
+    if (comp_method_in_chain(c, k, qm, NULL) >= 0 ||
+        comp_reader_in_chain(c, k, qm, NULL) ||
+        (is_wr && comp_writer_in_chain(c, k, wbase, NULL)))
+      return 1;
+  return 0;
+}
 static int class_responds_to(Compiler *c, int ci, const char *qm) {
   const NodeTable *nt = c->nt;
   if (comp_cmethod_in_chain(c, ci, qm, NULL) >= 0) return 1;
@@ -7185,14 +7200,40 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
             }
           }
         }
+        else if ((rt == TY_POLY || rt == TY_UNKNOWN) && any_class_defines(c, qm)) {
+          /* poly receiver + a user protocol method (some user class defines qm):
+             the analyze probe answers "SOME union member responds", which
+             mis-decides per value -- a String member of String|UserClass would
+             report true for the user's method and take the wrong branch. Emit a
+             runtime check against the exact user classes that define qm; a
+             builtin value (which cannot define a user protocol method) answers
+             false. This mirrors the poly is_a? runtime cls_id check. */
+          int tv = ++g_tmp;
+          buf_printf(b, "({ sp_RbVal _t%d = ", tv); emit_expr(c, recv, b); buf_puts(b, "; ");
+          buf_printf(b, "_t%d.tag == SP_TAG_OBJ && _t%d.cls_id >= 0 && (", tv, tv);
+          size_t ql = strlen(qm);
+          char wbase[256]; wbase[0] = '\0';
+          int is_wr = ql > 0 && qm[ql - 1] == '=' && ql - 1 < sizeof wbase;
+          if (is_wr) { memcpy(wbase, qm, ql - 1); wbase[ql - 1] = '\0'; }
+          int first = 1;
+          for (int k = 0; k < c->nclasses; k++) {
+            int has = comp_method_in_chain(c, k, qm, NULL) >= 0 ||
+                      comp_reader_in_chain(c, k, qm, NULL) ||
+                      (is_wr && comp_writer_in_chain(c, k, wbase, NULL));
+            if (has) { buf_printf(b, "%s_t%d.cls_id == %d", first ? "" : " || ", tv, k); first = 0; }
+          }
+          if (first) buf_puts(b, "0");
+          buf_printf(b, "); })");
+          return;
+        }
         else {
           /* primitive/builtin receiver (String/Integer/Array/...): consult the
              analyze-time probe -- a synthesized `recv.<qm>` call whose inferred
              type says whether spinel can actually dispatch the method. This
              derives the answer from the same resolver that types a real call,
              so it never drifts from what a real `recv.qm` would compile to. A
-             poly/unknown receiver gets no probe and stays unresolved (falls
-             through) rather than answering a possibly-wrong false. */
+             poly/unknown receiver with no user protocol method falls through
+             here (the builtin probe answer) rather than a possibly-wrong false. */
           int pn = 0; const int *probes = nt_arr(nt, id, "rt_probes", &pn);
           if (probes && pn > 0) {
             resolved = 1; yes = 0;

--- a/test/respond_to_poly.rb
+++ b/test/respond_to_poly.rb
@@ -1,0 +1,47 @@
+# respond_to?(:m) on a poly receiver must answer per runtime value, not from a
+# union-wide static approximation.
+#
+# `value.respond_to?(:to_css) ? value.to_css : value` where value is a String
+# from some call sites and a #to_css-defining user class from others: the
+# analyze probe types `value.to_css` (Color defines it) and reported a static
+# true, so the String took the wrong branch and returned "" instead of itself.
+#
+# Fix: for a poly receiver whose method is defined by a user class, emit a
+# runtime cls_id check (like the poly is_a? path) -- a builtin value, which
+# cannot define a user protocol method, answers false.
+
+class Color
+  def initialize(s) = (@s = s)
+  def to_css = @s
+end
+class Named
+  def initialize(n) = (@n = n)
+  def to_css = "named-#{@n}"
+end
+
+def coerce(value) = value.respond_to?(:to_css) ? value.to_css : value
+
+# 1. A String member takes the else branch (returns itself).
+p coerce("#fef6e0")               #=> "#fef6e0"
+# 2. A #to_css-defining member responds.
+p coerce(Color.new("#abc"))       #=> "#abc"
+# 3. A second class defining the method also responds.
+p coerce(Named.new("red"))        #=> "named-red"
+
+# 4. A method no class defines: false for every runtime value.
+def has_bogus(v) = v.respond_to?(:nonexistent_xyz)
+p has_bogus("s")                  #=> false
+p has_bogus(Color.new("x"))       #=> false
+
+# 5. A universal Object method: true for every value.
+def has_to_s(v) = v.respond_to?(:to_s)
+p has_to_s("s")                   #=> true
+p has_to_s(Color.new("x"))        #=> true
+p has_to_s(42)                    #=> true
+
+# 6. Concrete (non-poly) receivers are unaffected.
+p "hi".respond_to?(:upcase)       #=> true
+p Color.new("z").respond_to?(:to_css)  #=> true
+p 5.respond_to?(:to_css)          #=> false
+
+puts "done"

--- a/test/respond_to_poly.rb.expected
+++ b/test/respond_to_poly.rb.expected
@@ -1,0 +1,12 @@
+"#fef6e0"
+"#abc"
+"named-red"
+false
+false
+true
+true
+true
+true
+true
+false
+done


### PR DESCRIPTION
`respond_to?(:m)` on a poly receiver was answered from an analyze-time probe (a synthesized `recv.m` call) whose type reflects whether *any* union member can dispatch `m`. For a value that is a `String` from some call sites and a `#to_css`-defining user class from others, the probe typed `value.to_css` (Color defines it) and reported a static `true`, so `value.respond_to?(:to_css) ? value.to_css : value` took the wrong branch for the String and returned `""` instead of itself.

When the queried method is defined by a user class, the fix emits a runtime `cls_id` check on the boxed value (mirroring the poly `is_a?` path) instead of the static probe answer: a user object of a defining class answers true, a builtin value — which cannot define a user protocol method — answers false. A method no user class defines still falls through to the builtin probe unchanged.

Covered by `test/respond_to_poly.rb` (ruby-oracle): a String member falling to the else branch, one and two `#to_css`-defining classes, a method no class defines (false everywhere), a universal Object method (true everywhere), and concrete non-poly receivers.