### PR TITLE
codegen: fill raise-site constructor defaults, unbox poly exit status, match namespaced exceptions

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -4356,8 +4356,16 @@ char *codegen_program(const NodeTable *nt) {
     if (any) {
       for (int i = 0; i < c->nclasses; i++) {
         if (!class_is_exc_subclass(c, i)) continue;
-        const char *cn = class_ruby_name(c, i);
-        if (!cn) cn = c->classes[i].name;
+        /* snapshot: class_ruby_name returns a shared static buffer for nested
+           names, and the parent canonicalization below calls it again. Copy to
+           the heap, not a fixed buffer: the top-level path returns the class's
+           own arbitrary-length name, which a fixed size would truncate out of
+           agreement with the constructor emission. An unnamed entry has
+           nothing to match on. */
+        const char *cn0 = class_ruby_name(c, i);
+        if (!cn0) cn0 = c->classes[i].name;
+        if (!cn0) continue;
+        char *cn = strdup(cn0);
         /* find the direct parent name (builtin or user) */
         const char *par = NULL;
         int sc = nt_ref(c->nt, c->classes[i].def_node, "superclass");
@@ -4368,12 +4376,23 @@ char *codegen_program(const NodeTable *nt) {
         }
         if (!par && c->classes[i].parent >= 0)
           par = c->classes[c->classes[i].parent].name;
+        /* canonicalize a user parent to its qualified Ruby name so the
+           hierarchy walk meets the raised / rescue-arm names (both emitted
+           qualified); a builtin parent keeps its runtime name */
+        if (par && !is_exc_name(par)) {
+          int pci = comp_class_index(c, par);
+          if (pci >= 0) {
+            const char *pqn = class_ruby_name(c, pci);
+            if (pqn) par = pqn;
+          }
+        }
         if (par) {
           buf_printf(&b, "  if(!strcmp(cls,\"%s\"))return \"%s\";\n", cn, par);
           /* also register the leaf name if different from qualified name */
-          if (cn != c->classes[i].name && !sp_streq(cn, c->classes[i].name))
+          if (c->classes[i].name && !sp_streq(cn, c->classes[i].name))
             buf_printf(&b, "  if(!strcmp(cls,\"%s\"))return \"%s\";\n", c->classes[i].name, par);
         }
+        free(cn);
       }
     }
     buf_puts(&b, "  return 0;\n}\n");

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -4919,7 +4919,11 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
   }
   if (recv < 0 && (sp_streq(name, "exit") || sp_streq(name, "exit!"))) {
     if (argc == 0) { buf_puts(b, "({ exit(0); (mrb_int)0; })"); return; }
-    buf_puts(b, "({ exit((int)("); emit_expr(c, argv[0], b); buf_puts(b, ")); (mrb_int)0; })");
+    /* a poly status (e.g. a widened attr read or poly-hash get) must be
+       unboxed -- (int)(sp_RbVal) is a struct cast, a cc error. */
+    TyKind xt = comp_ntype(c, argv[0]);
+    if (xt == TY_POLY) { buf_puts(b, "({ exit((int)sp_poly_to_i("); emit_expr(c, argv[0], b); buf_puts(b, ")); (mrb_int)0; })"); }
+    else { buf_puts(b, "({ exit((int)("); emit_expr(c, argv[0], b); buf_puts(b, ")); (mrb_int)0; })"); }
     return;
   }
   if (recv < 0 && sp_streq(name, "abort")) {
@@ -4958,7 +4962,12 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
         emit_args_filled(c, ic, -1, "", b);
         buf_puts(b, "))");
       }
-      else buf_printf(b, "sp_raise_cls(\"%s\", (&(\"\\xff\")[1]))", cn ? cn : "");
+      else {
+        /* a known user class raises under its qualified Ruby name (matching
+           the constructor emission and the rescue-arm canonicalization) */
+        const char *rn = (xc >= 0) ? class_ruby_name(c, xc) : NULL;
+        buf_printf(b, "sp_raise_cls(\"%s\", (&(\"\\xff\")[1]))", rn ? rn : (cn ? cn : ""));
+      }
     }
     else if (ac >= 2 && nt_type(nt, av[0]) &&
              (sp_streq(nt_type(nt, av[0]), "ConstantReadNode") || sp_streq(nt_type(nt, av[0]), "ConstantPathNode"))) {
@@ -4973,16 +4982,26 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
         ic = comp_method_in_chain(c, xc, "initialize", NULL);
       if (xc >= 0 && ic >= 0 && c->scopes[ic].nparams >= 1) {
         buf_printf(b, "sp_raise_exc((sp_Exception *)sp_%s_new(", c->classes[xc].c_name);
-        /* match the constructor's first-param type, which falls back to poly
-           when unknown (same rule emit_class_new uses for the signature). */
-        LocalVar *p0 = scope_local(&c->scopes[ic], c->scopes[ic].pnames[0]);
-        TyKind pt0 = (p0 && p0->type != TY_UNKNOWN) ? p0->type : TY_POLY;
-        if (pt0 == TY_POLY) emit_boxed(c, av[1], b);
-        else emit_expr(c, av[1], b);
+        /* `raise Cls, msg` only ever supplies the message, but the generated
+           constructor keeps its full signature (defaulted positionals and
+           keywords included) -- fill param 0 with the message and every
+           remaining param from its default, or the call is emitted with too
+           few arguments. emit_arg_or_default also boxes/coerces the message
+           to the first param's type (poly when unknown, same rule
+           emit_class_new uses for the signature). */
+        Scope *im = &c->scopes[ic];
+        emit_arg_or_default(c, im, 0, av[1], b);
+        for (int pk = 1; pk < im->nparams; pk++) {
+          buf_puts(b, ", ");
+          emit_arg_or_default(c, im, pk, -1, b);
+        }
         buf_puts(b, "))");
       }
       else {
-        buf_printf(b, "sp_raise_cls(\"%s\", ", cn);
+        /* a known user class raises under its qualified Ruby name (matching
+           the constructor emission and the rescue-arm canonicalization) */
+        const char *rn = (xc >= 0) ? class_ruby_name(c, xc) : NULL;
+        buf_printf(b, "sp_raise_cls(\"%s\", ", rn ? rn : cn);
         emit_expr(c, av[1], b); buf_puts(b, ")");
       }
     }

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -423,7 +423,13 @@ else {
   if (sp_streq(name, "exit") || sp_streq(name, "exit!")) {
     emit_indent(b, indent);
     if (argc == 0) buf_puts(b, "exit(0);\n");
-    else { buf_puts(b, "exit((int)("); emit_expr(c, argv[0], b); buf_puts(b, "));\n"); }
+    else {
+      /* a poly status (e.g. a widened attr read or poly-hash get) must be
+         unboxed -- (int)(sp_RbVal) is a struct cast, a cc error. */
+      TyKind xt = comp_ntype(c, argv[0]);
+      if (xt == TY_POLY) { buf_puts(b, "exit((int)sp_poly_to_i("); emit_expr(c, argv[0], b); buf_puts(b, "));\n"); }
+      else { buf_puts(b, "exit((int)("); emit_expr(c, argv[0], b); buf_puts(b, "));\n"); }
+    }
     return 1;
   }
   if (sp_streq(name, "abort")) {
@@ -3501,10 +3507,21 @@ void emit_rescue(Compiler *c, int id, Buf *b, int indent, int fr, const char *re
           if (is_exc_name(enbuf)) ename = enbuf;
         }
       }
+      /* A user exception class is raised under its QUALIFIED Ruby name
+         (self->cls_name = "App::Error" -- the exception-subclass constructor
+         emission uses class_ruby_name). Canonicalize the rescue target
+         through the (leaf-keyed) class table so both a namespaced arm
+         (`rescue App::Error`, whose AST name is the leaf) and a
+         leaf-referenced arm inside the module match the raised name. Resolve
+         the index BEFORE swapping in the qualified name. */
+      int uci = (ename && !is_exc_name(ename)) ? comp_class_index(c, ename) : -1;
+      if (uci >= 0) {
+        const char *qn = class_ruby_name(c, uci);
+        if (qn) ename = qn;
+      }
       /* use hierarchy-aware check for exception classes */
       int is_exc_cls = (ename && is_exc_name(ename)) ||
-                       (ename && comp_class_index(c, ename) >= 0 &&
-                        class_is_exc_subclass(c, comp_class_index(c, ename)));
+                       (uci >= 0 && class_is_exc_subclass(c, uci));
       if (is_exc_cls)
         buf_printf(b, "sp_exc_cls_matches(_rcls_%d, \"%s\")", rc, ename);
       else

--- a/test/exit_poly_status.rb
+++ b/test/exit_poly_status.rb
@@ -1,0 +1,5 @@
+# An `exit(status)` whose status expression is poly-typed (here a poly-hash
+# get) must unbox the value -- a bare (int)(sp_RbVal) cast is a cc error.
+h = { "status" => 0, "note" => "text" }
+puts "before exit"
+exit(h["status"])

--- a/test/exit_poly_status.rb.expected
+++ b/test/exit_poly_status.rb.expected
@@ -1,0 +1,1 @@
+before exit

--- a/test/raise_shortform_default_args.rb
+++ b/test/raise_shortform_default_args.rb
@@ -1,0 +1,24 @@
+# A short-form `raise Cls, "msg"` of an exception whose initialize has
+# defaulted parameters (positional or keyword) must fill those defaults at
+# the generated constructor call site: sp_Cls_new keeps the full signature,
+# so a message-only emission is a cc arity error.
+class Boom < StandardError
+  attr_reader :level, :code
+  def initialize(message, level = 7, code: 3)
+    super(message)
+    @level = level
+    @code = code
+  end
+end
+
+begin
+  raise Boom, "one-arg raise"
+rescue Boom => e
+  puts "#{e.message} level=#{e.level} code=#{e.code}"
+end
+
+begin
+  raise Boom.new("explicit", 8, code: 9)
+rescue Boom => e
+  puts "#{e.message} level=#{e.level} code=#{e.code}"
+end

--- a/test/raise_shortform_default_args.rb.expected
+++ b/test/raise_shortform_default_args.rb.expected
@@ -1,0 +1,2 @@
+one-arg raise level=7 code=3
+explicit level=8 code=9

--- a/test/rescue_namespaced_exception.rb
+++ b/test/rescue_namespaced_exception.rb
@@ -1,0 +1,33 @@
+# A user exception raised under its qualified Ruby name ("App::Error") must be
+# matched by every arm shape: a namespaced arm (`rescue App::Error`, whose AST
+# name is the leaf), a leaf-referenced arm inside the module, a parent-class
+# arm catching a namespaced subclass (the hierarchy callback registers
+# qualified parents), and a builtin StandardError arm. Covers both the
+# class-fallback raise (sp_raise_cls) and the constructed-object raise.
+module App
+  class Error < StandardError
+  end
+
+  class SubError < Error
+  end
+
+  def self.leafy
+    raise Error, "leaf ref"
+  rescue Error => e
+    puts "leaf caught: #{e.message}"
+  end
+end
+
+begin
+  raise App::SubError, "sub raise"
+rescue App::Error => e
+  puts "parent arm caught: #{e.message}"
+end
+
+App.leafy
+
+begin
+  raise App::Error.new("explicit new")
+rescue StandardError => e
+  puts "std caught: #{e.message}"
+end

--- a/test/rescue_namespaced_exception.rb.expected
+++ b/test/rescue_namespaced_exception.rb.expected
@@ -1,0 +1,3 @@
+parent arm caught: sub raise
+leaf caught: leaf ref
+std caught: explicit new


### PR DESCRIPTION
Three exception/exit codegen fixes, each with a conformance test. Full suite passes with all three: 1434 pass, 0 fail, 0 error.

## 1. `raise Cls, msg` drops a defaulted constructor parameter (cc arity error)

The generated constructor keeps its full signature (defaulted positionals and keywords included), but the short-form raise emitted the call with only the message:

```ruby
class Boom < StandardError
  attr_reader :exit_code
  def initialize(message, exit_code: 1)
    super(message)
    @exit_code = exit_code
  end
end

raise Boom, "one-arg raise"   # cc: too few arguments to function call, expected 2, have 1
```

Fix: fill param 0 with the message and every remaining parameter from its default via `emit_arg_or_default` (which also boxes/coerces the message to the first param's type, same rule as before). Test: `test/raise_shortform_default_args.rb`.

## 2. `exit(status)` with a poly-typed status emits a struct-to-int cast (cc error)

```ruby
h = { "ok" => 0, "note" => "text" }
exit(h["ok"])   # cc: operand of type 'sp_RbVal' where arithmetic or pointer type is required
```

Both the statement emitter (codegen_stmt.c) and the value-position emitter (codegen_call.c) emitted `exit((int)(sp_RbVal))`. Fix: unbox via `sp_poly_to_i` when the operand is poly, mirroring the poly handling `sleep` already has. Test: `test/exit_poly_status.rb`.

## 3. A namespaced user exception is never matched by its own rescue arm (silent WRONG)

A module-nested exception object carries its qualified runtime name (`self->cls_name = "App::Error"`), but rescue arms, the `sp_raise_cls` class-only fallbacks, and the generated `sp_user_exc_parent` hierarchy callback all matched on the bare leaf name — so the handler was silently skipped and the program died with "unhandled exception":

```ruby
module App
  class Error < StandardError; end
end

begin
  raise App::Error.new("boom")
rescue App::Error => e         # never matches; unhandled exception, exit 1
  puts "caught: #{e.message}"
end
```

Fix: canonicalize all three sites through `class_ruby_name` (resolving the leaf-keyed class table BEFORE swapping in the qualified name so the hierarchy-aware check keeps working, and snapshotting around `class_ruby_name`'s shared static buffer in the callback emission, where it is called twice per class). Covers the namespaced arm, a leaf-referenced arm inside the module, a parent-class arm catching a namespaced subclass, and a builtin `StandardError` arm. Test: `test/rescue_namespaced_exception.rb`.