### PR TITLE
analyze,codegen,runtime: freeze / frozen? carry real state via bareword self

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -4111,6 +4111,17 @@ static inline const char *sp_poly_inspect(sp_RbVal v) {
     default:          return sp_str_empty;
   }
 }
+/* FrozenError for a frozen user instance: "can't modify frozen <Name>: <inspect>".
+   `what` carries the class-bearing prefix ("can't modify frozen C"), rodata
+   marker-prefixed at the emit site; the receiver renders through the full
+   poly inspect (per-class ivar walk). */
+static void __attribute__((noinline,cold)) sp_raise_frozen_obj(sp_RbVal v, const char *what) {
+  const char *ins = sp_poly_inspect(v);
+  SP_GC_ROOT_STR(ins);
+  const char *msg = sp_str_concat3(what, (&("\xff" ": ")[1]), ins);
+  SP_GC_ROOT_STR(msg);
+  sp_raise_cls("FrozenError", msg);
+}
 /* Raise Hash#fetch's KeyError with MRI's "key not found: <key.inspect>" text.
    Boxing the key lets one helper serve every key type (symbol, string, int,
    ...) via sp_poly_inspect. */

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -6385,6 +6385,37 @@ void analyze_program(Compiler *c) {
   for (int id = 0; id < c->nt->count; id++) {
     const char *ty = nt_type(c->nt, id);
     if (!ty) continue;
+    /* freeze/frozen? reaching a class's instances needs the GC-header frozen
+       bit, which a by-value struct doesn't have: force heap representation
+       and mark the class so codegen guards its ivar stores. A poly-receiver
+       freeze can hit any boxable instance, so it marks every class. */
+    if (sp_streq(ty, "CallNode")) {
+      const char *fzn = nt_str(c->nt, id, "name");
+      if (fzn && (sp_streq(fzn, "freeze") || sp_streq(fzn, "frozen?"))) {
+        int frecv = nt_ref(c->nt, id, "receiver");
+        int q = -1;
+        if (frecv >= 0) {
+          TyKind frt = comp_ntype(c, frecv);
+          if (ty_is_object(frt)) q = ty_object_class(frt);
+          else if (frt == TY_POLY && sp_streq(fzn, "freeze"))
+            /* a poly-receiver freeze can hit any class's instance, so every
+               class must carry the GC-header frozen bit -- disqualify them all
+               from the by-value layout too, matching the single-class path */
+            for (int q2 = 0; q2 < c->nclasses; q2++) {
+              c->classes[q2].is_value_type = 0;
+              c->classes[q2].freeze_observed = 1;
+            }
+        }
+        else {
+          Scope *fs = comp_scope_of(c, id);
+          if (fs && fs->class_id >= 0 && !fs->is_cmethod) q = fs->class_id;
+        }
+        if (q >= 0 && q < c->nclasses) {
+          c->classes[q].is_value_type = 0;
+          c->classes[q].freeze_observed = 1;
+        }
+      }
+    }
     /* nil-witness: a slot holding `nil | W` encodes nil as the heap
        pointer's NULL; a by-value struct has no nil representation, so any
        nil witness on a W-typed slot disqualifies the value layout (#1686).

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -1277,6 +1277,13 @@ TyKind infer_call(Compiler *c, int id) {
     if (s && s->class_id >= 0 && comp_method_in_chain(c, s->class_id, name, NULL) < 0)
       return ty_object(s->class_id);
   }
+  /* bareword frozen? reads the instance's GC-header bit (see the codegen arm) */
+  if (recv < 0 && argc == 0 && nt_ref(c->nt, id, "block") < 0 && sp_streq(name, "frozen?")) {
+    Scope *s = comp_scope_of(c, id);
+    if (s && s->class_id >= 0 && !s->is_cmethod &&
+        comp_method_in_chain(c, s->class_id, name, NULL) < 0)
+      return TY_BOOL;
+  }
 
   /* x.class -> a first-class Class value for every known receiver kind
      (name-backed for builtins, id-backed for user objects) */

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -6319,20 +6319,31 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     return;
   }
 
-  /* Bareword Object#freeze (implicit self) inside an instance method: freeze is
-     a no-op returning self, which is behaviorally faithful for the common
-     defensive-freeze idiom (`def initialize; ...; freeze; end`) since nothing
-     downstream can observe the difference without a frozen-state query. The
-     companion frozen? (and FrozenError on mutation) needs per-object frozen
-     state spinel does not track, so a bareword frozen? deliberately stays a
-     loud reject rather than silently reporting false. A class that defines its
-     own freeze keeps its method. */
-  if (recv < 0 && argc == 0 && nt_ref(nt, id, "block") < 0 && sp_streq(name, "freeze")) {
+  /* Bareword Object#freeze / frozen? (implicit self) inside an instance
+     method: heap-represented instances carry real frozen state in the GC
+     header (the analyze observation pass forces any freeze-touched class to
+     heap representation), so the defensive-freeze idiom
+     (`def initialize; ...; freeze; end`) sets the bit and `frozen?` reads it
+     back. A class that defines its own freeze/frozen? keeps its method; a
+     value-type self (unreachable for observed classes) keeps the identity
+     no-op for freeze and the loud reject for frozen?. */
+  if (recv < 0 && argc == 0 && nt_ref(nt, id, "block") < 0 &&
+      (sp_streq(name, "freeze") || sp_streq(name, "frozen?"))) {
     Scope *s = comp_scope_of(c, id);
     int scid = s ? s->class_id : -1;
     if (scid >= 0 && comp_method_in_chain(c, scid, name, NULL) < 0) {
-      buf_puts(b, g_self ? g_self : "self");
-      return;
+      if (!s->is_cmethod && !c->classes[scid].is_value_type) {
+        if (sp_streq(name, "freeze"))
+          buf_printf(b, "((sp_%s *)sp_gc_freeze((void *)%s))",
+                     c->classes[scid].c_name, g_self ? g_self : "self");
+        else
+          buf_printf(b, "sp_gc_is_frozen((void *)%s)", g_self ? g_self : "self");
+        return;
+      }
+      if (sp_streq(name, "freeze")) {
+        buf_puts(b, g_self ? g_self : "self");
+        return;
+      }
     }
   }
 

--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -822,20 +822,26 @@ void emit_expr(Compiler *c, int id, Buf *b) {
         v_empty_hash2 = (nt_arr(nt, v, "elements", &hen2), hen2 == 0);
     }
     char ref2e[300];
+    int fz_cid = -1;  /* instance-path writes guard the frozen bit */
     if (cws && cws->is_cmethod && cid2 >= 0)
       snprintf(ref2e, sizeof ref2e, "civ_%s_%s", c->classes[cid2].name, nm + 1);
-    else if (cid2 < 0 && g_ie_class_id >= 0)
+    else if (cid2 < 0 && g_ie_class_id >= 0) {
       snprintf(ref2e, sizeof ref2e, "%s%siv_%s", g_self, g_self_deref, nm + 1);
+      fz_cid = g_ie_class_id;
+    }
     else if (cid2 < 0 && comp_class_index(c, "Toplevel") >= 0)
       snprintf(ref2e, sizeof ref2e, "civ_Toplevel_%s", nm + 1);
-    else
+    else {
       snprintf(ref2e, sizeof ref2e, "%s%siv_%s", g_self, g_self_deref, nm + 1);
+      fz_cid = cid2;
+    }
     /* `@a = @b = nil` as expression: inner writes become statements inside the
        stmt-expr; this target takes its own typed nil (not the inner slot). */
     {
       int ncb = comp_nil_chain_bottom(nt, v);
       if (ncb >= 0) {
         buf_puts(b, "({ ");
+        if (fz_cid >= 0) emit_frozen_obj_guard(c, fz_cid, g_self ? g_self : "self", b);
         emit_stmt_inner(c, v, b, 0);
         buf_printf(b, "%s = ", ref2e);
         if (ivt2 == TY_RANGE) buf_puts(b, "(sp_Range){0}");
@@ -849,6 +855,7 @@ void emit_expr(Compiler *c, int id, Buf *b) {
       }
     }
     buf_puts(b, "({ ");
+    if (fz_cid >= 0) emit_frozen_obj_guard(c, fz_cid, g_self ? g_self : "self", b);
     buf_printf(b, "%s = ", ref2e);
     if (v_empty_array2 && ivt2 == TY_POLY_ARRAY) buf_puts(b, "sp_PolyArray_new()");
     else if (v_empty_array2 && array_kind(ivt2)) buf_printf(b, "sp_%sArray_new()", array_kind(ivt2));

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -351,6 +351,7 @@ void emit_boxed(Compiler *c, int node, Buf *b);
 void emit_hash_key(Compiler *c, int key, TyKind kt, Buf *b);
 void emit_boxed_text(Compiler *c, TyKind t, const char *expr, Buf *b);
 int emit_iter_bind_rest(Compiler *c, int block, int np, TyKind elem_t, const char *elem_src, Buf *b, int indent);
+void emit_frozen_obj_guard(Compiler *c, int cid, const char *selfexpr, Buf *b);
 /* For a reference-backed builtin type (a genuinely nilable C pointer that can
    be NULL), return the name of its SP_BUILTIN_* class-id constant; else NULL.
    Such a value must box via sp_box_nullable_obj so a NULL becomes SP_TAG_NIL. */

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -4959,10 +4959,22 @@ void emit_stmt_inner(Compiler *c, int id, Buf *b, int indent) {
                 int iv = comp_ivar_index(&c->classes[defc < 0 ? rc : defc], ivn);
                 TyKind ivt = iv >= 0 ? c->classes[defc < 0 ? rc : defc].ivar_types[iv] : TY_UNKNOWN;
                 emit_indent(b, indent);
-                buf_puts(b, "("); emit_expr(c, recv, b); buf_printf(b, ")->iv_%s = ", base);
+                int fo = rc >= 0 && rc < c->nclasses &&
+                         c->classes[rc].freeze_observed && !c->classes[rc].is_value_type;
+                int tw = fo ? ++g_tmp : -1;
+                if (fo) {
+                  char twn[32]; snprintf(twn, sizeof twn, "_t%d", tw);
+                  buf_printf(b, "{ sp_%s *_t%d = ", c->classes[rc].c_name, tw);
+                  emit_expr(c, recv, b); buf_puts(b, "; ");
+                  emit_frozen_obj_guard(c, rc, twn, b);
+                  buf_printf(b, "_t%d->iv_%s = ", tw, base);
+                }
+                else {
+                  buf_puts(b, "("); emit_expr(c, recv, b); buf_printf(b, ")->iv_%s = ", base);
+                }
                 if (ivt == TY_POLY && comp_ntype(c, argv[0]) != TY_POLY) emit_boxed(c, argv[0], b);
                 else emit_expr(c, argv[0], b);
-                buf_puts(b, ";\n");
+                buf_puts(b, fo ? "; }\n" : ";\n");
                 return;
               }
             }
@@ -4987,7 +4999,10 @@ void emit_stmt_inner(Compiler *c, int id, Buf *b, int indent) {
                   int iv = comp_ivar_index(&c->classes[k], ivn);
                   TyKind ivt = iv >= 0 ? c->classes[k].ivar_types[iv] : at;
                   if (at != ivt && at != TY_POLY && ivt != TY_POLY) continue;
-                  buf_printf(b, " case %d: ((sp_%s *)_t%d)->iv_%s = ", k, c->classes[k].c_name, tp, base);
+                  buf_printf(b, " case %d: ", k);
+                  { char tpn[32]; snprintf(tpn, sizeof tpn, "_t%d", tp);
+                    emit_frozen_obj_guard(c, k, tpn, b); }
+                  buf_printf(b, "((sp_%s *)_t%d)->iv_%s = ", c->classes[k].c_name, tp, base);
                   if (ivt == TY_POLY && at != TY_POLY) emit_boxed_text(c, at, src, b);
                   else if (at == TY_POLY && ivt != TY_POLY) emit_unbox_text(c, ivt, src, b);
                   else buf_puts(b, src);
@@ -5270,8 +5285,11 @@ else {
       emit_indent(b, indent);
       if (cws && cws->is_cmethod && cws->class_id >= 0)
         buf_printf(b, "civ_%s_%s = ", c->classes[cws->class_id].name, nm + 1);
-      else
+      else {
+        if (cws && cws->class_id >= 0)
+          emit_frozen_obj_guard(c, cws->class_id, g_self ? g_self : "self", b);
         buf_printf(b, "%s%siv_%s = ", g_self, g_self_deref, nm + 1);
+      }
     }
     const char *vty = nt_type(nt, v);
     int sc = cws ? cws->class_id : -1;

--- a/src/codegen_util.c
+++ b/src/codegen_util.c
@@ -1168,3 +1168,18 @@ int ty_matches_class(TyKind t, const char *cn, int exact) {
                                      t == TY_ENUMERATOR)) return 1;
   return 0;
 }
+
+/* `if (frozen) raise FrozenError` guard preceding an ivar store on a
+   freeze-observed class ("can't modify frozen <Name>: <inspect>"); emits
+   nothing when instances of the class are never frozen. `selfexpr` is a C
+   expression for the instance pointer, evaluated twice (bind a temp first
+   when it has effects). */
+void emit_frozen_obj_guard(Compiler *c, int cid, const char *selfexpr, Buf *b) {
+  if (cid < 0 || cid >= c->nclasses) return;
+  if (!c->classes[cid].freeze_observed || c->classes[cid].is_value_type) return;
+  const char *rn = class_ruby_name(c, cid) ? class_ruby_name(c, cid) : c->classes[cid].name;
+  buf_printf(b,
+      "if (sp_gc_is_frozen((void *)%s)) "
+      "sp_raise_frozen_obj(sp_box_obj((void *)%s, %d), (&(\"\\xff\" \"can't modify frozen %s\")[1])); ",
+      selfexpr, selfexpr, cid, rn);
+}

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -155,6 +155,8 @@ typedef struct {
   int is_native_class;
   char *c_struct;      /* e.g. "sp_StringIO", or NULL */
   char *native_free;   /* finalizer C symbol, or NULL */
+  int freeze_observed; /* freeze/frozen? reaches instances of this class: codegen
+                          guards its ivar stores with the GC-header frozen bit */
   int is_value_type;   /* small immutable scalar-ivar class represented by value
                           (sp_X, not sp_X *): no heap alloc / GC. Set by
                           detect_value_types after analysis. */

--- a/test/bareword_freeze.rb
+++ b/test/bareword_freeze.rb
@@ -1,7 +1,7 @@
-# Bareword freeze (implicit self) inside an instance method is a no-op that
-# returns self. spinel has no per-object frozen state, so this is behaviorally
-# faithful for the common defensive-freeze idiom; frozen? (which would need
-# that state) stays unsupported rather than reporting a wrong value.
+# Bareword freeze (implicit self) inside an instance method sets the
+# instance's GC-header frozen bit and returns self, so the defensive-freeze
+# idiom carries real state (frozen? reads it back; mutation raises).
+# Reads after freeze are unaffected.
 class Config
   def initialize(v)
     @v = v

--- a/test/freeze_user_object.rb
+++ b/test/freeze_user_object.rb
@@ -1,0 +1,76 @@
+# freeze / frozen? on user instances: the bareword self-freeze idiom sets
+# real state, frozen? reads it back, and mutation after freeze raises
+# FrozenError with CRuby's message (address-normalized for comparison).
+def norm(e) = "#{e.class}: #{e.message.sub(/0x[0-9a-f]+/, '0xADDR')}"
+
+class Sealed
+  attr_reader :x
+  attr_writer :x
+  def initialize
+    @x = 1
+    @tag = "s"
+    freeze
+  end
+  def poke = (@x = 2)
+  def poke_expr = (y = (@x = 3); y)
+end
+
+o = Sealed.new
+p o.frozen?
+p o.x
+begin
+  o.poke
+rescue => e
+  puts norm(e)
+end
+begin
+  o.poke_expr
+rescue => e
+  puts norm(e)
+end
+begin
+  o.x = 5
+rescue => e
+  puts norm(e)
+end
+p o.x
+
+class Lazy
+  attr_accessor :v
+  def initialize = (@v = 10)
+  def seal = freeze
+  def sealed? = frozen?
+end
+
+l = Lazy.new
+p l.sealed?
+l.v = 11
+p l.v
+l.seal
+p l.sealed?
+p l.frozen?
+begin
+  l.v = 12
+rescue => e
+  puts norm(e)
+end
+p l.v
+
+class OwnFreeze
+  attr_reader :log
+  def initialize = (@log = "clean")
+  def freeze = (@log = "custom"; self)
+end
+
+f = OwnFreeze.new
+f.freeze
+p f.log
+p f.frozen?
+
+class Never
+  attr_accessor :n
+  def initialize = (@n = 0)
+end
+nv = Never.new
+nv.n = 7
+p nv.n

--- a/test/freeze_user_object.rb.expected
+++ b/test/freeze_user_object.rb.expected
@@ -1,0 +1,15 @@
+true
+1
+FrozenError: can't modify frozen Sealed: #<Sealed:0xADDR @x=1, @tag="s">
+FrozenError: can't modify frozen Sealed: #<Sealed:0xADDR @x=1, @tag="s">
+FrozenError: can't modify frozen Sealed: #<Sealed:0xADDR @x=1, @tag="s">
+1
+false
+11
+true
+true
+FrozenError: can't modify frozen Lazy: #<Lazy:0xADDR @v=11>
+11
+"custom"
+false
+7


### PR DESCRIPTION
The bareword self-freeze idiom (`def initialize; ...; freeze; end`) was a no-op returning self, so `frozen?` on such an instance answered `false` and mutation after freeze silently succeeded.

**Analyze**: a new observation pass marks any class whose instances meet `freeze`/`frozen?` (typed receiver, bareword inside an instance method, or — bluntly — any poly-receiver freeze) as *freeze-observed*, and disqualifies it from the by-value representation so instances carry the GC-header frozen bit.

**Codegen**:
- bareword `freeze` emits `sp_gc_freeze(self)` (returning self, typed as the instance), mirroring the explicit-receiver arm; bareword `frozen?` — previously a loud compile reject — reads the bit;
- ivar stores in freeze-observed classes guard the bit and raise CRuby's exact `FrozenError` (`can't modify frozen C: #<C:0x... @x=1>`, rendered through the per-class inspect) at every store shape: statement and expression-position `@x =`, external attr-writer field writes, and the cls_id-dispatched subclass writer;
- classes never frozen anywhere in the program emit no guard and pay nothing.

**Runtime**: `sp_raise_frozen_obj` renders the receiver through the full poly inspect with the same GC-rooting discipline as the string raise.

**Tests**: `test/freeze_user_object.rb` — freeze-in-initialize, explicit freeze through a method, `frozen?` before/after (bareword and receiver forms), mutation-after-freeze through an instance method, an expression-position write, and an attr writer (messages address-normalized inside the test so ruby remains the oracle), writes before the freeze in the same initialize, a class defining its own `freeze` (kept), and a never-frozen control; verified under `SPINEL_GC_STRESS`. The pre-existing `bareword_freeze` test keeps its expected output (reads after freeze are unaffected); its stale header comment is updated.

**Residual**: ivar operator-writes (`@x += 1`) and instance_eval-spliced writes do not yet guard; they slot into the same helper when wired.
