### PR TITLE
analyze: a never-assigned ivar read gets a nil slot, not a reject

### DIFF
--- a/src/analyze_scope.c
+++ b/src/analyze_scope.c
@@ -2836,6 +2836,30 @@ int infer_ivar_types(Compiler *c) {
   for (int id = 0; id < nt->count; id++) {
     const char *ty = nt_type(nt, id);
     if (!ty) continue;
+    /* A top-level method that only READS an ivar (never assigned anywhere)
+       gets no slot from the write pass and none from register_locals (which
+       interns reads only for a real class scope), so the read can't be
+       lowered. An unassigned ivar is always nil in Ruby: register a slot for
+       it in the Toplevel pseudo-class (or the enclosing class body), leaving
+       its type unpinned so it stays a nil-valued poly. */
+    if (sp_streq(ty, "InstanceVariableReadNode")) {
+      Scope *s = comp_scope_of(c, id);
+      if (s->class_id >= 0) continue;  /* class/instance reads: register_locals */
+      const char *nm = nt_str(nt, id, "name");
+      if (!nm) continue;
+      int cid = c->node_cbody[id];
+      if (cid < 0) {
+        int old_nc = c->nclasses;
+        cid = comp_class_index(c, "Toplevel");
+        if (cid < 0) { comp_class_new(c, "Toplevel", -1); cid = c->nclasses - 1; }
+        if (c->nclasses != old_nc) changed = 1;
+      }
+      ClassInfo *ci = &c->classes[cid];
+      int old_ni = ci->nivars;
+      comp_ivar_intern(ci, nm);
+      if (ci->nivars != old_ni) changed = 1;
+      continue;
+    }
     if (sp_streq(ty, "InstanceVariableWriteNode") ||
         sp_streq(ty, "InstanceVariableOrWriteNode") ||
         sp_streq(ty, "InstanceVariableAndWriteNode") ||

--- a/test/unassigned_ivar_reads_nil.rb
+++ b/test/unassigned_ivar_reads_nil.rb
@@ -1,0 +1,16 @@
+# Reading an instance variable that is never assigned anywhere in the program
+# is nil in Ruby, not a compile error. A top-level method reading such an ivar
+# gets a nil-valued slot in the Toplevel pseudo-class.
+def f; @x; end
+p f            # nil
+
+p @top        # nil, read at top level
+
+def g; @z.nil?; end
+p g           # true
+
+def h; @w.inspect; end
+p h           # "nil"
+
+# defined? still reports it as absent until assigned.
+p defined?(@never)   # nil

--- a/test/unassigned_ivar_reads_nil.rb.expected
+++ b/test/unassigned_ivar_reads_nil.rb.expected
@@ -1,0 +1,5 @@
+nil
+nil
+true
+"nil"
+nil


### PR DESCRIPTION
Reading an `@ivar` with zero assignments anywhere is `nil` in Ruby, but a top-level method reading one was rejected:

```ruby
def f; @x; end
p f    # MRI: nil    was: REJECT "unsupported p argument (InstanceVariableReadNode)"
```

The write pass allocates a `Toplevel` slot only for assignments, and `register_locals` interns ivar reads only inside a real class scope, so a read-only top-level ivar fell through both and emitted an undeclared `civ_Toplevel_*` global. A read-only ivar inside a user class already worked (the struct field is nil-initialized) — this brings the top level to parity.

The ivar-type fixpoint now registers a slot for such reads, attributing it to the enclosing class body or the `Toplevel` pseudo-class and leaving the type unpinned so it stays a nil-valued poly.

Full suite green.