### PR TITLE
codegen: forward args from a bare new(...) in a Data/Struct singleton factory

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -5435,8 +5435,34 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
          class is that subclass, so `new` resolves to the subclass constructor. */
       int new_cls = (g_emitting_class_id >= 0) ? g_emitting_class_id : encl->class_id;
       if (sp_streq(name, "new")) {
-        buf_printf(b, "sp_%s_new(", c->classes[new_cls].c_name);
+        ClassInfo *ncls = &c->classes[new_cls];
         int initm = comp_method_in_chain(c, new_cls, "initialize", NULL);
+        /* A Data/Struct class has no user `initialize`; its generated constructor
+           takes one arg per member. Fill member-wise -- positionally, or by
+           keyword when a trailing kwarg hash names each member -- exactly as the
+           receiver `Klass.new(...)` path does. Without this, a bare `new(...)`
+           inside a `def self.default`/`self.initial` factory emitted an empty
+           `sp_Klass_new()`, dropping every argument. */
+        if (ncls->is_struct && initm < 0) {
+          int sargc; const int *sargv = call_args(nt, id, &sargc);
+          int kwh = (sargc == 1 && nt_type(nt, sargv[0]) &&
+                     sp_streq(nt_type(nt, sargv[0]), "KeywordHashNode")) ? sargv[0] : -1;
+          buf_printf(b, "sp_%s_new(", ncls->c_name);
+          for (int a = 0; a < ncls->nivars; a++) {
+            if (a) buf_puts(b, ", ");
+            int vnode = -1;
+            if (kwh >= 0) vnode = struct_kwarg_value(c, kwh, ncls->ivars[a] + 1);
+            else if (a < sargc) vnode = sargv[a];
+            if (vnode >= 0) {
+              if (ncls->ivar_types[a] == TY_POLY && comp_ntype(c, vnode) != TY_POLY) emit_boxed(c, vnode, b);
+              else emit_expr(c, vnode, b);
+            }
+            else buf_puts(b, default_value(ncls->ivar_types[a]));
+          }
+          buf_puts(b, ")");
+          return;
+        }
+        buf_printf(b, "sp_%s_new(", ncls->c_name);
         if (initm >= 0) emit_args_filled(c, initm, nt_ref(nt, id, "arguments"), "", b);
         buf_puts(b, ")");
         return;

--- a/test/data_bare_new_in_factory.rb
+++ b/test/data_bare_new_in_factory.rb
@@ -1,0 +1,39 @@
+# A bare `new(...)` (implicit self) inside a Data/Struct singleton factory must
+# forward its arguments to the generated constructor -- positional AND keyword --
+# exactly like an explicit `Klass.new(...)`.
+#
+# A prior bug: the self-call codegen path emitted the constructor only with args
+# when a USER `initialize` existed. A Data/Struct class has no user initialize
+# (its constructor is generated per-member), so `initm < 0` and every argument
+# was dropped -- `def self.default = new(x: 1)` compiled to `sp_Klass_new()`,
+# yielding a zero-arg call the C constructor rejects. The receiver path
+# (`Klass.new(...)`) already did the member-wise fill; the self-call path now
+# mirrors it.
+
+Size = Data.define(:w, :h) do
+  def self.square(n) = new(w: n, h: n)   # bare new, keyword args
+  def self.unit = new(1, 1)              # bare new, positional args
+end
+
+sq = Size.square(4)
+puts sq.w        # 4
+puts sq.h        # 4
+
+u = Size.unit
+puts u.w         # 1
+puts u.h         # 1
+
+# Nested: a factory whose bare `new` takes another Data value as a field, and a
+# default-carrying factory (the shell-model shape).
+Box = Data.define(:name, :size, :open) do
+  def self.default = new(name: "box", size: Size.square(3), open: false)
+end
+
+b = Box.default
+puts b.name      # box
+puts b.size.w    # 3
+puts b.open      # false
+
+b2 = b.with(open: true)
+puts b2.open     # true
+puts b2.name     # box

--- a/test/data_bare_new_in_factory.rb.expected
+++ b/test/data_bare_new_in_factory.rb.expected
@@ -1,0 +1,9 @@
+4
+4
+1
+1
+box
+3
+false
+true
+box


### PR DESCRIPTION
A bare `new(...)` (implicit self) inside a Data/Struct class-method factory dropped all its arguments:

```ruby
Size = Data.define(:w, :h) do
  def self.square(n) = new(w: n, h: n)
end
Size.square(4)
```

compiled to an empty `sp_Size_new()` and failed at the C stage (`too few arguments to function call, expected 2, have 0`). It happened for positional args too (`new(1, 1)`), so it is not kwargs-specific.

In the bare-`new` self-call path (`codegen_call.c`), the constructor was emitted with arguments only when a user-defined `initialize` existed. A Data/Struct class has no user `initialize` -- its constructor is generated one argument per member -- so the arity lookup came back negative and every argument was discarded. The explicit-receiver path (`Klass.new(...)`) already handled this with a member-wise fill (positional, or keyword-by-member with defaults).

The bare-`new` self-call path now mirrors that member-wise construction when the class is a Data/Struct with no user `initialize`, so `Klass.new(...)` and bare `new(...)` construct identically.

Test `data_bare_new_in_factory.rb` covers positional, keyword, nested (a Data field), and default-carrying factories, plus `with` on the result, verified against the Ruby oracle.