### PR TITLE
codegen: poly-array reverse, uniq, first(n), last(n)

### DIFF
--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -182,6 +182,33 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
         return 1;
       }
     }
+    /* poly-array collection readers whose runtime backing already exists but
+       whose typed-array forms live in the array_kind()-gated `if (k)` block
+       below -- that gate is NULL for poly, so mirror them with explicit "Poly"
+       dispatch (as drop/take above do). All return a fresh poly array. */
+    if (rt == TY_POLY_ARRAY && sp_streq(name, "reverse") && argc == 0) {
+      int t = ++g_tmp;
+      buf_printf(b, "({ sp_PolyArray *_t%d = sp_PolyArray_dup(", t); emit_expr(c, recv, b);
+      buf_printf(b, "); sp_PolyArray_reverse_bang(_t%d); _t%d; })", t, t);
+      return 1;
+    }
+    if (rt == TY_POLY_ARRAY && sp_streq(name, "uniq") && argc == 0 &&
+        nt_ref(nt, id, "block") < 0) {
+      int t = ++g_tmp;
+      buf_printf(b, "({ sp_PolyArray *_t%d = sp_PolyArray_dup(", t); emit_expr(c, recv, b);
+      buf_printf(b, "); sp_PolyArray_uniq_bang(_t%d); _t%d; })", t, t);
+      return 1;
+    }
+    if (rt == TY_POLY_ARRAY && (sp_streq(name, "first") || sp_streq(name, "last")) && argc == 1) {
+      /* first(n)/last(n) -> subarray via slice; a negative n is an ArgumentError. */
+      int tn = ++g_tmp;
+      buf_printf(b, "({ mrb_int _t%d = ", tn); emit_int_expr(c, argv[0], b);
+      buf_printf(b, "; if (_t%d < 0) sp_raise_cls(\"ArgumentError\", \"negative array size\"); sp_PolyArray_slice(", tn);
+      emit_expr(c, recv, b);
+      if (sp_streq(name, "first")) buf_printf(b, ", 0, _t%d); })", tn);
+      else                        buf_printf(b, ", -_t%d, _t%d); })", tn, tn);
+      return 1;
+    }
     /* poly-array max/min: boxed elements compared at runtime (numerics,
        strings, int-array tuples lexicographically). */
     if ((sp_streq(name, "max") || sp_streq(name, "min")) && argc == 0 &&

--- a/test/poly_array_readers.rb
+++ b/test/poly_array_readers.rb
@@ -1,0 +1,15 @@
+# a stays a poly array (heterogeneous elements) through the method param.
+def probe(a)
+  [a.reverse, a.uniq, a.first(2), a.last(2), a.first(0), a.last(10)]
+end
+
+r = probe(["x", 1, :y, "x", 2, 1])
+r.each { |x| p x }
+
+# edge: first/last beyond length, and negative -> ArgumentError
+def neg_first(a) = a.first(-1)
+begin
+  neg_first([1, "a", :b])
+rescue ArgumentError => e
+  puts "ArgumentError: #{e.message}"
+end

--- a/test/poly_array_readers.rb.expected
+++ b/test/poly_array_readers.rb.expected
@@ -1,0 +1,7 @@
+[1, 2, "x", :y, 1, "x"]
+["x", 1, :y, 2]
+["x", 1]
+[2, 1]
+[]
+["x", 1, :y, "x", 2, 1]
+ArgumentError: negative array size


### PR DESCRIPTION
On a poly (heterogeneous) array, `reverse`, `uniq`, `first(n)`, and `last(n)` rejected as unsupported:

```ruby
def probe(a) = [a.reverse, a.uniq, a.first(2), a.last(2)]
probe(["x", 1, :y, "x", 2])   # was: unsupported call
```

`array_kind()` returns `NULL` for `TY_POLY_ARRAY`, so the `array_kind()`-gated `if (k)` dispatch block — which implements these four for int/str/float arrays via `sp_%sArray_*` — is skipped entirely for poly arrays. A blanket enable is unsafe because not every method in that block has a `sp_PolyArray_*` backing, so this adds dedicated poly arms mirroring the existing `drop`/`take` pattern (explicit `"Poly"` dispatch):

- `reverse` / `uniq` — `dup` then `reverse_bang` / `uniq_bang`,
- `first(n)` / `last(n)` — `slice` (a negative `n` raises `ArgumentError`, matching CRuby and the typed-array form).

The backing runtime (`sp_PolyArray_dup` / `_reverse_bang` / `_uniq_bang` / `_slice`) already exists, and `analyze` already infers all four as the poly-array type, so no inference change is needed.

Other poly-array methods (`concat`, `unshift`, `rindex`, `reduce(init){}`, `combination`, `product`, `chunk_while`, `slice_when`) remain follow-ups — several need new runtime or a codegen loop.