### PR TITLE
codegen,runtime: divide a Complex by a real componentwise

### DIFF
--- a/lib/sp_format.c
+++ b/lib/sp_format.c
@@ -7,22 +7,36 @@
 #include <string.h>
 #include <time.h>       /* gmtime / strftime for sp_Time_inspect */
 
+/* Format a non-negative Complex-component magnitude the way MRI does: infinite
+   and NaN values become the Ruby names Infinity/NaN (not C's inf/nan), a whole
+   value stays integer-looking, else %g. Returns the written length. */
+static int sp_complex_mag(char *out, size_t sz, mrb_float v) {
+  if (isinf(v)) return snprintf(out, sz, "Infinity");
+  if (isnan(v)) return snprintf(out, sz, "NaN");
+  /* a float outside mrb_int's range makes (mrb_int)v undefined behavior; only
+     integer-print a whole value that fits, else fall through to %g. */
+  if (v >= -(mrb_float)INTPTR_MAX && v <= (mrb_float)INTPTR_MAX && v == (mrb_int)v)
+    return snprintf(out, sz, "%lld", (long long)v);
+  return snprintf(out, sz, "%g", v);
+}
+/* Append the imaginary part ("+<mag>i" / "-<mag>i") to buf. MRI inserts a `*`
+   before a non-numeric magnitude (Infinity/NaN) so `Infinity*i` stays readable,
+   while a plain number is written as `10i`. */
+static int sp_complex_imag(char *buf, int n, size_t sz, mrb_float im) {
+  if (n < 0 || (size_t)n >= sz) return 0;
+  char mag[64];
+  sp_complex_mag(mag, sizeof mag, im < 0 ? -im : im);
+  const char *sep = (mag[0] >= '0' && mag[0] <= '9') ? "" : "*";
+  return snprintf(buf + n, sz - (size_t)n, "%c%s%si", im < 0 ? '-' : '+', mag, sep);
+}
 const char *sp_complex_inspect(sp_Complex c) {
-  char buf[128];
-  int n = 0;
-  /* Real part: keep integer-looking values short. */
-  if (c.re == (mrb_int)c.re) n += snprintf(buf + n, sizeof(buf) - n, "(%lld", (long long)c.re);
-  else n += snprintf(buf + n, sizeof(buf) - n, "(%g", c.re);
-  /* Imaginary sign + value. */
-  if (c.im < 0) {
-    if (c.im == (mrb_int)c.im) n += snprintf(buf + n, sizeof(buf) - n, "-%lldi)", -(long long)c.im);
-    else n += snprintf(buf + n, sizeof(buf) - n, "%gi)", c.im);
-  }
-  else {
-    if (c.im == (mrb_int)c.im) n += snprintf(buf + n, sizeof(buf) - n, "+%lldi)", (long long)c.im);
-    else n += snprintf(buf + n, sizeof(buf) - n, "+%gi)", c.im);
-  }
-  if (n < 0) n = 0;
+  char buf[128], re[64];
+  sp_complex_mag(re, sizeof re, c.re < 0 ? -c.re : c.re);
+  int n = snprintf(buf, sizeof buf, "(%s%s", c.re < 0 ? "-" : "", re);
+  if (n < 0) n = 0; else if (n >= (int)sizeof buf) n = (int)sizeof buf - 1;
+  n += sp_complex_imag(buf, n, sizeof buf, c.im);
+  if (n < (int)sizeof buf) n += snprintf(buf + n, sizeof(buf) - (size_t)n, ")");
+  if (n < 0) n = 0; else if (n >= (int)sizeof buf) n = (int)sizeof buf - 1;
   char *r = sp_str_alloc_raw(n + 1);
   memcpy(r, buf, n);
   r[n] = 0;
@@ -30,19 +44,12 @@ const char *sp_complex_inspect(sp_Complex c) {
 }
 /* Complex#to_s: bare `re+imi` (no surrounding parens, unlike #inspect). */
 const char *sp_complex_to_s(sp_Complex c) {
-  char buf[128];
-  int n = 0;
-  if (c.re == (mrb_int)c.re) n += snprintf(buf + n, sizeof(buf) - n, "%lld", (long long)c.re);
-  else n += snprintf(buf + n, sizeof(buf) - n, "%g", c.re);
-  if (c.im < 0) {
-    if (c.im == (mrb_int)c.im) n += snprintf(buf + n, sizeof(buf) - n, "-%lldi", -(long long)c.im);
-    else n += snprintf(buf + n, sizeof(buf) - n, "%gi", c.im);
-  }
-  else {
-    if (c.im == (mrb_int)c.im) n += snprintf(buf + n, sizeof(buf) - n, "+%lldi", (long long)c.im);
-    else n += snprintf(buf + n, sizeof(buf) - n, "+%gi", c.im);
-  }
-  if (n < 0) n = 0;
+  char buf[128], re[64];
+  sp_complex_mag(re, sizeof re, c.re < 0 ? -c.re : c.re);
+  int n = snprintf(buf, sizeof buf, "%s%s", c.re < 0 ? "-" : "", re);
+  if (n < 0) n = 0; else if (n >= (int)sizeof buf) n = (int)sizeof buf - 1;
+  n += sp_complex_imag(buf, n, sizeof buf, c.im);
+  if (n < 0) n = 0; else if (n >= (int)sizeof buf) n = (int)sizeof buf - 1;
   char *r = sp_str_alloc_raw(n + 1);
   memcpy(r, buf, n);
   r[n] = 0;
@@ -100,6 +107,18 @@ sp_Complex sp_complex_sub(sp_Complex a, sp_Complex b) { sp_Complex c; c.re = a.r
 sp_Complex sp_complex_div(sp_Complex a, sp_Complex b) {
   mrb_float d = (b.re * b.re) + (b.im * b.im); sp_Complex c;
   c.re = ((a.re * b.re) + (a.im * b.im)) / d; c.im = ((a.im * b.re) - (a.re * b.im)) / d; return c;
+}
+/* Complex divided by a real scalar divides each component -- unlike the
+   conjugate formula, this yields Infinity (not NaN) when the divisor is 0.0,
+   matching MRI's Complex#/ against a Float. */
+sp_Complex sp_complex_div_real(sp_Complex a, mrb_float b) {
+  sp_Complex c; c.re = a.re / b; c.im = a.im / b; return c;
+}
+/* Complex divided by an Integer follows integer zero-division rules: dividing
+   by 0 raises ZeroDivisionError, as in MRI (a Float divisor gives Infinity). */
+sp_Complex sp_complex_div_int(sp_Complex a, mrb_int b) {
+  if (b == 0) sp_raise_cls("ZeroDivisionError", "divided by 0");
+  sp_Complex c; c.re = a.re / (mrb_float)b; c.im = a.im / (mrb_float)b; return c;
 }
 sp_Complex sp_complex_neg(sp_Complex a) { sp_Complex c; c.re = -a.re; c.im = -a.im; return c; }
 mrb_float sp_complex_abs2(sp_Complex a) { return (a.re * a.re) + (a.im * a.im); }

--- a/lib/sp_format.h
+++ b/lib/sp_format.h
@@ -26,6 +26,8 @@ sp_Complex sp_complex_add(sp_Complex a, sp_Complex b);
 sp_Complex sp_complex_sub(sp_Complex a, sp_Complex b);
 sp_Complex sp_complex_mul(sp_Complex a, sp_Complex b);
 sp_Complex sp_complex_div(sp_Complex a, sp_Complex b);
+sp_Complex sp_complex_div_real(sp_Complex a, mrb_float b);
+sp_Complex sp_complex_div_int(sp_Complex a, mrb_int b);
 sp_Complex sp_complex_neg(sp_Complex a);
 sp_Complex sp_complex_conjugate(sp_Complex a);
 sp_Complex sp_complex_pow(sp_Complex a, mrb_int e);

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -1115,6 +1115,18 @@ static int emit_complex_rational_call(Compiler *c, int id, Buf *b) {
       if (sp_streq(name, "inspect")) { buf_puts(b, "sp_complex_inspect("); emit_expr(c, recv, b); buf_puts(b, ")"); return 1; }
       TyKind cxa = argc == 1 ? comp_ntype(c, argv[0]) : TY_UNKNOWN;
       int cx_ok = cxa == TY_COMPLEX || cxa == TY_INT || cxa == TY_FLOAT;
+      /* Dividing a Complex by a real scalar divides each component: a Float
+         divisor yields Infinity at 0 (IEEE), an Integer divisor raises
+         ZeroDivisionError at 0 (integer rules). The conjugate-formula
+         sp_complex_div boxes the real to c+0i and produces NaN at c==0. */
+      if (argc == 1 && sp_streq(name, "/") && cxa == TY_FLOAT) {
+        buf_puts(b, "sp_complex_div_real("); emit_expr(c, recv, b); buf_puts(b, ", (mrb_float)("); emit_expr(c, argv[0], b); buf_puts(b, "))");
+        return 1;
+      }
+      if (argc == 1 && sp_streq(name, "/") && cxa == TY_INT) {
+        buf_puts(b, "sp_complex_div_int("); emit_expr(c, recv, b); buf_puts(b, ", (mrb_int)("); emit_expr(c, argv[0], b); buf_puts(b, "))");
+        return 1;
+      }
       if (cx_ok && argc == 1 && (sp_streq(name, "+") || sp_streq(name, "-") ||
                                  sp_streq(name, "*") || sp_streq(name, "/"))) {
         const char *fn = name[0] == '+' ? "add" : name[0] == '-' ? "sub" : name[0] == '*' ? "mul" : "div";

--- a/test/complex_division.rb
+++ b/test/complex_division.rb
@@ -1,0 +1,30 @@
+# Complex#/ by a real scalar divides each component. Boxing the real into c+0i
+# and running the conjugate formula produced NaN at a zero divisor; MRI divides
+# componentwise, so a Float zero yields Infinity and an Integer zero raises
+# ZeroDivisionError (integer division rules).
+def df(a, b); a / b; end
+p df(Complex(20, 40), 0.0)              # (Infinity+Infinity*i)
+p df(Complex(21, 41), 2.0)             # (10.5+20.5i)
+p df(Complex(-20, 40), 0.0)            # (-Infinity+Infinity*i)
+
+def dnan(a, b); a / b; end
+p dnan(Complex(0, 0), 0.0)             # (NaN+NaN*i)
+
+def di(a, b); a / b; end
+p di(Complex(20, 40), 4)               # (5+10i)
+
+def dz(a, b); a / b; end
+begin
+  dz(Complex(20, 40), 0)
+  puts "no raise"
+rescue ZeroDivisionError => e
+  puts e.message                        # divided by 0
+end
+
+# Complex / Complex still uses the full division.
+def dc(a, b); a / b; end
+p dc(Complex(20, 40), Complex(2, 0))   # (10+20i)
+
+# Infinity / NaN component formatting in inspect and to_s.
+def inf(a, b); a / b; end
+p inf(Complex(3, 0), 0.0).to_s          # "Infinity+NaN*i"  (0/0.0 imag is NaN)

--- a/test/complex_division.rb.expected
+++ b/test/complex_division.rb.expected
@@ -1,0 +1,8 @@
+(Infinity+Infinity*i)
+(10.5+20.5i)
+(-Infinity+Infinity*i)
+(NaN+NaN*i)
+(5+10i)
+divided by 0
+(10+20i)
+"Infinity+NaN*i"


### PR DESCRIPTION
`Complex#/` by a real scalar boxed the divisor into `c+0i` and ran the conjugate-formula division, whose `c*c+d*d` denominator is `0` for a zero divisor -- so every component came out `0/0 = NaN`. `Complex(20, 40) / 0.0` returned `(nan+nani)` instead of MRI's `(Infinity+Infinity*i)`, and `Complex(20, 40) / 0` returned NaN instead of raising.

MRI divides a Complex by a real componentwise, and the divisor's *type* decides zero handling: a Float zero follows IEEE rules (Infinity), an Integer zero follows integer rules (`ZeroDivisionError`). This adds `sp_complex_div_real` and `sp_complex_div_int` and routes the Float and Integer divisor cases through them; `Complex / Complex` keeps the full formula.

The Complex formatter also learns MRI's component spelling: an infinite or NaN part prints as `Infinity`/`NaN` rather than C's `inf`/`nan`, and a non-numeric imaginary magnitude takes a `*` separator (`Infinity*i`).

A whole-valued Float component still prints without its `.0` -- `Complex` stores both parts as `double`, so the int-vs-float distinction (`Complex(1, 0.0)` vs `Complex(1, 0)`) is lost in the representation. That, and `Complex.rect`/`.rectangular`, are left as separate items.