### PR TITLE
Gate the container-read pre-arms by name before probing the receiver (perf: Rails-scale compile 23s -> >10min regression)

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -1588,8 +1588,17 @@ TyKind infer_call(Compiler *c, int id) {
       nt_str(nt, recv, "name") && sp_streq(nt_str(nt, recv, "name"), "Hash")) {
     if (sp_streq(name, "try_convert")) return TY_POLY;
   }
-  /* container-read builtin pre-arms (#3234) */
-  if (recv >= 0 && infer_type(c, recv) == TY_POLY && argc == 1) {
+  /* container-read builtin pre-arms (#3234). The name/argc gates run
+     FIRST: the infer_type(recv) probe recurses through the receiver's
+     own call chain, and paying it for EVERY one-arg call re-infers each
+     chain suffix once more per level -- exponential on deep chains (a
+     Rails-scale tree went 23s -> >10min under it). Gated this way only
+     the arm names below ever pay the probe. */
+  if (recv >= 0 && argc == 1 &&
+      (sp_streq(name, "cover?") || sp_streq(name, "gcdlcm") ||
+       sp_streq(name, "sum") || sp_streq(name, "inject") ||
+       sp_streq(name, "reduce")) &&
+      infer_type(c, recv) == TY_POLY) {
     if (sp_streq(name, "cover?")) return TY_BOOL;
     if (sp_streq(name, "gcdlcm")) return TY_INT_ARRAY;
     if (sp_streq(name, "sum") && nt_ref(nt, id, "block") < 0) return TY_POLY;


### PR DESCRIPTION
The #3234 container-read pre-arms in `infer_call` evaluate `infer_type(c, recv)` before any name/argc gate, so **every** one-arg call with a receiver pays a recursive receiver-inference probe on top of the normal receiver typing — each level of a call chain re-infers its whole receiver suffix once more, which goes exponential on deep chains. Small trees barely notice; a Rails-scale tree (roundhouse's lobsters emit, ~735 files) went from **23s to >10 minutes** (killed; 100% CPU in `infer_call` self-recursion per `sample`).

This reorders the condition so the four rare arm names and `argc == 1` gate first, and only matching sites pay the `infer_type` probe. Behavior is identical — same arms, same results — so `test/container_read_builtin_methods.rb` continues to cover the semantics.

Measured on the same lobsters tree, same machine:

| compiler | time |
|---|---|
| `caa2426` (pre-#3234-series anchor) | 22.9s |
| `69cf91b^` | 20s |
| `69cf91b` .. current master | >600s (killed; clean-build verified) |
| master + this change | **21.6s** |

Bisected to `69cf91b` (the commit introducing the pre-arms); verified by clean-rebuild A/B against its parent, and by this one-block change restoring master to 21.6s. `make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
