### PR TITLE
codegen: an unresolved constant in a scalar slot raises NameError, not a C error

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -102,14 +102,27 @@ void emit_unbox_text(Compiler *c, TyKind t, const char *expr, Buf *b) {
   else buf_printf(b, "(%s).v.i", expr);
 }
 
+/* An unresolved constant read lowers to a runtime NameError raise whose C
+   value is an sp_Class struct (the class-position shape). In a scalar slot
+   that struct fails the C compile ("incompatible types"), so the scalar
+   emitters keep the raise, void the struct, and yield a typed zero -- dead
+   code, the raise fires first. Text-matched on the gate's own token, like
+   emit_str_expr's sp_raise_nomethod coerce (the node stays TY_UNKNOWN). */
+static int coerce_const_raise(const char *txt, const char *zero, Buf *b) {
+  if (strncmp(txt, "(sp_raise_cls(", 14) != 0 || !strstr(txt, "(sp_Class)")) return 0;
+  buf_printf(b, "((void)%s, %s)", txt, zero);
+  return 1;
+}
+
 /* Emit a node as an mrb_int, coercing a poly value through sp_poly_to_i. Used
    where the runtime ABI demands a raw integer (array indices, etc.) but the
    expression's static type widened to poly. */
 void emit_int_expr(Compiler *c, int node, Buf *b) {
   if (comp_ntype(c, node) == TY_POLY) {
     buf_puts(b, "sp_poly_to_i("); emit_expr(c, node, b); buf_puts(b, ")");
+    return;
   }
-  else emit_expr(c, node, b);
+  emit_scalar_operand(c, node, "0", b);
 }
 
 /* Emit a node as an mrb_float. A poly value is unboxed via sp_poly_to_f; any
@@ -117,8 +130,24 @@ void emit_int_expr(Compiler *c, int node, Buf *b) {
 void emit_float_expr(Compiler *c, int node, Buf *b) {
   if (comp_ntype(c, node) == TY_POLY) {
     buf_puts(b, "sp_poly_to_f("); emit_expr(c, node, b); buf_puts(b, ")");
+    return;
   }
-  else { buf_puts(b, "(mrb_float)("); emit_expr(c, node, b); buf_puts(b, ")"); }
+  Buf tmp; memset(&tmp, 0, sizeof tmp);
+  emit_expr(c, node, &tmp);
+  if (!coerce_const_raise(tmp.p ? tmp.p : "", "0.0", b)) {
+    buf_puts(b, "(mrb_float)(");
+    buf_puts(b, tmp.p ? tmp.p : "");
+    buf_puts(b, ")");
+  }
+  free(tmp.p);
+}
+
+/* See codegen_internal.h. */
+void emit_scalar_operand(Compiler *c, int node, const char *zero, Buf *b) {
+  Buf tmp; memset(&tmp, 0, sizeof tmp);
+  emit_expr(c, node, &tmp);
+  if (!coerce_const_raise(tmp.p ? tmp.p : "", zero, b)) buf_puts(b, tmp.p ? tmp.p : "");
+  free(tmp.p);
 }
 
 /* Emit a node as a `const char *` string. A poly value (e.g. a `String | nil`

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -4230,7 +4230,7 @@ static int emit_array_arith_call(Compiler *c, int id, Buf *b) {
       buf_printf(b, "%s(", int_arith_fn(name));
       emit_expr(c, recv, b); buf_puts(b, ", ");
       if (isdivmod) emit_int_divisor(c, argv[0], b);
-      else emit_expr(c, argv[0], b);
+      else emit_scalar_operand(c, argv[0], "0", b);
       buf_puts(b, ")");
       return 1;
     }
@@ -4261,9 +4261,9 @@ static int emit_array_arith_call(Compiler *c, int id, Buf *b) {
     }
     if (eff_res == TY_FLOAT && rt != TY_TIME && !sp_streq(name, "%") && !sp_streq(name, "**")) {
       buf_puts(b, "(");
-      emit_expr(c, recv, b);
+      emit_scalar_operand(c, recv, "0.0", b);
       buf_printf(b, " %s ", name);
-      emit_expr(c, argv[0], b);
+      emit_scalar_operand(c, argv[0], "0.0", b);
       buf_puts(b, ")");
       return 1;
     }

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -1137,7 +1137,10 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
           buf_printf(b, "; _t%d.v.i; })", t);
         }
 else {
-          emit_expr(c, argv[0], b);
+          /* emit_int_expr, not raw: an unresolved-constant index lowers to a
+             NameError raise whose C value is an sp_Class, which the int slot
+             rejects at C compile time. */
+          emit_int_expr(c, argv[0], b);
         }
         buf_puts(b, ")");
         return 1;

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -603,6 +603,11 @@ void emit_int_expr(Compiler *c, int node, Buf *b);
 void emit_str_expr(Compiler *c, int node, Buf *b);
 void emit_int_divisor(Compiler *c, int node, Buf *b);
 void emit_float_expr(Compiler *c, int node, Buf *b);
+/* Emit `node` as a scalar operand: like a plain emit_expr, except an
+   unresolved-constant read (which lowers to a NameError raise valued as an
+   sp_Class struct) is voided and replaced by `zero` ("0" / "0.0"), so the
+   raise survives but the struct never reaches an int/float slot. */
+void emit_scalar_operand(Compiler *c, int node, const char *zero, Buf *b);
 void declare_local(Compiler *c, Buf *b, LocalVar *lv, int vol);
 int scope_has_begin(Compiler *c, int si);
 void emit_scope_decls(Compiler *c, Scope *s, Buf *b);

--- a/test/undef_const_scalar_position.rb
+++ b/test/undef_const_scalar_position.rb
@@ -1,0 +1,58 @@
+# An unresolved constant read lowers to a runtime NameError raise whose C
+# value is an sp_Class; used in a scalar slot (Array.new count, array index,
+# int/float arithmetic operand) the struct used to leak into the generated C
+# and fail the compile ("incompatible types ... using type 'sp_Class'").
+# CRuby raises NameError at runtime -- and only when the read executes.
+
+module Params
+end
+
+def by_count
+  Array.new(Params::FRI_FINAL_MAX_LEN) { |i| i }
+end
+
+def by_index
+  [1, 2][Params::FOO]
+end
+
+def by_float_arith
+  1.5 * Params::RATIO
+end
+
+def by_int_arith
+  2 * Params::N
+end
+
+# defined but never called: the undefined constant must stay silent
+def never_called
+  Array.new(Params::UNUSED) { |i| i }
+end
+
+[1, 2].each do |unused|
+  # loop so the rescue sites emit once but run twice: the raise is per-read
+  begin
+    by_count
+  rescue NameError => e
+    puts e.message
+  end
+end
+
+begin
+  by_index
+rescue NameError => e
+  puts e.message
+end
+
+begin
+  by_float_arith
+rescue NameError => e
+  puts e.message
+end
+
+begin
+  by_int_arith
+rescue NameError => e
+  puts e.message
+end
+
+puts "done"

--- a/test/undef_const_scalar_position.rb.expected
+++ b/test/undef_const_scalar_position.rb.expected
@@ -1,0 +1,6 @@
+uninitialized constant Params::FRI_FINAL_MAX_LEN
+uninitialized constant Params::FRI_FINAL_MAX_LEN
+uninitialized constant Params::FOO
+uninitialized constant Params::RATIO
+uninitialized constant Params::N
+done


### PR DESCRIPTION
Reading an undefined constant in a scalar position killed the build with a raw C compiler error instead of Ruby's NameError:

```ruby
module Params
end

xs = Array.new(Params::FRI_FINAL_MAX_LEN) { |i| i }
```

CRuby raises `uninitialized constant Params::FRI_FINAL_MAX_LEN (NameError)` at runtime; spinel died at the C stage:

```
error: incompatible types when initializing type 'mrb_int' {aka 'long int'} using type 'sp_Class'
```

The same leak hits a typed-array index (`[1, 2][Params::FOO]`) and an int/float arithmetic operand (`2 * Params::N`, `1.5 * Params::RATIO`). Other positions (a `p` argument, unknown-receiver arithmetic) already stop with a loud `unsupported ...` reject — only the scalar slots let the C error through.

## Mechanism

An unresolved constant read already lowers to a runtime NameError, but the raise expression is valued as an sp_Class struct (the shape class positions want):

```c
(sp_raise_cls("NameError", "uninitialized constant Params::FOO"), ((sp_Class){-1}))
```

Spliced into an `mrb_int` initializer, an `sp_IntArray_get` index, or a `double *` operand, the struct fails the C compile.

## Fix

`emit_int_expr` / `emit_float_expr` — and a small new `emit_scalar_operand` used by the typed-array index arm and the
int/float binop arms — recognize the raise shape (text-matched on its own token, the same technique `emit_str_expr` already uses for `sp_raise_nomethod`) and rewrite it to `((void)<raise>, 0)`: the raise still fires first at runtime, the void discards the struct, and the typed zero keeps the C well-formed. This also matches the existing `Integer::MAX/MIN` precedent, which emits the raise with an int-shaped `, 0)` tail for the same reason.

Dead reads stay silent, matching CRuby — the raise only runs when the read executes (an uncalled method holding the undefined constant compiles and stays quiet).

Covered by test/undef_const_scalar_position.rb (Array.new count, array index, int and float operands — each rescued, the first re-run in a loop to show the raise is per-read — plus an uncalled method whose undefined constant must not fire).

`make test` (1710 pass) and `make optcarrot` (checksum match) are green.