### PR TITLE
Preserve boxed hash lookup values assigned to locals

### DIFF
--- a/src/analyze_pass.c
+++ b/src/analyze_pass.c
@@ -1853,6 +1853,34 @@ int infer_write_types(Compiler *c) {
     }
   }
 
+  /* The container-usage fold above can widen a hash's value layout after the
+     main write-site scan has already typed a destination local. Reconcile the
+     direct `value = hash[key]` shape now that the receiver is final: a boxed
+     hash value must flow into a boxed local, rather than being coerced through
+     an earlier scalar slot (for example, false becoming integer zero).
+
+     Keep this deliberately local to the affected assignment. The normal node
+     cache rebuild propagates the new slot type to its reads, while occurrence
+     typing can still narrow guarded reads later in analysis. */
+  NT_FOREACH_KIND(nt, NK_LocalVariableWriteNode, id) {
+    int value = nt_ref(nt, id, "value");
+    if (value < 0 || nt_kind(nt, value) != NK_CallNode) continue;
+    const char *name = nt_str(nt, value, "name");
+    if (!name || !sp_streq(name, "[]") || nt_ref(nt, value, "block") >= 0) continue;
+    int args = nt_ref(nt, value, "arguments");
+    int argc = 0;
+    if (args >= 0) nt_arr(nt, args, "arguments", &argc);
+    if (argc != 1) continue;
+    int recv = nt_ref(nt, value, "receiver");
+    TyKind rt = recv >= 0 ? infer_type(c, recv) : TY_UNKNOWN;
+    if (!ty_is_hash(rt) || ty_hash_val(rt) != TY_POLY) continue;
+    const char *nm = nt_str(nt, id, "name");
+    LocalVar *lv = nm ? scope_local(comp_scope_of(c, id), nm) : NULL;
+    if (!lv || lv->is_param || lv->is_block_param || lv->rbs_seeded) continue;
+    TyKind merged = ty_unify(lv->type, TY_POLY);
+    if (merged != lv->type) { lv->type = merged; changed = 1; }
+  }
+
   /* Second pass: re-compute proc_ret for proc-typed locals after body-internal
      locals have been typed. The first pass resets all locals to TY_UNKNOWN, so
      computing proc_ret there would see stale TY_UNKNOWN for variables assigned

--- a/test/hash_poly_value_local.rb
+++ b/test/hash_poly_value_local.rb
@@ -1,0 +1,27 @@
+h = {"int" => -9}
+h["array"] = [1, 2]
+h["bool"] = false
+h["float"] = 1.5
+h["hash"] = {"nested" => 7}
+h["nil"] = nil
+h["string"] = "text"
+
+h.keys.sort.each do |key|
+  value = h[key]
+  rendered = if value.is_a?(Array)
+    "array:" + value.length.to_s
+  elsif value.is_a?(Float)
+    "float:" + value.to_s
+  elsif value.is_a?(Integer)
+    "int:" + value.abs.to_s
+  elsif value.is_a?(String)
+    "string:" + value.upcase
+  elsif value.is_a?(Hash)
+    "hash"
+  elsif value.nil?
+    "nil"
+  else
+    "bool:" + value.to_s
+  end
+  puts key + "=" + rendered
+end

--- a/test/hash_poly_value_local.rb.expected
+++ b/test/hash_poly_value_local.rb.expected
@@ -1,0 +1,7 @@
+array=array:2
+bool=bool:false
+float=float:1.5
+hash=hash
+int=int:9
+nil=nil
+string=string:TEXT


### PR DESCRIPTION
## The bug

A hash can widen from scalar to boxed values after the main write-site scan has
already inferred scalar storage for a destination variable:

```ruby
h = {"echo" => -9}
h["cherry"] = false
value = h["cherry"]
p value
```

CRuby prints `false`; Spinel coerces the boxed result through the stale integer
slot and prints `0`.

## The fix

After container-usage inference finalizes hash layouts, reconcile direct
assignments such as `value = hash[key]` when the hash stores boxed values. Only
the affected variable's storage slot is widened.

The normal node-cache rebuild propagates the corrected slot type, and existing
`is_a?` occurrence typing still narrows guarded reads. The separate hash-layout
safety pass is unchanged.

## Tests

Add `test/hash_poly_value_local.rb` covering Array, Hash, Float, nil, String,
integer, and boolean values. The test also exercises guarded Array, Float,
Integer, and String operations to ensure occurrence narrowing is preserved.

## Validation

- The regression miscoerces every non-integer value on unpatched `23a12023`
  and matches CRuby with the fix
- Generated programs match CRuby 4.0.3 at `-O0`, `-O2`, and `-O3`
- Ruby 4.0.3 full suite: 1,839 pass, 0 fail, 0 error
- Ruby 3.4.9 CI-compatibility suite: 1,839 pass, 0 fail, 0 error
- Existing `block_local_shadow` regression: pass
- RBS extractor: 13 pass
- Benchmarks: 58 pass, 0 fail, 0 error, 0 skip
- Optcarrot: checksum 59662, OK
- `git diff --check`

Fixes #2610
