### PR TITLE
Route (scope, name) local-write queries through a shared LWIndex instead of whole-table rescans (perf: lobsters 20.3s -> 16.2s)

### DIFF
--- a/src/analyze_internal.h
+++ b/src/analyze_internal.h
@@ -139,6 +139,14 @@ extern int g_yvt_unify_all;
 TyKind method_call_ret(Compiler *c, int mi, int call_id);
 /* is_proc_constant / is_proc_literal are declared in analyze.h (codegen needs them). */
 int is_proc_create(Compiler *c, int id);
+
+/* Shared cached local-write index (analyze_pass.c): bucket walk over
+   (scope, name) for "every write of local X in scope S" queries, instead of
+   a whole-table rescan per query. Callers must still confirm scope/name
+   (hash collisions) and node kind on each record. */
+int lw_shared_first(Compiler *c, const char *name, int scope);
+int lw_shared_node(int rec);
+int lw_shared_next(int rec);
 TyKind proc_node_ret(Compiler *c, int create);
 TyKind proc_ret_of(Compiler *c, int node);
 TyKind proc_call_ret(Compiler *c, int recv);

--- a/src/analyze_pass.c
+++ b/src/analyze_pass.c
@@ -228,10 +228,15 @@ int infer_param_hash_value(Compiler *c) {
    assigns an empty `{}` hash literal -- i.e. it is a hash container whose
    contents come from elsewhere (passed by reference into a callee). Such a
    local can safely adopt a hash type from a parameter it is passed to. */
+/* Shared cached write-index accessors (defined after the LWIndex machinery
+   below): bucket walk over (scope, name) instead of a whole-table rescan per
+   query. */
 int local_all_writes_empty_hash(Compiler *c, Scope *sc, const char *name) {
   const NodeTable *nt = c->nt;
   int saw = 0;
-  for (int id = 0; id < nt->count; id++) {
+  int si = (int)(sc - c->scopes);
+  for (int r = lw_shared_first(c, name, si); r >= 0; r = lw_shared_next(r)) {
+    int id = lw_shared_node(r);
     if (nt_kind(nt, id) != NK_LocalVariableWriteNode) continue;
     const char *wn = nt_str(nt, id, "name");
     if (!wn || !sp_streq(wn, name) || comp_scope_of(c, id) != sc) continue;
@@ -251,7 +256,9 @@ int local_all_writes_empty_hash(Compiler *c, Scope *sc, const char *name) {
 static int local_all_writes_empty_array(Compiler *c, Scope *sc, const char *name) {
   const NodeTable *nt = c->nt;
   int saw = 0;
-  for (int id = 0; id < nt->count; id++) {
+  int si = (int)(sc - c->scopes);
+  for (int r = lw_shared_first(c, name, si); r >= 0; r = lw_shared_next(r)) {
+    int id = lw_shared_node(r);
     if (nt_kind(nt, id) != NK_LocalVariableWriteNode) continue;
     const char *wn = nt_str(nt, id, "name");
     if (!wn || !sp_streq(wn, name) || comp_scope_of(c, id) != sc) continue;
@@ -288,11 +295,21 @@ static unsigned lw_hash(const char *name, int scope) {
   return h;
 }
 
+static const NodeKind lw_write_kinds[4] = {
+  NK_LocalVariableWriteNode, NK_LocalVariableOrWriteNode,
+  NK_LocalVariableAndWriteNode, NK_LocalVariableOperatorWriteNode};
+
 static void lw_index_build(Compiler *c, LWIndex *ix) {
   const NodeTable *nt = c->nt;
+  /* Iterate only the write kinds (kind-grouped id lists) rather than the whole
+     table: the write population is a small fraction of the node count, and
+     this build runs per pass -- and per query while the scope index is
+     unfrozen. Chain order becomes kind-grouped instead of globally ascending;
+     every consumer is an order-independent existence/uniqueness walk. */
   int n = 0;
-  for (int id = 0; id < nt->count; id++)
-    if (lw_is_write_kind(nt_kind(nt, id))) n++;
+  for (int t = 0; t < 4; t++) {
+    int kn; nt_nodes_of_kind(nt, lw_write_kinds[t], &kn); n += kn;
+  }
   int cap = 16;
   while (cap < n * 2) cap <<= 1;
   ix->cap = cap;
@@ -301,15 +318,18 @@ static void lw_index_build(Compiler *c, LWIndex *ix) {
   ix->head = (int *)malloc(sizeof(int) * cap);
   for (int i = 0; i < cap; i++) ix->head[i] = -1;
   int k = 0;
-  for (int id = 0; id < nt->count; id++) {
-    if (!lw_is_write_kind(nt_kind(nt, id))) continue;
-    const char *nm = nt_str(nt, id, "name");
-    int sc = (int)(comp_scope_of(c, id) - c->scopes);
-    unsigned h = lw_hash(nm, sc) & (unsigned)(cap - 1);
-    ix->node[k] = id;
-    ix->next[k] = ix->head[h];
-    ix->head[h] = k;
-    k++;
+  for (int t = 0; t < 4; t++) {
+    int kn; const int *ids = nt_nodes_of_kind(nt, lw_write_kinds[t], &kn);
+    for (int j = 0; j < kn; j++) {
+      int id = ids[j];
+      const char *nm = nt_str(nt, id, "name");
+      int sc = (int)(comp_scope_of(c, id) - c->scopes);
+      unsigned h = lw_hash(nm, sc) & (unsigned)(cap - 1);
+      ix->node[k] = id;
+      ix->next[k] = ix->head[h];
+      ix->head[h] = k;
+      k++;
+    }
   }
 }
 
@@ -322,6 +342,31 @@ static void lw_index_free(LWIndex *ix) {
 static int lw_index_first(const LWIndex *ix, const char *name, int scope) {
   return ix->head[lw_hash(name, scope) & (unsigned)(ix->cap - 1)];
 }
+
+/* Long-lived LWIndex behind the local_all_writes_empty_* queries above.
+   Rebuilt when the node table or scope shape moves (append-only table, so
+   count is the growth signal; the scope-index epoch covers renames/reshapes
+   that re-home writes without growing the table). */
+static LWIndex lw_shared_ix;
+static const NodeTable *lw_shared_nt = NULL;
+static int lw_shared_ntc = -1;
+static unsigned lw_shared_gen = 0;
+int lw_shared_first(Compiler *c, const char *name, int scope) {
+  unsigned gen = comp_scope_index_gen();
+  /* While unfrozen, scope shape can move without the epoch ticking; rebuild
+     per query (the build is one table walk -- the same order as the scan
+     these helpers used to do, so the unfrozen phases pay what they always
+     paid while the frozen fixpoint gets the cached bucket walk). */
+  if (!comp_scope_index_is_frozen() ||
+      lw_shared_nt != c->nt || lw_shared_ntc != c->nt->count || lw_shared_gen != gen) {
+    if (lw_shared_nt) lw_index_free(&lw_shared_ix);
+    lw_index_build(c, &lw_shared_ix);
+    lw_shared_nt = c->nt; lw_shared_ntc = c->nt->count; lw_shared_gen = gen;
+  }
+  return lw_index_first(&lw_shared_ix, name, scope);
+}
+int lw_shared_node(int rec) { return lw_shared_ix.node[rec]; }
+int lw_shared_next(int rec) { return lw_shared_ix.next[rec]; }
 
 /* Per-pass index of instance-variable write nodes keyed by ivar name -- the
    ivar analogue of LWIndex. The usage-driven promotion scans below ask "does

--- a/src/analyze_util.c
+++ b/src/analyze_util.c
@@ -347,10 +347,12 @@ static int hash_new_default_arg_compute(Compiler *c, int recv) {
     const char *vn = nt_str(nt, recv, "name");
     if (!vn) return -1;
     Scope *sc = comp_scope_of(c, recv);
+    if (!sc) return -1;
     int found = -1;
-    for (int w = 0; w < nt->count; w++) {
-      const char *wty = nt_type(nt, w);
-      if (!wty || !sp_streq(wty, "LocalVariableWriteNode")) continue;
+    for (int r = lw_shared_first(c, vn, (int)(sc - c->scopes)); r >= 0;
+         r = lw_shared_next(r)) {
+      int w = lw_shared_node(r);
+      if (nt_kind(nt, w) != NK_LocalVariableWriteNode) continue;
       const char *wn = nt_str(nt, w, "name");
       if (!wn || !sp_streq(wn, vn) || comp_scope_of(c, w) != sc) continue;
       int val = nt_ref(nt, w, "value");


### PR DESCRIPTION
Three helpers still answer "every write of local X in scope S …" by rescanning the **entire node table** per query: `local_all_writes_empty_hash`, `local_all_writes_empty_array`, and the local-variable branch of `hash_new_default_arg_compute`. The first two sit forty lines above the `LWIndex` that #3123 introduced to fix exactly this shape — they just don't use it. All three are asked from `bind_call_params` / receiver typing for call arguments during the inference fixpoint; on roundhouse's lobsters emit (42k lines) they account for ~11% of compile time (`local_all_writes_empty_hash` alone was 7% of self-time in a `sample` profile).

This routes all three through one long-lived `LWIndex` keyed by (scope, name):

- cached while the scope index is frozen, stamped with `comp_scope_index_gen()`; unfrozen phases rebuild per query, which costs the single table walk they already paid (scope shape can move without the epoch ticking there, so the cache is never trusted across unfrozen mutations);
- `lw_index_build` itself now iterates only the four local-write node kinds via the kind-grouped id lists (`nt_nodes_of_kind`) instead of scanning the whole table — this also cheapens the existing per-pass builds. Chain order becomes kind-grouped rather than globally ascending; every consumer is an order-independent existence/uniqueness walk (`has_write` early-exits, all-writes-match folds, single-write checks);
- the accessors are exported through `analyze_internal.h` so `hash_new_default_arg_compute` (analyze_util.c) can walk the same index.

Measured on the lobsters tree, same machine, `spinel main.rb -c`:

| compiler | time |
|---|---|
| master (`5d75b84b`) | 20.3s |
| master + this change | **16.2s** |
| master + this + #3292 + #3294 | **9.0s** |

Compiler diagnostics on the lobsters tree are byte-identical before/after. `make test`: results identical to master, test-for-test (the suite currently fails 790 of 2397 on master on this machine, apparently from the recent shared-strings series; the failing set is byte-for-byte the same before and after this change).

Sibling PRs from the same profiling session, independent and individually mergeable: #3292 (`an_user_defines_method` memo), #3294 (proc-literal escape marking). This is the "sibling helpers" list #3115 predicted, still paying out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
