### PR TITLE
analyze: []= is a string mutator too, so an index-assigned param rides byref

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -3041,7 +3041,7 @@ static int an_str_mutator_name(const char *nm) {
   if (!l) return 0;
   return sp_streq(nm, "<<") || sp_streq(nm, "concat") || sp_streq(nm, "replace") ||
          sp_streq(nm, "prepend") || sp_streq(nm, "insert") || sp_streq(nm, "clear") ||
-         (l > 1 && nm[l - 1] == '!');
+         sp_streq(nm, "[]=") || (l > 1 && nm[l - 1] == '!');
 }
 
 /* Unique method scope index by name across the program, or -1 (absent or

--- a/test/string_param_mutate_byref.rb
+++ b/test/string_param_mutate_byref.rb
@@ -69,6 +69,14 @@ bang(w)
 f.call
 puts w
 
+# element assignment is an in-place mutator too
+def fix(s)
+  s[0] = "X"
+end
+e = "abc".dup
+fix(e)
+puts e
+
 # a frozen argument raises FrozenError from inside the callee, like CRuby
 frozen = "locked".freeze
 begin

--- a/test/string_param_mutate_byref.rb.expected
+++ b/test/string_param_mutate_byref.rb.expected
@@ -7,4 +7,5 @@ lit ok
 keep
 0,1,2,
 p?c
+Xbc
 FrozenError


### PR DESCRIPTION
CRuby's `String#[]=` mutates the receiver in place, but `[]=` was missing from the byref mutator set introduced in #1868 — a param mutated only through element assignment kept value semantics, so the write silently never reached the caller:

```ruby
def fix(s)
  s[0] = "X"
end
v = "abc".dup
fix(v)      # spinel: "abc"   MRI: "Xbc"
```

Adding `[]=` to an_str_mutator_name makes such a param ride byref like the other in-place mutators (<<, replace, bang forms, ...): the element assignment writes through the caller's slot, and every existing eligibility guard (static binding, required positional params, no plain rebind) applies unchanged. 