### PR TITLE
codegen: an unguarded yield with no block raises LocalJumpError

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -202,9 +202,11 @@ void emit_boxed(Compiler *c, int node, Buf *b) {
      int-block site into sp_box_str(int) -- a segfault). Box by the CURRENT
      block's inferred result instead. */
   if (nt_type(c->nt, node) && sp_streq(nt_type(c->nt, node), "YieldNode") && g_block_id < 0) {
-    /* no block at this call site: the yield arm is dead; a boxed nil keeps the
-       C well-typed (the cached node type would box the SP_INT_NIL sentinel). */
-    buf_puts(b, "sp_box_nil()");
+    /* An unguarded yield with no block raises LocalJumpError. A guarded yield
+       folds its guard to a compile-time false and sits inside an `if (0)`, so
+       the raise never executes there; the boxed nil keeps the comma expression
+       well-typed for the value position. */
+    buf_puts(b, "(sp_raise_cls(\"LocalJumpError\", \"no block given (yield)\"), sp_box_nil())");
     return;
   }
   if (g_block_id >= 0 && nt_type(c->nt, node) && sp_streq(nt_type(c->nt, node), "YieldNode")) {

--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -1015,10 +1015,13 @@ void emit_expr(Compiler *c, int id, Buf *b) {
       emit_proc_call_args(c, yargc, yargv, b, 1);
       return;
     }
-    if (g_block_id < 0) {  /* no block: yield is nil */
-      /* box the sentinel when the yield value feeds a poly slot (its method
-         return widened to poly in promote mode) */
-      buf_puts(b, comp_ntype(c, id) == TY_POLY ? "sp_box_nil()" : "SP_INT_NIL");
+    if (g_block_id < 0) {
+      /* An unguarded yield with no block raises LocalJumpError. A guarded yield
+         (`block_given? ? yield : x`) folds its guard to a compile-time false and
+         sits inside an `if (0)`, so the raise never executes there. The trailing
+         sentinel keeps the comma expression well-typed for the value position. */
+      buf_puts(b, "(sp_raise_cls(\"LocalJumpError\", \"no block given (yield)\"), ");
+      buf_puts(b, comp_ntype(c, id) == TY_POLY ? "sp_box_nil())" : "SP_INT_NIL)");
       return;
     }
     emit_block_invoke(c, nt_ref(nt, id, "arguments"), b, 0, 1);

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -3950,7 +3950,16 @@ void emit_stmt_inner(Compiler *c, int id, Buf *b, int indent) {
       buf_puts(b, ";\n");
       return;
     }
-    if (g_block_id < 0) return;  /* inlined without block: yield is dead code */
+    if (g_block_id < 0) {
+      /* Reaching a yield emission with no block means the yield is unguarded --
+         a `yield if block_given?` folds its guard to a compile-time false and
+         is never emitted here. An unguarded yield with no block raises
+         LocalJumpError (a guarded one that still reaches codegen sits inside an
+         `if (0)` and never executes the raise). */
+      emit_indent(b, indent);
+      buf_puts(b, "sp_raise_cls(\"LocalJumpError\", \"no block given (yield)\");\n");
+      return;
+    }
     emit_block_invoke(c, nt_ref(nt, id, "arguments"), b, indent, 0);
     return;
   }

--- a/test/yield_no_block_raises.rb
+++ b/test/yield_no_block_raises.rb
@@ -1,0 +1,37 @@
+# An unguarded yield in a method called with no block raises LocalJumpError.
+# A block_given?-guarded yield does not.
+def run
+  yield
+end
+begin
+  run
+rescue LocalJumpError => e
+  puts "stmt: #{e.message}"
+end
+
+def ex
+  x = yield
+  x + 1
+end
+begin
+  ex
+rescue LocalJumpError => e
+  puts "expr: #{e.message}"
+end
+
+def guarded
+  block_given? ? yield : 42
+end
+puts guarded
+
+def maybe
+  yield if block_given?
+  "done"
+end
+puts maybe
+
+# same method used with a block still works
+def twice
+  yield + yield
+end
+puts twice { 21 }

--- a/test/yield_no_block_raises.rb.expected
+++ b/test/yield_no_block_raises.rb.expected
@@ -1,0 +1,5 @@
+stmt: no block given (yield)
+expr: no block given (yield)
+42
+done
+42


### PR DESCRIPTION
A method with an unguarded `yield` called without a block silently did nothing — the inlined yield collapsed to a no-op (statement position) or a nil sentinel (value position), swallowing the error:

```ruby
def run = yield
run   # spinel: (nothing)   MRI: LocalJumpError: no block given (yield)
```

Reaching a yield emission with no block available means the yield is unguarded: a `yield if block_given?` folds its guard to a compile-time false and its body is never emitted, and a `block_given? ? yield : x` emits the yield arm inside an `if (0)`. So emitting the raise wherever a blockless yield is materialized is safe — a genuinely guarded yield sits in dead code and never runs the raise, while an unguarded one raises exactly as CRuby does.

The fix covers all three yield emission paths (statement, value, and boxed-value).

Covered by `test/yield_no_block_raises.rb` (statement and value yields raise; `block_given?`-guarded ternary and `yield if block_given?` stay quiet; the same method still works when given a block).