### PR TITLE
codegen: === on a scalar receiver accepts a poly argument

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -2507,6 +2507,15 @@ static int emit_case_eq_call(Compiler *c, int id, Buf *b) {
       else { buf_puts(b, "(("); emit_expr(c, recv, b); buf_puts(b, "), ("); emit_expr(c, argv[0], b); buf_puts(b, "), 0)"); }
       return 1;
     }
+    /* A scalar-comparable receiver against a poly argument (e.g. a boolean or
+       integer param `=== y` where y unified to poly across call sites): case
+       equality is value equality, so box the receiver and compare by the poly
+       runtime rule (int/float cross-compare numerically, other tags by tag). */
+    if (fr && fr != 5 && a0 == TY_POLY) {
+      buf_puts(b, "sp_poly_eq("); emit_boxed(c, recv, b); buf_puts(b, ", ");
+      emit_boxed(c, argv[0], b); buf_puts(b, ")");
+      return 1;
+    }
   }
 
   if (argc == 1 && (sp_streq(name, "==") || sp_streq(name, "!=") ||

--- a/test/case_eq_scalar_poly_arg.rb
+++ b/test/case_eq_scalar_poly_arg.rb
@@ -1,0 +1,30 @@
+# `===` on a scalar-comparable receiver (bool/int/float/string/symbol) is case
+# equality == value equality. When the argument unifies to a poly type across
+# call sites while the receiver stays a single scalar type, Spinel previously
+# rejected the call; it now boxes the receiver and compares by the poly runtime
+# rule (numbers cross-compare, other tags by tag).
+
+# In each method the receiver keeps one scalar type; the second argument varies
+# across call sites (Integer / Float / true / nil / String / Symbol), so the
+# parameter unifies to poly.
+def beq(x, y); x === y; end     # x : bool
+p beq(true, 1)        # false (true only case-equals true)
+p beq(true, true)     # true
+p beq(true, nil)      # false
+p beq(false, false)   # true
+
+def ieq(x, y); x === y; end     # x : int
+p ieq(1, 1)           # true
+p ieq(1, 1.0)         # true  (numeric cross-compare)
+p ieq(2, "x")         # false
+p ieq(3, nil)         # false
+
+def seq(x, y); x === y; end     # x : string
+p seq("a", "a")       # true
+p seq("a", :a)        # false
+p seq("a", 1)         # false
+
+def yeq(x, y); x === y; end     # x : symbol
+p yeq(:sym, :sym)     # true
+p yeq(:sym, "sym")    # false
+p yeq(:sym, 9)        # false

--- a/test/case_eq_scalar_poly_arg.rb.expected
+++ b/test/case_eq_scalar_poly_arg.rb.expected
@@ -1,0 +1,14 @@
+false
+true
+false
+true
+true
+true
+false
+false
+true
+false
+false
+true
+false
+false


### PR DESCRIPTION
A scalar-comparable receiver (bool/int/float/string/symbol) compared with `===` against an argument whose static type unified to poly across call sites rejected the call: the case-equality emitter only handled operands that are both in a known equality family.

Box the receiver and compare with the poly runtime equality rule, which is exactly `===` == `==` for these receivers (numbers cross-compare numerically, other tags by tag). A same-family or non-poly argument keeps the existing direct comparison.

Test `case_eq_scalar_poly_arg.rb` keeps each receiver monomorphic (bool/int/string/symbol) while the argument varies across call sites to force the poly unification, with output generated from the Ruby oracle. The exact single-call-site boolean-`===` case already passes on master; the Exception data accessors (`NameError#name` etc.) remain a separate item.