### PR TITLE
codegen,runtime: Kernel#Integer/Float reject nil strictly

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -2031,6 +2031,37 @@ static mrb_float sp_poly_to_f(sp_RbVal v) { if (v.tag == SP_TAG_FLT) return v.v.
    returns nil there) instead of coercing to 0.0 like sp_poly_to_f. */
 static mrb_float sp_poly_to_f_opt(sp_RbVal v) { return v.tag == SP_TAG_NIL ? sp_float_nil() : sp_poly_to_f(v); }
 static mrb_bool sp_poly_numeric_p(sp_RbVal v) { return v.tag == SP_TAG_INT || v.tag == SP_TAG_FLT || v.tag == SP_TAG_BIGINT; }
+/* Display form of a value in a `can't convert %s into ...` TypeError:
+   nil/true/false render lowercase, everything else by class name (CRuby). */
+static const char *sp_convert_src_name(sp_RbVal v) {
+  if (v.tag == SP_TAG_NIL) return "nil";
+  if (v.tag == SP_TAG_BOOL) return v.v.b ? "true" : "false";
+  return sp_poly_class_name(v);
+}
+/* Kernel#Integer / Kernel#Float: STRICT coercion. Unlike the lenient
+   sp_poly_to_i / sp_poly_to_f (which treat nil as 0 for `nil.to_i`), these
+   raise TypeError on nil / a non-numeric object and ArgumentError on an
+   unparseable String, matching CRuby's conversion methods. */
+static mrb_int sp_poly_Integer(sp_RbVal v) {
+  if (v.tag == SP_TAG_INT) return v.v.i;
+  if (v.tag == SP_TAG_BIGINT) return (mrb_int)sp_bigint_to_int((sp_Bigint *)v.v.p);
+  if (v.tag == SP_TAG_FLT) {
+    if (isnan(v.v.f) || isinf(v.v.f))
+      sp_raise_cls("FloatDomainError", sp_sprintf("%g", v.v.f));
+    return (mrb_int)v.v.f;
+  }
+  if (v.tag == SP_TAG_STR) return (mrb_int)sp_str_to_i_strict(v.v.s ? v.v.s : sp_str_empty);
+  sp_raise_cls("TypeError", sp_sprintf("can't convert %s into Integer", sp_convert_src_name(v)));
+  return 0;
+}
+static mrb_float sp_poly_Float(sp_RbVal v) {
+  if (v.tag == SP_TAG_FLT) return v.v.f;
+  if (v.tag == SP_TAG_INT) return (mrb_float)v.v.i;
+  if (v.tag == SP_TAG_BIGINT) return sp_poly_to_f(v);
+  if (v.tag == SP_TAG_STR) return sp_str_to_f_strict(v.v.s ? v.v.s : sp_str_empty);
+  sp_raise_cls("TypeError", sp_sprintf("can't convert %s into Float", sp_convert_src_name(v)));
+  return 0.0;
+}
 /* Numeric queries / rounding on a poly value: dispatch on the runtime tag the
    way CRuby dispatches on the class. A tag whose class does not define the
    method raises CRuby's NoMethodError (e.g. `1.nan?`, `"x".abs`). */

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -5006,7 +5006,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       TyKind at = comp_ntype(c, av[0]);
       if (at == TY_STRING) { buf_puts(b, "sp_str_to_i_strict("); emit_expr(c, av[0], b); buf_puts(b, ")"); }
       else if (at == TY_FLOAT) { buf_puts(b, "((mrb_int)("); emit_expr(c, av[0], b); buf_puts(b, "))"); }
-      else if (at == TY_POLY) { buf_puts(b, "sp_poly_to_i("); emit_expr(c, av[0], b); buf_puts(b, ")"); }
+      else if (at == TY_POLY) { buf_puts(b, "sp_poly_Integer("); emit_expr(c, av[0], b); buf_puts(b, ")"); }
       else { buf_puts(b, "("); emit_expr(c, av[0], b); buf_puts(b, ")"); }
       return;
     }
@@ -5023,7 +5023,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       TyKind at = comp_ntype(c, av[0]);
       if (at == TY_STRING) { buf_puts(b, "sp_str_to_f_strict("); emit_expr(c, av[0], b); buf_puts(b, ")"); }
       else if (at == TY_INT) { buf_puts(b, "((mrb_float)("); emit_expr(c, av[0], b); buf_puts(b, "))"); }
-      else if (at == TY_POLY) { buf_puts(b, "sp_poly_to_f("); emit_expr(c, av[0], b); buf_puts(b, ")"); }
+      else if (at == TY_POLY) { buf_puts(b, "sp_poly_Float("); emit_expr(c, av[0], b); buf_puts(b, ")"); }
       else { buf_puts(b, "("); emit_expr(c, av[0], b); buf_puts(b, ")"); }
       return;
     }

--- a/test/kernel_integer_float_strict_nil.rb
+++ b/test/kernel_integer_float_strict_nil.rb
@@ -1,0 +1,27 @@
+# Kernel#Integer / Kernel#Float are STRICT: nil or a non-numeric object raises
+# TypeError, an unparseable String raises ArgumentError. They must not coerce
+# nil to 0 the way the lenient nil.to_i / nil.to_f do.
+def i(x); Integer(x); end
+def fl(x); Float(x); end
+
+[nil, :sym, true, [1]].each do |v|
+  begin; i(v); rescue => e; puts "#{e.class}: #{e.message}"; end
+end
+begin; i("12abc"); rescue => e; puts "#{e.class}: #{e.message}"; end
+
+# valid inputs unchanged
+p i(3.9)      # 3 (truncates)
+p i("42")     # 42
+p i(7)        # 7
+
+[nil, :sym].each do |v|
+  begin; fl(v); rescue => e; puts "#{e.class}: #{e.message}"; end
+end
+begin; fl("x"); rescue => e; puts "#{e.class}: #{e.message}"; end
+
+p fl(5)       # 5.0
+p fl("3.5")   # 3.5
+
+# lenient nil.to_i / nil.to_f are unaffected (still 0 / 0.0)
+p nil.to_i    # 0
+p nil.to_f    # 0.0

--- a/test/kernel_integer_float_strict_nil.rb.expected
+++ b/test/kernel_integer_float_strict_nil.rb.expected
@@ -1,0 +1,15 @@
+TypeError: can't convert nil into Integer
+TypeError: can't convert Symbol into Integer
+TypeError: can't convert true into Integer
+TypeError: can't convert Array into Integer
+ArgumentError: invalid value for Integer(): "12abc"
+3
+42
+7
+TypeError: can't convert nil into Float
+TypeError: can't convert Symbol into Float
+ArgumentError: invalid value for Float(): "x"
+5.0
+3.5
+0
+0.0


### PR DESCRIPTION
`Integer(x)` and `Float(x)` with a poly argument lowered to the lenient `sp_poly_to_i` / `sp_poly_to_f`, which treat `nil` as `0` — correct for `nil.to_i`, wrong for the strict Kernel conversions:

```ruby
def f(x); Integer(x); end
p f(nil)   # MRI: TypeError (can't convert nil into Integer)   was: 0
```

The poly arg now routes through new strict `sp_poly_Integer` / `sp_poly_Float` helpers: a nil or non-numeric object raises `TypeError`, an unparseable String raises `ArgumentError` via the existing strict parsers, and a non-finite Float raises `FloatDomainError`. Messages match CRuby byte-for-byte. The lenient `nil.to_i` / `nil.to_f` paths are untouched. The sibling `Math.<fn>(nil)` case is handled separately.