### PR TITLE
analyze: fixpoint never converged — false change-reports kept every tree at the 128-iteration cap (~3x)

### DIFF
--- a/src/analyze_pass.c
+++ b/src/analyze_pass.c
@@ -1119,7 +1119,12 @@ int infer_write_types(Compiler *c) {
               LocalVar *lv_p = lnm_p ? scope_local(ms_poly, lnm_p) : NULL;
               if (!lv_p || lv_p->is_param || lv_p->is_block_param) continue;
               TyKind mg_p = ty_unify(lv_p->type, TY_POLY);
-              if (mg_p != lv_p->type) { lv_p->type = mg_p; changed = 1; }
+              /* plain locals are reset+recomputed each iteration; net change
+                 is detected by the end-of-pass stash compare. Reporting the
+                 re-derivation here reads as change every iteration and the
+                 fixpoint never converges. Only a non-reset (pinned) slot's
+                 transition is a real change. */
+              if (mg_p != lv_p->type) { lv_p->type = mg_p; if (lv_p->rbs_seeded) changed = 1; }
             }
           }
         }
@@ -1698,6 +1703,8 @@ int infer_write_types(Compiler *c) {
     /* fold into a local's type or an ivar's type (an empty `@buf=[]` filled by
        `@buf << x` infers its element type the same way a local does) */
     TyKind *slot = NULL;
+    int slot_reset = 0;  /* slot is a plain local, reset+recomputed per iteration:
+                            net change is the stash compare's job, not this site's */
     const char *watch_nm = NULL;  /* ivar name for SP_IVWATCH, NULL for locals */
     if (rty && sp_streq(rty, "LocalVariableReadNode")) {
       const char *rnm = nt_str(nt, recv, "name");
@@ -1734,6 +1741,7 @@ int infer_write_types(Compiler *c) {
         if (has_array_write) continue;
       }
       slot = &lv->type;
+      slot_reset = !lv->is_param && !lv->is_block_param && !lv->rbs_seeded;
     }
     else if (rty && sp_streq(rty, "InstanceVariableReadNode")) {
       const char *inm = nt_str(nt, recv, "name");
@@ -1893,7 +1901,7 @@ int infer_write_types(Compiler *c) {
       *slot = TY_POLY_POLY_HASH;
     }
     sp_ivwatch(watch_nm, is_push ? "usage_push" : (is_idx_write ? "usage_idxwrite" : "usage_read"), before, *slot);
-    if (*slot != before) changed = 1;
+    if (*slot != before && !slot_reset) changed = 1;
   }
 
   /* Propagate container widening across direct local aliases (`b = a`): the

--- a/src/analyze_pass.c
+++ b/src/analyze_pass.c
@@ -7742,6 +7742,12 @@ int infer_return_types(Compiler *c) {
        (backprop_hash_return_types), don't collapse it back to UNKNOWN -- that
        would re-emit a void C signature the caller can't assign (#1680). */
     if (r == TY_UNKNOWN && ty_is_hash(sc->ret) && scope_tail_empty_hash(c, s) >= 0) continue;
+    /* A void body-recompute must not downgrade an established return: an
+       abstract/raising body infers TY_VOID every pass, while the slot's real
+       type comes from descendant-override dispatch unification (or a caller
+       backprop). Re-deriving VOID here would flip the slot every iteration
+       and the fixpoint never converges. */
+    if (r == TY_VOID && sc->ret != TY_UNKNOWN && sc->ret != TY_VOID) continue;
     if (r != sc->ret) { sc->ret = r; changed = 1; }
     /* For a method with a &block param, record the value type its block yields
        (unified across all call sites). Blocks passed to it are emitted returning


### PR DESCRIPTION
## Summary

Follow-on to #3123. After those fixes the same lobsters ~370-file tree still took ~45s, so I instrumented `analyze_program`'s main fixpoint to see where the time actually goes — and the shape was not per-iteration cost (that's sane after #3123) but the multiplier: **the fixpoint never converges. It runs all 128 iterations with `ch=1` still set at iter 127 and terminates by cap, not by settling — on every non-trivial tree.** A ~1k-line synthetic converges in a handful of iterations; Rails-shaped trees never do.

Per-pass change tracing narrowed it to two independent causes, both of the class "a pass reports change it didn't make":

### 1. `infer_write_types` reports reset-local re-derivation as change

The pass deliberately resets every plain local to `TY_UNKNOWN` and recomputes it fresh each iteration (the narrowing design), and detects *net* change with the end-of-pass stash compare (`gc_root` vs final type). But two mid-pass sites also set `changed` when they move a slot *relative to the reset state* — which happens every iteration even when the final value is identical to the previous iteration's:

- the poly-RHS destructure widen (`a, b = <poly expr>` → targets unify to poly) touches only plain (reset) locals, so its report is always redundant with the stash compare;
- the usage-driven container fold's `*slot != before` — `before` is captured **after** the reset, so a local slot re-promoted from UNKNOWN reads as change every iteration. (Ivar slots are not reset and keep reporting here.)

Fix: these sites report change only for non-reset slots; net change for reset locals stays the stash compare's job.

### 2. `infer_return_types` re-derives VOID over an established return

An abstract/raising base-method body infers `TY_VOID` on every pass, while the slot's real type comes from descendant-override dispatch unification — the semantics `test/abstract_raise_override_return.rb` pins (#1416). The recompute downgraded the slot back to VOID each iteration and the unify re-widened it: a permanent ping-pong. On the lobsters tree the flip set is an ORM base class's `[]`, `[]=`, `instantiate`, `table_name`, `schema_columns`, plus a controller base's `process_action` — and every caller local flips in sympathy. Fix: a VOID body-recompute never downgrades an established non-void return; genuinely-void methods still settle (VOID only skips when the slot already holds a non-void, non-unknown type).

## Numbers

Lobsters ~370-file emitted tree (`spinel main.rb -c`, Apple Silicon):

|  | before | after |
|---|---|---|
| main-fixpoint iterations | 128 (cap, `ch=1` at exit) | **11 (converged)** |
| wall/user time | ~45s | **~12–14s (≈3.2×)** |

The blog fixture converges in 7 iterations; its full compile (with cc) drops 3.6s → 2.9s. Even small programs were previously burning the full cap.

## Verification

- `make test`: **2246 pass / 0 fail / 0 error** (RBS extractor + seed tests included).
- Diagnostics on the lobsters tree are byte-identical before/after when both binaries run from the same location (same warnings, same terminal refusal, same node ids) — the fixes change iteration count, not results.
- The existing #1416 test pins the semantics fix 2 makes sticky.
- The lobsters tree is the published roundhouse archive (same tree as #3123/#2457), available at https://rubys.github.io/roundhouse/browse/ if you want to reproduce.

With convergence real again, the 128 cap returns to being a backstop rather than the effective terminator; if useful I can follow up with a warning when the cap is actually hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
