### PR TITLE
base64: make strict_decode64 actually strict

### DIFF
--- a/packages/base64/sp_base64.c
+++ b/packages/base64/sp_base64.c
@@ -74,9 +74,44 @@ static const char *b64_dec(const char *src, size_t n, const char *alpha) {
   return r;
 }
 
+/* Strict decode (CRuby's `unpack1("m0")`): the input length must be a multiple
+   of 4, every byte must be an alphabet char or valid trailing `=` padding, and
+   any stray byte (whitespace, newline, out-of-alphabet) raises ArgumentError --
+   unlike b64_dec, which silently skips them. */
+static const char *b64_dec_strict(const char *src, size_t n, const char *alpha) {
+  if (n % 4 != 0) sp_raise_cls("ArgumentError", "invalid base64");
+  char *r = sp_str_alloc_raw(n / 4 * 3 + 4);
+  size_t o = 0;
+  for (size_t i = 0; i < n; i += 4) {
+    int q[4]; int npad = 0;
+    for (int k = 0; k < 4; k++) {
+      char c = src[i + k];
+      if (c == '=') {
+        /* `=` is legal only as trailing padding of the final block (position
+           2 with a following `=`, or position 3). */
+        if (i + 4 != n || k < 2) sp_raise_cls("ArgumentError", "invalid base64");
+        npad++; q[k] = 0;
+      } else {
+        if (npad) sp_raise_cls("ArgumentError", "invalid base64");  /* data after pad */
+        int v = b64_val(c, alpha);
+        if (v < 0) sp_raise_cls("ArgumentError", "invalid base64");
+        q[k] = v;
+      }
+    }
+    unsigned acc = ((unsigned)q[0] << 18) | ((unsigned)q[1] << 12) |
+                   ((unsigned)q[2] << 6) | (unsigned)q[3];
+    r[o++] = (char)(acc >> 16);
+    if (npad < 2) r[o++] = (char)(acc >> 8);
+    if (npad < 1) r[o++] = (char)acc;
+  }
+  r[o] = '\0';
+  sp_str_set_len(r, o);
+  return r;
+}
+
 const char *sp_base64_encode64(const char *s)        { return b64_enc(s, sp_str_byte_len(s), B64_STD, 60); }
 const char *sp_base64_strict_encode64(const char *s) { return b64_enc(s, sp_str_byte_len(s), B64_STD, 0); }
 const char *sp_base64_urlsafe_encode64(const char *s){ return b64_enc(s, sp_str_byte_len(s), B64_URL, 0); }
 const char *sp_base64_decode64(const char *s)        { return b64_dec(s, sp_str_byte_len(s), B64_STD); }
-const char *sp_base64_strict_decode64(const char *s) { return b64_dec(s, sp_str_byte_len(s), B64_STD); }
+const char *sp_base64_strict_decode64(const char *s) { return b64_dec_strict(s, sp_str_byte_len(s), B64_STD); }
 const char *sp_base64_urlsafe_decode64(const char *s){ return b64_dec(s, sp_str_byte_len(s), B64_URL); }

--- a/packages/base64/test/base64_strict_decode.rb
+++ b/packages/base64/test/base64_strict_decode.rb
@@ -1,0 +1,30 @@
+require "base64"
+
+# strict_decode64 (CRuby's unpack1("m0")) rejects anything the lax decoder would
+# silently skip: a length that is not a multiple of 4, a newline or whitespace,
+# out-of-alphabet bytes, and misplaced padding all raise ArgumentError. The lax
+# decode64 stays permissive.
+def sd(x); Base64.strict_decode64(x); end
+def check(x)
+  begin
+    r = sd(x)
+    puts "#{x.inspect} => #{r.inspect}"
+  rescue ArgumentError => e
+    puts "#{x.inspect} => AE: #{e.message}"
+  end
+end
+
+check("U2VuZA==")     # "Send"
+check("U2Vu")         # "Sen"
+check("QQ==")         # "A"
+check("")             # ""
+check("U2VuZA==\n")   # AE (trailing newline)
+check("U2V")          # AE (length not a multiple of 4)
+check("U2VuZA")       # AE (unpadded)
+check("QQ")           # AE (unpadded)
+check("AB!C")         # AE (invalid char)
+check("abcd\nefgh")   # AE (embedded newline)
+check("  U2Vu")       # AE (leading spaces)
+
+# The lax decoder is unaffected: it still skips a trailing newline.
+p Base64.decode64("U2VuZA==\n")   # "Send"

--- a/packages/base64/test/base64_strict_decode.rb.expected
+++ b/packages/base64/test/base64_strict_decode.rb.expected
@@ -1,0 +1,12 @@
+"U2VuZA==" => "Send"
+"U2Vu" => "Sen"
+"QQ==" => "A"
+"" => ""
+"U2VuZA==\n" => AE: invalid base64
+"U2V" => AE: invalid base64
+"U2VuZA" => AE: invalid base64
+"QQ" => AE: invalid base64
+"AB!C" => AE: invalid base64
+"abcd\nefgh" => AE: invalid base64
+"  U2Vu" => AE: invalid base64
+"Send"


### PR DESCRIPTION
`Base64.strict_decode64` delegated to the lax decoder, so an embedded newline, whitespace, out-of-alphabet byte, or a length that is not a multiple of 4 was silently skipped or decoded to partial bytes. CRuby's strict form (`unpack1("m0")`) raises `ArgumentError: invalid base64` on any of these.

This adds `b64_dec_strict`, which requires a multiple-of-4 length, rejects any non-alphabet byte, and accepts `=` only as valid trailing padding of the final block. The lax `decode64` is unchanged.