### PR TITLE
codegen,runtime: a bare rescue matches only StandardError

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -5008,7 +5008,7 @@ static mrb_int sp_exc_is_a(volatile sp_Exception *ve, const char *cn) {
     {"IOError",               "StandardError"},
     {"EOFError",              "IOError"},
     {"ZeroDivisionError",     "StandardError"},
-    {"NotImplementedError",   "StandardError"},
+    {"NotImplementedError",   "ScriptError"},
     {"StopIteration",         "IndexError"},
     {"FloatDomainError",      "RangeError"},
     {"Math_DomainError",      "StandardError"},
@@ -5068,7 +5068,7 @@ static int sp_exc_cls_matches(const char *raised, const char *target) {
     {"IOError",              "StandardError"},
     {"EOFError",             "IOError"},
     {"ZeroDivisionError",    "StandardError"},
-    {"NotImplementedError",  "StandardError"},
+    {"NotImplementedError",  "ScriptError"},
     {"StopIteration",        "IndexError"},
     {"FloatDomainError",     "RangeError"},
     {"Math_DomainError",     "StandardError"},
@@ -5102,6 +5102,34 @@ static int sp_exc_cls_matches(const char *raised, const char *target) {
   }
   if (!strcmp(target, "Object") || !strcmp(target, "BasicObject") || !strcmp(target, "Kernel")) return 1;
   return 0;
+}
+
+/* Does `raised` descend from StandardError? Used by a bare `rescue` (no class),
+   which catches StandardError and its subclasses only. CRuby's non-StandardError
+   branch is a small fixed set of system exceptions; EVERY other exception -- all
+   library and user classes -- descends from StandardError. So an unknown class
+   (a C-raised package error like JSON::ParserError, or a user class with no
+   registered parent) defaults to StandardError; only the listed roots and their
+   subclasses answer false. */
+static int sp_exc_is_standard_error(const char *raised) {
+  if (!raised) return 0;
+  static const char *const NONSTD[] = {
+    "Exception", "NoMemoryError", "ScriptError", "LoadError",
+    "NotImplementedError", "SyntaxError", "SecurityError", "SignalException",
+    "Interrupt", "SystemExit", "SystemStackError", "fatal", NULL
+  };
+  const char *cls = raised;
+  for (int depth = 0; depth < 30 && cls; depth++) {
+    if (!strcmp(cls, "StandardError")) return 1;
+    for (int i = 0; NONSTD[i]; i++)
+      if (!strcmp(cls, NONSTD[i])) return 0;
+    /* walk user subclasses toward their declared parent; a builtin StandardError
+       subclass has no user parent and terminates here, defaulting to true. */
+    const char *parent = sp_user_exc_parent_fn ? sp_user_exc_parent_fn(cls) : NULL;
+    if (!parent) return 1;
+    cls = parent;
+  }
+  return 1;
 }
 
 /* Cross-TU bridge for sp_bigint.c (compiled as a separate translation

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -3703,9 +3703,13 @@ void emit_rescue(Compiler *c, int id, Buf *b, int indent, int fr, const char *re
   emit_indent(b, indent);
   buf_printf(b, "const char *_rmsg_%d = sp_exc_msg[sp_exc_top]; (void)_rmsg_%d;\n", rc, rc);
 
-  /* type-match condition: catch-all when no types or a StandardError-ish
-     type; otherwise exact class-name match */
-  int catchall = (nexc == 0);
+  /* type-match condition: an explicit StandardError-ish type is treated as a
+     catch-all; otherwise exact class-name (hierarchy-aware) match. A BARE
+     rescue (no types) is NOT unconditional: CRuby matches only StandardError
+     and its subclasses, so a raised Exception/ScriptError/NotImplementedError
+     falls through to a later `rescue Exception`. */
+  int bare = (nexc == 0);
+  int catchall = 0;
   for (int i = 0; i < nexc; i++) {
     const char *en = nt_type(nt, exc[i]);
     if (en && sp_streq(en, "ConstantReadNode") && rescue_is_catchall_name(nt_str(nt, exc[i], "name")))
@@ -3720,6 +3724,10 @@ void emit_rescue(Compiler *c, int id, Buf *b, int indent, int fr, const char *re
   if (!catchall) {
     emit_indent(b, indent);
     buf_puts(b, "if (");
+    if (bare) {
+    /* bare rescue: match StandardError and its subclasses only */
+    buf_printf(b, "sp_exc_is_standard_error(_rcls_%d)", rc);
+    } else {
     int first = 1;
     for (int i = 0; i < nexc; i++) {
       const char *en = nt_type(nt, exc[i]);
@@ -3779,6 +3787,7 @@ void emit_rescue(Compiler *c, int id, Buf *b, int indent, int fr, const char *re
         buf_printf(b, "sp_str_eq(_rcls_%d, \"%s\")", rc, ename);
     }
     if (first) buf_puts(b, "1");  /* no usable type -> always */
+    }
     buf_puts(b, ") {\n");
     indent++;
   }

--- a/test/bare_rescue_standard_error_only.rb
+++ b/test/bare_rescue_standard_error_only.rb
@@ -1,0 +1,22 @@
+# A bare `rescue` matches only StandardError and its subclasses. An Exception
+# or NotImplementedError (which is a ScriptError, not a StandardError) falls
+# through to a later `rescue Exception`.
+def br(e)
+  begin
+    raise e
+  rescue => x
+    "bare"
+  rescue Exception => x
+    "typed"
+  end
+end
+
+p br(NotImplementedError.new)   # "typed"  (NotImplementedError < ScriptError)
+p br(Exception.new)             # "typed"
+p br(ArgumentError.new)         # "bare"   (ArgumentError < StandardError)
+p br(RuntimeError.new)          # "bare"
+p br(KeyError.new)              # "bare"   (KeyError < IndexError < StandardError)
+
+# NotImplementedError is NOT a StandardError.
+p NotImplementedError.new.is_a?(StandardError)   # false
+p NotImplementedError.new.is_a?(ScriptError)     # true

--- a/test/bare_rescue_standard_error_only.rb.expected
+++ b/test/bare_rescue_standard_error_only.rb.expected
@@ -1,0 +1,7 @@
+"typed"
+"typed"
+"bare"
+"bare"
+"bare"
+false
+true


### PR DESCRIPTION
An implicit bare `rescue` (no exception class) was compiled as an unconditional catch-all, so it swallowed `Exception`, `ScriptError`, `NotImplementedError`, and every other non-`StandardError` exception — silently altering control flow, where CRuby lets them fall through to a later `rescue Exception`.

```ruby
def br(e)
  begin; raise e; rescue => x; "bare"; rescue Exception => x; "typed"; end
end
p br(NotImplementedError.new)  # MRI: "typed"   was: "bare"
p br(ArgumentError.new)        # MRI: "bare"    ok
```

The bare clause now emits a runtime `StandardError`-descent test via a new `sp_exc_is_standard_error` predicate. Its non-`StandardError` branch is the small fixed set of system exceptions; every other class — all library and user exceptions — defaults to `StandardError`, so a C-raised package error like `JSON::ParserError` is still caught while a `NotImplementedError` is not. The built-in hierarchy is also corrected: `NotImplementedError` descends from `ScriptError`, not `StandardError`.

Full suite green; verified under `SPINEL_GC_STRESS`.