### PR TITLE
codegen: receiverless trampoline splice; paren value-tail ordering

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -8104,6 +8104,17 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
   }
   if (!ie_direct && recv >= 0 && nt_ref(nt, id, "block") >= 0 && ty_is_object(comp_ntype(c, recv)))
     ie_tramp = comp_trampoline_kind(c, ty_object_class(comp_ntype(c, recv)), name, NULL);
+  /* a RECEIVERLESS call to a trampoline method inside an instance method:
+     self is the receiver (`go { ... }` where `def go(&b) = instance_exec(&b)`).
+     Without this the call lowers to the real method, whose body is the
+     unreachable stub, and the literal block is silently dropped. */
+  if (!ie_direct && !ie_tramp && recv < 0 && nt_ref(nt, id, "block") >= 0) {
+    Scope *trs = comp_scope_of(c, id);
+    if (trs && trs->class_id >= 0 && !trs->is_cmethod) {
+      ie_tramp = comp_trampoline_kind(c, trs->class_id, name, NULL);
+      if (ie_tramp) ie_self_cls = trs->class_id;
+    }
+  }
   if (ie_direct || ie_tramp) {
     int blk = nt_ref(nt, id, "block");
     /* `instance_exec(args, &b)` forwarding the enclosing (now-inlined) method's

--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -1647,14 +1647,46 @@ void emit_expr(Compiler *c, int id, Buf *b) {
       buf_puts(b, "("); emit_expr(c, bd[0], b); buf_puts(b, ")");
       return;
     }
-    /* Multi-stmt parens: `(s1; s2; expr)` — run leading stmts in prelude,
-       return value of last expression via GNU statement expression. */
-    buf_puts(b, "({ ");
-    for (int j = 0; j < n - 1; j++) {
-      emit_stmt(c, bd[j], b, 0);
+    /* Multi-stmt parens: `(s1; s2; expr)` — run leading stmts, then the
+       value. The tail's emission may hoist statements into g_pre (an
+       instance_exec splice, a constructed receiver): the shared prelude is
+       flushed BEFORE the statement containing this paren, which would run
+       the tail's hoisted code ahead of the leading statements. When the tail
+       hoists, hoist the leading statements ahead of it too, preserving
+       intra-paren order. */
+    {
+      Buf cap; memset(&cap, 0, sizeof cap);
+      Buf vb; memset(&vb, 0, sizeof vb);
+      Buf *sv_pre = g_pre; g_pre = &cap;
+      emit_expr(c, bd[n - 1], &vb);
+      g_pre = sv_pre;
+      if (!(cap.p && cap.p[0])) {
+        buf_puts(b, "({ ");
+        for (int j = 0; j < n - 1; j++) {
+          emit_stmt(c, bd[j], b, 0);
+        }
+        buf_puts(b, vb.p ? vb.p : "0");
+        buf_puts(b, "; })");
+      }
+      else {
+        for (int j = 0; j < n - 1; j++) emit_stmt(c, bd[j], g_pre, g_indent);
+        buf_puts(g_pre, cap.p);
+        TyKind pvt = comp_ntype(c, bd[n - 1]);
+        if (is_scalar_ret(pvt) && pvt != TY_VOID && pvt != TY_NIL && pvt != TY_UNKNOWN) {
+          int tpv = ++g_tmp;
+          emit_indent(g_pre, g_indent); emit_ctype(c, pvt, g_pre);
+          buf_printf(g_pre, " _t%d = %s;\n", tpv, vb.p ? vb.p : "0");
+          buf_printf(b, "_t%d", tpv);
+        }
+        else {
+          /* no usable scalar value: run the tail for effect, yield nil */
+          emit_indent(g_pre, g_indent);
+          buf_printf(g_pre, "(void)(%s);\n", vb.p ? vb.p : "0");
+          buf_puts(b, "sp_box_nil()");
+        }
+      }
+      free(cap.p); free(vb.p);
     }
-    emit_expr(c, bd[n - 1], b);
-    buf_puts(b, "; })");
     return;
   }
   if (sp_streq(ty, "ArrayNode")) {

--- a/test/instance_exec_trampoline_receiverless.rb
+++ b/test/instance_exec_trampoline_receiverless.rb
@@ -1,0 +1,39 @@
+# A receiverless call to an instance_exec trampoline splices the literal
+# block with self rebound (previously the block was silently dropped), and
+# a parenthesized value-tail keeps its leading statements ordered ahead of
+# the spliced block body.
+class App
+  def initialize = (@o = [])
+  def go(&blk) = instance_exec(&blk)
+  def leaf(x) = (@o << x)
+  def render = (go { leaf("a") }; @o)
+end
+p App.new.render
+
+class Builder
+  def initialize = (@o = [])
+  def el(tag, &blk) = (@o << tag; instance_exec(&blk))
+  def leaf(x) = (@o << x)
+  def render = (el("col") { leaf("a") }; @o)
+end
+p Builder.new.render
+
+class WithArgs
+  def initialize = (@sum = 0)
+  def run(x, &blk) = instance_exec(x, &blk)
+  def add(n) = (@sum += n)
+  def total = (run(5) { |v| add(v * 2) }; @sum)
+end
+p WithArgs.new.total
+
+class Both
+  def initialize = (@log = [])
+  def outer(&blk) = instance_exec(&blk)
+  def mark(t) = (@log << t)
+  def drive
+    outer { mark(:first) }
+    self.outer { mark(:second) }
+    @log
+  end
+end
+p Both.new.drive

--- a/test/instance_exec_trampoline_receiverless.rb.expected
+++ b/test/instance_exec_trampoline_receiverless.rb.expected
@@ -1,0 +1,4 @@
+["a"]
+["col", "a"]
+10
+[:first, :second]


### PR DESCRIPTION
Two instance_exec splice fixes.

**Receiverless trampoline.** A receiverless call to an instance_exec trampoline (`go { leaf("a") }` where `def go(&b) = instance_exec(&b)`) never reached the splice gate, which required an explicit receiver: the call lowered to the real method — whose body is the unreachable stub — and the literal block was **silently dropped** (`render` returned `[]`). The gate now recognizes a receiverless call to a trampoline on self's class inside an instance method and splices with self as the receiver, through the same implicit-self machinery the direct receiverless `instance_exec` already uses.

**Paren value-tail ordering.** A multi-statement parenthesized value (`def el(tag, &blk) = (@o << tag; instance_exec(&blk))`) emitted its leading statements inside the statement expression while the tail's spliced block body hoisted into the shared prelude — which flushes *before* the statement containing the paren, so `leaf("a")` ran ahead of `@o << tag` (`["a", "col"]` instead of `["col", "a"]`). When the tail hoists, the leading statements now hoist ahead of it, preserving intra-paren order; the common non-hoisting form emits exactly as before (a `while (i += 1; i < 3)` condition is unaffected — re-verified).

**Tests**: `test/instance_exec_trampoline_receiverless.rb` — the bare trampoline, the ordered builder, a trampoline with extra args, and the same trampoline called both receiverless and via `self.` in one method; ruby-generated expected output. All existing instance_exec/instance_eval/trampoline tests re-verified.

**Residuals** (unchanged, still loud rejects): `instance_exec(&@ivar_block)`, presence-guarded forwards (`instance_exec(&blk) if blk`), and nested multi-statement builders — the runtime-proc instance_exec lowering is a separate structural work item.
