### PR TITLE
codegen: raise FrozenError on frozen Array#clear, String append, and Hash op-assign

### DIFF
--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -316,21 +316,30 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
       const char *rvt2 = nt_type(nt, recv);
       int lvw = rvt2 && (sp_streq(rvt2, "LocalVariableReadNode") ||
                          sp_streq(rvt2, "InstanceVariableReadNode"));
-      int tn2 = ++g_tmp;
-      buf_printf(b, "({ const char *_t%d = ", tn2);
+      int tn2 = ++g_tmp, trc = ++g_tmp;
+      /* Evaluate the receiver once into a temp: it feeds both the frozen-mutability
+         check and the concatenation, and a chained `s << a << b` receiver has a
+         side effect that must not run twice. */
+      buf_printf(b, "({ const char *_t%d = ", trc); emit_expr(c, recv, b); buf_puts(b, "; ");
+      buf_printf(b, "const char *_t%d = ", tn2);
       if (sp_streq(name, "prepend")) {
         /* args first (in order), then the receiver */
         for (int j = 0; j < argc; j++) buf_puts(b, "sp_str_concat(");
         emit_str_expr(c, argv[0], b);
         for (int j = 1; j < argc; j++) { buf_puts(b, ", "); emit_str_expr(c, argv[j], b); buf_puts(b, ")"); }
-        buf_puts(b, ", "); emit_expr(c, recv, b); buf_puts(b, ")");
+        buf_printf(b, ", _t%d)", trc);
       }
       else {
         for (int j = 0; j < argc; j++) buf_puts(b, "sp_str_concat(");
-        emit_expr(c, recv, b);
+        buf_printf(b, "_t%d", trc);
         for (int j = 0; j < argc; j++) { buf_puts(b, ", "); emit_str_expr(c, argv[j], b); buf_puts(b, ")"); }
       }
       buf_puts(b, "; ");
+      /* Ruby evaluates the argument(s) before invoking the mutator, so the
+         frozen check must fire AFTER the concatenation builds (which is what
+         evaluates the args). sp_str_concat allocates a fresh string and never
+         mutates the receiver, so a frozen receiver is still untouched here. */
+      buf_printf(b, "sp_str_check_mutable(_t%d); ", trc);
       if (lvw) { emit_expr(c, recv, b); buf_printf(b, " = _t%d; ", tn2); }
       buf_printf(b, "_t%d; })", tn2);
       return 1;
@@ -1305,7 +1314,7 @@ else {
         /* empty the array in place, evaluate to it (Ruby returns self) */
         int t = ++g_tmp;
         buf_printf(b, "({ sp_%sArray *_t%d = ", k, t); emit_expr(c, recv, b);
-        buf_printf(b, "; if (_t%d) _t%d->len = 0; _t%d; })", t, t, t);
+        buf_printf(b, "; if (_t%d && _t%d->frozen) sp_raise_cls(\"FrozenError\", sp_sprintf(\"can't modify frozen Array: %%s\", sp_%sArray_inspect(_t%d))); if (_t%d) _t%d->len = 0; _t%d; })", t, t, k, t, t, t, t);
         return 1;
       }
       if (sp_streq(name, "cycle") && argc == 1 && nt_ref(nt, id, "block") < 0) {
@@ -2310,7 +2319,7 @@ else {
       if (sp_streq(name, "clear") && argc == 0) {
         int t = ++g_tmp;
         buf_printf(b, "({ sp_PolyArray *_t%d = ", t); emit_expr(c, recv, b);
-        buf_printf(b, "; if (_t%d) _t%d->len = 0; _t%d; })", t, t, t);
+        buf_printf(b, "; if (_t%d && _t%d->frozen) sp_raise_cls(\"FrozenError\", sp_sprintf(\"can't modify frozen Array: %%s\", sp_PolyArray_inspect(_t%d))); if (_t%d) _t%d->len = 0; _t%d; })", t, t, t, t, t, t);
         return 1;
       }
       if (sp_streq(name, "+") && argc == 1 && a0 == TY_POLY_ARRAY) {

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -8064,11 +8064,15 @@ void emit_index_op_write(Compiler *c, int id, Buf *b, int indent) {
     buf_printf(b, "{ %s _t%d = ", c_type_name(rt), ta); emit_expr(c, recv, b);
     buf_printf(b, "; %s _t%d = ", c_type_name(ty_hash_key(rt)), tb); emit_hash_key(c, argv[0], ty_hash_key(rt), b);
     buf_puts(b, "; ");
-    buf_printf(b, "sp_%sHash_set(_t%d, _t%d, ", hn, ta, tb);
+    /* Build the new value (which reads the slot and evaluates the RHS) BEFORE
+       the frozen check: Ruby desugars `h[k] += v` to `h[k] = h[k] + v`, so the
+       read and the RHS run before []= raises on a frozen hash. */
+    int tv = ++g_tmp;
     const char *pf = vt == TY_POLY ?
         (sp_streq(op, "+") ? "sp_poly_add" : sp_streq(op, "-") ? "sp_poly_sub" :
          sp_streq(op, "*") ? "sp_poly_mul" : sp_streq(op, "/") ? "sp_poly_div" :
          sp_streq(op, "%") ? "sp_poly_mod" : sp_streq(op, "**") ? "sp_poly_pow" : NULL) : NULL;
+    buf_printf(b, "%s _t%d = ", c_type_name(vt), tv);
     if (vt == TY_STRING && sp_streq(op, "+")) {
       buf_printf(b, "sp_str_concat(sp_%sHash_get(_t%d, _t%d), ", hn, ta, tb);
       emit_expr(c, v, b); buf_puts(b, ")");
@@ -8082,7 +8086,9 @@ void emit_index_op_write(Compiler *c, int id, Buf *b, int indent) {
       buf_printf(b, "sp_%sHash_get(_t%d, _t%d) %s ", hn, ta, tb, op);
       buf_puts(b, "("); emit_expr(c, v, b); buf_puts(b, ")");
     }
-    buf_puts(b, "); }\n");
+    buf_puts(b, "; ");
+    buf_printf(b, "if (sp_gc_is_frozen(_t%d)) sp_raise_frozen_hash(); ", ta);
+    buf_printf(b, "sp_%sHash_set(_t%d, _t%d, _t%d); }\n", hn, ta, tb, tv);
     return;
   }
 

--- a/test/array_clear_frozen_guard.rb
+++ b/test/array_clear_frozen_guard.rb
@@ -1,0 +1,12 @@
+# Array#clear on a frozen array raises FrozenError with the CRuby message
+# (including the inspected contents); a non-frozen array clears normally.
+def cl(a); a.clear; a; end
+begin
+  cl([1, 2].freeze)
+rescue FrozenError => e
+  puts e.class
+  puts e.message
+end
+arr = [10, 20, 30]
+cl(arr)
+p arr

--- a/test/array_clear_frozen_guard.rb.expected
+++ b/test/array_clear_frozen_guard.rb.expected
@@ -1,0 +1,3 @@
+FrozenError
+can't modify frozen Array: [1, 2]
+[]

--- a/test/frozen_hash_opassign_guard.rb
+++ b/test/frozen_hash_opassign_guard.rb
@@ -1,0 +1,5 @@
+# A compound assignment (h[k] += v) to a frozen Hash raises FrozenError instead
+# of silently mutating; a non-frozen hash updates normally.
+def inc(h); h[:x] += 1; h[:x]; rescue FrozenError => e; e.class.name; end
+p inc({x: 5}.freeze)
+p inc({x: 5})

--- a/test/frozen_hash_opassign_guard.rb.expected
+++ b/test/frozen_hash_opassign_guard.rb.expected
@@ -1,0 +1,2 @@
+"FrozenError"
+6

--- a/test/frozen_mutation_arg_eval_order.rb
+++ b/test/frozen_mutation_arg_eval_order.rb
@@ -1,0 +1,14 @@
+# Ruby evaluates a mutator's arguments before the call runs, so a
+# side-effecting argument (and an op-assign RHS) must still execute even when
+# the receiver is frozen and the mutation ultimately raises FrozenError. Each
+# "arg:X" must print BEFORE its "... raised" line.
+def note(x); puts "arg:#{x}"; x; end
+
+begin; "hi".freeze.concat(note("!")); rescue FrozenError; puts "concat raised"; end
+begin; "yo".freeze.prepend(note(">")); rescue FrozenError; puts "prepend raised"; end
+
+h = {n: 1}.freeze
+begin; h[:n] += note(9); rescue FrozenError; puts "hash raised"; end
+
+# sanity: the unfrozen path still evaluates the arg AND mutates
+m = "go"; m << note("!"); puts m

--- a/test/frozen_mutation_arg_eval_order.rb.expected
+++ b/test/frozen_mutation_arg_eval_order.rb.expected
@@ -1,0 +1,8 @@
+arg:!
+concat raised
+arg:>
+prepend raised
+arg:9
+hash raised
+arg:!
+go!

--- a/test/frozen_string_append_guard.rb
+++ b/test/frozen_string_append_guard.rb
@@ -1,0 +1,10 @@
+# <<, concat, and prepend on a frozen String raise FrozenError with the CRuby
+# message (including contents), whether the receiver is a chained .freeze or a
+# frozen local; a mutable string appends normally.
+def ap(s, x); s << x; end
+begin; ap("abc".freeze, "x"); rescue FrozenError => e; puts e.message; end
+begin; "hi".freeze.concat("!"); rescue FrozenError => e; puts e.message; end
+begin; "yo".freeze.prepend(">"); rescue FrozenError => e; puts e.message; end
+d = "abc".dup.freeze
+begin; d << "z"; rescue FrozenError => e; puts e.message; end
+m = "go"; m << "!"; puts m

--- a/test/frozen_string_append_guard.rb.expected
+++ b/test/frozen_string_append_guard.rb.expected
@@ -1,0 +1,5 @@
+can't modify frozen String: "abc"
+can't modify frozen String: "hi"
+can't modify frozen String: "yo"
+can't modify frozen String: "abc"
+go!


### PR DESCRIPTION
Three in-place mutation paths skipped the frozen guard that the other array,
string, and hash mutators already carry, so a frozen receiver was silently
modified. Each now raises `FrozenError`, matching CRuby.

- `Array#clear` emitted an inline `len = 0` with no check. It now raises with
  the CRuby message (including the inspected contents), for both typed and poly
  arrays.
- String `<<` / `concat` / `prepend` on a non-chained receiver (e.g. a
  `.freeze` or `.dup` receiver) skipped the mutability check the chained-local
  path already performs. The receiver is now evaluated once into a temp (so a
  chained `s << a << b` receiver is not evaluated twice), and the frozen check
  runs **after** the arguments are evaluated — Ruby evaluates a method's
  arguments before invoking it, so a side-effecting argument still runs even
  when the receiver is frozen (`sp_str_concat` allocates a fresh string and
  never mutates the receiver, so it is untouched when the check raises).
- A compound `Hash` assignment (`h[k] += v`) emitted the set with no frozen
  check, unlike the plain `h[k] = v` path. It now builds the new value (which
  reads the slot and evaluates the RHS) and then guards with `sp_gc_is_frozen`,
  mirroring CRuby's `h[k] = h[k] + v` order.

Each behavior ships with a `test/` case (asserting the caught `FrozenError` and
its message) whose expected output is generated from CRuby, plus an argument
eval-order test covering the side-effecting-argument cases above.

Not covered here: `freeze` on an empty container literal (`{}.freeze`) is still
dropped before it can set the frozen bit — a separate empty-literal typing
issue — and the pre-existing statement-position string mutators, whose own
frozen check predates this change. Both are tracked separately.
