### PR TITLE
spin: portable parallel test compile on BSD/macOS (nproc, xargs -d/-S)

### DIFF
--- a/tools/spin.rb
+++ b/tools/spin.rb
@@ -1013,11 +1013,18 @@ def cmd_test(prj, files, regen)
     cmds.push(compile_cmd(prj, File.join(prj.root, "test", tests[i]), bins[i], "-O 1"))
   end
   unless cmds.empty?
-    nproc = `nproc`.to_i
+    # `nproc` is GNU coreutils; BSD/macOS answers via sysctl.
+    nproc = `nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null`.to_i
     nproc = 1 if nproc < 1
     cf = File.join(tdir, ".compile-cmds")
     File.write(cf, cmds.join("\n") + "\n")
-    system("xargs -P #{nproc} -d '\\n' -I CMD sh -c CMD < #{cf}")
+    # One compile command per input line. GNU xargs takes the delimiter
+    # explicitly (-d); BSD xargs has no -d, but -I already reads one
+    # line per command -- it just caps the substituted command at 255
+    # bytes unless -S raises the limit (65522 is the documented max),
+    # and GNU rejects -S. Pick the flag set by flavor.
+    flavor = `xargs --version 2>/dev/null`.include?("GNU") ? "-d '\\n'" : "-S 65522"
+    system("xargs -P #{nproc} #{flavor} -I CMD sh -c CMD < #{cf}")
     File.delete(cf) if File.exist?(cf)
   end
   # Phase 2: run each binary and compare, serial and in order (execution is


### PR DESCRIPTION
`spin test` on macOS fails before any compile runs: `nproc` is GNU coreutils, and BSD xargs has no `-d` — the run prints the xargs usage banner and every test reports `(build failed)`. The published packages so far are pure Ruby (tested on Linux), so this path had never run on a Mac; any carried-C package hits it immediately, and `spin publish`'s test gate is blocked with it.

Two-line portability fix in `cmd_test`:

- **nproc** → `nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null`.
- **xargs** → with `-I`, both flavors already consume one input line per command, so `-d '\n'` is only needed (and only exists) on GNU. BSD's `-I` instead caps the substituted command at 255 bytes unless `-S` raises the limit (65522 is the documented max) — and GNU rejects `-S`. So the flag set is picked by flavor: `xargs --version` mentioning GNU → `-d '\n'`, otherwise `-S 65522`.

Verified on macOS 15 (arm64) with a carried-C package ([spinel-bcrypt](https://github.com/rubys/spinel-bcrypt), spin-index PR #5): the test suite compiles in parallel and passes, and `spin publish`'s gate runs. Behavior on Linux/GNU is unchanged (`-d '\n'` exactly as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)