### PR TITLE
codegen: case/when matches a String scrutinee against a string range

### DIFF
--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -2941,6 +2941,39 @@ static int subtree_has_loop_break(Compiler *c, int root) {
   return 0;
 }
 
+/* `when <string-range>` with a String scrutinee: Range#=== is cover?, i.e.
+   lexicographic <=> against both endpoints (byte order, like String#<=>).
+   Handles beginless/endless forms. Emits nothing and returns 0 when the
+   condition isn't a range with String endpoints. */
+static int emit_when_string_range(Compiler *c, int cond, int t, Buf *b) {
+  const NodeTable *nt = c->nt;
+  const char *cty = nt_type(nt, cond);
+  if (!cty || !sp_streq(cty, "RangeNode")) return 0;
+  int left = nt_ref(nt, cond, "left");
+  int right = nt_ref(nt, cond, "right");
+  if (left < 0 && right < 0) return 0;
+  if (left >= 0 && comp_ntype(c, left) != TY_STRING) return 0;
+  if (right >= 0 && comp_ntype(c, right) != TY_STRING) return 0;
+  int excl = (int)(nt_int(nt, cond, "flags", 0) & 4) ? 1 : 0;
+  int tl = left >= 0 ? ++g_tmp : -1;
+  int tr = right >= 0 ? ++g_tmp : -1;
+  buf_puts(b, "({ ");
+  if (left >= 0) {
+    buf_printf(b, "const char *_t%d = ", tl); emit_expr(c, left, b); buf_puts(b, "; ");
+  }
+  if (right >= 0) {
+    buf_printf(b, "const char *_t%d = ", tr); emit_expr(c, right, b); buf_puts(b, "; ");
+  }
+  buf_printf(b, "_t%d", t);
+  /* A nil endpoint (NULL for a String-typed slot, e.g. an unset ivar) is an
+     open bound in CRuby -- `(nil.."m") === "c"` is true -- so a NULL endpoint
+     passes its side of the cover check rather than matching or dereferencing. */
+  if (left >= 0) buf_printf(b, " && (!_t%d || strcmp(_t%d, _t%d) <= 0)", tl, tl, t);
+  if (right >= 0) buf_printf(b, " && (!_t%d || strcmp(_t%d, _t%d) %s 0)", tr, t, tr, excl ? "<" : "<=");
+  buf_puts(b, "; })");
+  return 1;
+}
+
 void emit_case(Compiler *c, int id, Buf *b, int indent) {
   const NodeTable *nt = c->nt;
   int pred = nt_ref(nt, id, "predicate");
@@ -3107,6 +3140,9 @@ void emit_case(Compiler *c, int id, Buf *b, int indent) {
           int reidx = re_lit_index(c, conds[j]);
           if (reidx >= 0 && pt == TY_STRING) {
             buf_printf(b, "sp_re_match_p(sp_re_pat_%d, _t%d)", reidx, t);
+          }
+          else if (pt == TY_STRING && emit_when_string_range(c, conds[j], t, b)) {
+            /* emitted the lexicographic cover check */
           }
           else if (comp_ntype(c, conds[j]) == TY_RANGE && pt != TY_STRING) {
             /* `when lo..hi` is range membership, not equality */
@@ -3301,6 +3337,9 @@ void emit_case_expr(Compiler *c, int id, Buf *b) {
         else {
         int reidx = re_lit_index(c, conds[j]);
         if (reidx >= 0 && pt == TY_STRING) { buf_printf(b, "sp_re_match_p(sp_re_pat_%d, _t%d)", reidx, t); }
+        else if (pt == TY_STRING && emit_when_string_range(c, conds[j], t, b)) {
+          /* emitted the lexicographic cover check */
+        }
         else if (comp_ntype(c, conds[j]) == TY_RANGE && pt != TY_STRING) {
           int tr = ++g_tmp;
           buf_printf(b, "({ sp_Range _t%d = ", tr); emit_expr(c, conds[j], b);

--- a/test/case_when_string_range.rb
+++ b/test/case_when_string_range.rb
@@ -1,0 +1,57 @@
+# case/when with a String scrutinee and string-range conditions: Range#===
+# is cover? (lexicographic <=>), including exclusive, beginless, endless,
+# and non-literal endpoints, in both statement and value position.
+def label(c)
+  case c
+  when "a".."m" then "low"
+  else "hi"
+  end
+end
+p label("c")
+p label("a")
+p label("m")
+p label("n")
+p label("cat")
+p label("")
+
+def label_excl(c)
+  case c
+  when "a"..."m" then "low"
+  else "hi"
+  end
+end
+p label_excl("l")
+p label_excl("m")
+p label_excl("lz")
+
+def label_var(c, lo, hi)
+  case c
+  when lo..hi then "in"
+  else "out"
+  end
+end
+p label_var("dog", "d", "f")
+p label_var("cat", "d", "f")
+
+def label_open(c)
+  case c
+  when ..."d" then "early"
+  when "n".. then "late"
+  else "mid"
+  end
+end
+p label_open("b")
+p label_open("q")
+p label_open("g")
+
+def bucket(c)
+  r = case c
+      when "a".."m" then 1
+      when "x" then 2
+      else 3
+      end
+  r
+end
+p bucket("b")
+p bucket("x")
+p bucket("q")

--- a/test/case_when_string_range.rb.expected
+++ b/test/case_when_string_range.rb.expected
@@ -1,0 +1,17 @@
+"low"
+"low"
+"low"
+"hi"
+"low"
+"hi"
+"low"
+"hi"
+"low"
+"in"
+"out"
+"early"
+"late"
+"mid"
+1
+2
+3

--- a/test/case_when_string_range_nil_bound.rb
+++ b/test/case_when_string_range_nil_bound.rb
@@ -1,0 +1,23 @@
+# A nil endpoint of a string range (here an unset String ivar, which reads as a
+# NULL slot) is an OPEN bound under Range#=== / case-when, exactly like CRuby:
+# `(nil.."m") === "c"` is true. The endpoint must not be dereferenced by strcmp,
+# and must widen its side rather than fail the match.
+class Bounds
+  def initialize(set_lo, set_hi)
+    @lo = "d" if set_lo
+    @hi = "m" if set_hi
+  end
+  def classify(s)
+    case s
+    when @lo..@hi then "in"
+    else "out"
+    end
+  end
+end
+
+p Bounds.new(false, true).classify("c")   # open lower, "c" <= "m"  -> in
+p Bounds.new(false, true).classify("z")   # open lower, "z" >  "m"  -> out
+p Bounds.new(true, false).classify("f")   # "f" >= "d", open upper  -> in
+p Bounds.new(true, false).classify("a")   # "a" <  "d"              -> out
+p Bounds.new(true, true).classify("g")    # "d" <= "g" <= "m"       -> in
+p Bounds.new(false, false).classify("x")  # both open               -> in

--- a/test/case_when_string_range_nil_bound.rb.expected
+++ b/test/case_when_string_range_nil_bound.rb.expected
@@ -1,0 +1,6 @@
+"in"
+"out"
+"in"
+"out"
+"in"
+"in"


### PR DESCRIPTION
A `when lo..hi` arm with String endpoints under a String scrutinee compiled to the string-equality fallback (comparing the scrutinee against the range value itself), so it never matched and control fell to `else`. CRuby's `Range#===` over strings is `cover?`: a lexicographic `<=>` check against both endpoints.

This adds a shape-keyed arm to both case/when lowerings (statement chain and value form) that emits a `strcmp` cover check for a range condition whose endpoints are String-typed expressions:

- inclusive and exclusive (`...`) ends
- beginless (`..."d"`) and endless (`"n"..`) forms
- non-literal endpoint expressions (bound to temps, evaluated once)
- multi-byte scrutinees (`"cat"` matches `"a".."m"`, as in CRuby)

The check keys on the AST node shape rather than the inferred range type, and a nil scrutinee is guarded to non-matching. Tests cover all the above shapes in both statement and value position, with the expected output generated by `ruby`.
