### PR TITLE
runtime,codegen: validate Random#rand's bound and keep a Float bound's type

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -6339,12 +6339,19 @@ static sp_Random *sp_Random_new(mrb_int seed) {
   return r;
 }
 static mrb_int sp_Random_rand_int(sp_Random *r, mrb_int n) {
-  if (!r || n <= 0) return 0;
+  if (n <= 0) sp_raise_cls("ArgumentError", sp_sprintf("invalid argument - %lld", (long long)n));
+  if (!r) return 0;
   return (mrb_int)(sp_random_next(r) % (uint64_t)n);
 }
 static mrb_float sp_Random_rand_float(sp_Random *r) {
   if (!r) return 0.0;
   return (mrb_float)(sp_random_next(r) >> 11) / (mrb_float)(1ULL << 53);
+}
+/* Random#rand(Float bound): a random Float in [0, bound). A non-positive bound
+   raises ArgumentError like the Integer form (MRI validates both). */
+static mrb_float sp_Random_rand_float_bound(sp_Random *r, mrb_float bound) {
+  if (bound <= 0) sp_raise_cls("ArgumentError", sp_sprintf("invalid argument - %s", sp_float_to_s(bound)));
+  return sp_Random_rand_float(r) * bound;
 }
 /* Class-method forms (`Random.rand` / `Random.bytes`) share one
    lazily-seeded default instance, mirroring CRuby's Random::DEFAULT. */

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -1439,9 +1439,10 @@ else {
           (sp_streq(name, "report_on_exception") || sp_streq(name, "report_on_exception="))) return TY_BOOL;
       if (cn2 && sp_streq(cn2, "Fiber") && sp_streq(name, "current")) return TY_FIBER;
       if (cn2 && sp_streq(cn2, "Fiber") && sp_streq(name, "yield")) return TY_POLY;
-      /* Random class methods: Random.rand(n)->int / Random.rand->float */
+      /* Random class methods: Random.rand(float)->float / Random.rand(int)->int
+         / Random.rand->float */
       if (cn2 && sp_streq(cn2, "Random") && sp_streq(name, "rand"))
-        return argc >= 1 ? TY_INT : TY_FLOAT;
+        return argc >= 1 ? (infer_type(c, argv[0]) == TY_FLOAT ? TY_FLOAT : TY_INT) : TY_FLOAT;
       if (cn2 && sp_streq(cn2, "Random") && sp_streq(name, "bytes")) return TY_STRING;
     }
   }
@@ -1519,7 +1520,8 @@ else {
 
   /* TY_RANDOM instance methods */
   if (recv >= 0 && rt == TY_RANDOM) {
-    if (sp_streq(name, "rand")) return argc >= 1 ? TY_INT : TY_FLOAT;
+    if (sp_streq(name, "rand"))
+      return argc >= 1 ? (infer_type(c, argv[0]) == TY_FLOAT ? TY_FLOAT : TY_INT) : TY_FLOAT;
     if (sp_streq(name, "bytes")) return TY_STRING;
     if (sp_streq(name, "seed")) return TY_INT;
   }

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -4601,7 +4601,11 @@ void emit_call(Compiler *c, int id, Buf *b) {
   if (recv >= 0 && nt_type(nt, recv) && sp_streq(nt_type(nt, recv), "ConstantReadNode") &&
       nt_str(nt, recv, "name") && sp_streq(nt_str(nt, recv, "name"), "Random")) {
     if (sp_streq(name, "rand")) {
-      if (argc >= 1) {
+      if (argc >= 1 && comp_ntype(c, argv[0]) == TY_FLOAT) {
+        buf_puts(b, "sp_Random_rand_float_bound(sp_random_default_get(), ");
+        emit_expr(c, argv[0], b); buf_puts(b, ")");
+      }
+      else if (argc >= 1) {
         buf_puts(b, "sp_Random_rand_int(sp_random_default_get(), ");
         emit_expr(c, argv[0], b); buf_puts(b, ")");
       }
@@ -4618,7 +4622,11 @@ void emit_call(Compiler *c, int id, Buf *b) {
   /* Random instance methods */
   if (recv >= 0 && comp_ntype(c, recv) == TY_RANDOM) {
     if (sp_streq(name, "rand")) {
-      if (argc >= 1) {
+      if (argc >= 1 && comp_ntype(c, argv[0]) == TY_FLOAT) {
+        buf_puts(b, "sp_Random_rand_float_bound("); emit_expr(c, recv, b); buf_puts(b, ", ");
+        emit_expr(c, argv[0], b); buf_puts(b, ")");
+      }
+      else if (argc >= 1) {
         buf_puts(b, "sp_Random_rand_int("); emit_expr(c, recv, b); buf_puts(b, ", ");
         emit_expr(c, argv[0], b); buf_puts(b, ")");
       }

--- a/test/random_rand_argument.rb
+++ b/test/random_rand_argument.rb
@@ -1,0 +1,21 @@
+# Random#rand validates its bound and preserves a Float bound's return type. A
+# non-positive bound (Integer or Float) silently returned 0; MRI raises
+# ArgumentError "invalid argument - <n>". A Float bound was truncated to an
+# integer bound and dispatched to the integer path, losing the Float return.
+def ri(x); Random.new(5).rand(x); end
+begin; ri(0); rescue ArgumentError => e; puts e.message; end       # invalid argument - 0
+begin; ri(-12); rescue ArgumentError => e; puts e.message; end     # invalid argument - -12
+
+def rf(x); Random.new(5).rand(x); end
+begin; rf(-1.5); rescue ArgumentError => e; puts e.message; end    # invalid argument - -1.5
+
+# A Float bound returns a Float in [0, bound); an Integer bound returns an Integer.
+def clsf(x); Random.new(5).rand(x).class; end
+p clsf(20.43)                       # Float
+def clsi(x); Random.new(5).rand(x).class; end
+p clsi(5)                           # Integer
+
+def inrange(x); v = Random.new(5).rand(x); v >= 0.0 && v < 20.43; end
+p inrange(20.43)                    # true
+def ltbound(x); Random.new(5).rand(x) < 10; end
+p ltbound(10)                       # true

--- a/test/random_rand_argument.rb.expected
+++ b/test/random_rand_argument.rb.expected
@@ -1,0 +1,7 @@
+invalid argument - 0
+invalid argument - -12
+invalid argument - -1.5
+Float
+Integer
+true
+true


### PR DESCRIPTION
`Random#rand` silently returned `0` for a non-positive bound and truncated a Float bound to the integer path, so `rand(0)` and `rand(-12)` yielded `0` (MRI raises `ArgumentError: invalid argument - N`) and `rand(20.43)` returned an `Integer` instead of a `Float`.

`sp_Random_rand_int` now raises `ArgumentError` for a bound `<= 0`. A new `sp_Random_rand_float_bound` returns a Float in `[0, bound)` and raises the same on a non-positive bound; codegen routes a Float argument to it, and type inference reports `Float` for a Float bound (`Integer` otherwise).

A poly-typed bound (a bound param unified across Integer and Float call sites) still routes to the integer path -- a pre-existing limitation of the monomorphic dispatch, unchanged here.