### PR TITLE
codegen: equality between two statically nil-typed operands

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -2500,6 +2500,21 @@ static int emit_case_eq_call(Compiler *c, int id, Buf *b) {
     /* `x == nil` / `x != nil` for any receiver */
     int a_nil = nt_type(nt, argv[0]) && sp_streq(nt_type(nt, argv[0]), "NilNode");
     int r_nil = nt_type(nt, recv) && sp_streq(nt_type(nt, recv), "NilNode");
+    /* Both operands statically nil-TYPED: two calls the analyzer proved return
+       nil (`probe(1) == probe(2)`), or one such call against a literal nil
+       (`probe(5) == nil`). nil == nil is constant truth, but both expressions
+       must still evaluate for their effects. Checked before the literal-nil
+       paths below so a non-literal nil-typed operand is not constant-folded
+       away unevaluated. Receiver-then-arg order preserved by the C comma. */
+    if (rt == TY_NIL && a0 == TY_NIL) {
+      buf_puts(b, "((void)(");
+      emit_expr(c, recv, b);
+      buf_puts(b, "), (void)(");
+      emit_expr(c, argv[0], b);
+      buf_printf(b, "), %d)", eq ? 1 : 0);
+      return 1;
+    }
+    /* `x == nil` / `x != nil` for any receiver */
     if (a_nil || r_nil) {
       int other = a_nil ? recv : argv[0];
       TyKind ot = comp_ntype(c, other);

--- a/test/nil_typed_equality.rb
+++ b/test/nil_typed_equality.rb
@@ -1,0 +1,15 @@
+# Two operands whose STATIC type is nil (calls the analyzer proves return
+# nil) compare like literal nils: nil == nil is true, != is false, and both
+# expressions still evaluate for their effects (the counter increments).
+$calls = 0
+def probe(x)
+  $calls += 1
+  nil
+end
+
+p probe(1) == probe(2)
+p probe(3) != probe(4)
+# One operand a literal nil: the non-literal side must still evaluate.
+p probe(5) == nil
+p nil == probe(6)
+p $calls

--- a/test/nil_typed_equality.rb.expected
+++ b/test/nil_typed_equality.rb.expected
@@ -1,0 +1,5 @@
+true
+false
+true
+true
+6


### PR DESCRIPTION
Two operands whose STATIC type is nil (calls the analyzer proved return nil) were rejected with "unsupported equality" — the literal-nil comparison paths key on the AST node type, so a nil-TYPED expression never matched them.

```ruby
def probe(x) = nil
probe(1) == probe(2)   # was: unsupported equality; MRI: true
```

`nil == nil` now constant-folds (true for `==`, false for `!=`) with both operands still evaluated for their effects, receiver first.

Test: `test/nil_typed_equality.rb`