### PR TITLE
codegen: to_sym on a poly scalar receiver

### DIFF
--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -4246,6 +4246,25 @@ int emit_poly_call(Compiler *c, int id, Buf *b) {
     }
     if (sp_streq(name, "to_i")) { buf_puts(b, "sp_poly_to_i("); emit_expr(c, recv, b); buf_puts(b, ")"); return 1; }
     if (sp_streq(name, "to_f")) { buf_puts(b, "sp_poly_to_f("); emit_expr(c, recv, b); buf_puts(b, ")"); return 1; }
+    /* String#to_sym interns; Symbol#to_sym is identity; every other tag raises
+       CRuby's NoMethodError. A user class defining to_sym wins via poly dispatch. */
+    if (sp_streq(name, "to_sym")) {
+      int has_user = 0;
+      for (int kk = 0; kk < c->nclasses && !has_user; kk++)
+        if (comp_method_in_chain(c, kk, name, NULL) >= 0) has_user = 1;
+      if (!has_user) {
+        int t = ++g_tmp;
+        /* Root the boxed receiver: sp_sym_intern reads through the String's
+           data pointer and allocates, so a GC mid-intern could otherwise free
+           an unrooted temporary String out from under it. */
+        buf_printf(b, "({ sp_RbVal _t%d = ", t); emit_expr(c, recv, b);
+        buf_printf(b, "; SP_GC_ROOT_RBVAL(_t%d); _t%d.tag == SP_TAG_STR ? sp_sym_intern(_t%d.v.s)"
+                      " : (_t%d.tag == SP_TAG_SYM ? (sp_sym)_t%d.v.i"
+                      " : (sp_raise_poly_nomethod(\"to_sym\", _t%d), (sp_sym)0)); })",
+                   t, t, t, t, t, t);
+        return 1;
+      }
+    }
     /* Numeric queries / rounding: dispatch on the runtime tag (a non-numeric
        tag raises CRuby's NoMethodError). A user method or attr reader with
        the same name wins -- the poly method dispatch handles it instead. */

--- a/test/poly_to_sym.rb
+++ b/test/poly_to_sym.rb
@@ -1,0 +1,19 @@
+# x stays poly (called with String and Symbol), so #to_sym dispatches through
+# the poly-scalar runtime path rather than a concrete String/Symbol path.
+def as_sym(x) = x.to_sym
+
+p as_sym("hello")
+p as_sym(:already)
+p as_sym("with spaces")
+
+# map over a heterogeneous array whose elements are strings and symbols.
+p ["a", :b, "c", :d].map(&:to_sym)
+
+# a poly value that is neither String nor Symbol raises NoMethodError.
+def try_sym(x)
+  x.to_sym
+rescue NoMethodError => e
+  "NoMethodError: #{e.message}"
+end
+puts try_sym("ok")
+puts try_sym(42)

--- a/test/poly_to_sym.rb.expected
+++ b/test/poly_to_sym.rb.expected
@@ -1,0 +1,6 @@
+:hello
+:already
+:"with spaces"
+[:a, :b, :c, :d]
+ok
+NoMethodError: undefined method 'to_sym' for an instance of Integer


### PR DESCRIPTION
A poly value flowing into `#to_sym` — for example a parameter called with both a `String` and a `Symbol`, so the parameter widens to a boxed poly — fell through to the generic poly method dispatch and raised `undefined method 'to_sym' for poly` at runtime, even though every `String` and `Symbol` answers `to_sym`.

```ruby
def as_sym(x) = x.to_sym
as_sym("hello")   # => :hello   (was: undefined method 'to_sym' for poly)
as_sym(:already)  # => :already
```

The poly `argc == 0` dispatch chain now emits an inline tag dispatch:

- a `String` tag interns via `sp_sym_intern`,
- a `Symbol` tag is identity,
- any other tag raises CRuby's `NoMethodError` through `sp_raise_poly_nomethod` (`undefined method 'to_sym' for an instance of Integer`).

A user class that defines `to_sym` still wins through poly dispatch. `analyze` already infers `to_sym` as `TY_SYMBOL`, so no inference change is needed.

The `String`/`Symbol` `#intern` alias remains a separate pre-existing gap: `analyze` does not infer `#intern` as `TY_SYMBOL` even for a concrete `String` receiver, so it is intentionally out of scope here.