### PR TITLE
runtime: validate Integer#digits radix and reject a negative receiver

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -712,7 +712,7 @@ static sp_Object *sp_Object_new(void){return(sp_Object*)sp_gc_alloc(sizeof(sp_Ob
 /* sp_IntArray lives in sp_array.h (hot core inline) + lib/sp_array.c
    (cold ops). The Integer methods that happen to build an IntArray stay
    here; they call the inline sp_IntArray_new / _push from sp_array.h. */
-static sp_IntArray*sp_int_digits(mrb_int n,mrb_int base){sp_IntArray*a=sp_IntArray_new();if(base<2)base=10;if(n==0){sp_IntArray_push(a,0);return a;}if(n<0)n=-n;while(n>0){sp_IntArray_push(a,n%base);n/=base;}return a;}
+static sp_IntArray*sp_int_digits(mrb_int n,mrb_int base){if(base<0)sp_raise_cls("ArgumentError","negative radix");if(base<2)sp_raise_cls("ArgumentError",sp_sprintf("invalid radix %lld",(long long)base));if(n<0)sp_raise_cls("Math_DomainError","out of domain");sp_IntArray*a=sp_IntArray_new();if(n==0){sp_IntArray_push(a,0);return a;}while(n>0){sp_IntArray_push(a,n%base);n/=base;}return a;}
 /* Integer#bit_length: bits in the two's-complement representation excluding
    the sign bit (a negative n counts the bits of ~n). */
 static mrb_int sp_int_bit_length(mrb_int n){unsigned long long x=(n<0)?(unsigned long long)(~n):(unsigned long long)n;mrb_int b=0;if(x>=1ULL<<32){b+=32;x>>=32;}if(x>=1ULL<<16){b+=16;x>>=16;}if(x>=1ULL<<8){b+=8;x>>=8;}if(x>=1ULL<<4){b+=4;x>>=4;}if(x>=1ULL<<2){b+=2;x>>=2;}if(x>=1ULL<<1){b+=1;x>>=1;}return b+(mrb_int)x;}

--- a/test/integer_digits_invalid_radix.rb
+++ b/test/integer_digits_invalid_radix.rb
@@ -1,0 +1,19 @@
+# Integer#digits validates its radix: a base below 2 raises ArgumentError (a
+# negative base gives "negative radix", 0 or 1 give "invalid radix N"), and a
+# negative receiver raises Math::DomainError. The radix was silently coerced to
+# 10 and a negative receiver silently made positive.
+def d(x, b); x.digits(b); end
+p d(123, 10)                       # [3, 2, 1]
+p d(123, 16)                       # [11, 7]
+
+begin; d(123, 1); rescue ArgumentError => e; puts e.message; end   # invalid radix 1
+begin; d(123, 0); rescue ArgumentError => e; puts e.message; end   # invalid radix 0
+begin; d(123, -5); rescue ArgumentError => e; puts e.message; end  # negative radix
+
+def dn(x); x.digits; end
+# A negative receiver raises Math::DomainError; assert the message (the class
+# renders under its flattened runtime name, a separate display item).
+begin; dn(-123); rescue => e; puts e.message; end                  # out of domain
+
+# The no-arg form still defaults to base 10.
+p dn(90)                           # [0, 9]

--- a/test/integer_digits_invalid_radix.rb.expected
+++ b/test/integer_digits_invalid_radix.rb.expected
@@ -1,0 +1,7 @@
+[3, 2, 1]
+[11, 7]
+invalid radix 1
+invalid radix 0
+negative radix
+out of domain
+[0, 9]


### PR DESCRIPTION
`Integer#digits` silently coerced a radix below 2 to 10 and made a negative receiver positive, so `123.digits(1)` returned `[3, 2, 1]` and `(-123).digits` ran instead of raising.

MRI raises on each: a negative radix is `ArgumentError: negative radix`, a `0` or `1` radix is `ArgumentError: invalid radix N`, and a negative receiver is `Math::DomainError: out of domain`. `sp_int_digits` now raises those instead of masking the invalid input; valid calls are unchanged.

(The negative-receiver test asserts the message rather than the class, since `Math::DomainError` currently renders under its flattened runtime name -- a separate display item shared with `Integer#isqrt`.)