### PR TITLE
analyze: --rbs return seeds skip override-family methods (#3203)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -628,6 +628,9 @@ rbs-seed-test: $(SPINEL) $(RBS_EXTRACT_BIN) $(SP_RT_LIB)
 	  "$$tmp/ipc" > "$$tmp/ipc.out" 2>/dev/null; \
 	  cmp -s "$$tmp/ipc.out" test/rbs-seed/inherited_pin_conflict.expected || { echo "rbs-seed-test: FAIL (#1871 inherited-pin output mismatch)"; diff -u test/rbs-seed/inherited_pin_conflict.expected "$$tmp/ipc.out" || true; ok=0; }; \
 	else echo "rbs-seed-test: FAIL (#1871 inherited pin conflict: C did not compile)"; ok=0; fi; \
+	$(SPINEL) test/rbs-seed/override_family_ret.rb --rbs test/rbs-seed/sig \
+	  -c --no-line-map -o "$$tmp/ofr.c" 2>/dev/null; \
+	$(CC) -fsyntax-only -Ilib "$$tmp/ofr.c" 2>/dev/null || { echo "rbs-seed-test: FAIL (#3203 override-family return seed split decl/call-site repr)"; ok=0; }; \
 	rm -rf "$$tmp"; \
 	if [ $$ok -eq 1 ]; then echo "rbs-seed-test: pass"; else exit 1; fi
 endif

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -1806,6 +1806,30 @@ static void class_pin_ivar(ClassInfo *ci, const char *name) {
   ci->rbs_pin_ivars[ci->n_rbs_pin_ivars++] = strdup(name);
 }
 
+/* Does `name` belong to an override family -- defined on two related
+   classes (one an ancestor of the other)? A return seed on any member
+   would pin that member's C decl repr while poly-dispatch call sites
+   keep the family (boxed) view: `sp_Base_s_instantiate` declared
+   `sp_Base *` but unboxed `.v.p` at the call (#3203). Overridden
+   methods keep their inferred return -- the same never-makes-it-worse
+   rule the seed path applies to layout conflicts. Params still seed:
+   they are per-scope and carry no cross-family repr. */
+static int method_in_override_family(Compiler *c, int class_id,
+                                     const char *name, int is_cmethod) {
+  if (class_id < 0 || !name) return 0;
+  for (int si = 1; si < c->nscopes; si++) {
+    Scope *s = &c->scopes[si];
+    if (!!s->is_cmethod != !!is_cmethod) continue;
+    if (!s->name || !sp_streq(s->name, name)) continue;
+    if (s->class_id == class_id || s->class_id < 0) continue;
+    for (int ci = s->class_id; ci >= 0; ci = c->classes[ci].parent)
+      if (ci == class_id) return 1;
+    for (int ci = class_id; ci >= 0; ci = c->classes[ci].parent)
+      if (ci == s->class_id) return 1;
+  }
+  return 0;
+}
+
 /* Pin scope `s`'s return and each named parameter to its seeded type. ptypes
    is a comma-separated, param-index-aligned list (empty fields preserved so a
    skipped middle param doesn't shift the rest). */
@@ -1878,10 +1902,12 @@ static void apply_rbs_seeds(Compiler *c, const char *path) {
     else if (sp_streq(kw, "meth") && a1 && a2) {
       int class_id = (cur_ci == -2) ? -1 : cur_ci;
       if (cur_ci == -2 || cur_ci >= 0)
-        seed_method(c, find_method_scope(c, class_id, a1, 0), a2, a3);
+        seed_method(c, find_method_scope(c, class_id, a1, 0),
+                    method_in_override_family(c, class_id, a1, 0) ? NULL : a2, a3);
     }
     else if (sp_streq(kw, "cmeth") && a1 && a2 && cur_ci >= 0) {
-      seed_method(c, find_method_scope(c, cur_ci, a1, 1), a2, a3);
+      seed_method(c, find_method_scope(c, cur_ci, a1, 1),
+                  method_in_override_family(c, cur_ci, a1, 1) ? NULL : a2, a3);
     }
   }
   fclose(f);

--- a/test/rbs-seed/override_family_ret.rb
+++ b/test/rbs-seed/override_family_ret.rb
@@ -1,0 +1,29 @@
+# Regression for #3203: a return seed on a class method that a subclass
+# overrides pinned the base decl's C repr to the concrete class pointer
+# (`sp_OfrBase *`), while a call site reached through poly dispatch kept
+# the family (boxed) view and unboxed the result (`.v.p`) -- the
+# generated C failed to compile:
+#
+#   return (sp_OfrBase *)(sp_OfrBase_s_instantiate(lv_conditions)).v.p;
+#
+# Return seeds now skip override-family methods, keeping the family on
+# its inferred (consistent) repr -- the same never-makes-inference-worse
+# rule the seed path applies to layout conflicts. Params still seed.
+# All three ingredients are load-bearing: the nilable return seed on
+# find_by, the subclass override of instantiate, and the unresolved
+# (poly-dispatch) receiver at the call site.
+class OfrBase
+  def self.instantiate(_row)
+  end
+
+  def self.find_by(conditions)
+    instantiate(conditions)
+  end
+end
+
+class OfrSub < OfrBase
+  def self.instantiate(row)
+  end
+end
+
+OfrModel.find_by(1)

--- a/test/rbs-seed/sig/override_family_ret.rbs
+++ b/test/rbs-seed/sig/override_family_ret.rbs
@@ -1,0 +1,4 @@
+class OfrBase
+  def self.instantiate: (Hash[String, untyped] _row) -> OfrBase
+  def self.find_by: (Hash[Symbol, untyped] conditions) -> OfrBase?
+end


### PR DESCRIPTION
Fixes #3203.

A return seed on a class method that a subclass overrides pinned the base decl's C repr to the concrete class pointer, while call sites reached through poly dispatch kept the family (boxed) view and unboxed the result — the generated C failed to compile (15-line repro in #3203):

```c
return (sp_Base *)(sp_Base_s_instantiate(lv_conditions)).v.p;
```

This skips the **return** pin when the seeded method is defined on two related classes (one an ancestor of the other), keeping the whole family on its inferred, mutually consistent repr — the same "a seed never makes inference worse" rule the seed path already applies to layout conflicts. Param seeds still apply (per-scope, no cross-family repr). Resolved receivers were never affected — they take the per-class specialization path (#1451).

Validation:

- both #3203 repro variants (top-level and module-nested) compile and link;
- `make test`: 2303 pass, 0 fail — including all existing rbs-seed goldens;
- the Rails-shaped roundhouse tree that surfaced this (the rubys/roundhouse#67 roda exemplar) AOT-builds end-to-end with `--rbs` again; it began failing once a8bec8f (correctly) stopped dropping module-nested class seeds, letting `ActiveRecord::Base` method returns seed for the first time;
- new `test/rbs-seed/override_family_ret.*` asserts the emitted C passes `-fsyntax-only`; the stanza fails against the unpatched compiler.

An alternative fix would reconcile at codegen instead (box the concrete return at mismatched poly-dispatch call sites). The seed-side skip is smaller and keeps decl and call sites agreeing by construction — happy to rework in that direction if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
