### PR TITLE
codegen: map keyword super args to struct/data members by name

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -2921,7 +2921,12 @@ void emit_super(Compiler *c, int id, Buf *b) {
       int args_id = ty && sp_streq(ty, "SuperNode") ? nt_ref(c->nt, id, "arguments") : -1;
       int an = 0;
       const int *sargv = args_id >= 0 ? nt_arr(c->nt, args_id, "arguments", &an) : NULL;
-      int cnt = is_fwd ? s->nparams : an;
+      /* Data's `super(x: e, y: e2)` passes a single KeywordHashNode: map each
+         member to the like-named keyword's value. Assigning positionally would
+         drop the whole hash into the first (scalar) member slot. */
+      int kwh = (!is_fwd && an == 1 && sargv && nt_type(c->nt, sargv[0]) &&
+                 sp_streq(nt_type(c->nt, sargv[0]), "KeywordHashNode")) ? sargv[0] : -1;
+      int cnt = kwh >= 0 ? cls->nivars : (is_fwd ? s->nparams : an);
       buf_puts(b, "(");
       for (int a = 0; a < cls->nivars && a < cnt; a++) {
         TyKind ivt = cls->ivar_types[a];
@@ -2933,6 +2938,31 @@ void emit_super(Compiler *c, int id, Buf *b) {
           if (ivt == TY_POLY && at != TY_POLY) { Buf ex; memset(&ex, 0, sizeof ex); emit_boxed_text(c, at, src, &ex); buf_puts(b, ex.p ? ex.p : ""); free(ex.p); }
           else if (ivt != TY_POLY && at == TY_POLY) emit_unbox_text(c, ivt, src, b);
           else buf_puts(b, src);
+        }
+        else if (kwh >= 0) {
+          int vnode = struct_kwarg_value(c, kwh, cls->ivars[a] + 1);
+          if (vnode < 0) {
+            /* CRuby raises ArgumentError when a keyword super omits a member.
+               The trailing zero-value is dead (sp_raise_cls is noreturn) but
+               still type-checks against the member slot -- a value-type-object
+               member is an inline struct, so `NULL` won't assign; give it the
+               compound-literal zero instead. */
+            buf_printf(b, "(sp_raise_cls(\"ArgumentError\", \"missing keyword: :%s\"), ",
+                       cls->ivars[a] + 1);
+            if (comp_ty_value_obj(c, ivt))
+              buf_printf(b, "(sp_%s){0})", c->classes[ty_object_class(ivt)].c_name);
+            else
+              buf_printf(b, "%s)", default_value(ivt));
+          }
+          else {
+            TyKind at = comp_ntype(c, vnode);
+            if (ivt == TY_POLY && at != TY_POLY) emit_boxed(c, vnode, b);
+            else if (ivt != TY_POLY && at == TY_POLY) {
+              Buf ex; memset(&ex, 0, sizeof ex); emit_expr(c, vnode, &ex);
+              emit_unbox_text(c, ivt, ex.p ? ex.p : "", b); free(ex.p);
+            }
+            else emit_expr(c, vnode, b);
+          }
         }
         else {
           TyKind at = comp_ntype(c, sargv[a]);

--- a/test/data_super_kwarg.rb
+++ b/test/data_super_kwarg.rb
@@ -1,0 +1,45 @@
+# A custom initialize on a Data/Struct value class delegates to super to set
+# the members. Data passes its members as keywords (super(x: ..., y: ...)),
+# which must map each member by name -- not positionally, which would drop the
+# whole keyword hash into the first member's slot. Args are routed through a
+# method so the values are not constant-folded at the call site.
+
+Point = Data.define(:x, :y) do
+  def initialize(x:, y:)
+    super(x: x * 100, y: y + 1)
+  end
+end
+
+def make_point(a, b)
+  Point.new(x: a, y: b)
+end
+
+p make_point(5, 2)
+p make_point(3, 7)
+
+# Struct with a positional super still assigns members positionally.
+Tally = Struct.new(:a, :b) do
+  def initialize(a, b)
+    super(a * 2, b * 3)
+  end
+end
+
+def make_tally(a, b)
+  Tally.new(a, b)
+end
+
+t = make_tally(4, 5)
+p [t.a, t.b]
+
+# A keyword super that omits a member raises ArgumentError, as in CRuby.
+Pair = Data.define(:m, :n) do
+  def initialize(m:, n:)
+    super(m: m)
+  end
+end
+
+begin
+  Pair.new(m: 1, n: 2)
+rescue ArgumentError => e
+  puts "error: #{e.message}"
+end

--- a/test/data_super_kwarg.rb.expected
+++ b/test/data_super_kwarg.rb.expected
@@ -1,0 +1,4 @@
+#<data Point x=500, y=3>
+#<data Point x=300, y=8>
+[8, 15]
+error: missing keyword: :n


### PR DESCRIPTION
A custom `initialize` on a `Data` value class delegates to `super` with the members passed as keywords (`super(x: ..., y: ...)`). The struct-super lowering read the argument list positionally, so a single `KeywordHashNode` was assigned whole into the first member's scalar slot — a type-incompatible store that fails to compile.

Detect a lone keyword-hash super-argument and map each member to its like-named keyword value via `struct_kwarg_value`, the same by-name lookup the `.new` call site already uses. A member that the keyword `super` omits raises `ArgumentError`, matching CRuby. The positional `super(...)` and bare `super` arms are unchanged.

Test routes constructor arguments through a method so the values are not constant-folded, exercising the runtime path.