### PR TITLE
codegen: fix STDOUT/STDERR constant puts/print with a compound argument

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -4526,19 +4526,34 @@ void emit_call(Compiler *c, int id, Buf *b) {
     if (sp_streq(name, "print") || sp_streq(name, "puts")) {
       /* emit as a statement-like expression: print each arg, return nil.
          Non-string args are stringified via sp_poly_to_s (sp_File_write wants
-         a char *), matching Kernel#puts/#print coercion. */
-      int t = ++g_tmp;
+         a char *), matching Kernel#puts/#print coercion.
+
+         Render each arg into a local buffer first: a compound arg
+         (format/sprintf/join, array/hash literal) pushes its temp decls to
+         g_pre, which must land as whole statements before this block, not
+         inside the half-built sp_File_write(...) call. Same class of bug as
+         the format/sprintf codegen below (#1498 / #1508). */
+      Buf *abs = (Buf *)calloc(argc > 0 ? (size_t)argc : 1, sizeof(Buf));
+      for (int k = 0; k < argc; k++) {
+        if (comp_ntype(c, argv[k]) == TY_STRING) emit_expr(c, argv[k], &abs[k]);
+        else { buf_puts(&abs[k], "sp_poly_to_s("); emit_boxed(c, argv[k], &abs[k]); buf_puts(&abs[k], ")"); }
+      }
+      /* puts uses sp_File_puts, which appends a newline per argument (and only
+         when the arg isn't already newline-terminated), matching CRuby's
+         `puts a, b` -> "a\nb\n" and `puts "x\n"` -> "x\n". print writes the raw
+         arg. Array flattening (puts [1,2] -> one line each) is not yet modelled
+         here -- a non-string arg is stringified via sp_poly_to_s above. */
+      int is_puts = sp_streq(name, "puts");
       emit_indent(g_pre, g_indent);
       buf_puts(g_pre, "({ ");
       for (int k = 0; k < argc; k++) {
-        buf_printf(g_pre, "sp_File_write(%s, ", r);
-        if (comp_ntype(c, argv[k]) == TY_STRING) emit_expr(c, argv[k], g_pre);
-        else { buf_puts(g_pre, "sp_poly_to_s("); emit_boxed(c, argv[k], g_pre); buf_puts(g_pre, ")"); }
-        buf_puts(g_pre, "); ");
+        buf_printf(g_pre, "sp_File_%s(%s, %s); ", is_puts ? "puts" : "write",
+                   r, abs[k].p ? abs[k].p : "\"\"");
+        free(abs[k].p);
       }
-      if (sp_streq(name, "puts")) buf_printf(g_pre, "sp_File_write(%s, \"\\n\"); ", r);
+      free(abs);
+      if (is_puts && argc == 0) buf_printf(g_pre, "sp_File_write(%s, \"\\n\"); ", r);
       buf_puts(g_pre, "});\n");
-      (void)t;
       buf_puts(b, "((mrb_int)0)");
       free(rb.p); return;
     }

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -4540,20 +4540,33 @@ void emit_call(Compiler *c, int id, Buf *b) {
       }
       /* puts uses sp_File_puts, which appends a newline per argument (and only
          when the arg isn't already newline-terminated), matching CRuby's
-         `puts a, b` -> "a\nb\n" and `puts "x\n"` -> "x\n". print writes the raw
-         arg. Array flattening (puts [1,2] -> one line each) is not yet modelled
-         here -- a non-string arg is stringified via sp_poly_to_s above. */
+         `puts a, b` -> "a\nb\n" and `puts "x\n"` -> "x\n". A nullable string
+         arg can be NULL (nil); sp_File_puts is a no-op on NULL, so coalesce it
+         to "" first so `puts nil` still prints the blank line. print writes the
+         raw arg (a NULL write is correctly a no-op). Array flattening
+         (puts [1,2] -> one line each) is not yet modelled here -- a non-string
+         arg is stringified via sp_poly_to_s above. */
       int is_puts = sp_streq(name, "puts");
-      emit_indent(g_pre, g_indent);
-      buf_puts(g_pre, "({ ");
-      for (int k = 0; k < argc; k++) {
-        buf_printf(g_pre, "sp_File_%s(%s, %s); ", is_puts ? "puts" : "write",
-                   r, abs[k].p ? abs[k].p : "\"\"");
-        free(abs[k].p);
+      /* An empty `print` (argc == 0, not puts) would emit an empty `({ })`,
+         which is not a valid statement-expression; skip the block entirely. */
+      if (argc > 0 || is_puts) {
+        emit_indent(g_pre, g_indent);
+        buf_puts(g_pre, "({ ");
+        for (int k = 0; k < argc; k++) {
+          const char *at = abs[k].p ? abs[k].p : "\"\"";
+          if (is_puts) {
+            int ts = ++g_tmp;
+            buf_printf(g_pre, "sp_File_puts(%s, ({ const char *_t%d = %s; _t%d ? _t%d : \"\"; })); ",
+                       r, ts, at, ts, ts);
+          }
+          else buf_printf(g_pre, "sp_File_write(%s, %s); ", r, at);
+          free(abs[k].p);
+        }
+        if (is_puts && argc == 0) buf_printf(g_pre, "sp_File_write(%s, \"\\n\"); ", r);
+        buf_puts(g_pre, "});\n");
       }
+      else for (int k = 0; k < argc; k++) free(abs[k].p);
       free(abs);
-      if (is_puts && argc == 0) buf_printf(g_pre, "sp_File_write(%s, \"\\n\"); ", r);
-      buf_puts(g_pre, "});\n");
       buf_puts(b, "((mrb_int)0)");
       free(rb.p); return;
     }

--- a/test/io_puts_compound_arg.rb
+++ b/test/io_puts_compound_arg.rb
@@ -1,0 +1,34 @@
+# STDOUT/STDERR (constants) .puts/.print with a COMPOUND-expression argument --
+# a call that lowers to a C compound literal / statement-expression
+# (format/sprintf/Array#join, array literals). Previously the constant
+# .puts/.print codegen rendered the argument directly into the g_pre preamble
+# buffer, so the argument's own setup lines (e.g. sp_str_format_polyarr temps)
+# were spliced into the middle of the half-built sp_File_write(...) call and
+# the generated C failed to compile ("expected expression").
+
+STDOUT.puts(format("x=%d", 5))
+STDOUT.puts(sprintf("y=%d", 7))
+STDOUT.puts([1, 2, 3].join(","))
+STDOUT.print(format("p=%d", 9))
+STDOUT.print("\n")
+STDOUT.puts format("noparen=%d", 11)   # no parens -- same lowering
+STDOUT.puts([10, 20].map { |x| x * 2 }.join("-"))
+
+# Regression guards: the forms that already worked must keep working.
+m = format("bound=%d", 42)
+STDOUT.puts(m)                          # bind to a local first
+STDOUT.puts("a".upcase)                 # inline call that is NOT a compound expr
+STDOUT.puts("z=%d" % 3)                 # `%` instead of format(...)
+
+# puts adds a newline after EACH argument, and does NOT double a newline when
+# the argument already ends in one.
+STDOUT.puts("a", "b", "c")              # a\nb\nc\n
+STDOUT.puts("already\n")                # already\n (no extra blank line)
+STDOUT.puts(format("m=%d", 1), format("n=%d", 2))
+STDOUT.puts                             # a single blank line
+
+# STDERR goes to stderr (asserted against the .err.expected sidecar).
+STDERR.puts(format("err=%d", 5))
+STDERR.print(sprintf("errp=%d\n", 6))
+STDERR.puts("e1", "e2")                 # e1\ne2\n
+STDERR.puts("edone\n")                  # edone\n (no double newline)

--- a/test/io_puts_compound_arg.rb
+++ b/test/io_puts_compound_arg.rb
@@ -26,6 +26,9 @@ STDOUT.puts("a", "b", "c")              # a\nb\nc\n
 STDOUT.puts("already\n")                # already\n (no extra blank line)
 STDOUT.puts(format("m=%d", 1), format("n=%d", 2))
 STDOUT.puts                             # a single blank line
+STDOUT.puts("abc"[10])                  # nil (out-of-range index) -> blank line
+STDOUT.print                            # print with no args -> nothing (no empty ({}) )
+STDOUT.puts("dprint-guard")
 
 # STDERR goes to stderr (asserted against the .err.expected sidecar).
 STDERR.puts(format("err=%d", 5))

--- a/test/io_puts_compound_arg.rb.err.expected
+++ b/test/io_puts_compound_arg.rb.err.expected
@@ -1,0 +1,5 @@
+err=5
+errp=6
+e1
+e2
+edone

--- a/test/io_puts_compound_arg.rb.expected
+++ b/test/io_puts_compound_arg.rb.expected
@@ -1,0 +1,16 @@
+x=5
+y=7
+1,2,3
+p=9
+noparen=11
+20-40
+bound=42
+A
+z=3
+a
+b
+c
+already
+m=1
+n=2
+

--- a/test/io_puts_compound_arg.rb.expected
+++ b/test/io_puts_compound_arg.rb.expected
@@ -14,3 +14,5 @@ already
 m=1
 n=2
 
+
+dprint-guard


### PR DESCRIPTION
## Summary

- `STDERR.puts(format("x=%d", 5))` (and `sprintf`, `Array#join`, array/hash literals, with or without parens, on `STDOUT`/`STDERR`) produced uncompilable C: `error: expected expression`.
- The constant `.puts`/`.print` codegen built its `sp_File_write(...)` statement-expression by writing directly into the `g_pre` preamble buffer and rendered each argument straight into `g_pre` too. A compound argument lowers by pushing its own setup lines (e.g. `sp_str_format_polyarr` temporaries) onto `g_pre`, which then landed in the middle of the half-built `sp_File_write(...)` call. The fix renders each argument into a local buffer first so its preamble flushes to `g_pre` as whole statements ahead of the block, matching the existing `format`/`sprintf` codegen pattern (#1498/#1508).
- While here, `puts` now emits through the existing `sp_File_puts` runtime helper, so it adds a newline after each argument and does not double an already-terminated newline: `STDERR.puts("a", "b")` -> `a\nb\n` and `STDERR.puts("x\n")` -> `x\n` (previously `ab\n` / `x\n\n`).

Array-argument flattening (`STDOUT.puts([1,2,3])` -> one element per line) is a separate, pre-existing gap noted in a code comment and left for a follow-up.

## Test plan

- [x] New `test/io_puts_compound_arg.rb` (+ stdout `.expected` and stderr `.err.expected`, generated from CRuby): `format`/`sprintf`/`join`/`map...join` args, no-parens form, `print`, multi-arg and trailing-newline newline semantics, and the already-working forms as regression guards, on both `STDOUT` and `STDERR`
- [x] Original repro compiles and prints `x=5` to stderr, matching CRuby
- [x] `make test REF_RUBY=/opt/homebrew/bin/ruby`: 1435 pass, 0 fail, 0 error
- [x] `make optcarrot`: OK (checksum 59662)