### PR TITLE
analyze,codegen,runtime: float-begin ranges carry exact endpoints

### DIFF
--- a/lib/sp_format.c
+++ b/lib/sp_format.c
@@ -85,6 +85,18 @@ const char *sp_Range_inspect(sp_Range *r) {
   return buf;
 }
 
+const char *sp_FRange_inspect(sp_FRange r) {
+  /* "first..last" over the float renderings (1.0..3.0, matching p); each
+     rendering is a fresh GC string, rooted across the next allocation */
+  const char *a = sp_float_to_s(r.first);
+  SP_GC_ROOT_STR(a);
+  const char *z = sp_float_to_s(r.last);
+  SP_GC_ROOT_STR(z);
+  char *buf = sp_str_alloc_raw(80);
+  snprintf(buf, 80, r.excl ? "%s...%s" : "%s..%s", a, z);
+  return buf;
+}
+
 /* "YYYY-MM-DD HH:MM:SS UTC" via gmtime: the spinel runtime keeps Time
    timezone-naive, so UTC is the unambiguous choice that needs no tzdata. */
 static const char *sp_Time_fmt(sp_Time *t, int frac) {

--- a/lib/sp_format.h
+++ b/lib/sp_format.h
@@ -16,6 +16,7 @@ const char *sp_complex_to_s(sp_Complex c);
 const char *sp_rational_inspect(sp_Rational r);
 const char *sp_rational_to_s(sp_Rational r);
 const char *sp_Range_inspect(sp_Range *r);
+const char *sp_FRange_inspect(sp_FRange r);
 const char *sp_Time_inspect(sp_Time *t);
 const char *sp_Time_to_s(sp_Time *t);
 

--- a/lib/sp_types.h
+++ b/lib/sp_types.h
@@ -133,6 +133,9 @@ typedef mrb_int sp_sym;
    A zero step (every range built by the literal `a..b` / sp_range_new path) is
    treated as +1, so existing constructions need no change. */
 typedef struct{mrb_int first;mrb_int last;mrb_int excl;mrb_int step;}sp_Range;
+/* a float-endpoint Range: min/max/cover?/clamp carry the exact endpoints
+   (iteration raises TypeError like CRuby). Value struct, never boxed. */
+typedef struct{mrb_float first;mrb_float last;mrb_int excl;}sp_FRange;
 /* A class value. `name`, when non-NULL, is a rodata class name carried by a
    class whose cls_id table entry may not exist (an exception's class -- the
    Errno:: family and many builtin error classes have no assigned cls_id). It

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -660,6 +660,24 @@ TyKind infer_call(Compiler *c, int id) {
   TyKind rt = recv >= 0 ? infer_type(c, recv) : TY_UNKNOWN;
   /* endless literal range: size is the Float infinity; take/first with a
      count materialize just the counted prefix (nothing else can) */
+  if (rt == TY_FLOAT_RANGE && recv >= 0) {
+    if (sp_streq(name, "begin") || sp_streq(name, "first") ||
+        sp_streq(name, "end") || sp_streq(name, "last") ||
+        sp_streq(name, "min") || sp_streq(name, "max"))
+      return TY_FLOAT;
+    if (sp_streq(name, "include?") || sp_streq(name, "cover?") ||
+        sp_streq(name, "member?") || sp_streq(name, "===") ||
+        sp_streq(name, "exclude_end?"))
+      return TY_BOOL;
+    if (sp_streq(name, "to_s") || sp_streq(name, "inspect")) return TY_STRING;
+    if (sp_streq(name, "step") && argc == 1) return TY_FLOAT_ARRAY;
+    if (sp_streq(name, "to_a") || sp_streq(name, "entries") ||
+        sp_streq(name, "map") || sp_streq(name, "collect") ||
+        sp_streq(name, "select") || sp_streq(name, "reject"))
+      return TY_POLY;   /* raises TypeError before producing a value */
+    if (sp_streq(name, "sum") || sp_streq(name, "count") ||
+        sp_streq(name, "size")) return TY_POLY;
+  }
   if (rt == TY_RANGE && recv >= 0) {
     int rnA = recv;
     while (rnA >= 0 && nt_type(nt, rnA) && sp_streq(nt_type(nt, rnA), "ParenthesesNode")) {
@@ -819,6 +837,12 @@ TyKind infer_call(Compiler *c, int id) {
     return TY_CURRY;
   }
 
+  /* float-endpoint range argument: an int receiver may return either the
+     Float bound or itself (poly); a float receiver stays float */
+  if (sp_streq(name, "clamp") && argc == 1 && infer_type(c, argv[0]) == TY_FLOAT_RANGE) {
+    if (rt == TY_INT) return TY_POLY;
+    if (rt == TY_FLOAT) return TY_FLOAT;
+  }
   if (rt == TY_INT && sp_streq(name, "clamp") && argc == 1 &&
       nt_type(nt, argv[0]) && sp_streq(nt_type(nt, argv[0]), "RangeNode") &&
       ((nt_ref(nt, argv[0], "left") >= 0 && infer_type(c, nt_ref(nt, argv[0], "left")) == TY_FLOAT) ||
@@ -1805,7 +1829,7 @@ else {
       /* Random class methods: Random.rand(float)->float / Random.rand(int)->int
          / Random.rand->float */
       if (cn2 && sp_streq(cn2, "Random") && sp_streq(name, "rand"))
-        return argc >= 1 ? (infer_type(c, argv[0]) == TY_FLOAT ? TY_FLOAT : TY_INT) : TY_FLOAT;
+        return argc >= 1 ? ((infer_type(c, argv[0]) == TY_FLOAT || infer_type(c, argv[0]) == TY_FLOAT_RANGE) ? TY_FLOAT : TY_INT) : TY_FLOAT;
       if (cn2 && sp_streq(cn2, "Random") && sp_streq(name, "bytes")) return TY_STRING;
     }
   }
@@ -1907,7 +1931,7 @@ else {
   /* TY_RANDOM instance methods */
   if (recv >= 0 && rt == TY_RANDOM) {
     if (sp_streq(name, "rand"))
-      return argc >= 1 ? (infer_type(c, argv[0]) == TY_FLOAT ? TY_FLOAT : TY_INT) : TY_FLOAT;
+      return argc >= 1 ? ((infer_type(c, argv[0]) == TY_FLOAT || infer_type(c, argv[0]) == TY_FLOAT_RANGE) ? TY_FLOAT : TY_INT) : TY_FLOAT;
     if (sp_streq(name, "bytes")) return TY_STRING;
     if (sp_streq(name, "seed")) return TY_INT;
   }
@@ -2505,6 +2529,7 @@ else {
       if (argc == 0) return TY_FLOAT;
       /* rand(float_range) → Float */
       const char *atype = nt_type(nt, argv[0]);
+      if (infer_type(c, argv[0]) == TY_FLOAT_RANGE) return TY_FLOAT;
       if (atype && sp_streq(atype, "RangeNode")) {
         int lo = nt_ref(nt, argv[0], "left");
         if (lo >= 0 && infer_type(c, lo) == TY_FLOAT) return TY_FLOAT;
@@ -4376,8 +4401,16 @@ TyKind infer_uncached(Compiler *c, int id) {
     }
     /* infer the bounds so codegen can tell an int range from a string range */
     int lo = nt_ref(nt, id, "left"), hi = nt_ref(nt, id, "right");
-    if (lo >= 0) infer_type(c, lo);
-    if (hi >= 0) infer_type(c, hi);
+    TyKind lot = lo >= 0 ? infer_type(c, lo) : TY_UNKNOWN;
+    TyKind hit = hi >= 0 ? infer_type(c, hi) : TY_UNKNOWN;
+    /* a FLOAT BEGIN over numeric bounds: the int-backed sp_Range would
+       truncate it, so carry the exact endpoints in an sp_FRange. An
+       int-begin range keeps the int representation regardless of its end
+       (iteration from an int begin is legal -- (1..Float::INFINITY) rides
+       the existing infinite-end handling). */
+    if (lo >= 0 && hi >= 0 && lot == TY_FLOAT &&
+        (hit == TY_FLOAT || hit == TY_INT))
+      return TY_FLOAT_RANGE;
     return TY_RANGE;
   }
   /* A splat inside an array literal (`[*0..10]`, `[*arr]`) contributes the

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -373,6 +373,7 @@ void emit_boxed(Compiler *c, int node, Buf *b) {
     case TY_BOOL:   fn = "sp_box_bool";  break;
     case TY_SYMBOL: fn = "sp_box_sym";   break;
     case TY_RANGE:  fn = "sp_box_range"; break;
+    case TY_FLOAT_RANGE: unsupported(c, node, "boxing a float range into poly"); return;
     case TY_TIME:   fn = "sp_box_time";  break;
     case TY_COMPLEX:  fn = "sp_box_complex";  break;
     case TY_RATIONAL: fn = "sp_box_rational"; break;
@@ -423,6 +424,7 @@ void declare_local(Compiler *c, Buf *b, LocalVar *lv, int vol) {
     case TY_TIME:   buf_puts(&cty, "sp_Time"); init = "{0}"; break;
     case TY_COMPLEX:  buf_puts(&cty, "sp_Complex"); init = "{0}"; break;
     case TY_RATIONAL: buf_puts(&cty, "sp_Rational"); init = "{0}"; break;
+    case TY_FLOAT_RANGE: buf_puts(&cty, "sp_FRange"); init = "{0}"; break;
     case TY_STRING: buf_puts(&cty, "const char *"); init = "(&(\"\\xff\")[1])"; ptr = 1; break;
     case TY_POLY:   buf_puts(&cty, "sp_RbVal"); init = "sp_box_nil()"; break;
     case TY_CLASS:  buf_puts(&cty, "sp_Class"); init = "((sp_Class){-1})"; break;

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -6258,6 +6258,18 @@ void emit_call(Compiler *c, int id, Buf *b) {
         buf_puts(b, "sp_Random_rand_float_bound(sp_random_default_get(), ");
         emit_expr(c, argv[0], b); buf_puts(b, ")");
       }
+      else if (argc >= 1 && comp_ntype(c, argv[0]) == TY_FLOAT_RANGE) {
+        /* Random.rand(range), unlike bare Kernel#rand(range), raises on an
+           inverted/empty range instead of returning nil (verified against
+           CRuby: `Random.rand(3.0..1.0)` -> ArgumentError). */
+        int tfr = ++g_tmp;
+        buf_printf(b, "({ sp_FRange _t%d = ", tfr);
+        emit_expr(c, argv[0], b);
+        buf_printf(b, "; if (_t%d.first > _t%d.last || (_t%d.first == _t%d.last && _t%d.excl))"
+                      " sp_raise_cls(\"ArgumentError\", sp_sprintf(\"invalid argument - %%s\", sp_FRange_inspect(_t%d)));"
+                      " _t%d.first + sp_Random_rand_float(sp_random_default_get()) * (_t%d.last - _t%d.first); })",
+                   tfr, tfr, tfr, tfr, tfr, tfr, tfr, tfr, tfr);
+      }
       else if (argc >= 1) {
         buf_puts(b, "sp_Random_rand_int(sp_random_default_get(), ");
         emit_expr(c, argv[0], b); buf_puts(b, ")");
@@ -6278,6 +6290,18 @@ void emit_call(Compiler *c, int id, Buf *b) {
       if (argc >= 1 && comp_ntype(c, argv[0]) == TY_FLOAT) {
         buf_puts(b, "sp_Random_rand_float_bound("); emit_expr(c, recv, b); buf_puts(b, ", ");
         emit_expr(c, argv[0], b); buf_puts(b, ")");
+      }
+      else if (argc >= 1 && comp_ntype(c, argv[0]) == TY_FLOAT_RANGE) {
+        /* r.rand(range) raises on an inverted/empty range, like Random.rand
+           (verified against CRuby: `Random.new(1).rand(3.0..1.0)` ->
+           ArgumentError), unlike bare Kernel#rand which returns nil. */
+        int tfr2 = ++g_tmp, trn2 = ++g_tmp;
+        buf_printf(b, "({ sp_Random *_t%d = ", trn2); emit_expr(c, recv, b);
+        buf_printf(b, "; sp_FRange _t%d = ", tfr2); emit_expr(c, argv[0], b);
+        buf_printf(b, "; if (_t%d.first > _t%d.last || (_t%d.first == _t%d.last && _t%d.excl))"
+                      " sp_raise_cls(\"ArgumentError\", sp_sprintf(\"invalid argument - %%s\", sp_FRange_inspect(_t%d)));"
+                      " _t%d.first + sp_Random_rand_float(_t%d) * (_t%d.last - _t%d.first); })",
+                   tfr2, tfr2, tfr2, tfr2, tfr2, tfr2, tfr2, trn2, tfr2, tfr2);
       }
       else if (argc >= 1 && comp_ntype(c, argv[0]) == TY_RANGE) {
         buf_puts(b, "sp_Random_rand_range("); emit_expr(c, recv, b); buf_puts(b, ", ");
@@ -6792,6 +6816,17 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     if (sp_streq(name, "rand")) {
       if (ac == 0) { buf_puts(b, "(mrb_float)((double)rand() / (RAND_MAX + 1.0))"); return; }
       TyKind a0t = comp_ntype(c, av[0]);
+      if (a0t == TY_FLOAT_RANGE) {
+        /* bare Kernel#rand(range), unlike Random.rand/instance rand, returns
+           nil on an inverted/empty range instead of raising (verified:
+           `rand(3.0..1.0)` -> nil in CRuby). */
+        int tr = ++g_tmp;
+        buf_printf(b, "({ sp_FRange _t%d = ", tr); emit_expr(c, av[0], b);
+        buf_printf(b, "; (_t%d.first > _t%d.last || (_t%d.first == _t%d.last && _t%d.excl)) ? sp_float_nil()"
+                      " : (_t%d.first + sp_Random_rand_float(sp_random_default_get()) * (_t%d.last - _t%d.first)); })",
+                   tr, tr, tr, tr, tr, tr, tr, tr, tr);
+        return;
+      }
       if (a0t == TY_RANGE) {
         int tr = ++g_tmp;
         /* is the range a float range? */

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -5262,6 +5262,20 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
         buf_printf(b, "sp_num_clamp(sp_box_int(%s), ", r); emit_boxed(c, argv[0], b); buf_puts(b, ", "); emit_boxed(c, argv[1], b); buf_puts(b, ")");
       }
       else if (sp_streq(name, "clamp") && argc == 2) { buf_printf(b, "sp_int_clamp_ck(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ", "); emit_expr(c, argv[1], b); buf_puts(b, ")"); }
+      else if (sp_streq(name, "clamp") && argc == 1 && comp_ntype(c, argv[0]) == TY_FLOAT_RANGE) {
+        /* float bounds over an int receiver: the clamped-to bound is the
+           Float endpoint itself, an in-range receiver stays Integer (poly
+           result); an exclusive range raises like CRuby */
+        int tv3 = ++g_tmp;
+        buf_printf(b, "({ mrb_int _t%d = (%s); sp_FRange _r%d = ", tv3, r, tv3);
+        emit_expr(c, argv[0], b);
+        buf_printf(b, "; if (_r%d.excl) sp_raise_cls(\"ArgumentError\", (&(\"\\xff\" \"cannot clamp with an exclusive range\")[1]));", tv3);
+        buf_printf(b, " if (_r%d.first > _r%d.last) sp_raise_cls(\"ArgumentError\", (&(\"\\xff\" \"min argument must be less than or equal to max argument\")[1]));", tv3, tv3);
+        buf_printf(b, " ((double)_t%d < _r%d.first) ? sp_box_float(_r%d.first)"
+                      " : ((double)_t%d > _r%d.last) ? sp_box_float(_r%d.last)"
+                      " : sp_box_int(_t%d); })",
+                   tv3, tv3, tv3, tv3, tv3, tv3, tv3);
+      }
       else if (sp_streq(name, "clamp") && argc == 1 && comp_ntype(c, argv[0]) == TY_RANGE &&
                nt_type(nt, argv[0]) && sp_streq(nt_type(nt, argv[0]), "RangeNode") &&
                ((nt_ref(nt, argv[0], "left") >= 0 && comp_ntype(c, nt_ref(nt, argv[0], "left")) == TY_FLOAT) ||
@@ -5410,6 +5424,15 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
                         " (mrb_int)%s(_t%d); })",
                      tg, r, tg, tg, tg, cfn, tg);
         }
+      }
+      else if (sp_streq(name, "clamp") && argc == 1 && comp_ntype(c, argv[0]) == TY_FLOAT_RANGE) {
+        int tv4 = ++g_tmp;
+        buf_printf(b, "({ double _t%d = (%s); sp_FRange _r%d = ", tv4, r, tv4);
+        emit_expr(c, argv[0], b);
+        buf_printf(b, "; if (_r%d.excl) sp_raise_cls(\"ArgumentError\", (&(\"\\xff\" \"cannot clamp with an exclusive range\")[1]));", tv4);
+        buf_printf(b, " if (_r%d.first > _r%d.last) sp_raise_cls(\"ArgumentError\", (&(\"\\xff\" \"min argument must be less than or equal to max argument\")[1]));", tv4, tv4);
+        buf_printf(b, " _t%d < _r%d.first ? _r%d.first : _t%d > _r%d.last ? _r%d.last : _t%d; })",
+                   tv4, tv4, tv4, tv4, tv4, tv4, tv4);
       }
       else if (sp_streq(name, "clamp") && argc == 1 && comp_ntype(c, argv[0]) == TY_RANGE) {
         /* the clamped-to bound is the range's endpoint itself (keeping its
@@ -6624,6 +6647,14 @@ TyKind emit_range_step_array(Compiler *c, int id, Buf *b) {
   }
   int t = ++g_tmp;
   Buf rb = expr_buf(c, recv);
+  if (comp_ntype(c, recv) == TY_FLOAT_RANGE) {
+    buf_printf(b, "({ sp_FRange _t%d = %s; sp_FloatArray_from_step(_t%d.first, _t%d.last, ",
+               t, rb.p ? rb.p : "", t, t);
+    emit_float_expr(c, argv[0], b);
+    buf_printf(b, ", _t%d.excl != 0); })", t);
+    free(rb.p);
+    return TY_FLOAT_ARRAY;
+  }
   if (is_float)
     buf_printf(b, "({ sp_Range _t%d = %s; sp_FloatArray_from_step((mrb_float)_t%d.first, (mrb_float)_t%d.last, ",
                t, rb.p ? rb.p : "", t, t);
@@ -6644,6 +6675,82 @@ int emit_range_call(Compiler *c, int id, Buf *b) {
   const int *argv = call_args(nt, id, &argc);
   TyKind rt = comp_recv_type(c, recv);
   /* range value methods (evaluate the range once into a temp) */
+  if (recv >= 0 && rt == TY_FLOAT_RANGE) {
+    /* float-endpoint range: exact endpoint reads and the cover predicate;
+       iteration raises TypeError like CRuby (can't iterate from Float). */
+    if (argc == 0 && (sp_streq(name, "begin") || sp_streq(name, "first"))) {
+      int t = ++g_tmp;
+      buf_printf(b, "({ sp_FRange _t%d = ", t); emit_expr(c, recv, b);
+      buf_printf(b, "; _t%d.first; })", t);
+      return 1;
+    }
+    if (argc == 0 && (sp_streq(name, "end") || sp_streq(name, "last"))) {
+      int t = ++g_tmp;
+      buf_printf(b, "({ sp_FRange _t%d = ", t); emit_expr(c, recv, b);
+      buf_printf(b, "; _t%d.last; })", t);
+      return 1;
+    }
+    if (argc == 0 && sp_streq(name, "min")) {
+      int t = ++g_tmp;
+      buf_printf(b, "({ sp_FRange _t%d = ", t); emit_expr(c, recv, b);
+      buf_printf(b, "; (_t%d.excl ? _t%d.first < _t%d.last : _t%d.first <= _t%d.last) ? _t%d.first : sp_float_nil(); })",
+                 t, t, t, t, t, t);
+      return 1;
+    }
+    if (argc == 0 && sp_streq(name, "max")) {
+      int t = ++g_tmp;
+      buf_printf(b, "({ sp_FRange _t%d = ", t); emit_expr(c, recv, b);
+      buf_printf(b, "; if (_t%d.excl) sp_raise_cls(\"TypeError\", \"cannot exclude non Integer end value\");"
+                    " _t%d.first <= _t%d.last ? _t%d.last : sp_float_nil(); })",
+                 t, t, t, t);
+      return 1;
+    }
+    if (argc == 0 && sp_streq(name, "exclude_end?")) {
+      int t = ++g_tmp;
+      buf_printf(b, "({ sp_FRange _t%d = ", t); emit_expr(c, recv, b);
+      buf_printf(b, "; _t%d.excl != 0; })", t);
+      return 1;
+    }
+    if (argc == 0 && (sp_streq(name, "to_s") || sp_streq(name, "inspect"))) {
+      buf_puts(b, "sp_FRange_inspect(");
+      emit_expr(c, recv, b);
+      buf_puts(b, ")");
+      return 1;
+    }
+    if (sp_streq(name, "step") && argc == 1 && nt_ref(nt, id, "block") < 0) {
+      emit_range_step_array(c, id, b);
+      return 1;
+    }
+    if (argc == 1 && (sp_streq(name, "include?") || sp_streq(name, "cover?") ||
+                      sp_streq(name, "member?") || sp_streq(name, "==="))) {
+      TyKind at = comp_ntype(c, argv[0]);
+      if (at != TY_INT && at != TY_FLOAT && at != TY_POLY) {
+        /* an incomparable argument type never matches (CRuby: <=> returns
+           nil, cover?/include?/=== answer false) -- evaluate both operands
+           for any side effects, never cast a non-numeric value to mrb_float. */
+        buf_puts(b, "({ "); emit_expr(c, recv, b); buf_puts(b, "; ");
+        emit_expr(c, argv[0], b); buf_puts(b, "; 0; })");
+        return 1;
+      }
+      int t = ++g_tmp, tv = ++g_tmp;
+      buf_printf(b, "({ sp_FRange _t%d = ", t); emit_expr(c, recv, b);
+      buf_printf(b, "; mrb_float _t%d = (mrb_float)(", tv);
+      if (at == TY_POLY) { buf_puts(b, "sp_poly_to_f("); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+      else emit_expr(c, argv[0], b);
+      buf_printf(b, "); _t%d.first <= _t%d && (_t%d.excl ? _t%d < _t%d.last : _t%d <= _t%d.last); })",
+                 t, tv, t, tv, t, tv, t);
+      return 1;
+    }
+    if (sp_streq(name, "each") || sp_streq(name, "to_a") || sp_streq(name, "entries") ||
+        sp_streq(name, "map") || sp_streq(name, "collect") || sp_streq(name, "sum") ||
+        sp_streq(name, "select") || sp_streq(name, "reject") || sp_streq(name, "size") ||
+        sp_streq(name, "reduce") || sp_streq(name, "inject") || sp_streq(name, "count")) {
+      buf_puts(b, "(sp_raise_cls(\"TypeError\", (&(\"\\xff\" \"can't iterate from Float\")[1])), sp_box_nil())");
+      return 1;
+    }
+    return 0;  /* anything else: loud fall-through */
+  }
+
   if (recv >= 0 && rt == TY_RANGE) {
     int block = nt_ref(nt, id, "block");
     /* endless literal: size is infinite; take/first(n) count from the start

--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -718,6 +718,15 @@ void emit_expr(Compiler *c, int id, Buf *b) {
                  ta);
       return;
     }
+    /* a float endpoint over numeric bounds: exact sp_FRange value */
+    if (left >= 0 && right >= 0 && comp_ntype(c, id) == TY_FLOAT_RANGE) {
+      buf_puts(b, "((sp_FRange){(mrb_float)(");
+      emit_expr(c, left, b);
+      buf_puts(b, "), (mrb_float)(");
+      emit_expr(c, right, b);
+      buf_printf(b, "), %d})", excl);
+      return;
+    }
     buf_puts(b, "sp_range_new(");
     if (left >= 0) emit_int_expr(c, left, b); else buf_puts(b, "INTPTR_MIN");  /* beginless */
     buf_puts(b, ", ");

--- a/src/codegen_iter.c
+++ b/src/codegen_iter.c
@@ -1252,7 +1252,7 @@ int emit_iteration_stmt(Compiler *c, int id, Buf *b, int indent) {
   /* (range).step(k) { |x| ... } -- materialise the stepped values (shared with
      the no-block path so they match exactly) and walk them; the element type
      follows the array, int or float. */
-  if (sp_streq(name, "step") && rt == TY_RANGE) {
+  if (sp_streq(name, "step") && (rt == TY_RANGE || rt == TY_FLOAT_RANGE)) {
     int args = nt_ref(nt, id, "arguments"); int sargc = 0;
     if (args >= 0) nt_arr(nt, args, "arguments", &sargc);
     if (sargc < 1) return 0;

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -405,6 +405,11 @@ void emit_p_one(Compiler *c, int arg, Buf *b, int indent) {
     buf_printf(b, "{ sp_Time _t%d = ", tv); emit_expr(c, arg, b);
     buf_printf(b, "; fputs(sp_time_inspect_v(_t%d), stdout); putchar('\\n'); }\n", tv);
   }
+  else if (t == TY_FLOAT_RANGE) {
+    int tv = ++g_tmp;
+    buf_printf(b, "{ sp_FRange _t%d = ", tv); emit_expr(c, arg, b);
+    buf_printf(b, "; fputs(sp_FRange_inspect(_t%d), stdout); putchar('\\n'); }\n", tv);
+  }
   else if (t == TY_RANGE) {   /* a Range inspects as "first..last" / "first...last" */
     /* A string-endpoint range has no int sp_Range value; inspect its literal
        endpoints directly (each String quoted), e.g. `"a".."c"`. */
@@ -3210,6 +3215,27 @@ void emit_case(Compiler *c, int id, Buf *b, int indent) {
             if (pt == TY_POLY) buf_printf(b, "; sp_range_include(&_t%d, sp_poly_to_i(_t%d)); })", tr, t);
             else buf_printf(b, "; sp_range_include(&_t%d, _t%d); })", tr, t);
           }
+          else if (comp_ntype(c, conds[j]) == TY_FLOAT_RANGE && (pt == TY_INT || pt == TY_FLOAT || pt == TY_POLY)) {
+            /* `when lo..hi` (float-begin range) is range membership too --
+               mirror the sp_Range arm above with sp_FRange's cover?/===
+               semantics (exclusive end compares strictly). Only a numeric
+               scrutinee can be cast to mrb_float here -- see the sibling
+               arm below for anything else. */
+            int tr = ++g_tmp, tv2 = ++g_tmp;
+            buf_printf(b, "({ sp_FRange _t%d = ", tr); emit_expr(c, conds[j], b);
+            buf_printf(b, "; mrb_float _t%d = (mrb_float)(", tv2);
+            if (pt == TY_POLY) buf_printf(b, "sp_poly_to_f(_t%d)", t);
+            else buf_printf(b, "_t%d", t);
+            buf_printf(b, "); _t%d.first <= _t%d && (_t%d.excl ? _t%d < _t%d.last : _t%d <= _t%d.last); })",
+                       tr, tv2, tr, tv2, tr, tv2, tr);
+          }
+          else if (comp_ntype(c, conds[j]) == TY_FLOAT_RANGE) {
+            /* a non-numeric scrutinee can never be a float-range member
+               (CRuby: <=> returns nil, cover?/=== answer false) -- evaluate
+               the range expression for any side effects, never cast a
+               non-numeric scrutinee to mrb_float. */
+            buf_puts(b, "({ "); emit_expr(c, conds[j], b); buf_puts(b, "; 0; })");
+          }
           else if (eq_family(pt) && eq_family(comp_ntype(c, conds[j])) && eq_family(pt) != eq_family(comp_ntype(c, conds[j]))) {
             /* a when value of a different comparable family never matches */
             buf_puts(b, "0");
@@ -3428,6 +3454,25 @@ void emit_case_expr(Compiler *c, int id, Buf *b) {
           buf_printf(b, "({ sp_Range _t%d = ", tr); emit_expr(c, conds[j], b);
           if (pt == TY_POLY) buf_printf(b, "; sp_range_include(&_t%d, sp_poly_to_i(_t%d)); })", tr, t);
           else buf_printf(b, "; sp_range_include(&_t%d, _t%d); })", tr, t);
+        }
+        else if (comp_ntype(c, conds[j]) == TY_FLOAT_RANGE && (pt == TY_INT || pt == TY_FLOAT || pt == TY_POLY)) {
+          /* mirror the sp_Range arm above with sp_FRange's cover?/=== semantics;
+             only a numeric scrutinee can be cast to mrb_float here -- see the
+             sibling arm below for anything else. */
+          int tr = ++g_tmp, tv2 = ++g_tmp;
+          buf_printf(b, "({ sp_FRange _t%d = ", tr); emit_expr(c, conds[j], b);
+          buf_printf(b, "; mrb_float _t%d = (mrb_float)(", tv2);
+          if (pt == TY_POLY) buf_printf(b, "sp_poly_to_f(_t%d)", t);
+          else buf_printf(b, "_t%d", t);
+          buf_printf(b, "); _t%d.first <= _t%d && (_t%d.excl ? _t%d < _t%d.last : _t%d <= _t%d.last); })",
+                     tr, tv2, tr, tv2, tr, tv2, tr);
+        }
+        else if (comp_ntype(c, conds[j]) == TY_FLOAT_RANGE) {
+          /* a non-numeric scrutinee can never be a float-range member
+             (CRuby: <=> returns nil, cover?/=== answer false) -- evaluate
+             the range expression for any side effects, never cast a
+             non-numeric scrutinee to mrb_float. */
+          buf_puts(b, "({ "); emit_expr(c, conds[j], b); buf_puts(b, "; 0; })");
         }
         else if (eq_family(pt) && eq_family(comp_ntype(c, conds[j])) && eq_family(pt) != eq_family(comp_ntype(c, conds[j]))) {
           buf_puts(b, "0");

--- a/src/codegen_util.c
+++ b/src/codegen_util.c
@@ -683,6 +683,7 @@ const char *c_type_name(TyKind t) {
     case TY_STRING:      return "const char *";
     case TY_SYMBOL:      return "sp_sym";
     case TY_RANGE:       return "sp_Range";
+    case TY_FLOAT_RANGE: return "sp_FRange";
     case TY_TIME:        return "sp_Time";
     case TY_COMPLEX:     return "sp_Complex";
     case TY_RATIONAL:    return "sp_Rational";
@@ -720,7 +721,7 @@ const char *c_type_name(TyKind t) {
 }
 int is_scalar_ret(TyKind t) {
   return t == TY_INT || t == TY_BIGINT || t == TY_FLOAT || t == TY_BOOL || t == TY_STRING ||
-         t == TY_SYMBOL || t == TY_RANGE || t == TY_TIME || t == TY_COMPLEX || t == TY_RATIONAL || t == TY_MATCHDATA || t == TY_REGEX || t == TY_EXCEPTION ||
+         t == TY_SYMBOL || t == TY_RANGE || t == TY_FLOAT_RANGE || t == TY_TIME || t == TY_COMPLEX || t == TY_RATIONAL || t == TY_MATCHDATA || t == TY_REGEX || t == TY_EXCEPTION ||
          t == TY_INT_ARRAY || t == TY_FLOAT_ARRAY || t == TY_STR_ARRAY ||
          t == TY_STRBUF ||
          t == TY_POLY || t == TY_POLY_ARRAY || t == TY_PROC || t == TY_CURRY || t == TY_FIBER || t == TY_THREAD || t == TY_QUEUE || t == TY_MUTEX || t == TY_CONDVAR || t == TY_RANDOM || t == TY_METHOD || t == TY_IO || t == TY_ARGF || t == TY_ENUMERATOR || t == TY_CLASS ||
@@ -766,6 +767,7 @@ const char *default_value(TyKind t) {
     case TY_STRING: return "(&(\"\\xff\")[1])";
     case TY_SYMBOL: return "((sp_sym)-1)";
     case TY_RANGE:  return "(sp_Range){0}";
+    case TY_FLOAT_RANGE: return "(sp_FRange){0}";
     case TY_TIME:   return "(sp_Time){0}";
     case TY_COMPLEX: return "(sp_Complex){0}";
     case TY_RATIONAL: return "(sp_Rational){0}";

--- a/src/types.c
+++ b/src/types.c
@@ -15,6 +15,7 @@ const char *ty_name(TyKind t) {
     case TY_SYMBOL:  return "symbol";
     case TY_BOOL:    return "bool";
     case TY_RANGE:   return "range";
+    case TY_FLOAT_RANGE: return "float_range";
     case TY_TIME:    return "time";
     case TY_COMPLEX: return "complex";
     case TY_RATIONAL: return "rational";

--- a/src/types.h
+++ b/src/types.h
@@ -35,6 +35,7 @@ typedef enum {
   TY_SYMBOL,
   TY_BOOL,
   TY_RANGE,
+  TY_FLOAT_RANGE,  /* a float-endpoint Range (sp_FRange: first, last, excl) */
   TY_TIME,
   TY_COMPLEX,      /* Cartesian Complex value (sp_Complex: re, im) */
   TY_RATIONAL,     /* Rational value (sp_Rational: num, den) */

--- a/test/float_range_endpoints.rb
+++ b/test/float_range_endpoints.rb
@@ -1,0 +1,87 @@
+# A float-begin range carries its exact endpoints (sp_FRange) instead of
+# truncating into the int-backed representation: min/max/first/last/cover?
+# and clamp are exact through parameters; iteration raises like CRuby.
+def mn(x) = x.min
+def mx(x) = x.max
+p mn(303.2..908.9)
+p mx(303.2..908.9)
+p mn(3.0..1.0)
+def fst(x) = x.first
+p fst(1.5..9.5)
+p (1.5...9.5).last
+p (1.5...9.5).exclude_end?
+
+def cl(v, r) = v.clamp(r)
+p cl(5.0, 1.0..3.0)
+p cl(0.0, 1.0..3.0)
+p cl(2.0, 1.0..3.0)
+p 2.clamp(1.0..3.0)
+p 5.clamp(1.0..3.0)
+
+def cov(r, v) = r.cover?(v)
+p cov(1.5..2.5, 2.0)
+p cov(1.5..2.5, 3.0)
+p (1.0...2.0) === 2.0
+p (1.0..2.0).include?(2)
+
+p (1.0..3.0)
+p (1.0...3.0).to_s
+
+def iter_err(r)
+  r.to_a
+rescue TypeError => e
+  "#{e.class}: #{e.message}"
+end
+p iter_err(1.0..3.0)
+begin
+  (1.0...3.0).max
+rescue TypeError => e
+  puts "#{e.class}: #{e.message}"
+end
+begin
+  2.0.clamp(1.0...3.0)
+rescue ArgumentError => e
+  puts "#{e.class}: #{e.message}"
+end
+
+p (1.0..3.0).step(0.5).to_a
+
+def cw(x)
+  case x
+  when 1.5..3.5 then "in"
+  else "out"
+  end
+end
+p cw(2.0)
+p cw(10.0)
+p cw(1)
+p cw(Time.at(0))
+
+def inc(r, x) = r.include?(x)
+p inc(1.5..3.5, "hello")
+p inc(1.5..3.5, 2.0)
+
+begin
+  5.0.clamp(3.0..1.0)
+rescue => e
+  puts "#{e.class}: #{e.message}"
+end
+begin
+  5.clamp(3.0..1.0)
+rescue => e
+  puts "#{e.class}: #{e.message}"
+end
+
+begin
+  Random.rand(3.0..1.0)
+rescue => e
+  puts "#{e.class}: #{e.message}"
+end
+begin
+  Random.new(1).rand(3.0..1.0)
+rescue => e
+  puts "#{e.class}: #{e.message}"
+end
+p rand(3.0..1.0)
+p rand(1.0...1.0)
+p Random.new(1).rand(1.0..1.0).class

--- a/test/float_range_endpoints.rb.expected
+++ b/test/float_range_endpoints.rb.expected
@@ -1,0 +1,34 @@
+303.2
+908.9
+nil
+1.5
+9.5
+true
+3.0
+1.0
+2.0
+2
+3.0
+true
+false
+false
+true
+1.0..3.0
+"1.0...3.0"
+"TypeError: can't iterate from Float"
+TypeError: cannot exclude non Integer end value
+ArgumentError: cannot clamp with an exclusive range
+[1.0, 1.5, 2.0, 2.5, 3.0]
+"in"
+"out"
+"out"
+"out"
+false
+true
+ArgumentError: min argument must be less than or equal to max argument
+ArgumentError: min argument must be less than or equal to max argument
+ArgumentError: invalid argument - 3.0..1.0
+ArgumentError: invalid argument - 3.0..1.0
+nil
+nil
+Float


### PR DESCRIPTION
A float-begin range was materialized into the int-backed `sp_Range`, truncating its endpoints: `(303.2..908.9).min` answered `303` through a parameter, and `x.clamp(1.0..3.0)` clamped to integer bounds (returning `3`/`1`).

A float-begin numeric range now types `TY_FLOAT_RANGE` and lowers to a new by-value `sp_FRange` (exact double endpoints + the exclusive flag), passable through parameters like `sp_Range`.

**Surface**: begin/first/end/last; min (nil on an empty range); max (`TypeError: cannot exclude non Integer end value` on an exclusive end, like CRuby); exclude_end?; include?/cover?/=== for float, int, and boxed arguments; `case`/`when` membership (`when lo..hi`); to_s/inspect and `p` (`1.0..3.0`); blockless and block-form `step` through the existing float-step walk; and `rand` over a float range (Kernel and Random-instance forms). Iteration and `size` raise CRuby's `TypeError: can't iterate from Float`. Int-receiver `clamp` over float bounds returns the Float bound or the Integer receiver itself (poly: `2.clamp(1.0..3.0) # => 2`, `5.clamp(1.0..3.0) # => 3.0`); an exclusive clamp range raises `ArgumentError: cannot clamp with an exclusive range`.

**Deliberately narrow**: an int-**begin** range keeps the int representation regardless of its end — `(1..Float::INFINITY)` rides the existing infinite-end handling and iteration from an int begin stays legal (its `size`/take/first semantics are pinned by existing tests). Boxing a float range into a poly slot loudly rejects at compile time rather than being represented (both boxing entry points, `emit_boxed` and `emit_boxed_text`, now agree on this — the former previously fell through to a generic "evaluate for effect, box nil" path, silently discarding the value instead of rejecting).

**Tests**: `test/float_range_endpoints.rb` — min/max/first/last/exclude_end? through parameters, empty-range min, the full clamp matrix (float and int receivers, in/below/above range), cover?/===/include? with float and int arguments, inspect/to_s/p, `case`/`when` membership across float/int/poly scrutinees, the three exception cases with exact messages, and `step(0.5).to_a`; ruby-generated expected output, verified under `SPINEL_GC_STRESS`. The full clamp/range/float/rand/case/hash/poly test sweep is green (including `range_step_float`, `range_float_begin_iterate`, `range_size_infinite_local`, and `range_and_array_range_args`, which exercise the boundary with the int representation).

**Residuals**: a float range boxed into a poly slot is not represented (loud reject); beginless/endless float ranges keep the previous behavior.
