### PR TITLE
codegen: thread an explicit initialize block parameter through new

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -2443,10 +2443,15 @@ void emit_class_new(Compiler *c, ClassInfo *ci, Buf *b) {
   }
   int initcls = cid;
   int init = comp_method_in_chain(c, cid, "initialize", &initcls);
+  /* An explicit `&blk` block parameter on a non-yielding initialize is a real
+     sp_Proc* the constructor must accept and forward (a yielding initialize is
+     inlined at the call site instead, see emit_ctor_yield_inline). */
+  int init_has_blk = init >= 0 && c->scopes[init].blk_param &&
+                     c->scopes[init].blk_param[0] && !c->scopes[init].yields;
   if (ci->is_value_type) {
     /* value-type: build on the stack and return by value (no heap / GC) */
     buf_printf(b, "static sp_%s sp_%s_new(", ci->c_name, ci->c_name);
-    if (init >= 0 && c->scopes[init].nparams > 0) {
+    if (init >= 0 && (c->scopes[init].nparams > 0 || init_has_blk)) {
       Scope *s = &c->scopes[init];
       for (int i = 0; i < s->nparams; i++) {
         if (i) buf_puts(b, ", ");
@@ -2454,6 +2459,10 @@ void emit_class_new(Compiler *c, ClassInfo *ci, Buf *b) {
         TyKind pt = (p && p->type != TY_UNKNOWN) ? p->type : TY_POLY;
         emit_ctype(c, pt, b);
         buf_printf(b, " lv_%s", s->pnames[i]);
+      }
+      if (init_has_blk) {
+        if (s->nparams > 0) buf_puts(b, ", ");
+        buf_printf(b, "sp_Proc *lv_%s", s->blk_param);
       }
     }
     else buf_puts(b, "void");
@@ -2463,6 +2472,7 @@ void emit_class_new(Compiler *c, ClassInfo *ci, Buf *b) {
       buf_printf(b, "  sp_%s_initialize(&self", c->classes[initcls].c_name);
       Scope *s = &c->scopes[init];
       for (int i = 0; i < s->nparams; i++) buf_printf(b, ", lv_%s", s->pnames[i]);
+      if (init_has_blk) buf_printf(b, ", lv_%s", s->blk_param);
       buf_puts(b, ");\n");
     }
     buf_puts(b, "  return self;\n}\n");
@@ -2474,7 +2484,7 @@ void emit_class_new(Compiler *c, ClassInfo *ci, Buf *b) {
      subclasses use sp_exc_new_sub storage, so they are not pooled. */
   if (!class_is_exc_subclass(c, cid)) buf_printf(b, "SP_POOL_DEFINE(%s)\n", ci->c_name);
   buf_printf(b, "static sp_%s *sp_%s_new(", ci->c_name, ci->c_name);
-  if (init >= 0 && c->scopes[init].nparams > 0) {
+  if (init >= 0 && (c->scopes[init].nparams > 0 || init_has_blk)) {
     Scope *s = &c->scopes[init];
     for (int i = 0; i < s->nparams; i++) {
       if (i) buf_puts(b, ", ");
@@ -2482,6 +2492,10 @@ void emit_class_new(Compiler *c, ClassInfo *ci, Buf *b) {
       TyKind pt = (p && p->type != TY_UNKNOWN) ? p->type : TY_POLY;
       emit_ctype(c, pt, b);
       buf_printf(b, " lv_%s", s->pnames[i]);
+    }
+    if (init_has_blk) {
+      if (s->nparams > 0) buf_puts(b, ", ");
+      buf_printf(b, "sp_Proc *lv_%s", s->blk_param);
     }
   }
   else {
@@ -2531,6 +2545,7 @@ void emit_class_new(Compiler *c, ClassInfo *ci, Buf *b) {
     buf_puts(b, "self");
     Scope *s = &c->scopes[init];
     for (int i = 0; i < s->nparams; i++) buf_printf(b, ", lv_%s", s->pnames[i]);
+    if (init_has_blk) buf_printf(b, ", lv_%s", s->blk_param);
     buf_puts(b, ");\n");
   }
   buf_puts(b, "  return self;\n}\n");
@@ -4376,7 +4391,9 @@ char *codegen_program(const NodeTable *nt) {
       int icid = i;
       int init = comp_method_in_chain(c, i, "initialize", &icid);
       const char *star = ci->is_value_type ? "" : "*";
-      if (init >= 0 && c->scopes[init].nparams > 0) {
+      int p_has_blk = init >= 0 && c->scopes[init].blk_param &&
+                      c->scopes[init].blk_param[0] && !c->scopes[init].yields;
+      if (init >= 0 && (c->scopes[init].nparams > 0 || p_has_blk)) {
         buf_printf(&b, "static sp_%s %ssp_%s_new(", ci->c_name, star, ci->c_name);
         Scope *s = &c->scopes[init];
         for (int m = 0; m < s->nparams; m++) {
@@ -4385,6 +4402,7 @@ char *codegen_program(const NodeTable *nt) {
           TyKind pm = (p && p->type != TY_UNKNOWN) ? p->type : TY_POLY;
           emit_ctype(c, pm, &b);
         }
+        if (p_has_blk) { if (s->nparams > 0) buf_puts(&b, ", "); buf_puts(&b, "sp_Proc *"); }
         buf_puts(&b, ");\n");
       }
       else buf_printf(&b, "static sp_%s %ssp_%s_new(void);\n", ci->c_name, star, ci->c_name);

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -2013,6 +2013,17 @@ static int emit_class_new_call(Compiler *c, int id, Buf *b) {
         buf_printf(b, "sp_%s_new(", c->classes[ci].c_name);
         int initm = comp_method_in_chain(c, ci, "initialize", NULL);
         if (initm >= 0) emit_args_filled(c, initm, nt_ref(nt, id, "arguments"), "", b);
+        /* An explicit `&blk` on a non-yielding initialize is threaded as a
+           trailing sp_Proc* (the constructor accepts + forwards it). Pass the
+           call's block, or NULL when the block is omitted. */
+        if (initm >= 0 && c->scopes[initm].blk_param && c->scopes[initm].blk_param[0] &&
+            !c->scopes[initm].yields) {
+          if (c->scopes[initm].nparams > 0) buf_puts(b, ", ");
+          int blk = nt_ref(nt, id, "block");
+          if (blk >= 0 && nt_type(nt, blk) && sp_streq(nt_type(nt, blk), "BlockNode"))
+            emit_proc_literal(c, blk, b);
+          else buf_puts(b, "NULL");
+        }
         buf_puts(b, ")");
         return 1;
       }

--- a/test/initialize_block_param.rb
+++ b/test/initialize_block_param.rb
@@ -1,0 +1,30 @@
+# An explicit `&blk` block parameter on initialize is threaded through .new:
+# the constructor accepts the block and forwards it, so a stored block can be
+# called later.
+class Widget
+  def initialize(&blk)
+    @cb = blk
+  end
+  def fire = @cb.call(10)
+end
+puts Widget.new { |x| x * 3 }.fire
+
+# block combined with a positional argument
+class Handler
+  def initialize(name, &cb)
+    @name = name
+    @cb = cb
+  end
+  def run(x) = "#{@name}: #{@cb.call(x)}"
+end
+puts Handler.new("double") { |n| n * 2 }.run(21)
+
+# optional block: absent -> nil ivar
+class Maybe
+  def initialize(&blk)
+    @blk = blk
+  end
+  def has? = !@blk.nil?
+end
+puts Maybe.new { }.has?
+puts Maybe.new.has?

--- a/test/initialize_block_param.rb.expected
+++ b/test/initialize_block_param.rb.expected
@@ -1,0 +1,4 @@
+30
+double: 42
+true
+false


### PR DESCRIPTION
A class whose `initialize` declared an explicit `&blk` block parameter and stored it failed to compile — the generated constructor took no block, so it neither accepted nor forwarded one, and the internal `initialize` call was missing an argument:

```ruby
class Widget
  def initialize(&blk) = @cb = blk
  def fire = @cb.call(10)
end
Widget.new { |x| x * 3 }.fire   # spinel: C compile error (too few arguments)
```

The constructor's parameter list is built from `initialize`'s positional params, which exclude the block param. This adds a trailing `sp_Proc*` parameter to `sp_X_new` when a non-yielding `initialize` declares a block, forwards it to `initialize`, and passes the call's block (or `NULL` when omitted) at the `.new` site. Prototype, definition (value and heap object paths), and call site are kept in sync. A yielding `initialize` keeps its existing inline-at-call-site lowering.

Covered by `test/initialize_block_param.rb` (stored block called later, block combined with a positional arg, and an optional block absent at the call site).

Two block cases remain out of scope: a block *called during* `initialize` on a value-typed class (a distinct value-type/constructor interaction), and a block supplied as a block-pass argument (`X.new(&proc)`). The latter needs the constructor-stored-block return ABI to be bridged first — forwarding the proc alone compiles but silently drops a typed-return lambda's value — so both are left for a separate change.