### PR TITLE
codegen,runtime: Math.<fn> rejects a non-numeric argument

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -2063,6 +2063,20 @@ static mrb_float sp_poly_Float(sp_RbVal v) {
   sp_raise_cls("TypeError", sp_sprintf("can't convert %s into Float", sp_convert_src_name(v)));
   return 0.0;
 }
+/* Coerce a value to a C double for a Math.<fn> argument. Math accepts only a
+   real Numeric (no String parsing, unlike Kernel#Float), so nil / String /
+   any non-numeric raises TypeError -- where the lenient sp_poly_to_f coerced
+   nil to 0.0 and a String cast was a C compile error. */
+static mrb_float sp_num_to_f(sp_RbVal v) {
+  if (v.tag == SP_TAG_FLT) return v.v.f;
+  if (v.tag == SP_TAG_INT) return (mrb_float)v.v.i;
+  if (v.tag == SP_TAG_BIGINT) return (mrb_float)sp_bigint_to_int((sp_Bigint *)v.v.p);
+  const char *w = v.tag == SP_TAG_NIL ? "nil"
+                : v.tag == SP_TAG_BOOL ? (v.v.b ? "true" : "false")
+                : sp_poly_class_name(v);
+  sp_raise_cls("TypeError", sp_sprintf("can't convert %s into Float", w));
+  return 0.0;
+}
 /* Numeric queries / rounding on a poly value: dispatch on the runtime tag the
    way CRuby dispatches on the class. A tag whose class does not define the
    method raises CRuby's NoMethodError (e.g. `1.nan?`, `"x".abs`). */

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -3770,6 +3770,19 @@ static int const_name_is_wrong(const char *s) {
   return 0;
 }
 
+/* Emit a Math.<fn> argument as a C double. A statically numeric operand casts
+   directly (hot path for trig-heavy code); anything else is boxed and coerced
+   through sp_num_to_f, which raises TypeError for nil / String / non-numeric
+   rather than the lenient sp_poly_to_f's 0.0 (or a String->double CC error). */
+static void emit_math_arg(Compiler *c, int node, Buf *out) {
+  TyKind t = comp_ntype(c, node);
+  if (t == TY_INT || t == TY_FLOAT) {
+    buf_puts(out, "(mrb_float)("); emit_expr(c, node, out); buf_puts(out, ")");
+    return;
+  }
+  buf_puts(out, "sp_num_to_f("); emit_boxed(c, node, out); buf_puts(out, ")");
+}
+
 void emit_call(Compiler *c, int id, Buf *b) {
   const NodeTable *nt = c->nt;
   if (emit_dynamic_send(c, id, b)) return;   /* recv.send(runtime_name, args) static dispatch */
@@ -6987,36 +7000,36 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     else if (sp_streq(name, "erfc"))  cfn = "erfc";
     else if (sp_streq(name, "gamma")) cfn = "sp_math_gamma";
     if (cfn && argc == 1) {
-      /* emit_float_expr casts a plain int and unboxes a poly value alike
-         (sp_poly_to_f) -- a bare `if (a0t==TY_INT) "(double)"` cast, as this
-         used to do, left a poly-typed arg (e.g. `Math.sqrt(dx*dx + dy*dy)`
-         over locals that unify to Integer|Float) passed straight through as
-         an unconvertible sp_RbVal. */
+      /* emit_math_arg casts a plain int and coerces a poly value alike -- a
+         bare `if (a0t==TY_INT) "(double)"` cast left a poly-typed arg (e.g.
+         `Math.sqrt(dx*dx + dy*dy)` over locals that unify to Integer|Float)
+         passed straight through as an unconvertible sp_RbVal -- and raises
+         TypeError on a nil / String / non-numeric operand. */
       buf_printf(b, "%s(", cfn);
-      emit_float_expr(c, argv[0], b);
+      emit_math_arg(c, argv[0], b);
       buf_puts(b, ")");
       return;
     }
     if (sp_streq(name, "lgamma") && argc == 1) {
       /* Math.lgamma(x) -> [log(|gamma(x)|), sign] as a poly array */
-      buf_puts(b, "sp_math_lgamma("); emit_float_expr(c, argv[0], b); buf_puts(b, ")");
+      buf_puts(b, "sp_math_lgamma("); emit_math_arg(c, argv[0], b); buf_puts(b, ")");
       return;
     }
     /* Math.log(x) or Math.log(x, base) */
     if (sp_streq(name, "log") && (argc == 1 || argc == 2)) {
       if (argc == 1) {
         buf_puts(b, "sp_math_log(");
-        emit_float_expr(c, argv[0], b);
+        emit_math_arg(c, argv[0], b);
         buf_puts(b, ")");
       }
       else {
         int t0 = ++g_tmp, t1 = ++g_tmp;
         emit_indent(g_pre, g_indent);
         buf_printf(g_pre, "double _t%d = ", t0);
-        emit_float_expr(c, argv[0], g_pre); buf_puts(g_pre, ";\n");
+        emit_math_arg(c, argv[0], g_pre); buf_puts(g_pre, ";\n");
         emit_indent(g_pre, g_indent);
         buf_printf(g_pre, "double _t%d = ", t1);
-        emit_float_expr(c, argv[1], g_pre); buf_puts(g_pre, ";\n");
+        emit_math_arg(c, argv[1], g_pre); buf_puts(g_pre, ";\n");
         buf_printf(b, "(sp_math_log(_t%d) / sp_math_log(_t%d))", t0, t1);
       }
       return;
@@ -7024,24 +7037,24 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     /* Math.log2(x), Math.log10(x) */
     if (sp_streq(name, "log2") && argc == 1) {
       buf_puts(b, "sp_math_log2(");
-      emit_float_expr(c, argv[0], b); buf_puts(b, ")");
+      emit_math_arg(c, argv[0], b); buf_puts(b, ")");
       return;
     }
     if (sp_streq(name, "log10") && argc == 1) {
       buf_puts(b, "sp_math_log10(");
-      emit_float_expr(c, argv[0], b); buf_puts(b, ")");
+      emit_math_arg(c, argv[0], b); buf_puts(b, ")");
       return;
     }
     /* Math.atan2(y, x), Math.hypot(x, y), Math.ldexp(x, e) */
     if ((sp_streq(name, "atan2") || sp_streq(name, "hypot")) && argc == 2) {
       buf_printf(b, "%s(", name);
-      emit_float_expr(c, argv[0], b); buf_puts(b, ", ");
-      emit_float_expr(c, argv[1], b); buf_puts(b, ")");
+      emit_math_arg(c, argv[0], b); buf_puts(b, ", ");
+      emit_math_arg(c, argv[1], b); buf_puts(b, ")");
       return;
     }
     if (sp_streq(name, "ldexp") && argc == 2) {
       buf_puts(b, "ldexp(");
-      emit_float_expr(c, argv[0], b); buf_puts(b, ", (int)");
+      emit_math_arg(c, argv[0], b); buf_puts(b, ", (int)");
       emit_expr(c, argv[1], b); buf_puts(b, ")");
       return;
     }

--- a/test/math_fn_nil_typeerror.rb
+++ b/test/math_fn_nil_typeerror.rb
@@ -1,0 +1,18 @@
+# Math.<fn> accepts only a real Numeric: nil, a String, a Symbol, or any other
+# non-numeric argument raises TypeError (Math does not parse strings). Spinel
+# previously coerced nil to 0.0 and a String cast was a C compile error.
+def ms(x); Math.sqrt(x); end
+
+[nil, :sym, "2", [1]].each do |v|
+  begin; ms(v); rescue => e; puts "#{e.class}: #{e.message}"; end
+end
+
+# valid numeric inputs (Integer and Float) still work across the fn family.
+p Math.sqrt(9)          # 3.0
+p Math.sqrt(2.0)        # 1.4142135623730951
+p Math.log(1.0)         # 0.0
+p Math.hypot(3, 4)      # 5.0
+p Math.log2(8)          # 3.0
+
+def ml(x); Math.log(x); end
+begin; ml(nil); rescue => e; puts "#{e.class}: #{e.message}"; end

--- a/test/math_fn_nil_typeerror.rb.expected
+++ b/test/math_fn_nil_typeerror.rb.expected
@@ -1,0 +1,10 @@
+TypeError: can't convert nil into Float
+TypeError: can't convert Symbol into Float
+TypeError: can't convert String into Float
+TypeError: can't convert Array into Float
+3.0
+1.4142135623730951
+0.0
+5.0
+3.0
+TypeError: can't convert nil into Float


### PR DESCRIPTION
Every `Math.<fn>` coerced its argument through the lenient `emit_float_expr`, which unboxed a poly value with `sp_poly_to_f` (treating `nil` as `0.0`) and cast a String straight to `double` (a C compile error):

```ruby
def f(x); Math.sqrt(x); end
p f(nil)        # MRI: TypeError   was: 0.0
Math.sqrt("2")  # MRI: TypeError   was: C compile error
```

Each Math argument now routes through a new `emit_math_arg`: a statically numeric operand casts directly (the hot trig path), anything else is boxed and coerced by `sp_num_to_f`, which accepts only a real Numeric and otherwise raises `TypeError` ("can’t convert X into Float"). Math does not parse Strings, unlike `Kernel#Float`. Applies across the whole family (sqrt/sin/cos/log/hypot/atan2/…).