### PR TITLE
codegen,runtime: **hash forward rejects an unknown keyword

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -3755,6 +3755,30 @@ static mrb_bool sp_SymPolyHash_has_value(sp_SymPolyHash*h,sp_RbVal v){if(!h)retu
 static sp_sym sp_SymPolyHash_key(sp_SymPolyHash*h,sp_RbVal v){if(!h)return (sp_sym)-1;for(mrb_int i=0;i<h->len;i++)if(sp_poly_eq(sp_SymPolyHash_get(h,h->order[i]),v))return h->order[i];return (sp_sym)-1;}
 static sp_SymPolyHash*sp_SymPolyHash_merge(sp_SymPolyHash*a,sp_SymPolyHash*b){sp_SymPolyHash*r=sp_SymPolyHash_new();r->default_v=a->default_v;for(mrb_int i=0;i<a->len;i++)sp_SymPolyHash_set(r,a->order[i],sp_SymPolyHash_get(a,a->order[i]));for(mrb_int i=0;i<b->len;i++)sp_SymPolyHash_set(r,b->order[i],sp_SymPolyHash_get(b,b->order[i]));return r;}
 static void sp_SymPolyHash_update(sp_SymPolyHash*a,sp_SymPolyHash*b){if(!a||!b||a==b)return;SP_GC_ROOT(a);SP_GC_ROOT(b);for(mrb_int i=0;i<b->len;i++)sp_SymPolyHash_set(a,b->order[i],sp_SymPolyHash_get(b,b->order[i]));}
+/* A `**hash` forwarded into a method with fixed keyword params (and no
+   keyword-rest to absorb extras) must carry only declared keys; CRuby raises
+   ArgumentError otherwise. `allowed` is a NULL-terminated array of the callee's
+   keyword names, in declaration order. The message matches CRuby:
+   `unknown keyword: :x` for one, `unknown keywords: :x, :y` for several. */
+static void sp_kwargs_check(sp_SymPolyHash *h, const char *const *allowed) {
+  if (!h) return;
+  char list[256]; int n = 0, cnt = 0;
+  for (mrb_int i = 0; i < h->len; i++) {
+    const char *nm = sp_sym_to_s(h->order[i]);
+    int ok = 0;
+    for (const char *const *a = allowed; *a; a++) if (!strcmp(nm, *a)) { ok = 1; break; }
+    if (ok) continue;
+    if (n < (int)sizeof(list) - 1) {
+      int w = snprintf(list + n, sizeof(list) - n, "%s:%s", cnt ? ", " : "", nm);
+      /* snprintf returns the untruncated length; clamp so n never runs past the
+         buffer and sizeof(list)-n stays a valid size on the next iteration. */
+      n = (w > 0 && n + w < (int)sizeof(list)) ? n + w : (int)sizeof(list) - 1;
+    }
+    cnt++;
+  }
+  if (cnt == 0) return;
+  sp_raise_cls("ArgumentError", sp_sprintf("unknown keyword%s: %s", cnt > 1 ? "s" : "", list));
+}
 /* Hash#delete for sym_poly_hash. Removes key and re-tombstones the
    slot, shifting probe-chain successors backward and dropping the
    key from the insertion-order list. Issue #510. */

--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -4697,6 +4697,29 @@ void emit_args_filled(Compiler *c, int callee_idx, int argsNode, const char *lea
   TyKind ds_hash_type = TY_UNKNOWN;
   int ds_hash_tmp = emit_ds_hash_materialize(c, kwh, &ds_hash_type);
 
+  /* A `**hash` forwarded into a method with fixed keyword params and no
+     keyword-rest must carry only declared keys, else CRuby raises
+     ArgumentError. Emit a runtime check over the materialized (symbol-keyed)
+     hash against the callee's declared keyword names. (A kwrest absorbs the
+     extras, so only guard when there is none.) */
+  if (ds_hash_tmp >= 0 && m && m->kwrest_idx < 0 && m->def_node >= 0) {
+    const char *dshn = ty_hash_cname(ds_hash_type);
+    int pn = nt_ref(nt, m->def_node, "parameters");
+    int kn = 0; const int *kws = pn >= 0 ? nt_arr(nt, pn, "keywords", &kn) : NULL;
+    if (kn > 0 && dshn && sp_streq(dshn, "SymPoly")) {
+      int chk = ++g_tmp;
+      emit_indent(g_pre, g_indent);
+      buf_printf(g_pre, "static const char *const _kw%d[] = {", chk);
+      for (int ki = 0; ki < kn; ki++) {
+        const char *kpn = nt_str(nt, kws[ki], "name");
+        if (kpn) buf_printf(g_pre, "\"%s\", ", kpn);
+      }
+      buf_puts(g_pre, "0};\n");
+      emit_indent(g_pre, g_indent);
+      buf_printf(g_pre, "sp_kwargs_check(_t%d, _kw%d);\n", ds_hash_tmp, chk);
+    }
+  }
+
   /* Find the first SplatNode in positional args. If it comes before rest_idx
      (or before nparams for rest-less methods), pre-evaluate it to a temp so
      we can index into it per fixed param. */

--- a/test/kwargs_splat_unknown_keyword.rb
+++ b/test/kwargs_splat_unknown_keyword.rb
@@ -1,0 +1,28 @@
+# Forwarding a **hash that carries a key not accepted by the callee's fixed
+# keyword params raises ArgumentError, matching CRuby, instead of silently
+# ignoring the extra key.
+def take(a:); a; end
+def f(h); take(**h); end
+
+begin
+  f({a: 1, b: 2})
+rescue ArgumentError => e
+  puts e.message          # unknown keyword: :b
+end
+
+p f({a: 5})               # 5, a valid forward still works
+
+def two(a:, b:); [a, b]; end
+def g(h); two(**h); end
+
+begin
+  g({a: 1, b: 2, c: 3, d: 4})
+rescue ArgumentError => e
+  puts e.message          # unknown keywords: :c, :d
+end
+
+p g({a: 1, b: 2})         # [1, 2]
+
+# a callee WITH a keyword-rest absorbs the extras (no error).
+def rest(a:, **opts); [a, opts]; end
+p rest(a: 1, x: 9, y: 8)  # [1, {x: 9, y: 8}]

--- a/test/kwargs_splat_unknown_keyword.rb.expected
+++ b/test/kwargs_splat_unknown_keyword.rb.expected
@@ -1,0 +1,5 @@
+unknown keyword: :b
+5
+unknown keywords: :c, :d
+[1, 2]
+[1, {x: 9, y: 8}]


### PR DESCRIPTION
Forwarding a `**hash` into a method with fixed keyword params silently dropped any key the callee did not declare; CRuby raises ArgumentError.

```ruby
def take(a:); a; end
def f(h); take(**h); end
f({a: 1, b: 2})   # MRI: ArgumentError (unknown keyword: :b)   was: silently returns 1
```

The per-param extraction pulled each declared keyword out of the materialized hash and never inspected the leftovers. After materializing the double-splat hash, a runtime `sp_kwargs_check` now validates the keys against the callee’s declared keyword names — but only when the callee has fixed keywords and no keyword-rest (a `**rest` legitimately absorbs the extras). The message matches CRuby exactly: `unknown keyword: :x` for one, `unknown keywords: :x, :y` for several.

Scope note: this covers the runtime `**h` splat; a separate pre-existing compile error when forwarding `**h` into a method that itself has a `**opts` keyword-rest is untouched.