### PR TITLE
codegen: chained string appends evaluate each link exactly once

### DIFF
--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -254,6 +254,51 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
         }
       }
     }
+    /* chained append in value position (`t = s << a << b`): the generic form
+       below writes back only when the receiver is a direct lvalue read, so a
+       chain's outer links never reach the base -- `s` kept just the first
+       append. Unroll the chain onto the base, one write-back per link, and
+       yield the base (each `<<` returns its receiver). */
+    if (sp_streq(name, "<<") && argc == 1) {
+      int chain[64]; int nchain = 0; int cur = recv;
+      while (nchain < 64) {
+        while (nt_type(nt, cur) && sp_streq(nt_type(nt, cur), "ParenthesesNode")) {
+          int pb = nt_ref(nt, cur, "body");
+          if (pb < 0) break;
+          int bn = 0; const int *bb = nt_arr(nt, pb, "body", &bn);
+          if (bn != 1) break;
+          cur = bb[0];
+        }
+        const char *cty = nt_type(nt, cur);
+        if (!cty || !sp_streq(cty, "CallNode")) break;
+        const char *cnm = nt_str(nt, cur, "name");
+        int crecv = nt_ref(nt, cur, "receiver");
+        if (!cnm || !sp_streq(cnm, "<<") || crecv < 0 || comp_ntype(c, crecv) != TY_STRING) break;
+        int cargs = nt_ref(nt, cur, "arguments");
+        int cac = 0; const int *cav = cargs >= 0 ? nt_arr(nt, cargs, "arguments", &cac) : NULL;
+        if (cac != 1) break;
+        chain[nchain++] = cav[0];
+        cur = crecv;
+      }
+      const char *bty = nt_type(nt, cur);
+      LocalVar *blv = (bty && sp_streq(bty, "LocalVariableReadNode"))
+                      ? scope_local(comp_scope_of(c, cur), nt_str(nt, cur, "name")) : NULL;
+      if (nchain > 0 && bty && !(blv && blv->type == TY_STRBUF) &&
+          (sp_streq(bty, "LocalVariableReadNode") || sp_streq(bty, "InstanceVariableReadNode"))) {
+        buf_puts(b, "({ ");
+        for (int j = nchain; j >= 0; j--) {  /* innermost link first, outer arg last */
+          int arg = j > 0 ? chain[j - 1] : argv[0];
+          buf_puts(b, "sp_str_check_mutable("); emit_expr(c, cur, b); buf_puts(b, "); ");
+          emit_expr(c, cur, b); buf_puts(b, " = sp_str_concat(");
+          emit_expr(c, cur, b); buf_puts(b, ", ");
+          emit_str_expr(c, arg, b);
+          buf_puts(b, "); ");
+        }
+        emit_expr(c, cur, b);
+        buf_puts(b, "; })");
+        return 1;
+      }
+    }
     if ((sp_streq(name, "concat") || sp_streq(name, "<<") ||
          sp_streq(name, "prepend")) && argc >= 1) {
       const char *rvt2 = nt_type(nt, recv);

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -6648,6 +6648,34 @@ else {
   buf_puts(b, ";\n");
 }
 
+/* The base receiver of a string append chain: `s << a << b` bottoms out at
+   `s` (unwrapping parens); a plain `s << x` yields its receiver unchanged.
+   Mirrors the chain walks in emit_array_mutate_stmt, so after the statement
+   form has run a tail `<<` can return the base instead of re-evaluating the
+   inner links (which would append their arguments a second time). */
+static int str_append_chain_base(Compiler *c, int id) {
+  const NodeTable *nt = c->nt;
+  int cur = id;
+  for (;;) {
+    while (nt_type(nt, cur) && sp_streq(nt_type(nt, cur), "ParenthesesNode")) {
+      int pb = nt_ref(nt, cur, "body");
+      if (pb < 0) break;
+      int bn = 0; const int *bb = nt_arr(nt, pb, "body", &bn);
+      if (bn != 1) break;
+      cur = bb[0];
+    }
+    const char *cty = nt_type(nt, cur);
+    if (!cty || !sp_streq(cty, "CallNode")) return cur;
+    const char *cnm = nt_str(nt, cur, "name");
+    int crecv = nt_ref(nt, cur, "receiver");
+    if (!cnm || (!sp_streq(cnm, "<<") && !sp_streq(cnm, "concat")) || crecv < 0) return cur;
+    int cargs = nt_ref(nt, cur, "arguments");
+    int cac = 0; if (cargs >= 0) nt_arr(nt, cargs, "arguments", &cac);
+    if (cac != 1) return cur;
+    cur = crecv;
+  }
+}
+
 /* Tail position: the value of this statement is the method's return value. */
 void emit_stmt_tail_inner(Compiler *c, int id, Buf *b, int indent) {
   const NodeTable *nt = c->nt;
@@ -6788,10 +6816,15 @@ void emit_stmt_tail_inner(Compiler *c, int id, Buf *b, int indent) {
     if (_srecv >= 0 && _snm && sp_streq(_snm, "<<") &&
         comp_ntype(c, _srecv) == TY_STRING &&
         emit_array_mutate_stmt(c, id, b, indent)) {
+      /* return the chain's BASE receiver: for `buf << a << b` the immediate
+         receiver is the inner `<<` call, and re-emitting it would run the
+         inner links a second time (doubling the appended text -- and writing
+         the doubled string back through a byref param) */
+      int _sbase = str_append_chain_base(c, id);
       emit_indent(b, indent); emit_tail_lead(b);
       int _wp = g_result_var ? g_result_poly : (g_ret_type == TY_POLY);
-      if (_wp) emit_boxed(c, _srecv, b);
-      else emit_expr(c, _srecv, b);
+      if (_wp) emit_boxed(c, _sbase, b);
+      else emit_expr(c, _sbase, b);
       buf_puts(b, ";\n");
       return;
     }

--- a/test/string_shift_chain.rb
+++ b/test/string_shift_chain.rb
@@ -1,0 +1,57 @@
+# chained string appends (`s << a << b`) evaluate each link exactly once and
+# every append lands on the base. The tail form used to re-run the inner
+# links when emitting the return value (doubling the appended text, and
+# writing the doubled string back through a byref param); the value form
+# wrote back only the innermost link, so the base missed the later appends.
+
+# tail position, through a mutated parameter (the byref shape)
+def emit(buf, label)
+  buf << "[" << label << "]"
+end
+
+s = +""
+emit(s, "ok")
+p s
+r = emit(s, "go")
+p r
+p s
+
+# value position: assignment keeps base and result in step
+t = +"x"
+u = (t << "a" << "b")
+p t
+p u
+
+# parenthesized links and a longer chain
+v = +""
+(v << "1") << "2" << "3"
+p v
+
+# int argument appends its codepoint character
+w = +"y"
+w << "-" << 33
+p w
+
+# ivar base
+class Sink
+  def initialize
+    @buf = +"<"
+  end
+
+  def push(a, b)
+    @buf << a << b
+  end
+end
+
+k = Sink.new
+p k.push("m", ">")
+
+# repeated tail chains accumulate (the serializer shape)
+def line(out, op, arg)
+  out << op << " " << arg << "\n"
+end
+
+prog = +""
+line(prog, "LOAD", "a")
+line(prog, "JUMP", "top")
+print prog

--- a/test/string_shift_chain.rb.expected
+++ b/test/string_shift_chain.rb.expected
@@ -1,0 +1,10 @@
+"[ok]"
+"[ok][go]"
+"[ok][go]"
+"xab"
+"xab"
+"123"
+"y-!"
+"<m>"
+LOAD a
+JUMP top


### PR DESCRIPTION
A chained string append (`buf << a << b`) produced wrong values in both of its value-bearing positions, silently:

```ruby
def emit(buf, label)
  buf << "[" << label << "]"
end

s = +""
emit(s, "ok")
p s          # CRuby: "[ok]"; spinel: "[ok]["

t = +"x"
u = (t << "a" << "b")
p t          # CRuby: "xab"; spinel: "xa"
p u          # "xab" in both -- only the base went wrong
```

The tail shape also corrupts the caller's string through a byref parameter (#1868), which is how it surfaced in a real serializer loop.

## Mechanism

Two emitters, two different failure shapes:

**Tail position** (`emit_stmt_tail_inner`): the `string << at tail` path first runs `emit_array_mutate_stmt`, which correctly unrolls the whole chain into per-link reassignments of the base. But the return value was then emitted by re-evaluating the call's IMMEDIATE receiver — for a chain that is the inner `<<` call (`buf << "[" << label`), so its links appended a second time and wrote the doubled string back:

```c
(*_cell_buf) = sp_str_concat((*_cell_buf), "[");        /* correct: */
(*_cell_buf) = sp_str_concat((*_cell_buf), lv_label);   /* "[ok]" built */
(*_cell_buf) = sp_str_concat((*_cell_buf), "]");
/* then the return value re-ran the inner links: */
return sp_str_concat(({ _t2 = sp_str_concat((*_cell_buf), "["); (*_cell_buf) = _t2; _t2; }), lv_label);
```

Since every `<<` returns its receiver, the chain's value IS the base; the tail now walks down to the chain's base receiver (the same walk `emit_array_mutate_stmt` uses, parens unwrapped) and returns that.

**Value position** (the generic `<<` form in `codegen_call_recv.c`): write-back only happened when the receiver is a direct local/ivar read, so a chain's outer links concatenated onto a temp that never reached the base — `t` kept only the first append. A `<<` chain bottoming out at a local/ivar read now unrolls onto the base, one mutability-checked
write-back per link (matching the statement emitter), and yields the base. Non-chain appends keep the existing single-link form, and a STRBUF-promoted base keeps its dedicated in-place arm.

Covered by test/string_shift_chain.rb (the byref tail shape, a chained return value, value-position assignment, parenthesized links, a longer chain, an int codepoint argument, an ivar base, and repeated serializer-style calls).

`make test` (1601 pass) and `make optcarrot` (checksum match) are green.