### PR TITLE
codegen: Kernel#Rational parses a String and rejects a zero denominator

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -1080,13 +1080,35 @@ static int emit_complex_rational_call(Compiler *c, int id, Buf *b) {
     return 1;
   }
   if (recv < 0 && sp_streq(name, "Rational") && (argc == 1 || argc == 2)) {
-    buf_puts(b, "sp_rational_new((mrb_int)(");
-    emit_expr(c, argv[0], b);
-    buf_puts(b, "), (mrb_int)(");
-    if (argc == 2) emit_expr(c, argv[1], b);
-    else buf_puts(b, "1");
-    buf_puts(b, "))");
-    return 1;
+    /* Rational(String): parse "n", "n/d", or "n.d" like String#to_r rather than
+       reading the string pointer as an integer. */
+    if (argc == 1 && comp_ntype(c, argv[0]) == TY_STRING) {
+      Buf sb = expr_buf(c, argv[0]);
+      buf_printf(b, "sp_str_to_r(%s)", sb.p ? sb.p : "\"\"");
+      free(sb.p);
+      return 1;
+    }
+    if (argc == 2) {
+      /* a zero denominator raises ZeroDivisionError (CRuby), not (n/0). Both
+         arguments are evaluated first, in order. Render each into a local Buf so
+         a complex argument's prelude is hoisted whole to g_pre, not spliced into
+         this line when b is g_pre. */
+      int tn = ++g_tmp, td = ++g_tmp;
+      Buf nb = expr_buf(c, argv[0]);
+      Buf db = expr_buf(c, argv[1]);
+      buf_printf(b, "({ mrb_int _t%d = (mrb_int)(%s); mrb_int _t%d = (mrb_int)(%s);"
+                    " if (_t%d == 0) sp_raise_cls(\"ZeroDivisionError\", \"divided by 0\");"
+                    " sp_rational_new(_t%d, _t%d); })",
+                 tn, nb.p ? nb.p : "0", td, db.p ? db.p : "0", td, tn, td);
+      free(nb.p); free(db.p);
+      return 1;
+    }
+    {
+      Buf sb = expr_buf(c, argv[0]);
+      buf_printf(b, "sp_rational_new((mrb_int)(%s), (mrb_int)(1))", sb.p ? sb.p : "0");
+      free(sb.p);
+      return 1;
+    }
   }
   if (recv >= 0) {
     const char *rrty = nt_type(nt, recv);

--- a/test/kernel_rational_string_zerodenom.rb
+++ b/test/kernel_rational_string_zerodenom.rb
@@ -1,0 +1,23 @@
+# Kernel#Rational parses a String argument ("n", "n/d", "n.d", with optional
+# whitespace and sign) instead of reading the string pointer as an integer, and
+# raises ZeroDivisionError for a zero denominator instead of building (n/0).
+def r1(s); Rational(s); end
+p r1("3/4")                    # (3/4)
+p r1("  -5/2 ")                # (-5/2)
+p r1("6")                      # (6/1)
+p r1("2.5")                    # (5/2)
+
+def r2(a, b); Rational(a, b); end
+p r2(6, 4)                     # (3/2)  (still reduces)
+p r2(-1, 3)                    # (-1/3)
+
+def check
+  yield
+rescue ZeroDivisionError => e
+  puts "ZeroDivisionError: #{e.message}"
+end
+check { r2(1, 0) }             # ZeroDivisionError: divided by 0
+check { r2(0, 0) }             # ZeroDivisionError: divided by 0
+
+# The single-argument integer form is unchanged.
+p Rational(3)                  # (3/1)

--- a/test/kernel_rational_string_zerodenom.rb.expected
+++ b/test/kernel_rational_string_zerodenom.rb.expected
@@ -1,0 +1,9 @@
+(3/4)
+(-5/2)
+(6/1)
+(5/2)
+(3/2)
+(-1/3)
+ZeroDivisionError: divided by 0
+ZeroDivisionError: divided by 0
+(3/1)


### PR DESCRIPTION
`Rational(str)` cast the string pointer to an integer (garbage), and `Rational(n, 0)` built `(n/0)` instead of raising.

Parse a String argument with `sp_str_to_r` (the same "n", "n/d", "n.d" grammar as `String#to_r`), and for the two-argument form evaluate both arguments then raise `ZeroDivisionError` ("divided by 0") when the denominator is zero.

Test `kernel_rational_string_zerodenom.rb` covers the string forms (fraction, sign+whitespace, whole, decimal), the reducing two-argument form, and the zero-denominator raises, verified against the Ruby oracle. A Float argument still truncates (`Rational(2.5)` -> `(2/1)`), left as a follow-up.