### PR TITLE
codegen: coerce a poly super(message) into an exception's msg slot

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -2943,12 +2943,26 @@ void emit_super(Compiler *c, int id, Buf *b) {
       const int *argv2 = NULL;
       if (args_id >= 0) argv2 = nt_arr(c->nt, args_id, "arguments", &argc2);
       if (argc2 > 0) {
-        buf_printf(b, "(%s->msg = (", g_self);
-        emit_expr(c, argv2[0], b);
-        buf_puts(b, "))");
+        /* msg is a const char*; a poly message (e.g. an un-instantiated
+           subclass whose `message` param never got constrained to a String)
+           must be coerced, not assigned raw. emit_str_expr also coerces the
+           unresolved-call gate (TY_UNKNOWN sp_raise_nomethod) that comp_ntype
+           can't see. */
+        buf_printf(b, "(%s->msg = ", g_self);
+        emit_str_expr(c, argv2[0], b);
+        buf_puts(b, ")");
       }
-      else if (ty && sp_streq(ty, "ForwardingSuperNode") && s->nparams > 0)
-        buf_printf(b, "(%s->msg = lv_%s)", g_self, rename_local(s->pnames[0]));
+      else if (ty && sp_streq(ty, "ForwardingSuperNode") && s->nparams > 0) {
+        LocalVar *p0 = scope_local(s, s->pnames[0]);
+        const char *rn = rename_local(s->pnames[0]);
+        /* Effective type mirrors emit_method_signature: a NULL/TY_UNKNOWN
+           param is declared TY_POLY (sp_RbVal), so it too must be coerced. */
+        TyKind pt = (p0 && p0->type != TY_UNKNOWN) ? p0->type : TY_POLY;
+        if (pt == TY_POLY)
+          buf_printf(b, "(%s->msg = sp_poly_to_s(lv_%s))", g_self, rn);
+        else
+          buf_printf(b, "(%s->msg = lv_%s)", g_self, rn);
+      }
       else
         buf_puts(b, "((void)0)");
       return;

--- a/test/rescue_attr_with_sibling_exc_subclass.rb
+++ b/test/rescue_attr_with_sibling_exc_subclass.rb
@@ -1,0 +1,35 @@
+# Reading a rescued exception's attr must still compile when the program
+# defines a SECOND, unrelated exception subclass. The second subclass's
+# `initialize` `message` param is never constrained to a String (its own
+# call sites don't pin it), so `super(message)` must coerce the poly message
+# into the const-char* msg slot rather than emit a struct assignment.
+
+class AError < StandardError
+  attr_reader :code
+  def initialize(message, code: 3)
+    super(message)
+    @code = code
+  end
+end
+
+class BError < StandardError
+  attr_reader :level
+  def initialize(message, level = 7)
+    super(message)
+    @level = level
+  end
+end
+
+begin
+  raise AError.new("boom", code: 9)
+rescue AError => ea
+  puts ea.code
+  puts "code is #{ea.code}"
+end
+
+begin
+  raise BError.new("bad", 5)
+rescue BError => eb
+  puts eb.level
+  puts "msg=#{eb.message} level=#{eb.level}"
+end

--- a/test/rescue_attr_with_sibling_exc_subclass.rb.expected
+++ b/test/rescue_attr_with_sibling_exc_subclass.rb.expected
@@ -1,0 +1,4 @@
+9
+code is 9
+5
+msg=bad level=5


### PR DESCRIPTION
Defining a second exception subclass whose `initialize` is never called (its `message` param is never constrained to a `String`) left that param typed poly. Its `super(message)` then emitted `self->msg = <sp_RbVal>`, but `msg` is a `const char *`, so the whole program failed to compile — even though the second subclass was unrelated to the one being rescued.

The fix coerces a poly super-message through `sp_poly_to_s` before assigning it to the `const char *` msg slot, in both the explicit `super(msg)` and forwarding-super paths. A `String` message is unchanged.

Conformance test `test/rescue_attr_with_sibling_exc_subclass.rb` reads a rescued exception's attr (plain and in string interpolation) with a second, independently-typed exception subclass present.