### PR TITLE
analyze: index the two whole-table scans in the post-fixpoint tail (~27%)

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -4923,6 +4923,29 @@ static void narrow_poly_int_locals(Compiler *c) {
   int nc = nt->count ? nt->count : 1;
   char *is_read = (char *)malloc(nc);
   char *claimed = (char *)malloc(nc);
+  memset(is_read, 0, (size_t)nc);
+  memset(claimed, 0, (size_t)nc);
+  /* Every check below only cares about nodes in the candidate local's own
+     scope (a read's consumer in receiver/argument position shares the read's
+     scope -- only a block opens a new one, and blocks are separate refs).
+     Bucket node ids by scope once, so each candidate walks its scope's nodes
+     instead of the whole table: the old shape was O(poly-locals * nodes) and
+     a dominant post-fixpoint cost on large trees. */
+  int *sc_cnt = (int *)calloc((size_t)(c->nscopes + 1), sizeof(int));
+  int *sc_off = (int *)malloc(sizeof(int) * (size_t)(c->nscopes + 1));
+  int *sc_nodes = (int *)malloc(sizeof(int) * (size_t)nc);
+  if (!is_read || !claimed || !sc_cnt || !sc_off || !sc_nodes) { fprintf(stderr, "spinel: out of memory\n"); exit(1); }
+  for (int id = 0; id < nt->count; id++) {
+    int s2 = c->nscope[id];
+    if (s2 >= 0 && s2 < c->nscopes) sc_cnt[s2]++;
+  }
+  sc_off[0] = 0;
+  for (int s = 0; s < c->nscopes; s++) sc_off[s + 1] = sc_off[s] + sc_cnt[s];
+  for (int s = 0; s <= c->nscopes; s++) sc_cnt[s] = 0;
+  for (int id = 0; id < nt->count; id++) {
+    int s2 = c->nscope[id];
+    if (s2 >= 0 && s2 < c->nscopes) sc_nodes[sc_off[s2] + sc_cnt[s2]++] = id;
+  }
   for (int s = 0; s < c->nscopes; s++) {
     Scope *sc = &c->scopes[s];
     for (int li = 0; li < sc->nlocals; li++) {
@@ -4934,9 +4957,10 @@ static void narrow_poly_int_locals(Compiler *c) {
 
       /* 1. writes: plain LocalVariableWriteNode with an int/poly value; any
             op/and/or-write or multi-target leaves it poly. */
-      for (int id = 0; id < nt->count && ok; id++) {
+      for (int k = sc_off[s]; k < sc_off[s + 1] && ok; k++) {
+        int id = sc_nodes[k];
         const char *ty = nt_type(nt, id);
-        if (!ty || c->nscope[id] != s) continue;
+        if (!ty) continue;
         if (sp_streq(ty, "LocalVariableOperatorWriteNode") ||
             sp_streq(ty, "LocalVariableAndWriteNode") ||
             sp_streq(ty, "LocalVariableOrWriteNode") ||
@@ -4955,16 +4979,20 @@ static void narrow_poly_int_locals(Compiler *c) {
       }
       if (!ok || !saw_write) continue;
 
-      /* 2. map this local's reads, then claim those in an int context. */
-      for (int id = 0; id < nt->count; id++) {
+      /* 2. map this local's reads, then claim those in an int context.
+         (is_read/claimed are re-cleared per candidate over this scope's nodes
+         only -- nothing outside the scope is ever set.) */
+      for (int k = sc_off[s]; k < sc_off[s + 1]; k++) {
+        int id = sc_nodes[k];
         is_read[id] = 0; claimed[id] = 0;
         const char *ty = nt_type(nt, id);
-        if (!ty || !sp_streq(ty, "LocalVariableReadNode") || c->nscope[id] != s) continue;
+        if (!ty || !sp_streq(ty, "LocalVariableReadNode")) continue;
         const char *rn = nt_str(nt, id, "name");
         if (rn && sp_streq(rn, nm)) is_read[id] = 1;
       }
       int has_index = 0;
-      for (int id = 0; id < nt->count; id++) {
+      for (int k = sc_off[s]; k < sc_off[s + 1]; k++) {
+        int id = sc_nodes[k];
         const char *ty = nt_type(nt, id);
         if (!ty) continue;
         if (sp_streq(ty, "CallNode")) {
@@ -4975,7 +5003,7 @@ static void narrow_poly_int_locals(Compiler *c) {
           int is_idx = cn && (sp_streq(cn, "[]") || sp_streq(cn, "at") || sp_streq(cn, "[]="));
           if (npi_is_int_op(cn)) {
             if (recv >= 0 && is_read[recv]) claimed[recv] = 1;
-            for (int k = 0; k < an; k++) if (is_read[av[k]]) claimed[av[k]] = 1;
+            for (int k2 = 0; k2 < an; k2++) if (is_read[av[k2]]) claimed[av[k2]] = 1;
           }
           else if (is_idx && an >= 1 && is_read[av[0]]) {
             /* the index is arg 0, and only an ARRAY index proves an int (a hash
@@ -4990,17 +5018,20 @@ static void narrow_poly_int_locals(Compiler *c) {
           if (ty_is_array(rt) || ty_is_obj_array(rt)) {
             int args = nt_ref(nt, id, "arguments"); int an = 0;
             const int *av = args >= 0 ? nt_arr(nt, args, "arguments", &an) : NULL;
-            for (int k = 0; k < an; k++) if (is_read[av[k]]) { claimed[av[k]] = 1; has_index = 1; }
+            for (int k2 = 0; k2 < an; k2++) if (is_read[av[k2]]) { claimed[av[k2]] = 1; has_index = 1; }
           }
         }
       }
       /* every read must be claimed, and at least one must be an index (which
          proves the value is an integer, making a poly-source coercion sound). */
-      for (int id = 0; id < nt->count && ok; id++)
+      for (int k = sc_off[s]; k < sc_off[s + 1] && ok; k++) {
+        int id = sc_nodes[k];
         if (is_read[id] && !claimed[id]) ok = 0;
+      }
       if (ok && has_index) lv->type = TY_INT;
     }
   }
+  free(sc_cnt); free(sc_off); free(sc_nodes);
   free(is_read); free(claimed);
 }
 
@@ -7234,18 +7265,31 @@ void analyze_program(Compiler *c) {
      Done before the drop decision below so the freshly-typed params can
      propagate through poly-dispatch param binding (e.g. a poke dispatch table
      entry typed here flows into `@pads[0].poke(data)` -> Pad#poke). */
+  /* Collect the names referenced by `method(:sym)` nodes once (they are
+     rare), instead of rescanning every node per scope: the old shape was
+     O(scopes * nodes) and dominated the post-fixpoint tail on large trees. */
+  const char **msym_names = NULL;
+  int msym_n = 0, msym_cap = 0;
+  for (int id = 0; id < c->nt->count; id++) {
+    const char *nty = nt_type(c->nt, id);
+    if (!nty || !sp_streq(nty, "CallNode")) continue;
+    const char *nm = nt_str(c->nt, id, "name");
+    if (!nm || !sp_streq(nm, "method")) continue;
+    const char *msym = method_sym_arg(c, id);
+    if (!msym) continue;
+    if (msym_n >= msym_cap) {
+      msym_cap = msym_cap ? msym_cap * 2 : 16;
+      msym_names = realloc(msym_names, sizeof(*msym_names) * (size_t)msym_cap);
+      if (!msym_names) { fprintf(stderr, "spinel: out of memory\n"); exit(1); }
+    }
+    msym_names[msym_n++] = msym;
+  }
   for (int s = 0; s < c->nscopes; s++) {
     Scope *sc = &c->scopes[s];
     if (!sc->reachable || !sc->name) continue;
     int taken = 0;
-    for (int id = 0; id < c->nt->count && !taken; id++) {
-      const char *nty = nt_type(c->nt, id);
-      if (!nty || !sp_streq(nty, "CallNode")) continue;
-      const char *nm = nt_str(c->nt, id, "name");
-      if (!nm || !sp_streq(nm, "method")) continue;
-      const char *msym = method_sym_arg(c, id);
-      if (msym && sp_streq(msym, sc->name)) taken = 1;
-    }
+    for (int i = 0; i < msym_n && !taken; i++)
+      if (sp_streq(msym_names[i], sc->name)) taken = 1;
     if (taken) {
       /* The bound-Method ABI is `mrb_int (*)(void *, mrb_int...)`: the dispatch
          site (sp_poly_arr_get_hash / sp_poly_slice) reads the return as mrb_int
@@ -7261,6 +7305,7 @@ void analyze_program(Compiler *c) {
       if (sc->ret == TY_UNKNOWN || sc->ret == TY_POLY) sc->ret = TY_INT;
     }
   }
+  free(msym_names);
 
 
   /* Propagate ivar types up the inheritance chain: a base-class method runs on

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -4923,8 +4923,6 @@ static void narrow_poly_int_locals(Compiler *c) {
   int nc = nt->count ? nt->count : 1;
   char *is_read = (char *)malloc(nc);
   char *claimed = (char *)malloc(nc);
-  memset(is_read, 0, (size_t)nc);
-  memset(claimed, 0, (size_t)nc);
   /* Every check below only cares about nodes in the candidate local's own
      scope (a read's consumer in receiver/argument position shares the read's
      scope -- only a block opens a new one, and blocks are separate refs).
@@ -4935,6 +4933,8 @@ static void narrow_poly_int_locals(Compiler *c) {
   int *sc_off = (int *)malloc(sizeof(int) * (size_t)(c->nscopes + 1));
   int *sc_nodes = (int *)malloc(sizeof(int) * (size_t)nc);
   if (!is_read || !claimed || !sc_cnt || !sc_off || !sc_nodes) { fprintf(stderr, "spinel: out of memory\n"); exit(1); }
+  memset(is_read, 0, (size_t)nc);
+  memset(claimed, 0, (size_t)nc);
   for (int id = 0; id < nt->count; id++) {
     int s2 = c->nscope[id];
     if (s2 >= 0 && s2 < c->nscopes) sc_cnt[s2]++;


### PR DESCRIPTION
## Summary

Fourth in the analyze-perf series (#3123 → #3134 → #3149). With those in, a per-segment timing profile of `analyze_program` on the lobsters ~370-file tree showed the post-fixpoint tail at ~3.3s of a ~7.3s compile — and the two dominant costs are the same bug class again (a per-item helper rescanning the whole node table):

### 1. The `method(:sym)` backstop — O(scopes × nodes), ~1.3s

For every reachable scope it rescanned every node looking for `method` CallNodes naming that scope. Inverted: the `method(:sym)` names are collected once (they're rare — a handful per program) and each scope does a membership test over that small list. Same match, same pin behavior.

### 2. `narrow_poly_int_locals` — four whole-table walks per candidate, ~0.6s

Per candidate poly local it walked (and re-cleared bookkeeping over) the entire node table four times, though every check only concerns nodes in the local's own scope: a read's consumer in receiver/argument position shares the read's scope (only a block opens a new scope, and blocks are separate refs), and reads outside the scope are never marked, so no claim outside the scope's nodes can ever fire. Node ids are now bucketed by scope once, and each candidate walks its bucket. Behavior-identical by construction.

## Numbers

Lobsters tree, `--rbs` lane: **7.3s → 5.3s user (~27%)**. Post-fix segment profile: main fixpoint 2.1s, re-narrow loop 0.7s, everything else in the tail now ≤0.5s per segment.

Noted for a future round (not in this PR): `class_var_static_ci` still rescans the table per query — the same shape fd13553e indexed inside `desugar_builtin_class_var_recv`, reached via `desugar_struct_index_ctor` on every `lvar[...]` call (~0.3s, needs an index thread-through or a generation-stamped memo since desugars mutate the write set mid-fixpoint) — and the bounded post-fixpoint re-runs of the heavy infer passes (~0.5s).

## Verification

- Full suite: **2281 pass / 0 fail / 0 error**.
- Both inversions preserve the original loops' match semantics exactly (argued in the commit message; the second's scope-locality argument is the load-bearing one).
- Same tree as the previous three PRs (the published roundhouse archive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
