### PR TITLE
flatten: an absolute entry path keeps its leading slash through ".."

### DIFF
--- a/tools/flatten.rb
+++ b/tools/flatten.rb
@@ -30,6 +30,10 @@ end
 # a require cycle that compounds into runaway re-inlining (the path keeps
 # growing) and a flattened file many times larger than the program.
 def canonicalize(path)
+  # An absolute path's leading "/" splits off as an empty segment; remember it
+  # and put it back, or an absolute entry resolves to a relative path that
+  # File.exist? rejects. "/.." stays the root, so ".." never stacks when abs.
+  abs = path.start_with?("/")
   stack = []
   path.split("/").each { |p|
     if p == "" || p == "."
@@ -37,14 +41,14 @@ def canonicalize(path)
     elsif p == ".."
       if stack.length > 0 && stack[stack.length - 1] != ".."
         stack.pop
-      else
+      elsif !abs
         stack.push(p)
       end
     else
       stack.push(p)
     end
   }
-  stack.join("/")
+  abs ? "/" + stack.join("/") : stack.join("/")
 end
 
 # Resolve a require_relative target against the requiring file's directory,


### PR DESCRIPTION
Passing spinel-flatten an **absolute** entry path whose require graph contains a `..` (`require_relative "../lib/foo"`) dropped the leading slash during canonicalization, so the resolved path became relative, `File.exist?` rejected it, and the require was silently replaced with a `missing file:` comment — while the tool still reported success:

```sh
mkdir -p demo/lib demo/bin
printf 'FOO = 1\n' > demo/lib/foo.rb
printf 'require_relative "../lib/foo"\nputs FOO\n' > demo/bin/app.rb

spinel-flatten -o flat.rb "$PWD/demo/bin/app.rb"
# spinel-flatten: wrote flat.rb          <- exit 0
grep missing flat.rb
# spinel-flatten: missing file: home/user/demo/lib/foo.rb
#                               ^ no leading slash; flat.rb no longer runs
```

A relative entry path works, which is how this hid: it only bites when a build script hands flatten an absolute path.

## Mechanism

`canonicalize` rebuilds the path from `path.split("/")` segments to collapse `.` / `..` (needed so one file reached via two spellings dedups instead of re-inlining). An absolute path's leading `/` splits off as an empty segment, and the dot-segment filter discards empty segments — so the rejoin came back relative.

`canonicalize` now remembers whether the input was absolute and puts the leading `/` back. While absolute, a `..` at the root stays at the root (POSIX: `/..` is `/`) instead of stacking a bogus `..` segment; relative inputs keep the old leading-`..` preservation.

Verified against the repro above (absolute entry inlines and the output runs), a relative entry (unchanged), and the dedup case (`require_relative "../lib/../lib/foo"` alongside `"../lib/foo"` still inlines once).

The tools have no test harness (they are kept honest by being compiled in the spinel subset — a broken tool breaks the build), so this ships with the manual verification above; `make test` (1643 pass) and `make optcarrot` (checksum match) are green.