### PR TITLE
codegen: dispatch a user exception's #message/#to_s override

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -4483,6 +4483,46 @@ char *codegen_program(const NodeTable *nt) {
 
   /* method prototypes (scope 0 is top-level) */
   for (int s = 1; s < c->nscopes; s++) { if (c->scopes[s].yields || !c->scopes[s].reachable || scope_is_shadowed(c, s) || c->scopes[s].is_transplanted_source) continue; emit_method_signature(c, &c->scopes[s], &b); buf_puts(&b, ";\n"); }
+
+  /* User exception #message / #to_s overrides: a cls_name-keyed dispatcher so
+     the default message path yields the user-overridden text. Ruby's #message
+     calls #to_s, so #to_s uses a user #to_s if defined else the stored message,
+     and #message uses a user #message, else a user #to_s, else the stored
+     message. Emitted after the method prototypes it calls. Marked unused: a
+     program can define an override yet never query it, and the call sites only
+     reference these when a query is compiled. */
+  if (exc_has_user_msg_override(c)) {
+    for (int pass = 0; pass < 2; pass++) {
+      int want_message = pass;  /* 0 = to_s dispatcher, 1 = message dispatcher */
+      buf_printf(&b, "__attribute__((unused)) static const char *%s(sp_Exception *e){\n",
+                 want_message ? "sp_user_exc_message" : "sp_user_exc_to_s");
+      buf_puts(&b, "  if(!e)return (&(\"\\xff\")[1]);\n  const char *cls=e->cls_name;\n");
+      for (int i = 0; i < c->nclasses; i++) {
+        if (!class_is_exc_subclass(c, i)) continue;
+        int dmsg = -1, dtos = -1;
+        int mi_msg = comp_method_in_chain(c, i, "message", &dmsg);
+        int mi_tos = comp_method_in_chain(c, i, "to_s", &dtos);
+        int mi = -1, dcls = -1;
+        const char *fn = NULL;
+        if (want_message) {
+          if (mi_msg >= 0)      { mi = mi_msg; dcls = dmsg; fn = "message"; }
+          else if (mi_tos >= 0) { mi = mi_tos; dcls = dtos; fn = "to_s"; }
+        } else if (mi_tos >= 0) { mi = mi_tos; dcls = dtos; fn = "to_s"; }
+        if (mi < 0) continue;
+        if ((TyKind)c->scopes[mi].ret != TY_STRING) continue;  /* string-returning only */
+        const char *dcn = c->classes[dcls].c_name;
+        const char *cn0 = class_ruby_name(c, i);
+        if (!cn0) cn0 = c->classes[i].name;
+        if (!cn0) continue;
+        buf_printf(&b, "  if(!strcmp(cls,\"%s\"))return (const char*)sp_%s_%s((sp_%s*)e);\n",
+                   cn0, dcn, fn, dcn);
+        if (c->classes[i].name && !sp_streq(cn0, c->classes[i].name))
+          buf_printf(&b, "  if(!strcmp(cls,\"%s\"))return (const char*)sp_%s_%s((sp_%s*)e);\n",
+                     c->classes[i].name, dcn, fn, dcn);
+      }
+      buf_puts(&b, "  return sp_exc_message(e);\n}\n");
+    }
+  }
   /* constructor prototypes + definitions (after method protos: new calls initialize) */
   for (int i = 0; i < c->nclasses; i++) {
     ClassInfo *ci = &c->classes[i];

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -5095,7 +5095,10 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
   if (recv >= 0 && ty_is_object(comp_ntype(c, recv)) &&
       class_is_exc_subclass(c, ty_object_class(comp_ntype(c, recv)))) {
     if (sp_streq(name, "message") || sp_streq(name, "to_s") || sp_streq(name, "to_str")) {
-      buf_puts(b, "sp_exc_message((sp_Exception *)("); emit_expr(c, recv, b); buf_puts(b, "))");
+      const char *fn = exc_has_user_msg_override(c)
+        ? (sp_streq(name, "message") ? "sp_user_exc_message" : "sp_user_exc_to_s")
+        : "sp_exc_message";
+      buf_printf(b, "%s((sp_Exception *)(", fn); emit_expr(c, recv, b); buf_puts(b, "))");
       return;
     }
   }
@@ -5128,7 +5131,10 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       emit_indent(g_pre, g_indent);
       buf_printf(g_pre, "sp_Exception *_t%d = ", t);
       buf_puts(g_pre, rb.p ? rb.p : ""); buf_puts(g_pre, ";\n"); free(rb.p);
-      buf_printf(b, "(_t%d ? sp_exc_message(_t%d) : \"\")", t, t);
+      const char *fn = exc_has_user_msg_override(c)
+        ? (sp_streq(name, "message") ? "sp_user_exc_message" : "sp_user_exc_to_s")
+        : "sp_exc_message";
+      buf_printf(b, "(_t%d ? %s(_t%d) : \"\")", t, fn, t);
       return;
     }
     if (sp_streq(name, "cause")) {

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -310,6 +310,7 @@ void emit_expr(Compiler *c, int id, Buf *b);
 int is_builtin_reopen(const char *name);
 int is_exc_name(const char *n);
 int class_is_exc_subclass(Compiler *c, int ci);
+int exc_has_user_msg_override(Compiler *c);
 const char *class_ruby_name(Compiler *c, int ci);
 const char *obj_str_cname(Compiler *c, int cid, int want_inspect);
 const char *exc_builtin_parent(Compiler *c, int ci);

--- a/src/codegen_util.c
+++ b/src/codegen_util.c
@@ -926,6 +926,25 @@ const char *bigint_arith_fn(const char *op) {
   if (sp_streq(op, "%"))  return "sp_bigint_mod";
   return NULL;
 }
+/* True if any user exception subclass overrides #message or #to_s, so the
+   default exception message/to_s path must dispatch to the user method rather
+   than reporting the stored message (which defaults to the class name). */
+int exc_has_user_msg_override(Compiler *c) {
+  for (int i = 0; i < c->nclasses; i++) {
+    if (!class_is_exc_subclass(c, i)) continue;
+    /* Only a string-returning override is dispatched (see codegen_program),
+       so gate on TY_STRING to match -- otherwise a non-string override would
+       route every exception query through an empty dispatcher for nothing. */
+    int mi_msg = comp_method_in_chain(c, i, "message", NULL);
+    if (mi_msg >= 0 && (TyKind)c->scopes[mi_msg].ret == TY_STRING)
+      return 1;
+    int mi_tos = comp_method_in_chain(c, i, "to_s", NULL);
+    if (mi_tos >= 0 && (TyKind)c->scopes[mi_tos].ret == TY_STRING)
+      return 1;
+  }
+  return 0;
+}
+
 const char *mc(const char *name) {
   static char buf[256];
   int j = 0;

--- a/test/exception_message_override.rb
+++ b/test/exception_message_override.rb
@@ -1,0 +1,42 @@
+# A user exception's #message / #to_s override must drive the reported message.
+# Ruby's Exception#message calls #to_s, so overriding either changes #message,
+# while overriding only #message leaves #to_s at the default (the class name).
+
+class MsgOnly < StandardError
+  def message = "msg-only"
+end
+
+class TosOnly < StandardError
+  def to_s = "tos-only"
+end
+
+class Both < StandardError
+  def message = "the-message"
+  def to_s = "the-to-s"
+end
+
+class WithIvar < StandardError
+  def initialize(n)
+    @n = n
+    super("stored")
+  end
+  def message = "n=#{@n}"
+end
+
+class Plain < StandardError
+end
+
+def show(e)
+  puts "message=#{e.message} to_s=#{e.to_s}"
+end
+
+begin; raise MsgOnly; rescue => e; show(e); end
+begin; raise TosOnly; rescue => e; show(e); end
+begin; raise Both; rescue => e; show(e); end
+begin; raise Both, "ignored-arg"; rescue => e; show(e); end
+begin; raise WithIvar.new(7); rescue => e; show(e); end
+begin; raise Plain, "explicit"; rescue => e; show(e); end
+begin; raise Plain; rescue => e; show(e); end
+
+# specialized rescue (statically-typed binding) hits the override too
+begin; raise Both; rescue Both => e; show(e); end

--- a/test/exception_message_override.rb.expected
+++ b/test/exception_message_override.rb.expected
@@ -1,0 +1,8 @@
+message=msg-only to_s=MsgOnly
+message=tos-only to_s=tos-only
+message=the-message to_s=the-to-s
+message=the-message to_s=the-to-s
+message=n=7 to_s=stored
+message=explicit to_s=explicit
+message=Plain to_s=Plain
+message=the-message to_s=the-to-s


### PR DESCRIPTION
A user exception subclass that overrides `#message` or `#to_s` had the override silently ignored: the default message path emitted the stored message (which defaults to the class name), so `raise E; rescue => e; e.message` returned `"E"` instead of the overridden text.

Emit two `cls_name`-keyed dispatchers, `sp_user_exc_to_s` and `sp_user_exc_message`, mirroring the existing `sp_user_exc_parent` hierarchy callback, and route the `.message` / `.to_s` / `.to_str` call sites through them when any exception subclass defines an override.

Ruby precedence is honored: `#message` calls `#to_s`, so `#to_s` uses a user `#to_s` if defined else the stored message, and `#message` uses a user `#message`, else a user `#to_s`, else the stored message. Only a string-returning override is dispatched; the dispatchers fall back to `sp_exc_message` for every non-overriding class, so programs without an override are byte-identical to before.

Conformance test `test/exception_message_override.rb` covers message-only, to_s-only, both, an ivar-reading message, a specialized (class-typed) rescue binding, and the no-override default; the `.expected` is the MRI oracle.