### PR TITLE
runtime,codegen: name the missing key in Hash#fetch's KeyError

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -3575,6 +3575,12 @@ static inline const char *sp_poly_inspect(sp_RbVal v) {
     default:          return sp_str_empty;
   }
 }
+/* Raise Hash#fetch's KeyError with MRI's "key not found: <key.inspect>" text.
+   Boxing the key lets one helper serve every key type (symbol, string, int,
+   ...) via sp_poly_inspect. */
+SP_NORETURN static void sp_raise_key_not_found(sp_RbVal key) {
+  sp_raise_cls("KeyError", sp_sprintf("key not found: %s", sp_poly_inspect(key)));
+}
 /* Array#inspect for heterogeneous poly arrays. Each element dispatches
    through sp_poly_inspect, so a mixed `[1, "x", :y]` renders
    `[1, "x", :y]` byte-for-byte identical to CRuby. NULL renders

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -1259,19 +1259,31 @@ static int emit_complex_rational_call(Compiler *c, int id, Buf *b) {
   return 0;
 }
 
+/* Emit a `fetch`-miss KeyError raise carrying MRI's "key not found: <key>"
+   text. The key node is boxed so sp_raise_key_not_found can inspect any key
+   type; re-evaluating it on the (aborting) miss path is harmless. */
+static void emit_key_not_found(Compiler *c, int key_node, Buf *b) {
+  buf_puts(b, "sp_raise_key_not_found(");
+  emit_boxed(c, key_node, b);
+  buf_puts(b, ")");
+}
+
 /* Emit the else-branch of a poly-Hash `fetch` dispatched through the poly value
    switch: the caller's default (fetch(k, dflt)) or a KeyError raise (fetch(k)),
    coerced to the dispatch's result-temp representation (poly, or the scalar
-   `trt`). `argv1` is the default-argument node (only read when argc == 2). */
+   `trt`). `argv1` is the default-argument node (only read when argc == 2);
+   `key_node` is the fetched key (argv[0]) for the KeyError message. */
 static void emit_poly_fetch_absent(Compiler *c, int argc, const int *atmp, int argv1,
-                                   TyKind ret, TyKind trt, Buf *b) {
+                                   int key_node, TyKind ret, TyKind trt, Buf *b) {
   if (argc == 2) {
     char dn[32]; snprintf(dn, sizeof dn, "_t%d", atmp[1]);
     if (ret == TY_POLY) emit_boxed_text(c, infer_type(c, argv1), dn, b);
     else buf_puts(b, dn);
   }
   else {
-    buf_puts(b, "(sp_raise_cls(\"KeyError\", \"key not found\"), ");
+    buf_puts(b, "(");
+    emit_key_not_found(c, key_node, b);
+    buf_puts(b, ", ");
     buf_puts(b, ret == TY_POLY ? "sp_box_nil()" : default_value(trt));
     buf_puts(b, ")");
   }
@@ -1867,7 +1879,7 @@ else {
             char dn[32]; snprintf(dn, sizeof dn, "_t%d", atmp[1]);
             if (ret == TY_POLY) emit_boxed_text(c, infer_type(c, argv[1]), dn, b); else buf_puts(b, dn);
           }
-          else if (is_fetch) { buf_puts(b, "(sp_raise_cls(\"KeyError\", \"key not found\"), "); buf_puts(b, ret == TY_POLY ? "sp_box_nil()" : default_value(trt)); buf_puts(b, ")"); }
+          else if (is_fetch) { buf_puts(b, "("); emit_key_not_found(c, argv[0], b); buf_puts(b, ", "); buf_puts(b, ret == TY_POLY ? "sp_box_nil()" : default_value(trt)); buf_puts(b, ")"); }
           else buf_puts(b, ret == TY_POLY ? "sp_box_nil()" : default_value(trt));
           buf_puts(b, "; break;");
         }
@@ -1890,7 +1902,7 @@ else {
           if (is_fetch) buf_printf(b, "%s ? ", hx);
           if (ret == TY_POLY) buf_puts(b, getx);
           else emit_unbox_text(c, trt, getx, b);
-          if (is_fetch) { buf_puts(b, " : "); emit_poly_fetch_absent(c, argc, atmp, argc == 2 ? argv[1] : -1, ret, trt, b); }
+          if (is_fetch) { buf_puts(b, " : "); emit_poly_fetch_absent(c, argc, atmp, argc == 2 ? argv[1] : -1, argv[0], ret, trt, b); }
           buf_puts(b, "; break;");
         }
       }
@@ -1911,7 +1923,7 @@ else {
           char dn[32]; snprintf(dn, sizeof dn, "_t%d", atmp[1]);
           if (ret == TY_POLY) emit_boxed_text(c, infer_type(c, argv[1]), dn, b); else buf_puts(b, dn);
         }
-        else if (is_fetch) { buf_puts(b, "(sp_raise_cls(\"KeyError\", \"key not found\"), "); buf_puts(b, ret == TY_POLY ? "sp_box_nil()" : default_value(trt)); buf_puts(b, ")"); }
+        else if (is_fetch) { buf_puts(b, "("); emit_key_not_found(c, argv[0], b); buf_puts(b, ", "); buf_puts(b, ret == TY_POLY ? "sp_box_nil()" : default_value(trt)); buf_puts(b, ")"); }
         else buf_puts(b, ret == TY_POLY ? "sp_box_nil()" : default_value(trt));
         buf_puts(b, "; break;");
       }
@@ -1942,7 +1954,7 @@ else {
         if (is_fetch) buf_printf(b, "%s ? ", hx);
         if (ret == TY_POLY) buf_puts(b, gx);
         else emit_unbox_text(c, ptrt, gx, b);
-        if (is_fetch) { buf_puts(b, " : "); emit_poly_fetch_absent(c, argc, atmp, argc == 2 ? argv[1] : -1, ret, ptrt, b); }
+        if (is_fetch) { buf_puts(b, " : "); emit_poly_fetch_absent(c, argc, atmp, argc == 2 ? argv[1] : -1, argv[0], ret, ptrt, b); }
         buf_puts(b, "; break;");
       }
       /* eql?/equal?/is_a?/kind_of?/instance_of? on a builtin-scalar (or

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -2387,7 +2387,12 @@ int emit_hash_call(Compiler *c, int id, Buf *b) {
           if (vt == TY_POLY) buf_puts(b, getexpr);
           else emit_boxed_text(c, vt, getexpr, b);
           buf_puts(b, ");");
-          if (is_fetch) buf_puts(b, " else sp_raise_cls(\"KeyError\", \"key not found\");");
+          if (is_fetch) {
+            char keytmp[32]; snprintf(keytmp, sizeof keytmp, "_t%d", tk);
+            buf_puts(b, " else sp_raise_key_not_found(");
+            emit_boxed_text(c, kt, keytmp, b);
+            buf_puts(b, ");");
+          }
           else buf_printf(b, " else sp_PolyArray_push(_t%d, sp_box_nil());", tr);
         }
         buf_printf(b, " _t%d; })", tr);
@@ -2434,9 +2439,12 @@ else {
         int th = ++g_tmp, tk = ++g_tmp;
         buf_printf(b, "({ %s _t%d = ", c_type_name(rt), th); emit_expr(c, recv, b);
         buf_printf(b, "; %s _t%d = ", c_type_name(ty_hash_key(rt)), tk); emit_hash_key(c, argv[0], ty_hash_key(rt), b);
-        buf_printf(b, "; sp_%sHash_has_key(_t%d, _t%d) ? sp_%sHash_get(_t%d, _t%d)"
-                      " : (sp_raise_cls(\"KeyError\", \"key not found\"), %s); })",
-                   hn, th, tk, hn, th, tk, vt == TY_POLY ? "sp_box_nil()" : default_value(vt));
+        buf_printf(b, "; sp_%sHash_has_key(_t%d, _t%d) ? sp_%sHash_get(_t%d, _t%d) : (",
+                   hn, th, tk, hn, th, tk);
+        char keytmp[32]; snprintf(keytmp, sizeof keytmp, "_t%d", tk);
+        buf_puts(b, "sp_raise_key_not_found(");
+        emit_boxed_text(c, ty_hash_key(rt), keytmp, b);
+        buf_printf(b, "), %s); })", vt == TY_POLY ? "sp_box_nil()" : default_value(vt));
         return 1;
       }
       if (sp_streq(name, "fetch") && argc == 2) {

--- a/test/hash_fetch_keyerror_message.rb
+++ b/test/hash_fetch_keyerror_message.rb
@@ -1,0 +1,26 @@
+# Hash#fetch's KeyError must carry the missing key: "key not found: <key.inspect>".
+# The suffix was dropped, so the message was a bare "key not found". Each key type
+# inspects differently (:sym, "str", 99), so the key is boxed and inspected.
+def fs(h, k); h.fetch(k); end
+begin; fs({a: 1, b: 2}, :zzz); rescue KeyError => e; puts e.message; end   # key not found: :zzz
+
+def fstr(h, k); h.fetch(k); end
+begin; fstr({"x" => 1}, "yy"); rescue KeyError => e; puts e.message; end   # key not found: "yy"
+
+def fi(h, k); h.fetch(k); end
+begin; fi({1 => "a"}, 99); rescue KeyError => e; puts e.message; end       # key not found: 99
+
+# fetch_values reports the first missing key.
+def fv(h, a, b); h.fetch_values(a, b); end
+begin; fv({a: 1}, :a, :nope); rescue KeyError => e; puts e.message; end     # key not found: :nope
+
+# A hash held in a poly slot (mixed value types) dispatches through the poly
+# fetch path, which shared the same bare message.
+def poly_h; { one: 1, two: "second" }; end
+def pf(h, k); h.fetch(k); end
+begin; pf(poly_h, :three); rescue KeyError => e; puts e.message; end        # key not found: :three
+
+# A present key still returns its value, and fetch with a default is unaffected.
+p fs({a: 1, b: 2}, :b)                                                       # 2
+def fd(h, k); h.fetch(k, -1); end
+p fd({a: 1}, :missing)                                                       # -1

--- a/test/hash_fetch_keyerror_message.rb.expected
+++ b/test/hash_fetch_keyerror_message.rb.expected
@@ -1,0 +1,7 @@
+key not found: :zzz
+key not found: "yy"
+key not found: 99
+key not found: :nope
+key not found: :three
+2
+-1


### PR DESCRIPTION
`Hash#fetch` and `fetch_values` raised a bare `"key not found"` `KeyError`, dropping MRI's `": <key.inspect>"` suffix -- `{a: 1}.fetch(:zzz)` reported `key not found` instead of `key not found: :zzz`.

This adds `sp_raise_key_not_found`, which boxes the key and appends its `inspect` so a single helper serves every key type (symbol, string, integer, ...). The typed-hash, poly-dispatch, and `fetch_values` miss sites all route through it; the key is boxed on the aborting miss path, so re-evaluating it is harmless.