### PR TITLE
File.unlink alias + File.rename

### DIFF
--- a/lib/sp_io.c
+++ b/lib/sp_io.c
@@ -171,3 +171,4 @@ mrb_bool sp_file_symlink(const char *path) {
 
 mrb_bool sp_file_exist(const char *path) { FILE *f = fopen(path, "r"); if (f) { fclose(f); return TRUE; } return FALSE; }
 void sp_file_delete(const char *path) { remove(path); }
+void sp_file_rename(const char *from, const char *to) { rename(from, to); }

--- a/lib/sp_io.h
+++ b/lib/sp_io.h
@@ -48,5 +48,6 @@ mrb_bool sp_file_file(const char *path);
 mrb_bool sp_file_exist(const char *path);
 mrb_bool sp_file_symlink(const char *path);
 void sp_file_delete(const char *path);
+void sp_file_rename(const char *from, const char *to);
 
 #endif

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -1746,7 +1746,7 @@ else {
       if (sp_streq(name, "exist?") || sp_streq(name, "exists?"))
         return TY_BOOL;
       if (sp_streq(name, "write") || sp_streq(name, "binwrite") || sp_streq(name, "delete") ||
-          sp_streq(name, "size"))
+          sp_streq(name, "unlink") || sp_streq(name, "size"))
         return TY_INT;
       if (sp_streq(name, "readable?") || sp_streq(name, "directory?") || sp_streq(name, "file?") ||
           sp_streq(name, "zero?") || sp_streq(name, "empty?") || sp_streq(name, "symlink?"))

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -1746,7 +1746,7 @@ else {
       if (sp_streq(name, "exist?") || sp_streq(name, "exists?"))
         return TY_BOOL;
       if (sp_streq(name, "write") || sp_streq(name, "binwrite") || sp_streq(name, "delete") ||
-          sp_streq(name, "unlink") || sp_streq(name, "size"))
+          sp_streq(name, "unlink") || sp_streq(name, "rename") || sp_streq(name, "size"))
         return TY_INT;
       if (sp_streq(name, "readable?") || sp_streq(name, "directory?") || sp_streq(name, "file?") ||
           sp_streq(name, "zero?") || sp_streq(name, "empty?") || sp_streq(name, "symlink?"))

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -8781,7 +8781,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     if (sp_streq(name, "file?") && argc == 1) {
       buf_puts(b, "(!sp_file_directory("); emit_expr(c, argv[0], b); buf_puts(b, ") && sp_file_exist("); emit_expr(c, argv[0], b); buf_puts(b, "))"); return;
     }
-    if (sp_streq(name, "delete") && argc == 1) {
+    if ((sp_streq(name, "delete") || sp_streq(name, "unlink")) && argc == 1) {
       buf_puts(b, "({ sp_file_delete("); emit_expr(c, argv[0], b); buf_puts(b, "); (mrb_int)1; })"); return;
     }
     if (sp_streq(name, "mtime") && argc == 1) {

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -8784,6 +8784,10 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     if ((sp_streq(name, "delete") || sp_streq(name, "unlink")) && argc == 1) {
       buf_puts(b, "({ sp_file_delete("); emit_expr(c, argv[0], b); buf_puts(b, "); (mrb_int)1; })"); return;
     }
+    if (sp_streq(name, "rename") && argc == 2) {
+      buf_puts(b, "({ sp_file_rename("); emit_expr(c, argv[0], b); buf_puts(b, ", ");
+      emit_expr(c, argv[1], b); buf_puts(b, "); (mrb_int)0; })"); return;
+    }
     if (sp_streq(name, "mtime") && argc == 1) {
       buf_puts(b, "sp_file_mtime("); emit_expr(c, argv[0], b); buf_puts(b, ")"); return;
     }

--- a/test/file_unlink_rename.rb
+++ b/test/file_unlink_rename.rb
@@ -1,0 +1,8 @@
+filename = "test_unlink_rename_temp.txt"
+renamed = "test_unlink_rename_temp2.txt"
+File.write(filename, "file op test")
+File.rename(filename, renamed)
+puts File.exist?(filename)
+puts File.exist?(renamed)
+File.unlink(renamed)
+puts File.exist?(renamed)

--- a/test/file_unlink_rename.rb.expected
+++ b/test/file_unlink_rename.rb.expected
@@ -1,0 +1,3 @@
+false
+true
+false


### PR DESCRIPTION
Two small File-constant ops Rails cache code uses:

- `File.unlink` — alias of `File.delete`; recognized in the analyzer (TY_INT) and codegen (same `sp_file_delete` emit).
- `File.rename(from, to)` — new `sp_file_rename` wrapping stdio `rename(2)`; TY_INT (Ruby returns 0).

Repro that fails before / passes after:

```ruby
File.write("/tmp/probe-a", "x")
File.rename("/tmp/probe-a", "/tmp/probe-b")
puts File.exist?("/tmp/probe-b") ? "renamed" : "missing"
File.unlink("/tmp/probe-b")
puts File.exist?("/tmp/probe-b") ? "still there" : "gone"
```

Real-world shape: lobsters' avatar cache expiry and rotation (`File.unlink("#{CACHE_DIR}/#{f}")`, `File.rename(tmp, path)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)