### PR TITLE
codegen: defined?(yield) reflects block presence at runtime

### DIFF
--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -1427,7 +1427,6 @@ void emit_expr(Compiler *c, int id, Buf *b) {
                sp_streq(vt, "SourceEncodingNode") || sp_streq(vt, "ForNode") ||
                sp_streq(vt, "WhileNode") || sp_streq(vt, "UntilNode"))
         res = "expression";
-      else if (sp_streq(vt, "YieldNode")) res = "yield";
     }
     /* a CONTAINER literal builds its elements, so an unresolvable constant
        anywhere inside nils the answer; short-circuiting forms (&&/||) do
@@ -1451,6 +1450,21 @@ void emit_expr(Compiler *c, int id, Buf *b) {
         buf_printf(b, "(sp_re_captures[%d] ? SPL(\"global-variable\") : NULL)", refn);
         return;
       }
+    }
+    /* defined?(yield) answers "yield" only when the current method actually
+       received a block, else nil — the same runtime question as block_given?.
+       An inlined yielding scope statically has a block; a lowered scope tests
+       its runtime __yblk__ parameter; any other scope has no block. */
+    if (!res && vt && sp_streq(vt, "YieldNode")) {
+      if (g_block_id >= 0) { buf_puts(b, "SPL(\"yield\")"); return; }
+      if (g_current_scope_is_lowered) {
+        buf_puts(b, "(");
+        emit_yblk_ref(b);
+        buf_puts(b, " != NULL ? SPL(\"yield\") : NULL)");
+        return;
+      }
+      buf_puts(b, "NULL");
+      return;
     }
     if (res) buf_printf(b, "SPL(\"%s\")", res);
     else buf_puts(b, "NULL");

--- a/test/defined_yield_no_block.rb
+++ b/test/defined_yield_no_block.rb
@@ -1,0 +1,15 @@
+# defined?(yield) must reflect whether the current method actually received a
+# block: nil when called without one, "yield" when a block is present.
+def f
+  defined?(yield)
+end
+p f                 # no block -> nil
+p f { 1 }           # block    -> "yield"
+
+# routed through a helper that conditionally yields, to exercise the lowered
+# __yblk__ runtime path rather than a fully-inlined block.
+def g(&blk)
+  defined?(yield)
+end
+p g                 # nil
+p g { 42 }          # "yield"

--- a/test/defined_yield_no_block.rb.expected
+++ b/test/defined_yield_no_block.rb.expected
@@ -1,0 +1,4 @@
+nil
+"yield"
+nil
+"yield"


### PR DESCRIPTION
`defined?(yield)` unconditionally returned the literal string `"yield"`, even when the enclosing method was called without a block. CRuby answers `"yield"` only when the current method actually received a block, and `nil` otherwise — the same runtime question `block_given?` asks.

```ruby
def f; defined?(yield); end
p f        # MRI: nil       was: "yield"
p f { 1 }  # MRI: "yield"   ok
```

`YieldNode` in `defined?` now uses the identical three cases the `block_given?` emitter uses: an inlined yielding scope statically has a block (fold to the `"yield"` label); a lowered scope inspects its runtime `__yblk__` parameter; any other scope has no block and answers `nil`.