### PR TITLE
runtime: heap-copy exception messages at construction

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -5289,15 +5289,19 @@ static sp_Exception *sp_exc_new(const char *cls_name, const char *msg) {
   sp_Exception *e = (sp_Exception *)sp_gc_alloc(sizeof(sp_Exception), NULL, sp_exc_gc_scan);
   e->cls_name = cls_name ? cls_name : "RuntimeError";
   e->parent_cls_name = NULL;
-  e->msg = (msg && msg[0]) ? msg : (cls_name ? cls_name : "RuntimeError");
+  e->msg = NULL;    /* set below; scan-safe if the copy triggers a GC */
   e->cause = NULL;  /* set all fields explicitly; sp_exc_gc_scan reads cause */
   e->result = sp_box_nil();
+  /* Launder the message into a GC-heap string: sp_exc_gc_scan marks it via
+     the tag byte at msg[-1], which only heap strings carry -- keeping a
+     raise site's rodata literal would under-read one byte before it. */
+  SP_GC_ROOT(e);
+  e->msg = sp_sprintf("%s", (msg && msg[0]) ? msg : (cls_name ? cls_name : "RuntimeError"));
   return e;
 }
 static sp_Exception *sp_exc_new_sub(const char *cls_name, const char *parent_cls, const char *msg) {
-  sp_Exception *e = sp_exc_new(cls_name, msg);
+  sp_Exception *e = sp_exc_new(cls_name, msg);   /* empty msg already fell back to cls_name */
   e->parent_cls_name = parent_cls;
-  if (!msg || !msg[0]) e->msg = cls_name ? cls_name : "RuntimeError";
   return e;
 }
 /* Allocate a zeroed exception-subclass struct of `sz` bytes with the base
@@ -5309,9 +5313,12 @@ static void *sp_exc_new_sub_sized(size_t sz, const char *cls_name, const char *m
   sp_Exception *e = (sp_Exception *)sp_gc_alloc(sz, NULL, sp_exc_gc_scan);
   memset(e, 0, sz);
   e->cls_name = cls_name ? cls_name : "RuntimeError";
-  e->msg = (msg && msg[0]) ? msg : e->cls_name;
   e->result = sp_box_nil();   /* memset left tag 0 (int 0); StopIteration#result wants nil */
   if (sp_user_exc_parent_fn) e->parent_cls_name = sp_user_exc_parent_fn(e->cls_name);
+  /* heap-launder the message (see sp_exc_new); memset left msg NULL, so a GC
+     during the copy scans a consistent struct */
+  SP_GC_ROOT(e);
+  e->msg = sp_sprintf("%s", (msg && msg[0]) ? msg : e->cls_name);
   return e;
 }
 /* Accept `volatile` pointers: LV slots holding sp_Exception * are


### PR DESCRIPTION
`sp_exc_gc_scan` marks `e->msg` through `sp_mark_string`, which reads the heap-string tag byte at `msg[-1]` — a byte only GC-heap strings carry. Raise sites routinely pass rodata string literals (`sp_raise_cls("NoMatchingPatternError", "[array pattern mismatch]")`), and once such an exception is rescued and bound, every subsequent GC mark reads one byte before the literal. That is an out-of-bounds global read: it goes unnoticed until the literal happens to sit beside an ASAN-instrumented global, at which point the program aborts with a global-buffer-overflow report in `sp_exc_gc_scan`.

The fix launders the message into a GC-heap string at exception construction, in `sp_exc_new` and `sp_exc_new_sub_sized`. Ordering is GC-safe: the exception object is fully initialized (`msg = NULL`) and rooted before the copy allocates, so a collection triggered mid-copy scans a consistent struct. `sp_exc_new_sub`'s empty-message fallback re-assigned the same class-name pointer `sp_exc_new` already applies; it is dropped so it cannot clobber the laundered copy with a rodata pointer.

Messages built with `sp_sprintf` (already heap) get copied once more at construction; message content is unchanged in all cases.

## Testing

- A rescued `expr => pattern` mismatch (rodata-literal message) followed by allocations runs clean under ASAN + `SPINEL_GC_STRESS=1`, and `e.class` / `e.message` render unchanged.
- All exception/rescue/raise/ensure/catch tests pass.