### PR TITLE
analyze,codegen: bounded Array#cycle.first/take; reject unbounded

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -681,6 +681,18 @@ TyKind infer_call(Compiler *c, int id) {
     if (sp_streq(name, "respond_to?")) return TY_BOOL;
   }
 
+  /* <array>.cycle.first(n) / .take(n) -> same array kind (bounded consumer of the
+     infinite cycle; the unbounded forms stay a loud reject). */
+  if (recv >= 0 && (sp_streq(name, "first") || sp_streq(name, "take")) &&
+      nt_type(nt, recv) && sp_streq(nt_type(nt, recv), "CallNode") &&
+      nt_str(nt, recv, "name") && sp_streq(nt_str(nt, recv, "name"), "cycle") &&
+      nt_ref(nt, recv, "block") < 0) {
+    int cargs = nt_ref(nt, recv, "arguments");
+    int cac = 0; if (cargs >= 0) nt_arr(nt, cargs, "arguments", &cac);
+    int pr = nt_ref(nt, recv, "receiver");
+    if (cac == 0 && pr >= 0) { TyKind rt2 = infer_type(c, pr); if (ty_is_array(rt2)) return rt2; }
+  }
+
   /* int_array.chunk_while { |a, b| } .to_a -> a poly array of int-array runs */
   if (recv >= 0 && sp_streq(name, "to_a") &&
       nt_type(nt, recv) && sp_streq(nt_type(nt, recv), "CallNode") &&

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -3484,6 +3484,7 @@ void emit_call(Compiler *c, int id, Buf *b) {
   if (emit_minmax_cmp_expr(c, id, b)) return;
   if (emit_step_array_expr(c, id, b)) return;
   if (emit_chunk_while_expr(c, id, b)) return;
+  if (emit_cycle_bounded_expr(c, id, b)) return;
   if (emit_slice_when_chunk_inspect_expr(c, id, b)) return;
   if (emit_product_inspect_expr(c, id, b)) return;
   if (emit_bsearch_expr(c, id, b)) return;

--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -1663,6 +1663,52 @@ int emit_slice_when_chunk_inspect_expr(Compiler *c, int id, Buf *b) {
   return 1;
 }
 
+/* <array>.cycle.first(n) / .cycle.take(n) -> the first n elements of the infinite
+   cycle: arr[i % len] for i in [0, n). Only the bounded consumers are handled; an
+   unbounded cycle (bare, .to_a, .each, .map) is left to the loud reject so it can
+   never hang. Returns 1 if handled. */
+int emit_cycle_bounded_expr(Compiler *c, int id, Buf *b) {
+  const NodeTable *nt = c->nt;
+  const char *name = nt_str(nt, id, "name");
+  if (!name || (!sp_streq(name, "first") && !sp_streq(name, "take"))) return 0;
+  int args = nt_ref(nt, id, "arguments");
+  int ac = 0; const int *av = args >= 0 ? nt_arr(nt, args, "arguments", &ac) : NULL;
+  if (ac != 1) return 0;
+  int recv = nt_ref(nt, id, "receiver");
+  if (recv < 0 || !nt_type(nt, recv) || !sp_streq(nt_type(nt, recv), "CallNode")) return 0;
+  const char *rn = nt_str(nt, recv, "name");
+  if (!rn || !sp_streq(rn, "cycle") || nt_ref(nt, recv, "block") >= 0) return 0;
+  int cargs = nt_ref(nt, recv, "arguments");
+  int cac = 0; if (cargs >= 0) nt_arr(nt, cargs, "arguments", &cac);
+  if (cac != 0) return 0;  /* only the argless (infinite) cycle */
+  int pr = nt_ref(nt, recv, "receiver");
+  TyKind rt = pr >= 0 ? comp_ntype(c, pr) : TY_UNKNOWN;
+  if (!ty_is_array(rt)) return 0;
+  const char *k = array_kind(rt);
+  int ta = ++g_tmp, tn = ++g_tmp, tr = ++g_tmp, tlen = ++g_tmp, ti = ++g_tmp;
+  Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, pr, &rb);
+  Buf nb; memset(&nb, 0, sizeof nb);
+  Buf npre; memset(&npre, 0, sizeof npre);
+  Buf *sv = g_pre; g_pre = &npre; emit_expr(c, av[0], &nb); g_pre = sv;
+  if (npre.p) buf_puts(g_pre, npre.p); free(npre.p);
+  emit_indent(g_pre, g_indent);
+  buf_printf(g_pre, "sp_%sArray *_t%d = %s; SP_GC_ROOT(_t%d);\n", k, ta, rb.p ? rb.p : "", ta); free(rb.p);
+  emit_indent(g_pre, g_indent);
+  buf_printf(g_pre, "mrb_int _t%d = %s;\n", tn, nb.p ? nb.p : "0"); free(nb.p);
+  emit_indent(g_pre, g_indent);
+  buf_printf(g_pre, "if (_t%d < 0) sp_raise_cls(\"ArgumentError\", \"attempt to take negative size\");\n", tn);
+  emit_indent(g_pre, g_indent);
+  buf_printf(g_pre, "sp_%sArray *_t%d = sp_%sArray_new(); SP_GC_ROOT(_t%d);\n", k, tr, k, tr);
+  emit_indent(g_pre, g_indent);
+  buf_printf(g_pre, "mrb_int _t%d = sp_%sArray_length(_t%d);\n", tlen, k, ta);
+  emit_indent(g_pre, g_indent);
+  buf_printf(g_pre, "if (_t%d > 0) for (mrb_int _t%d = 0; _t%d < _t%d; _t%d++) "
+             "sp_%sArray_push(_t%d, sp_%sArray_get(_t%d, _t%d %% _t%d));\n",
+             tlen, ti, ti, tn, ti, k, tr, k, ta, ti, tlen);
+  buf_printf(b, "_t%d", tr);
+  return 1;
+}
+
 /* int_array.chunk_while { |a, b| cond }.to_a -> array of runs. Adjacent elements
    stay in one run while the block is true; a boundary falls where it is false
    (the inverse of slice_when). Materialized as a poly array of boxed int arrays

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -480,6 +480,7 @@ int emit_with_index_expr(Compiler *c, int id, Buf *b);
 int emit_each_with_index_chain(Compiler *c, int id, Buf *b);
 int emit_each_with_index_terminal(Compiler *c, int id, Buf *b);
 int emit_chunk_while_expr(Compiler *c, int id, Buf *b);
+int emit_cycle_bounded_expr(Compiler *c, int id, Buf *b);
 int emit_predicate_expr(Compiler *c, int id, Buf *b);
 int emit_grep_pred(Compiler *c, int pat, const char *ev, TyKind et, Buf *b);
 void emit_obj_alloc_expr(Compiler *c, int cid, Buf *b);

--- a/test/array_cycle_bounded.rb
+++ b/test/array_cycle_bounded.rb
@@ -1,0 +1,24 @@
+# <array>.cycle.first(n) / .take(n) consume the infinite cycle by a bounded count.
+# Unbounded forms (cycle.to_a / .each / bare cycle) remain a compile-time reject so
+# they can never hang -- see the note in the PR; they are intentionally not tested
+# here (they do not compile).
+p [1, 2, 3].cycle.first(7)
+p [1, 2, 3].cycle.take(2)
+p ["a", "b"].cycle.first(5)
+p [10, 20, 30].cycle.first(0)
+p [42].cycle.take(4)
+# a negative count is an ArgumentError, matching Enumerable#first/#take
+begin
+  [1, 2, 3].cycle.first(-1)
+rescue ArgumentError => e
+  p e.message
+end
+begin
+  [1, 2, 3].cycle.take(-2)
+rescue ArgumentError => e
+  p e.message
+end
+# the finite block form cycle(n) { } is unchanged
+out = []
+[1, 2].cycle(3) { |x| out << x }
+p out

--- a/test/array_cycle_bounded.rb.expected
+++ b/test/array_cycle_bounded.rb.expected
@@ -1,0 +1,8 @@
+[1, 2, 3, 1, 2, 3, 1]
+[1, 2]
+["a", "b", "a", "b", "a"]
+[]
+[42, 42, 42, 42]
+"attempt to take negative size"
+"attempt to take negative size"
+[1, 2, 1, 2, 1, 2]


### PR DESCRIPTION
An argless `arr.cycle` is an infinite Enumerator, which cannot be materialized in an AOT binary. The bounded consumers `cycle.first(n)` and `cycle.take(n)` are well-defined, so this peepholes that two-node chain into a direct loop over `arr[i % len]` for `i` in `[0, n)` (any element kind).

Bare `cycle`, `cycle.to_a`, `cycle.each`, `cycle.map` stay a compile-time reject so they can never hang — no silent-wrong, no infinite loop. The finite block form `cycle(n) { }` is unchanged.

Covered by `test/array_cycle_bounded.rb` with `ruby` as the oracle. Full suite green.