### PR TITLE
parse,analyze,codegen: public_send enforces method visibility

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -5184,6 +5184,7 @@ void analyze_program(Compiler *c) {
     ch |= desugar_for_enumerable(c);           /* for x in obj -> for x in obj.__enum_to_a */
     ch |= desugar_to_enum(c);                  /* recv.to_enum(:m) -> generator/blockless */
     ch |= desugar_implicit_send(c);            /* send(:m, a) -> m(a) on self */
+    ch |= desugar_public_send_recv(c);         /* r.public_send(:m, a) -> r.m(a), visibility-stamped */
     ch |= desugar_symbol_string_methods(c);    /* :sym.match(re) -> :sym.to_s.match(re) */
     ch |= desugar_symbol_var_block_arg(c);     /* m(&sym_var) -> m { |x| x.send(sym_var) } */
     ch |= desugar_kernel_method_block_arg(c);  /* m(&method(:Integer)) -> m { |x| Integer(x) } */

--- a/src/analyze_internal.h
+++ b/src/analyze_internal.h
@@ -211,6 +211,7 @@ int desugar_to_hash_splat(Compiler *c);
 int desugar_value_callable_forwards(Compiler *c);
 int desugar_block_destructure_params(Compiler *c);
 int desugar_implicit_send(Compiler *c);
+int desugar_public_send_recv(Compiler *c);
 int desugar_dynamic_send(Compiler *c);
 int desugar_toplevel_instance_exec(Compiler *c);
 int desugar_binding_lvget(Compiler *c);

--- a/src/analyze_pass.c
+++ b/src/analyze_pass.c
@@ -3028,12 +3028,62 @@ int desugar_implicit_send(Compiler *c) {
     for (int k = 0; k < nrest; k++) rest[k] = argv[k + 1];  /* copy before realloc */
     char namebuf[256];
     snprintf(namebuf, sizeof namebuf, "%s", mname);        /* copy before realloc */
+    /* public_send dispatches only public methods: stamp the retargeted call
+       so codegen raises NoMethodError for a private/protected target */
+    int vis_enf = sp_streq(nm, "public_send");
     int base = nt->count;
     int newargs = nt_new_node(nt, "ArgumentsNode");
     if (newargs < 0) continue;
     nt_node_set_arr(nt, newargs, "arguments", rest, nrest);
     nt_node_set_str(nt, id, "name", namebuf);              /* retarget the call */
     nt_node_set_ref(nt, id, "arguments", newargs);         /* drop the name arg */
+    if (vis_enf) nt_node_set_str(nt, id, "vis_enforce", "1");
+    comp_grow_node_arrays(c);
+    int encl = c->nscope[id];
+    for (int j = base; j < nt->count; j++) c->nscope[j] = encl;
+    changed = 1;
+  }
+  return changed;
+}
+
+/* `recv.public_send(:m, args)` with a literal name -> a direct `recv.m(args)`
+   call stamped `vis_enforce`, so codegen raises NoMethodError for a
+   private/protected target. send/__send__ keep the visibility-blind textual
+   rewrite in spinel_parse.c (CRuby's send ignores visibility). Mirrors
+   desugar_implicit_send's node-retarget model. */
+int desugar_public_send_recv(Compiler *c) {
+  NodeTable *nt = (NodeTable *)c->nt;
+  int changed = 0;
+  int n0 = nt->count;
+  for (int id = 0; id < n0; id++) {
+    if (!nt_type(nt, id) || !sp_streq(nt_type(nt, id), "CallNode")) continue;
+    if (nt_ref(nt, id, "receiver") < 0) continue;          /* explicit receiver only */
+    const char *nm = nt_str(nt, id, "name");
+    if (!nm || !sp_streq(nm, "public_send")) continue;
+    int args = nt_ref(nt, id, "arguments");
+    if (args < 0) continue;
+    int argc = 0; const int *argv = nt_arr(nt, args, "arguments", &argc);
+    if (argc < 1 || !argv) continue;
+    const char *a0ty = nt_type(nt, argv[0]);
+    const char *mname = NULL;
+    if (a0ty && sp_streq(a0ty, "SymbolNode")) mname = nt_str(nt, argv[0], "value");
+    else if (a0ty && sp_streq(a0ty, "StringNode")) mname = nt_str(nt, argv[0], "content");
+    if (!mname || !*mname) continue;                       /* runtime name: dyn_send_arms */
+    if (sp_streq(mname, "send") || sp_streq(mname, "__send__") ||
+        sp_streq(mname, "public_send")) continue;
+    int nrest = argc - 1;
+    if (nrest > 64) continue;
+    int rest[64];
+    for (int k = 0; k < nrest; k++) rest[k] = argv[k + 1];
+    char namebuf[256];
+    snprintf(namebuf, sizeof namebuf, "%s", mname);
+    int base = nt->count;
+    int newargs = nt_new_node(nt, "ArgumentsNode");
+    if (newargs < 0) continue;
+    nt_node_set_arr(nt, newargs, "arguments", rest, nrest);
+    nt_node_set_str(nt, id, "name", namebuf);
+    nt_node_set_ref(nt, id, "arguments", newargs);
+    nt_node_set_str(nt, id, "vis_enforce", "1");
     comp_grow_node_arrays(c);
     int encl = c->nscope[id];
     for (int j = base; j < nt->count; j++) c->nscope[j] = encl;
@@ -3249,6 +3299,8 @@ int desugar_dynamic_send(Compiler *c) {
       nt_node_set_ref(nt, call, "receiver", recv);
       nt_node_set_str(nt, call, "name", cand[k]);
       nt_node_set_ref(nt, call, "arguments", na);
+      /* public_send arms enforce visibility at the dispatch site */
+      if (sp_streq(nm, "public_send")) nt_node_set_str(nt, call, "vis_enforce", "1");
       arms[narm++] = call;
     }
     nt_node_set_arr(nt, id, "dyn_send_arms", arms, narm);

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -4626,6 +4626,36 @@ static void emit_math_arg(Compiler *c, int node, Buf *out) {
 void emit_call(Compiler *c, int id, Buf *b) {
   const NodeTable *nt = c->nt;
   if (emit_dynamic_send(c, id, b)) return;   /* recv.send(runtime_name, args) static dispatch */
+  /* a public_send-lowered call (stamped by the desugars): a private or
+     protected target raises NoMethodError like CRuby, which enforces
+     visibility on public_send regardless of caller context. The receiver
+     still evaluates for its effects; the never-taken comma value keeps the
+     expression's static type. */
+  if (nt_str(nt, id, "vis_enforce")) {
+    const char *vnm = nt_str(nt, id, "name");
+    int vrecv = nt_ref(nt, id, "receiver");
+    int vcid = -1;
+    if (vrecv >= 0) {
+      TyKind vrt = comp_ntype(c, vrecv);
+      if (ty_is_object(vrt)) vcid = ty_object_class(vrt);
+    }
+    else {
+      Scope *vs = comp_scope_of(c, id);
+      if (vs && vs->class_id >= 0 && !vs->is_cmethod) vcid = vs->class_id;
+    }
+    if (vnm && vcid >= 0) {
+      int vis = comp_method_vis_in_chain(c, vcid, vnm);
+      if (vis != SP_VIS_PUBLIC) {
+        const char *vrn = class_ruby_name(c, vcid) ? class_ruby_name(c, vcid) : c->classes[vcid].name;
+        buf_puts(b, "(");
+        if (vrecv >= 0) { buf_puts(b, "(void)("); emit_expr(c, vrecv, b); buf_puts(b, "), "); }
+        buf_printf(b, "sp_raise_cls(\"NoMethodError\", (&(\"\\xff\" \"%s method '%s' called for an instance of %s\")[1])), %s)",
+                   vis == SP_VIS_PRIVATE ? "private" : "protected", vnm, vrn,
+                   default_value(comp_ntype(c, id)));
+        return;
+      }
+    }
+  }
   /* k = Struct.new(:a, :b): the registered anonymous struct class, as a
      first-class class value */
   {

--- a/src/spinel_parse.c
+++ b/src/spinel_parse.c
@@ -2760,17 +2760,6 @@ static char *rewrite_syntax_sugar(char *source) {
       REWRITE_SEND_CALL(".__send__(\"", 11, 1);
       continue;
     }
-    /* .public_send(:foo, args) → .foo(args). Visibility isn't modeled
-       in Spinel's static dispatch -- public_send is semantically
-       identical to send. Issue #735. */
-    if (i + 14 < len && strncmp(source + i, ".public_send(:", 14) == 0) {
-      REWRITE_SEND_CALL(".public_send(:", 14, 0);
-      continue;
-    }
-    if (i + 14 < len && strncmp(source + i, ".public_send(\"", 14) == 0) {
-      REWRITE_SEND_CALL(".public_send(\"", 14, 1);
-      continue;
-    }
     /* `&:symbol` symbol-to-proc. Prism parses `&:sym` natively, but
        Spinel only lowers the native BlockArgumentNode+SymbolNode shape
        for a few methods (inject / reduce / sort_by); general block

--- a/test/public_send_visibility.rb
+++ b/test/public_send_visibility.rb
@@ -1,0 +1,51 @@
+# public_send dispatches only public methods: a private or protected target
+# raises NoMethodError with CRuby's message, while send/__send__ stay
+# visibility-blind.
+def err
+  yield
+rescue NoMethodError => e
+  "#{e.class}: #{e.message}"
+end
+
+class Acct
+  def balance = 100
+  def show(label) = "#{label}: #{balance}"
+
+  def peer_check(other) = other.guarded
+
+  protected
+
+  def guarded = "prot"
+
+  private
+
+  def secret = 42
+end
+
+a = Acct.new
+p a.public_send(:balance)
+p a.public_send(:show, "acct")
+p a.public_send("balance")
+puts err { a.public_send(:secret) }
+puts err { a.public_send("secret") }
+puts err { a.public_send(:guarded) }
+
+# send / __send__ ignore visibility
+p a.send(:secret)
+p a.__send__(:secret)
+
+# protected still callable through peer dispatch
+p a.peer_check(Acct.new)
+
+# receiverless public_send of a private method raises too
+class Inner
+  def run = public_send(:hidden)
+  private
+  def hidden = 1
+end
+puts err { Inner.new.run }
+
+# runtime-computed name: visibility enforced per resolved arm
+def dyn(o, m) = o.public_send(m)
+p dyn(a, :balance)
+puts err { dyn(a, :secret) }

--- a/test/public_send_visibility.rb.expected
+++ b/test/public_send_visibility.rb.expected
@@ -1,0 +1,12 @@
+100
+"acct: 100"
+100
+NoMethodError: private method 'secret' called for an instance of Acct
+NoMethodError: private method 'secret' called for an instance of Acct
+NoMethodError: protected method 'guarded' called for an instance of Acct
+42
+42
+"prot"
+NoMethodError: private method 'hidden' called for an instance of Inner
+100
+NoMethodError: private method 'secret' called for an instance of Acct


### PR DESCRIPTION
`public_send` was textually rewritten to a plain direct call at parse time, discarding the one semantic it exists for: a private or protected target must raise `NoMethodError` regardless of caller context (unlike plain calls, protected gets no peer exemption through public_send).

- The textual rewrite is replaced by an analyze desugar that retargets `recv.public_send(:m, args)` to a direct `recv.m(args)` stamped `vis_enforce` (same node-retarget model as the receiverless send desugar).
- The receiverless desugar stamps its `public_send(:m)` retargets the same way, and the runtime-name dispatch arms (`o.public_send(m)`) stamp each synthesized arm — so visibility holds for dynamic names too.
- At emission, a stamped call whose target resolves private/protected on the receiver's class chain raises CRuby's exact message (`private method 'secret' called for an instance of C`), evaluating the receiver for its effects; the visibility registry (`comp_method_vis_in_chain`) already existed.
- `send`/`__send__` keep the visibility-blind rewrite, matching CRuby.

**Tests**: `test/public_send_visibility.rb` — public targets (symbol/string names, with args), private and protected targets via symbol and string, `send`/`__send__` bypass, protected-through-peer plain call still allowed, receiverless `public_send` of a private method, and a runtime-computed name enforcing per arm; ruby-generated expected output. The nine surrounding send/visibility tests re-verified.

**Residuals**: a stamped call's arguments are not evaluated before the raise (CRuby evaluates them first); plain explicit-receiver private calls (`o.secret`) remain unenforced — that is the broader gate this PR's pieces were built for, kept separate deliberately.
