### PR TITLE
analyze: two O(N^2) passes on large trees (empty-hash / Hash.new default)

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -5369,6 +5369,12 @@ static int param_nonstr_index_written(Compiler *c, int mi, int p) {
 static void mark_empty_literal_args(Compiler *c) {
   if (!c->empty_hash_arg) return;
   const NodeTable *nt = c->nt;
+  /* This pass does not create or rename scopes, so the scope-shape index is
+     stable across it: freeze so the per-class method lookups below (called for
+     every CallNode * every class) hit the O(1) hash index instead of the
+     unfrozen O(nscopes) linear reverse scan -- the dominant analyze cost on
+     large apps (lobsters: ~72% of compile time was this triple loop). */
+  comp_scope_index_set_frozen(1);
   for (int id = 0; id < nt->count; id++) {
     if (nt_kind(nt, id) != NK_CallNode) continue;
     const char *nm = nt_str(nt, id, "name");
@@ -5419,6 +5425,7 @@ static void mark_empty_literal_args(Compiler *c) {
       }
     }
   }
+  comp_scope_index_set_frozen(0);
 }
 /* An empty `{}` compared against a hash-typed peer takes that peer's variant,
    so the two sides share a representation and `==` can compare contents

--- a/src/analyze_util.c
+++ b/src/analyze_util.c
@@ -301,7 +301,44 @@ int anon_struct_ci_for_value(Compiler *c, int val) {
    return the default-value argument node, or -1. Lets a literal receiver's
    .default / [] / fetch fold to the default when the hash type never
    narrows (no writes ever reach it). */
+static int hash_new_default_arg_compute(Compiler *c, int recv);
+
+/* hash_new_default_arg's result is a pure function of the (static) AST node
+   table plus scope assignments, which are fixed while the scope-index is
+   frozen. The local-variable branch scans every write node in the program, and
+   the function is called for every `x[k]` / `x.default` on an untyped receiver
+   during the inference fixpoint -- O(N) per call, O(N^2) overall. Memoize per
+   receiver node while frozen, discarding the cache when the scope epoch changes
+   (see comp_scope_index_gen); fall back to a direct compute while unfrozen. */
 int hash_new_default_arg(Compiler *c, int recv) {
+  if (recv < 0) return -1;
+  if (!comp_scope_index_is_frozen() || recv >= c->node_cap)
+    return hash_new_default_arg_compute(c, recv);
+  unsigned gen = comp_scope_index_gen();
+  if (!c->hash_default_arg_memo || c->hash_default_arg_memo_cap < c->node_cap) {
+    free(c->hash_default_arg_memo);
+    c->hash_default_arg_memo = malloc((size_t)c->node_cap * sizeof(int));
+    c->hash_default_arg_memo_cap = c->hash_default_arg_memo ? c->node_cap : 0;
+    c->hash_default_arg_memo_gen = gen - 1u; /* force the re-init below */
+  }
+  if (!c->hash_default_arg_memo) return hash_new_default_arg_compute(c, recv);
+  if (c->hash_default_arg_memo_gen != gen) {
+    for (int i = 0; i < c->hash_default_arg_memo_cap; i++) c->hash_default_arg_memo[i] = INT_MIN;
+    c->hash_default_arg_memo_gen = gen;
+  }
+  if (c->hash_default_arg_memo[recv] != INT_MIN) return c->hash_default_arg_memo[recv];
+  /* Mark the slot resolved-but-dynamic (-1) before recomputing: the compute
+     recurses through a local's writes, which can re-enter for this same node
+     via a write cycle (`a = b; b = a`). -1 is the correct conservative result
+     for such a cyclic (non-single-Hash.new) definition and breaks the cycle;
+     the real result overwrites it below. */
+  c->hash_default_arg_memo[recv] = -1;
+  int r = hash_new_default_arg_compute(c, recv);
+  c->hash_default_arg_memo[recv] = r;
+  return r;
+}
+
+static int hash_new_default_arg_compute(Compiler *c, int recv) {
   const NodeTable *nt = c->nt;
   if (recv < 0 || !nt_type(nt, recv)) return -1;
   /* a local whose every same-scope write is the same Hash.new(d) shape

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -80,6 +80,8 @@ void comp_grow_node_arrays(Compiler *c) {
 
 void comp_free(Compiler *c) {
   if (!c) return;
+  free(c->hash_default_arg_memo);
+  c->hash_default_arg_memo = NULL;
   free(c->blk_body_map);
   c->blk_body_map = NULL;
   for (int s = 0; s < c->nscopes; s++) {
@@ -352,7 +354,13 @@ static int *tm_next = NULL, *tm_head = NULL;
    count-keyed cache would go stale. analyze_program freezes the index just
    before the inference fixpoint (where lookups are hottest and scope shape is
    fixed) and unfreezes at entry. While unfrozen, fall back to the linear scan. */
-void comp_scope_index_set_frozen(int f) { sm_frozen = f; sm_nscopes = -1; ci_frozen = f; ci_nclasses = -1; }
+/* Bumped on every freeze/unfreeze transition so consumers that cache a result
+   which is only stable while scope shape is fixed (e.g. hash_new_default_arg's
+   per-node memo) can stamp their cache and discard it when the epoch changes. */
+static unsigned sm_gen = 0;
+void comp_scope_index_set_frozen(int f) { if (sm_frozen != f) sm_gen++; sm_frozen = f; sm_nscopes = -1; ci_frozen = f; ci_nclasses = -1; }
+int comp_scope_index_is_frozen(void) { return sm_frozen; }
+unsigned comp_scope_index_gen(void) { return sm_gen; }
 static void sm_build(Compiler *c) {
   int ns = c->nscopes;
   free(sm_next); free(sm_head); free(tm_next); free(tm_head);

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -274,6 +274,9 @@ typedef struct {
   char *empty_hash_recv; /* [node_cap] empty `{}` used as a hash block-method receiver -> TY_STR_POLY_HASH */
   char *empty_hash_arg;  /* [node_cap] empty `{}` passed as a user-method arg -> TY_POLY_POLY_HASH */
   TyKind *empty_hash_want; /* [node_cap] variant an empty `{}` should take from its use context (#3040) */
+  int *hash_default_arg_memo; /* [node_cap] hash_new_default_arg(node) memo; INT_MIN = uncomputed */
+  unsigned hash_default_arg_memo_gen; /* scope-index generation the memo was built for */
+  int hash_default_arg_memo_cap;      /* allocated length of hash_default_arg_memo */
   int node_cap;     /* allocated length of ntype/nscope (>= nt->count) */
 
   Scope *scopes;    /* scope[0] = top level */
@@ -449,6 +452,10 @@ int        comp_method_in_class(Compiler *c, int class_id, const char *name);
 /* Freeze/unfreeze the (class_id,name,is_cmethod)->scope lookup index. Frozen
    only while scope shape is fixed (the inference fixpoint); see compiler.c. */
 void       comp_scope_index_set_frozen(int frozen);
+/* Whether the scope-index is currently frozen (scope shape fixed). */
+int        comp_scope_index_is_frozen(void);
+/* Generation counter, bumped on every freeze/unfreeze transition. */
+unsigned   comp_scope_index_gen(void);
 /* Find the class (singleton) method scope for class_id + name, or -1 (no chain). */
 int        comp_cmethod_in_class(Compiler *c, int class_id, const char *name);
 /* Find the class (singleton) method scope, walking the superclass chain. */


### PR DESCRIPTION
Follow-on to fd13553e (`analyze: index writes in desugar_builtin_class_var_recv`). Profiling the same lobsters ~370-file tree afterwards surfaced two more O(N^2) analyze passes stacked behind it; together they were ~65% of compile time.

**Baseline:** ~82s to analyze the tree, single core pinned, 1.25T instructions. A `sample` showed ~72% of stacks in a single `sm_lookup` loop.

### 1. `mark_empty_literal_args` — freeze the scope index
For every `CallNode` it does `for k in nclasses { comp_method_in_class; comp_cmethod_in_class }`, and it runs in `analyze_program`'s *unfrozen* region, so each lookup falls back to `sm_lookup`'s linear reverse scan over all scopes → O(nodes × classes × scopes). The pass never creates or renames scopes, so freezing the index for its duration lets the lookups hit the existing O(1) hash index. Behaviour-identical (the frozen chain resolves in the same order as the reverse scan). **~82s → ~67s.**

### 2. `hash_new_default_arg` — memoize while frozen
Its `LocalVariableReadNode` branch scans every write node in the program, and `infer_call` calls it for every `x[k]` / `x.default` / `x.values_at` on an untyped receiver during the inference fixpoint → O(N) per call, O(N^2) overall. The result is a pure function of the static AST + (frozen) scope assignments, so it's memoized per receiver node while frozen, stamped with a scope-index generation counter (bumped on every freeze/unfreeze) so the cache is discarded whenever scope shape could have changed. **~67s → ~45s.**

**Net: ~82s → ~45s (~45% faster), 1.25T → 0.67T instructions.**

Both are the same bug class as fd13553e (a per-node helper rescanning the whole node/scope table). Verification: full suite **2219 pass / 0 fail / 0 error**; RBS extractor + seed tests pass; `Hash.new` default folding verified behaviorally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)