### PR TITLE
analyze,codegen: mutated string params ride byref, appends reach the caller

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -2955,6 +2955,189 @@ static void mark_empty_array_receivers(Compiler *c) {
   }
 }
 
+/* --- byref string out-params (see LocalVar.byref_out) ---------------------
+   CRuby strings are shared heap objects: a callee's `s << "x"` mutates the
+   very object the caller passed. Spinel strings are immutable const char*
+   values and `<<` is a local reassignment, so the mutation silently stops at
+   the callee -- the classic pass-an-output-buffer pattern loses every append.
+   Mark the mutated string params of statically-bound methods byref: codegen
+   passes the caller's slot (const char **), the callee reads and reassigns
+   through it (the existing is_cell deref forms), and the mutation lands in
+   the caller's variable like CRuby.
+
+   Eligibility is deliberately narrow -- byref changes the C ABI, so every
+   call site must know the callee statically and no plain rebind may leak:
+   - toplevel / class (singleton) methods only: an instance method can be
+     reached through poly dispatch stubs and same-name subtree dispatch,
+     which keep the plain ABI;
+   - the name is unique program-wide, never aliased, and never appears as a
+     symbol/string literal (send/method(:x)/define_method material);
+   - all params required positional (no rest/kw/defaults: those fill slots
+     through temps and per-name extraction, where an address is meaningless);
+   - the param is mutated via a receiver-reassigning string mutator (`<<`,
+     replace, prepend, insert, clear, concat, bang forms) or passed on into
+     another method's byref slot (fixpoint), and is never PLAIN-reassigned:
+     CRuby `s = ...` rebinds the local invisibly to the caller, which a
+     write-through cell would wrongly propagate. */
+static int an_str_mutator_name(const char *nm) {
+  size_t l = nm ? strlen(nm) : 0;
+  if (!l) return 0;
+  return sp_streq(nm, "<<") || sp_streq(nm, "concat") || sp_streq(nm, "replace") ||
+         sp_streq(nm, "prepend") || sp_streq(nm, "insert") || sp_streq(nm, "clear") ||
+         (l > 1 && nm[l - 1] == '!');
+}
+
+/* Unique method scope index by name across the program, or -1 (absent or
+   defined more than once). Scope 0 is the top level (name NULL). */
+static int an_unique_scope_by_name(Compiler *c, const char *nm) {
+  int found = -1;
+  if (!nm) return -1;
+  for (int i = 1; i < c->nscopes; i++) {
+    Scope *s = &c->scopes[i];
+    if (!s->name || !sp_streq(s->name, nm)) continue;
+    if (found >= 0) return -1;
+    found = i;
+  }
+  return found;
+}
+
+/* Param index of `vn` in s->pnames, or -1. */
+static int an_param_idx(Scope *s, const char *vn) {
+  if (!vn) return -1;
+  for (int i = 0; i < s->nparams; i++)
+    if (s->pnames[i] && sp_streq(s->pnames[i], vn)) return i;
+  return -1;
+}
+
+int comp_byref_param(Compiler *c, Scope *m, int idx) {
+  if (!m || idx < 0 || idx >= m->nparams || !m->pnames[idx]) return 0;
+  LocalVar *p = scope_local(m, m->pnames[idx]);
+  return p && p->byref_out;
+}
+
+static void compute_byref_out_params(Compiler *c) {
+  const NodeTable *nt = c->nt;
+  int n = c->nscopes;
+  char *elig = calloc((size_t)n, 1);
+  unsigned *blocked = calloc((size_t)n, sizeof(unsigned));  /* per-scope param bitmask */
+  if (!elig || !blocked) { free(elig); free(blocked); return; }
+
+  for (int si = 1; si < n; si++) {
+    Scope *s = &c->scopes[si];
+    if (!s->name || s->def_node < 0 || s->body < 0) continue;
+    if (s->yields || s->is_lowered_yield || s->dm_subst_name || s->cs_synth) continue;
+    if (s->is_transplanted_source) continue;
+    if (s->class_id >= 0 && !s->is_cmethod) continue;
+    if (s->rest_idx >= 0 || s->kwrest_idx >= 0 || s->npost_rest > 0) continue;
+    if (s->nparams <= 0 || s->nparams > 32 || s->nrequired != s->nparams) continue;
+    int pn = nt_ref(nt, s->def_node, "parameters");
+    if (pn >= 0) {
+      int kn = 0; nt_arr(nt, pn, "keywords", &kn);
+      if (kn > 0) continue;
+    }
+    if (an_unique_scope_by_name(c, s->name) != si) continue;
+    elig[si] = 1;
+  }
+  /* an aliased name reaches the method under another spelling; the alias call
+     sites keep the plain ABI, so the method must too */
+  for (int ci = 0; ci < c->nclasses; ci++) {
+    ClassInfo *cls = &c->classes[ci];
+    for (int a = 0; a < cls->naliases; a++)
+      for (int si = 1; si < n; si++)
+        if (elig[si] && ((cls->alias_old[a] && sp_streq(cls->alias_old[a], c->scopes[si].name)) ||
+                         (cls->alias_new[a] && sp_streq(cls->alias_new[a], c->scopes[si].name))))
+          elig[si] = 0;
+  }
+  for (int id = 0; id < nt->count; id++) {
+    const char *ty = nt_type(nt, id);
+    if (!ty) continue;
+    /* a symbol/string literal spelling the name: send / method(:x) /
+       define_method / respond_to? -- all reach the plain ABI */
+    const char *v = NULL;
+    if (sp_streq(ty, "SymbolNode")) {
+      v = nt_str(nt, id, "value");
+      if (!v) v = nt_str(nt, id, "unescaped");
+    }
+    else if (sp_streq(ty, "StringNode")) {
+      v = nt_str(nt, id, "content");
+      if (!v) v = nt_str(nt, id, "unescaped");
+    }
+    if (v)
+      for (int si = 1; si < n; si++)
+        if (elig[si] && sp_streq(c->scopes[si].name, v)) elig[si] = 0;
+    /* a plain rebind of a param blocks it (see the header comment) */
+    if (sp_streq(ty, "LocalVariableWriteNode") ||
+        sp_streq(ty, "LocalVariableOperatorWriteNode") ||
+        sp_streq(ty, "LocalVariableOrWriteNode") ||
+        sp_streq(ty, "LocalVariableAndWriteNode") ||
+        sp_streq(ty, "LocalVariableTargetNode")) {
+      Scope *s = comp_scope_of(c, id);
+      int si = s ? (int)(s - c->scopes) : -1;
+      if (si > 0 && si < n && elig[si]) {
+        int pi = an_param_idx(s, nt_str(nt, id, "name"));
+        if (pi >= 0 && pi < 32) blocked[si] |= 1u << pi;
+      }
+    }
+  }
+
+  int changed = 1;
+  while (changed) {
+    changed = 0;
+    for (int id = 0; id < nt->count; id++) {
+      const char *ty = nt_type(nt, id);
+      if (!ty || !sp_streq(ty, "CallNode")) continue;
+      Scope *s = comp_scope_of(c, id);
+      int si = s ? (int)(s - c->scopes) : -1;
+      if (si <= 0 || si >= n || !elig[si]) continue;
+      const char *nm = nt_str(nt, id, "name");
+      int recv = nt_ref(nt, id, "receiver");
+      const char *rty = recv >= 0 ? nt_type(nt, recv) : NULL;
+      /* direct mutator: param << ... / param.gsub!(...) */
+      if (rty && sp_streq(rty, "LocalVariableReadNode") && an_str_mutator_name(nm)) {
+        const char *vn = nt_str(nt, recv, "name");
+        int pi = an_param_idx(s, vn);
+        if (pi >= 0 && pi < 32 && !(blocked[si] & (1u << pi))) {
+          LocalVar *p = scope_local(s, vn);
+          if (p && p->is_param && p->type == TY_STRING && !p->is_cell &&
+              !p->rbs_seeded && !p->is_block_param && !p->byref_out) {
+            p->byref_out = 1;
+            p->is_cell = 1;   /* body reads/writes ride the cell deref forms */
+            changed = 1;
+          }
+        }
+      }
+      /* transitive: the param passed on into another method's byref slot */
+      if (recv < 0 || (rty && (sp_streq(rty, "ConstantReadNode") ||
+                               sp_streq(rty, "ConstantPathNode") ||
+                               sp_streq(rty, "SelfNode")))) {
+        int mi = an_unique_scope_by_name(c, nm);
+        if (mi < 0) continue;
+        Scope *m = &c->scopes[mi];
+        int argsN = nt_ref(nt, id, "arguments");
+        int argc2 = 0;
+        const int *argv2 = argsN >= 0 ? nt_arr(nt, argsN, "arguments", &argc2) : NULL;
+        for (int j = 0; j < argc2 && j < m->nparams; j++) {
+          if (!comp_byref_param(c, m, j)) continue;
+          const char *aty = nt_type(nt, argv2[j]);
+          if (!aty || !sp_streq(aty, "LocalVariableReadNode")) continue;
+          const char *vn = nt_str(nt, argv2[j], "name");
+          int pi = an_param_idx(s, vn);
+          if (pi < 0 || pi >= 32 || (blocked[si] & (1u << pi))) continue;
+          LocalVar *p = scope_local(s, vn);
+          if (p && p->is_param && p->type == TY_STRING && !p->is_cell &&
+              !p->rbs_seeded && !p->is_block_param && !p->byref_out) {
+            p->byref_out = 1;
+            p->is_cell = 1;
+            changed = 1;
+          }
+        }
+      }
+    }
+  }
+  free(elig);
+  free(blocked);
+}
+
 void analyze_program(Compiler *c) {
   comp_scope_index_set_frozen(0);  /* scope shape changes during the passes below */
   /* scope 0 = top level */
@@ -4262,6 +4445,11 @@ void analyze_program(Compiler *c) {
     an_ie_class_id = saved2;
   }
 
+  /* Byref string out-params: must run before the STRBUF promotion below so
+     the promotion can exclude locals whose address is passed to a byref slot
+     (a STRBUF local is an sp_String*, not the const char* slot byref needs). */
+  compute_byref_out_params(c);
+
   /* Promote `<<`-appended string locals to mutable strings (TY_STRBUF) so the
      append is amortized O(1) instead of an O(n) copy-concat (which makes a
      build-in-a-loop O(n^2)). This is a storage-only refinement: comp_ntype
@@ -4330,6 +4518,27 @@ void analyze_program(Compiler *c) {
     }
     if (has_reassign_mutate) continue;
     if (lv->rbs_seeded) continue;
+    /* Exclude vars passed into a byref out-param slot: the call site takes
+       the local's address as const char**, which a promoted sp_String* slot
+       cannot provide. */
+    int passed_byref = 0;
+    for (int u = 0; u < c->nt->count && !passed_byref; u++) {
+      const char *uty = nt_type(c->nt, u);
+      if (!uty || !sp_streq(uty, "CallNode")) continue;
+      if (comp_scope_of(c, u) != s) continue;
+      int mi = an_unique_scope_by_name(c, nt_str(c->nt, u, "name"));
+      if (mi < 0) continue;
+      int argsN = nt_ref(c->nt, u, "arguments");
+      int uargc = 0;
+      const int *uargv = argsN >= 0 ? nt_arr(c->nt, argsN, "arguments", &uargc) : NULL;
+      for (int j = 0; j < uargc && j < c->scopes[mi].nparams; j++) {
+        if (!comp_byref_param(c, &c->scopes[mi], j)) continue;
+        const char *aty = nt_type(c->nt, uargv[j]);
+        const char *an2 = aty && sp_streq(aty, "LocalVariableReadNode") ? nt_str(c->nt, uargv[j], "name") : NULL;
+        if (an2 && sp_streq(an2, vn)) { passed_byref = 1; break; }
+      }
+    }
+    if (passed_byref) continue;
     lv->type = TY_STRBUF;
   }
 

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -500,6 +500,10 @@ void emit_scope_decls(Compiler *c, Scope *s, Buf *b) {
     /* Virtual &block slot: skip declaration UNLESS it's a lowered __yblk__ that
        needs a cell (so forwarding procs can capture it). */
     if (s->blk_param && lv->name && sp_streq(lv->name, s->blk_param) && !lv->is_cell) continue;
+    /* Byref string out-param: the C parameter already IS the cell (the
+       caller's rooted slot), so no heap cell, no copy-in, and no root --
+       the pointee lives in the caller's frame, not on the GC heap. */
+    if (lv->byref_out) continue;
     /* Captured-by-closure local: lives in a heap cell so the proc and this
        scope share storage. A param's incoming value is copied into the cell;
        a body local starts at 0. Int and proc cells supported. */
@@ -630,6 +634,12 @@ void emit_method_signature(Compiler *c, Scope *s, Buf *b) {
   for (int i = 0; i < s->nparams; i++) {
     if (wrote++) buf_puts(b, ", ");
     LocalVar *p = scope_local(s, s->pnames[i]);
+    /* byref string out-param: the caller's slot, so body mutation propagates.
+       Named _cell_<name> so the ordinary is_cell deref forms read/write it. */
+    if (p && p->byref_out) {
+      buf_printf(b, "const char * *_cell_%s", s->pnames[i]);
+      continue;
+    }
     TyKind pt = (p && p->type != TY_UNKNOWN) ? p->type : TY_POLY;
     if (!is_scalar_ret(pt)) {
       fprintf(stderr, "spinel: method '%s' param '%s' has unsupported type %s\n",
@@ -726,6 +736,7 @@ static void inherit_transplant_locals(Compiler *c, Scope *s) {
       dl->is_block_param = sl.is_block_param;
       dl->proc_ret = sl.proc_ret;
       dl->is_cell = sl.is_cell;
+      dl->byref_out = sl.byref_out;
     }
     break;
   }

--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -3749,6 +3749,47 @@ int emit_grep_expr(Compiler *c, int id, Buf *b) {
 void emit_arg_or_default(Compiler *c, Scope *m, int idx, int provided, Buf *out) {
   LocalVar *p = scope_local(m, m->pnames[idx]);
   TyKind pt = p ? p->type : TY_INT;
+  /* Byref string out-param: pass the caller's slot (const char**) so the
+     callee's mutation lands in the caller's variable. A plain string local
+     passes its address; an already-celled local (captured, or itself a byref
+     param) passes its cell. Anything else -- literal, expression, ivar,
+     filled default -- materializes a rooted temp and passes that: for a
+     non-lvalue argument CRuby's mutation is equally invisible to the caller,
+     for the rest this keeps the pre-byref behavior. */
+  if (p && p->byref_out) {
+    if (provided >= 0) {
+      const char *aty = nt_type(c->nt, provided);
+      if (aty && sp_streq(aty, "LocalVariableReadNode")) {
+        const char *vn = nt_str(c->nt, provided, "name");
+        if (g_cap_struct && g_cap_names && vn && nameset_has(g_cap_names, vn)) {
+          /* inside a proc body: the capture struct holds the cell pointer */
+          buf_printf(out, "((%s *)_cap)->%s", g_cap_struct, vn);
+          return;
+        }
+        LocalVar *clv = vn ? scope_local(comp_scope_of(c, provided), vn) : NULL;
+        if (clv && clv->type == TY_STRING && clv->is_cell) {
+          buf_printf(out, "_cell_%s", vn);
+          return;
+        }
+        if (clv && clv->type == TY_STRING) {
+          buf_printf(out, "&lv_%s", rename_local(vn));
+          return;
+        }
+      }
+    }
+    Buf ab; memset(&ab, 0, sizeof ab);
+    p->byref_out = 0;   /* reenter for the plain coerced value */
+    emit_arg_or_default(c, m, idx, provided, &ab);
+    p->byref_out = 1;
+    int t = ++g_tmp;
+    emit_indent(g_pre, g_indent);
+    buf_printf(g_pre, "const char *_t%d = %s;\n", t, ab.p ? ab.p : "NULL");
+    emit_indent(g_pre, g_indent);
+    buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", t);
+    buf_printf(out, "&_t%d", t);
+    free(ab.p);
+    return;
+  }
   /* An unused/unresolved param is declared poly (sp_RbVal) in the method
      signature (codegen.c maps TY_UNKNOWN params to TY_POLY); box the argument
      to match, so a virtually-dispatched call into such a slot passes a valid
@@ -4063,6 +4104,9 @@ else {
 static void emit_arg_rooted(Compiler *c, Scope *m, int idx, int provided, Buf *out) {
   LocalVar *p = scope_local(m, m->pnames[idx]);
   TyKind pt = p ? p->type : TY_UNKNOWN;
+  /* a byref out-param arg is a slot address, not a heap value: it hoists its
+     own rooted temp when one is needed (see emit_arg_or_default) */
+  if (p && p->byref_out) { emit_arg_or_default(c, m, idx, provided, out); return; }
   int poly = (pt == TY_POLY);
   if (!poly && !needs_root(pt)) { emit_arg_or_default(c, m, idx, provided, out); return; }
   /* A bare read (local/ivar/const/self/nil/string literal) is already reachable
@@ -4364,6 +4408,13 @@ void emit_args_filled(Compiler *c, int callee_idx, int argsNode, const char *lea
         LocalVar *mp = scope_local(m, m->pnames[i]);
         TyKind et = ep ? ep->type : TY_POLY;
         TyKind mt = mp ? mp->type : TY_POLY;
+        /* forwarding into a byref out-param slot: pass the enclosing param's
+           slot (its cell when it is itself byref/celled, else its address) */
+        if (mp && mp->byref_out && ep && et == TY_STRING) {
+          if (ep->is_cell) buf_printf(out, "_cell_%s", encl->pnames[i]);
+          else buf_printf(out, "&lv_%s", encl->pnames[i]);
+          continue;
+        }
         char txt[80]; snprintf(txt, sizeof txt, "lv_%s", encl->pnames[i]);
         if (mt == TY_POLY && et != TY_POLY) emit_boxed_text(c, et, txt, out);
         else buf_puts(out, txt);
@@ -4580,6 +4631,17 @@ else if (splat_tmp >= 0 && i >= splat_idx) {
         buf_printf(out, "(%d < (_t%d ? _t%d->len : 0) ? %s : %s)", off, splat_tmp, splat_tmp,
                    eb.p ? eb.p : "", db.p ? db.p : default_value(pt));
         free(db.p);
+      }
+      else if (sp && sp->byref_out) {
+        /* a splat element filling a byref out-param slot has no caller
+           variable to write back to: pass a rooted temp's address (the
+           mutation stays local, like the pre-byref behavior). */
+        int bt = ++g_tmp;
+        emit_indent(g_pre, g_indent);
+        buf_printf(g_pre, "const char *_t%d = %s;\n", bt, eb.p ? eb.p : "NULL");
+        emit_indent(g_pre, g_indent);
+        buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", bt);
+        buf_printf(out, "&_t%d", bt);
       }
       else buf_puts(out, eb.p ? eb.p : "");
       free(eb.p);

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -901,6 +901,7 @@ LocalVar *scope_local_intern(Scope *s, const char *name) {
   lv->is_block_param = 0;
   lv->proc_ret = TY_UNKNOWN;
   lv->is_cell = 0;
+  lv->byref_out = 0;
   lv->init_guarded = 0;
   lv->rbs_seeded = 0;
   return lv;

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -37,6 +37,12 @@ typedef struct {
   int is_cell;      /* captured by an escaping proc: lives in a heap cell
                        (mrb_int *_cell_<name>) so the closure and the enclosing
                        scope share mutable storage */
+  int byref_out;    /* (params) a string param the method body mutates in place
+                       (`<<`/bang mutators): passed as const char** so the
+                       mutation lands in the caller's variable, like CRuby's
+                       shared-object semantics. Implies is_cell (body reads and
+                       writes go through *_cell_<name>), but the cell is the
+                       caller's slot -- no heap cell is allocated on entry. */
   int init_guarded; /* (consts) initialized via `CONST = Class.new(...)`: reads
                        during the init raise NameError (uninitialized constant) */
   int rbs_seeded;   /* param type pinned from an --rbs advisory seed: the
@@ -396,6 +402,9 @@ int        comp_ivar_index(ClassInfo *ci, const char *name);  /* -1 if none */
 int        comp_ivar_intern(ClassInfo *ci, const char *name); /* find or add; returns index */
 int        comp_cvar_index(ClassInfo *ci, const char *name);  /* class var; -1 if none */
 int        comp_cvar_intern(ClassInfo *ci, const char *name); /* find or add; returns index */
+/* 1 iff method m's param idx is a byref string out-param (LocalVar.byref_out):
+   passed as const char** so callee mutation lands in the caller's variable. */
+int        comp_byref_param(Compiler *c, Scope *m, int idx);
 /* Find the instance-method scope index for class_id + method name, or -1. */
 int        comp_method_in_class(Compiler *c, int class_id, const char *name);
 /* Freeze/unfreeze the (class_id,name,is_cmethod)->scope lookup index. Frozen

--- a/test/string_param_mutate_byref.rb
+++ b/test/string_param_mutate_byref.rb
@@ -1,0 +1,78 @@
+# A string param mutated via `<<` is a byref out-param: the append lands in
+# the caller's variable, like CRuby's shared-object semantics (the classic
+# pass-an-output-buffer serializer pattern).
+def append(s)
+  s << "world"
+end
+str = "hello".dup
+append(str)
+puts str
+
+# transitive: a wrapper that passes its param on into a byref slot
+def inner(s)
+  s << "!"
+end
+def outer(s)
+  inner(s)
+end
+a = "x".dup
+outer(a)
+puts a
+
+# the mutator's return value is the receiver, usable alongside the mutation
+def bang(s)
+  s << "?"
+end
+b = "y".dup
+r = bang(b)
+puts b
+puts r
+
+# only the mutated param rides byref; its sibling stays a plain value
+def tag(buf, label)
+  buf << "["
+  buf << label
+  buf << "]"
+end
+t = "".dup
+tag(t, "hi")
+puts t
+
+# a non-lvalue argument still compiles (CRuby's mutation is equally
+# invisible to the caller there)
+bang("zzz".dup)
+puts "lit ok"
+
+# a plain rebind keeps value semantics: CRuby `s = ...` rebinds the local,
+# invisible to the caller, so the param must NOT ride byref
+def rebind(s)
+  s = "gone"
+  s << "!"
+end
+u = "keep".dup
+rebind(u)
+puts u
+
+# repeated appends through a call inside a block (build-a-buffer loop)
+def ser(buf, n)
+  buf << n.to_s
+  buf << ","
+end
+o = "".dup
+3.times { |i| ser(o, i) }
+puts o
+
+# a caller variable that is also captured by a proc (celled) passes its cell
+w = "p".dup
+f = proc { w << "c" }
+bang(w)
+f.call
+puts w
+
+# a frozen argument raises FrozenError from inside the callee, like CRuby
+frozen = "locked".freeze
+begin
+  bang(frozen)
+rescue FrozenError
+  puts "FrozenError"
+end

--- a/test/string_param_mutate_byref.rb.expected
+++ b/test/string_param_mutate_byref.rb.expected
@@ -1,0 +1,10 @@
+helloworld
+x!
+y?
+y?
+[hi]
+lit ok
+keep
+0,1,2,
+p?c
+FrozenError


### PR DESCRIPTION
A string passed as a method argument and appended with << inside the callee silently lost the mutation — the pass-an-output-buffer serializer pattern dropped every append: 

```ruby                                                                                                                                                                                                                
def append(s)                                                                                                                                                                                                                
  s << "world"                                                                                                                                                                                                               
end                                                                                                                                                                                                                          
str = "hello".dup                                                                                                                                                                                                            
append(str)                                                                                                                                                                                                                  
puts str   # spinel: "hello"   MRI: "helloworld"
```

CRuby strings are shared heap objects, so the callee mutates the very object the caller passed. Spinel strings are immutable const char* values and << lowers to a local reassignment, so the mutation stopped at the callee with no diagnostic.

Analysis now marks the mutated string params of statically-bound methods byref (LocalVar.byref_out): the C param becomes the caller's slot (const char **_cell_<name>, the closure-cell deref forms the body already emits),  a plain local argument passes its address, an already-celled one passes its cell, and anything else — literal, expression, splat element, filled default — passes a rooted temp, where CRuby's mutation is equally invisible to the caller. Mutation propagates transitively through wrappers that pass their param on into a byref slot (fixpoint). A frozen argument now raises FrozenError from inside the callee, matching CRuby.

Byref changes the C ABI, so eligibility is deliberately narrow: toplevel / class methods whose name is unique program-wide, never aliased and never spelled as a symbol/string literal (send / method(:x) material), with all params required positional. A param that is also plain-reassigned stays a value: CRuby s = ... rebinds the local invisibly to the caller, which a write-through cell would wrongly propagate. Everything outside the guards  keeps the previous value-semantics behavior. STRBUF promotion excludes locals whose address flows into a byref slot.

Covered by `test/string_param_mutate_byref.rb` (direct append, transitive wrapper, return-value use, multi-arg, literal arg, plain-rebind guard, loop serializer, proc-celled caller var, FrozenError).