### PR TITLE
codegen: all?/any?/none?/one? on a poly receiver

### DIFF
--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -3550,9 +3550,10 @@ int emit_predicate_expr(Compiler *c, int id, Buf *b) {
   if (recv < 0) return 0;
   TyKind rt = comp_ntype(c, recv);
   int range_recv = (rt == TY_RANGE);
-  if (!ty_is_array(rt) && !range_recv) return 0;
+  int poly_recv = (rt == TY_POLY);
+  if (!ty_is_array(rt) && !range_recv && !poly_recv) return 0;
   const char *k = range_recv ? "Int" : (rt == TY_POLY_ARRAY ? "Poly" : array_kind(rt));
-  if (!k) return 0;
+  if (!k && !poly_recv) return 0;
   int body = nt_ref(nt, block, "body");
   int bn = 0;
   const int *bb = body >= 0 ? nt_arr(nt, body, "body", &bn) : NULL;
@@ -3562,8 +3563,53 @@ int emit_predicate_expr(Compiler *c, int id, Buf *b) {
      are truthy in Ruby but false in C), so leave those unsupported. */
   if (comp_ntype(c, bb[bn - 1]) != TY_BOOL) return 0;
 
-  const char *p0 = block_param_name(c, block, 0); if (p0) p0 = rename_local(p0);
+  const char *p0raw = block_param_name(c, block, 0);
+  const char *p0 = p0raw ? rename_local(p0raw) : NULL;
   int trecv = ++g_tmp, tcnt = ++g_tmp, ti = ++g_tmp;
+
+  if (poly_recv) {
+    /* boxed receiver (a widened array): the same runtime-dispatch loop
+       poly `each` uses -- sp_poly_arr_len_ex + sp_poly_each_elem, the block
+       param unboxed to its analyzed type. */
+    int tlen = ++g_tmp;
+    Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);
+    emit_indent(g_pre, g_indent);
+    buf_printf(g_pre, "sp_RbVal _t%d = %s;\n", trecv, rb.p ? rb.p : "sp_box_nil()"); free(rb.p);
+    emit_indent(g_pre, g_indent);
+    buf_printf(g_pre, "SP_GC_ROOT_RBVAL(_t%d);\n", trecv);
+    emit_indent(g_pre, g_indent);
+    buf_printf(g_pre, "mrb_int _t%d = sp_poly_arr_len_ex(_t%d);\n", tlen, trecv);
+    emit_indent(g_pre, g_indent);
+    buf_printf(g_pre, "mrb_int _t%d = 0;\n", tcnt);
+    emit_indent(g_pre, g_indent);
+    buf_printf(g_pre, "for (mrb_int _t%d = 0; _t%d < _t%d; _t%d++) {\n", ti, ti, tlen, ti);
+    int bodyIndentP = g_indent + 1;
+    if (p0) {
+      Scope *blkv = comp_scope_of(c, block);
+      LocalVar *plv = (blkv && p0raw) ? scope_local(blkv, p0raw) : NULL;
+      TyKind pt = plv ? plv->type : TY_POLY;
+      char src[64]; snprintf(src, sizeof src, "sp_poly_each_elem(_t%d, _t%d)", trecv, ti);
+      emit_indent(g_pre, bodyIndentP);
+      emit_block_param_from_boxed(c, p0, pt, src, g_pre);
+    }
+    for (int j = 0; j < bn - 1; j++) emit_stmt(c, bb[j], g_pre, bodyIndentP);
+    int saveIndentP = g_indent;
+    g_indent = bodyIndentP;
+    Buf vb; memset(&vb, 0, sizeof vb);
+    emit_expr(c, bb[bn - 1], &vb);
+    g_indent = saveIndentP;
+    emit_indent(g_pre, bodyIndentP);
+    buf_printf(g_pre, "if (%s) _t%d++;\n", vb.p ? vb.p : "0", tcnt);
+    free(vb.p);
+    emit_indent(g_pre, g_indent);
+    buf_puts(g_pre, "}\n");
+
+    if (is_all) buf_printf(b, "(_t%d == _t%d)", tcnt, tlen);
+    else if (is_any) buf_printf(b, "(_t%d > 0)", tcnt);
+    else if (is_none) buf_printf(b, "(_t%d == 0)", tcnt);
+    else buf_printf(b, "(_t%d == 1)", tcnt);
+    return 1;
+  }
 
   Buf rb; memset(&rb, 0, sizeof rb);
   if (range_recv) {

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -489,6 +489,7 @@ void emit_obj_alloc_expr(Compiler *c, int cid, Buf *b);
 int emit_grep_expr(Compiler *c, int id, Buf *b);
 void emit_arg_or_default(Compiler *c, Scope *m, int idx, int provided, Buf *out);
 int kwh_lookup(const NodeTable *nt, int kwh, const char *kname);
+void emit_block_param_from_boxed(Compiler *c, const char *pname, TyKind pt, const char *src, Buf *b);
 void emit_rest_pack(Compiler *c, int from, int pos_argc, const int *argv, Buf *b);
 void emit_array_elem_at(TyKind at, int tmp, int elem_idx, Buf *b);
 void emit_rest_from_splat_and_argv(int tmp, TyKind at, int from_idx, Compiler *c, int argv_from, int pos_argc, const int *argv, Buf *b);

--- a/src/codegen_iter.c
+++ b/src/codegen_iter.c
@@ -753,8 +753,8 @@ static void emit_block_param_nil(Compiler *c, TyKind pt, Buf *b) {
    unboxes down to its slot type. As in emit_block_param_nil, `pt` is TY_POLY
    or a scalar slot type only -- a value-type element is boxed to poly in its
    container, so emit_unbox_text is never asked for a struct-by-value slot. */
-static void emit_block_param_from_boxed(Compiler *c, const char *pname, TyKind pt,
-                                        const char *src, Buf *b) {
+void emit_block_param_from_boxed(Compiler *c, const char *pname, TyKind pt,
+                                 const char *src, Buf *b) {
   buf_printf(b, "lv_%s = ", pname);
   if (pt == TY_POLY) buf_puts(b, src);
   else emit_unbox_text(c, pt, src, b);

--- a/test/poly_predicate_dispatch.rb
+++ b/test/poly_predicate_dispatch.rb
@@ -1,0 +1,9 @@
+# all?/any?/none?/one? on a POLY receiver (a value the analyzer can only type
+# as poly, here a heterogeneous hash get) dispatch over the boxed array at
+# runtime instead of raising "undefined method for poly".
+h = { "nums" => [1, 2, 3], "label" => "x" }
+vals = h["nums"]
+p vals.all? { |v| !v.nil? }
+p vals.any? { |v| v.nil? }
+p vals.none? { |v| v.nil? }
+p vals.one? { |v| !v.nil? }

--- a/test/poly_predicate_dispatch.rb.expected
+++ b/test/poly_predicate_dispatch.rb.expected
@@ -1,0 +1,4 @@
+true
+false
+true
+false

--- a/test/poly_predicate_method_dispatch.rb
+++ b/test/poly_predicate_method_dispatch.rb
@@ -1,0 +1,18 @@
+# all?/any?/none?/one? on a POLY receiver whose elements are used via a METHOD
+# DISPATCH (a struct element's reader) inside the block, not just a direct
+# predicate on the block param (which test/poly_predicate_dispatch.rb covers).
+# The param stays boxed as poly and `c.key` dispatches by class id -- the shape a
+# real object list (e.g. a reconciler's child nodes) takes.
+class Item
+  def initialize(k)
+    @k = k
+  end
+
+  def key = @k
+end
+h = { "items" => [Item.new("a"), Item.new(nil)], "label" => "x" }
+items = h["items"]
+p items.all? { |c| !c.key.nil? }
+p items.any? { |c| c.key.nil? }
+p items.none? { |c| c.key.nil? }
+p items.one? { |c| c.key.nil? }

--- a/test/poly_predicate_method_dispatch.rb.expected
+++ b/test/poly_predicate_method_dispatch.rb.expected
@@ -1,0 +1,4 @@
+false
+true
+false
+true


### PR DESCRIPTION
A block predicate on a value the analyzer can only type as poly (e.g. a heterogeneous hash get holding an array) compiled but raised `undefined method 'all?' for poly` at runtime.

```ruby
h = { "nums" => [1, 2, 3], "label" => "x" }
h["nums"].all? { |v| !v.nil? }   # was: unhandled exception at runtime
```

`emit_predicate_expr` gains a boxed-receiver variant: the same count-matches loop over `sp_poly_arr_len_ex` / `sp_poly_each_elem`, the block param unboxed to its analyzed type (`emit_block_param_from_boxed` promoted from codegen_iter.c to a shared helper).

Test: `test/poly_predicate_dispatch.rb`