### PR TITLE
bigint: forward-declare sp_sprintf for the base-radix error path

### DIFF
--- a/lib/sp_bigint.c
+++ b/lib/sp_bigint.c
@@ -18,6 +18,7 @@
 /* Defined in sp_runtime.h (linked into the final program); forward-declared
    here so the bigint object can raise without pulling in the whole header. */
 extern __attribute__((noreturn)) void sp_raise_cls(const char *cls, const char *msg);
+extern const char *sp_sprintf(const char *fmt, ...);
 
 #define DIG_SIZE (MPZ_DIG_SIZE)
 #define DIG_BASE (1ULL << DIG_SIZE)


### PR DESCRIPTION
The eighth conformance wave (part three) added `sp_bigint_to_s_base`, whose invalid-radix path calls `sp_sprintf`. That function is defined in `sp_runtime.h` (linked into the final program), not in any header the standalone `lib/sp_bigint.c` translation unit includes, so it was called with no visible declaration -- the implicit `int` return then fails `-Werror=int-conversion` when passed to `sp_raise_cls(const char *, const char *)`, breaking the `build/sp_bigint.o` compile.

Forward-declare `sp_sprintf` alongside the existing `sp_raise_cls` forward-declaration at the top of the file, matching the same "defined in sp_runtime.h, declared here to avoid pulling in the whole header" pattern.