### PR TITLE
codegen: bind captures of a one-line `expr in pattern`

### DIFF
--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -639,8 +639,20 @@ void emit_expr(Compiler *c, int id, Buf *b) {
       unsupported(c, id, "one-line `in` pattern");
       return;
     }
-    buf_printf(b, "(%s)", cb.p ? cb.p : "0");
+    /* Bind the pattern's captures in the enclosing scope on a successful match
+       (CRuby introduces them like `value => pattern` does, but returns a boolean
+       instead of raising). Evaluate the condition once, bind under it, yield it. */
+    int tc = ++g_tmp;
+    emit_indent(g_pre, g_indent);
+    buf_printf(g_pre, "int _t%d = (%s);\n", tc, cb.p ? cb.p : "0");
     free(cb.p);
+    emit_indent(g_pre, g_indent); buf_printf(g_pre, "if (_t%d) {\n", tc);
+    char tvname[24]; snprintf(tvname, sizeof tvname, "_t%d", tv);
+    Buf boxb; memset(&boxb, 0, sizeof boxb); emit_boxed_text(c, vt, tvname, &boxb);
+    emit_pm_bind_pattern(c, pattern, boxb.p ? boxb.p : "sp_box_nil()", g_indent + 1, g_pre, comp_scope_of(c, id));
+    free(boxb.p);
+    emit_indent(g_pre, g_indent); buf_puts(g_pre, "}\n");
+    buf_printf(b, "_t%d", tc);
     return;
   }
 

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -570,6 +570,7 @@ void emit_if(Compiler *c, int id, Buf *b, int indent, int is_unless, int tail);
 int emit_poly_class_when(Compiler *c, int cond_id, const char *tmp, Buf *b);
 void emit_pm_eq(Compiler *c, int t, TyKind pt, int valnode, Buf *b);
 int emit_pm_cond(Compiler *c, int pat, int t, TyKind pt, Buf *b);
+void emit_pm_bind_pattern(Compiler *c, int pat, const char *src_poly, int indent, Buf *b, Scope *sc);
 void emit_case_match(Compiler *c, int id, Buf *b, int indent, int tail, int value_cr);
 void emit_case(Compiler *c, int id, Buf *b, int indent);
 void emit_case_branch_value(Compiler *c, int stmts, TyKind rt, int cr, Buf *b);

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -1924,6 +1924,27 @@ static int emit_pm_bind_container_poly(Compiler *c, int spat, const char *src,
   return 1;
 }
 
+/* Public entry to the case/in capture binders, for the expression-position
+   one-line `expr in pattern`: bind the pattern's locals from a boxed scrutinee
+   expression. A non-container pattern (a bare value/pin) binds nothing. */
+void emit_pm_bind_pattern(Compiler *c, int pat, const char *src_poly, int indent, Buf *b, Scope *sc) {
+  const NodeTable *nt = c->nt;
+  const char *pty = pat >= 0 ? nt_type(nt, pat) : NULL;
+  /* A top-level `<pattern> => name` binds the whole scrutinee to name, then
+     recurses into the inner pattern. */
+  if (pty && sp_streq(pty, "CapturePatternNode")) {
+    int tgt = nt_ref(nt, pat, "target");
+    const char *ttype = tgt >= 0 ? nt_type(nt, tgt) : NULL;
+    if (ttype && sp_streq(ttype, "LocalVariableTargetNode")) {
+      const char *lnm = nt_str(nt, tgt, "name");
+      if (lnm) emit_pm_typed_assign(sc, lnm, src_poly, b, indent);
+    }
+    emit_pm_bind_container_poly(c, nt_ref(nt, pat, "value"), src_poly, indent, b, sc);
+    return;
+  }
+  emit_pm_bind_container_poly(c, pat, src_poly, indent, b, sc);
+}
+
 static void emit_pm_bind_poly(Compiler *c, int pat, const char *arr, int indent, Buf *b, Scope *sc) {
   const NodeTable *nt = c->nt;
   int apn = 0;

--- a/test/oneline_in_pattern_bind.rb
+++ b/test/oneline_in_pattern_bind.rb
@@ -1,0 +1,23 @@
+# A one-line boolean `expr in pattern` binds the pattern's captured locals in
+# the enclosing scope on a successful match (like `value => pattern`, but
+# returning a boolean instead of raising).
+x = [1, 2]
+if x in [a, b]
+  puts "matched #{a} #{b}"
+else
+  puts "no"
+end
+y = [10, 20, 30]
+if y in [head, *rest]
+  puts "head=#{head} rest=#{rest.inspect}"
+end
+h = {name: "ruby", ver: 3}
+if h in {name: String => n, ver: Integer => v}
+  puts "#{n} #{v}"
+end
+if 5 in Integer => q
+  puts "q=#{q}"
+end
+z = [1, 2]
+puts((z in [Integer, Integer]) ? "ints" : "no")
+puts((z in [String, String]) ? "strs" : "no-match")

--- a/test/oneline_in_pattern_bind.rb.expected
+++ b/test/oneline_in_pattern_bind.rb.expected
@@ -1,0 +1,6 @@
+matched 1 2
+head=10 rest=[20, 30]
+ruby 3
+q=5
+ints
+no-match


### PR DESCRIPTION
The predicate form of a pattern match (`expr in pattern`, distinct from the
rightward `=>` form) evaluated the match condition correctly but never
introduced the pattern's captured locals — so they read back `nil` in the
enclosing scope even after a successful match.

The predicate now evaluates the condition once, binds the pattern's captures
from the boxed scrutinee under a successful match (reusing the case/in capture
binders via a new public entry point), and yields the boolean. Covers array,
splat-rest, hash, and top-level `=> name` captures; a non-matching predicate
binds nothing and returns false.

Test: `oneline_in_pattern_bind` (expected output generated from CRuby).