### PR TITLE
runtime: String#setbyte sizes the receiver NUL-safely

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -2145,7 +2145,10 @@ static const char *sp_str_setbyte_cow(const char *s, mrb_int i, mrb_int v) {
      place so aliases observe the write (CRuby identity semantics); only a
      plain literal -- static storage, marker 0xff -- copies (#2029). */
   sp_str_check_mutable(s);
-  mrb_int n = (mrb_int)strlen(s);
+  /* NUL-safe stored length: strlen would stop at the first NUL byte, making
+     every setbyte on a NUL-prefixed buffer (e.g. Array.new(n, 0).pack("C*"))
+     raise IndexError. */
+  mrb_int n = (mrb_int)sp_str_byte_len(s);
   if (i < 0) i += n;
   if (i < 0 || i >= n) {
     sp_raise_cls("IndexError", sp_sprintf("index %lld out of string", (long long)i));

--- a/test/setbyte_nul_bytes.rb
+++ b/test/setbyte_nul_bytes.rb
@@ -1,0 +1,30 @@
+# Regression: String#setbyte sized the receiver with strlen, which stops at
+# the first NUL byte. An all-NUL buffer (the pack("C*") byte-buffer pattern)
+# measured length 0, so every setbyte raised IndexError despite length/
+# bytesize correctly reporting the stored length. setbyte must use the
+# NUL-safe stored length like getbyte/bytesize do.
+
+# all-NUL buffer: previously every call here raised IndexError
+s = Array.new(5, 0).pack("C*")
+puts "len=#{s.length}"
+s.setbyte(0, 65)
+s.setbyte(4, 90)
+puts s.bytes.inspect
+
+# NUL-prefixed buffer, negative index counts from the true end
+t = [0, 0, 66, 0].pack("C*")
+t.setbyte(-1, 67)
+t.setbyte(0, 68)
+puts t.bytes.inspect
+
+# out-of-range past the stored length still raises
+begin
+  s.setbyte(5, 1)
+  puts "no error"
+rescue IndexError => e
+  puts "IndexError: #{e.message}"
+end
+
+# setbyte return value is the byte written
+puts s.setbyte(1, 200)
+puts s.bytes.inspect

--- a/test/setbyte_nul_bytes.rb.expected
+++ b/test/setbyte_nul_bytes.rb.expected
@@ -1,0 +1,6 @@
+len=5
+[65, 0, 0, 0, 90]
+[68, 0, 66, 67]
+IndexError: index 5 out of string
+200
+[65, 200, 0, 0, 90]


### PR DESCRIPTION
## Summary

`String#setbyte` measured the receiver with `strlen`, which stops at the first NUL byte. An all-NUL buffer — the `Array.new(n, 0).pack("C*")` byte-buffer construction pattern — measured length 0, so **every** `setbyte` call raised `IndexError: index N out of string`, even though `length`/`bytesize` correctly reported the stored length. CRuby sets the bytes fine.

`docs/limitations.md` lists `length`/`bytesize`/`pack`/`unpack` as byte-exact and does not list `setbyte` among the NUL-truncating transforms, so this was an undocumented divergence, not a known trade-off.

Fix: `sp_str_setbyte_cow` now uses `sp_str_byte_len` — the NUL-safe stored-length accessor that `getbyte`/`bytesize`/`bytesplice` already use — instead of `strlen`. The length feeds the bounds check, negative-index normalization, and the copy-on-write literal path (which previously copied only up to the first NUL), so all three are now NUL-safe.

- `lib/sp_runtime.h`: `strlen` -> `sp_str_byte_len` in `sp_str_setbyte_cow`
- `test/setbyte_nul_bytes.rb` + `.expected`: all-NUL buffer, NUL-prefixed buffer with negative index, out-of-range IndexError past the stored length, and the return value — expected output generated from CRuby

## Test plan

- [x] Repro (`Array.new(5, 0).pack("C*")` + setbyte loop) now prints `[65, 0, 0, 0, 90]`, byte-identical to CRuby
- [x] New test `test/setbyte_nul_bytes.rb` passes; output matches the CRuby oracle
- [x] `make test`: 1740 pass, 0 fail
- [x] `make optcarrot`: OK (checksum 59662)