### PR TITLE
parse: keep the node-kind name table bsearch-sorted

### DIFF
--- a/src/node_table.h
+++ b/src/node_table.h
@@ -132,8 +132,8 @@ typedef struct {
   X(LocalVariableReadNode) \
   X(LocalVariableTargetNode) \
   X(LocalVariableWriteNode) \
-  X(MatchRequiredNode) \
   X(MatchPredicateNode) \
+  X(MatchRequiredNode) \
   X(ModuleNode) \
   X(MultiTargetNode) \
   X(MultiWriteNode) \


### PR DESCRIPTION
`nt_kind` resolves a node's type string against `sp_kind_names` with a bsearch, so the X-macro kind list must stay alphabetically ordered. `MatchRequiredNode` was inserted ahead of `MatchPredicateNode`, breaking the sort invariant: bsearch could resolve neither name, `nt_kind` returned `NK_NONE` for both, and every `NT_FOREACH_KIND` pass over those kinds silently iterated zero nodes.

The visible casualty is pattern-local inference for rightward assignment: the `MatchRequiredNode` block in `infer_write_types` never ran, so `x => [a, b]` inside a method left `a` and `b` untyped, the enclosing method's return type collapsed to unknown, and a caller like `p f([3, 4])` rejected at compile ("unsupported p argument"). With the two entries swapped back into order, the same program compiles and prints `7`.

Codegen was unaffected (it string-compares `nt_type` directly), which is why the emitters worked while the analyzer was blind.

## Testing

- `def f(x); x => [a, b]; a + b; end; p f([3, 4])` compiles and prints `7` (previously a compile reject).
- All pattern/case-in/deconstruct/match tests pass.