### PR TITLE
Poly zero?/positive?/negative? answer from the runtime tag

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -2085,7 +2085,15 @@ static sp_RbVal sp_poly_imaginary(sp_RbVal v) {
   if (sp_poly_numeric_p(v) || sp_poly_is_rational(v)) return sp_box_int(0);
   sp_raise_poly_nomethod("imaginary", v);
 }
-static mrb_bool sp_poly_zero_p(sp_RbVal v) { if (v.tag == SP_TAG_INT) return v.v.i == 0; if (v.tag == SP_TAG_FLT) return v.v.f == 0.0; if (v.tag == SP_TAG_BIGINT) return sp_bigint_sign((sp_Bigint *)v.v.p) == 0; sp_raise_poly_nomethod("zero?", v); }
+/* Sign of a boxed Rational / big Rational: its numerator's, both being kept
+   with a positive denominator. Read exactly rather than through a double --
+   a ratio smaller than DBL_MIN would round to 0.0 and lose its sign. */
+static int sp_poly_rat_sign(sp_RbVal v) {
+  if (sp_poly_is_rational(v)) { mrb_int n = ((sp_Rational *)v.v.p)->num; return n > 0 ? 1 : (n < 0 ? -1 : 0); }
+  return sp_bigint_sign(((sp_BigRational *)v.v.p)->num);
+}
+static inline int sp_poly_is_rat_kind(sp_RbVal v) { return (sp_poly_is_rational(v) || sp_poly_is_brat(v)) && v.v.p; }
+static mrb_bool sp_poly_zero_p(sp_RbVal v) { if (v.tag == SP_TAG_INT) return v.v.i == 0; if (v.tag == SP_TAG_FLT) return v.v.f == 0.0; if (v.tag == SP_TAG_BIGINT) return sp_bigint_sign((sp_Bigint *)v.v.p) == 0; if (sp_poly_is_rat_kind(v)) return sp_poly_rat_sign(v) == 0; sp_raise_poly_nomethod("zero?", v); }
 /* Complex#conjugate / #conj on a boxed value: negate the imaginary part; a real
    number (numeric/rational) is its own conjugate. */
 static sp_RbVal sp_poly_conjugate(sp_RbVal v) {
@@ -2098,8 +2106,8 @@ static sp_RbVal sp_poly_conjugate(sp_RbVal v) {
    poly container): the endpoint as an Integer. */
 static mrb_int sp_poly_range_begin(sp_RbVal v) { if (v.tag == SP_TAG_OBJ && v.cls_id == SP_BUILTIN_RANGE) return ((sp_Range *)v.v.p)->first; sp_raise_poly_nomethod("begin", v); }
 static mrb_int sp_poly_range_end(sp_RbVal v) { if (v.tag == SP_TAG_OBJ && v.cls_id == SP_BUILTIN_RANGE) return ((sp_Range *)v.v.p)->last; sp_raise_poly_nomethod("end", v); }
-static mrb_bool sp_poly_positive_p(sp_RbVal v) { if (v.tag == SP_TAG_INT) return v.v.i > 0; if (v.tag == SP_TAG_FLT) return v.v.f > 0.0; if (v.tag == SP_TAG_BIGINT) return sp_bigint_sign((sp_Bigint *)v.v.p) > 0; sp_raise_poly_nomethod("positive?", v); }
-static mrb_bool sp_poly_negative_p(sp_RbVal v) { if (v.tag == SP_TAG_INT) return v.v.i < 0; if (v.tag == SP_TAG_FLT) return v.v.f < 0.0; if (v.tag == SP_TAG_BIGINT) return sp_bigint_sign((sp_Bigint *)v.v.p) < 0; sp_raise_poly_nomethod("negative?", v); }
+static mrb_bool sp_poly_positive_p(sp_RbVal v) { if (v.tag == SP_TAG_INT) return v.v.i > 0; if (v.tag == SP_TAG_FLT) return v.v.f > 0.0; if (v.tag == SP_TAG_BIGINT) return sp_bigint_sign((sp_Bigint *)v.v.p) > 0; if (sp_poly_is_rat_kind(v)) return sp_poly_rat_sign(v) > 0; sp_raise_poly_nomethod("positive?", v); }
+static mrb_bool sp_poly_negative_p(sp_RbVal v) { if (v.tag == SP_TAG_INT) return v.v.i < 0; if (v.tag == SP_TAG_FLT) return v.v.f < 0.0; if (v.tag == SP_TAG_BIGINT) return sp_bigint_sign((sp_Bigint *)v.v.p) < 0; if (sp_poly_is_rat_kind(v)) return sp_poly_rat_sign(v) < 0; sp_raise_poly_nomethod("negative?", v); }
 /* abs of a negative int goes through SP_POLY_INT_OP(sub, 0, x): plain -x is
    UB for INT_MIN; promote mode boxes it as a bigint, wrap mode keeps the
    documented wrapping C arithmetic. fabs covers -0.0 -> 0.0 too. */

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -3120,7 +3120,14 @@ static void emit_poly_fetch_absent(Compiler *c, int argc, const int *atmp, int a
    real gap under the ruby/spec harness (`x.should.eql?(y)` and friends). */
 static int poly_pred_kind(const char *name, int argc) {
   if (!name) return 0;
-  if (argc == 0) return (sp_streq(name, "frozen?") || sp_streq(name, "nil?")) ? 1 : 0;
+  /* zero?/positive?/negative? are numeric rather than universal, but they take
+     the same default arm: a user class defining one of them makes this switch
+     the only path, and a Float or Integer reaching it must still answer its own
+     sign instead of the empty default. sp_poly_zero_p and friends raise
+     NoMethodError for a tag that has no sign, as CRuby does. */
+  if (argc == 0) return (sp_streq(name, "frozen?") || sp_streq(name, "nil?") ||
+                         sp_streq(name, "zero?") || sp_streq(name, "positive?") ||
+                         sp_streq(name, "negative?")) ? 1 : 0;
   if (argc == 1) return (sp_streq(name, "eql?") || sp_streq(name, "equal?") ||
                          sp_streq(name, "is_a?") || sp_streq(name, "kind_of?") ||
                          sp_streq(name, "instance_of?")) ? 1 : 0;
@@ -3141,6 +3148,9 @@ static int emit_poly_pred_value(Compiler *c, int id, const char *tvref,
   const int *argv = call_args(nt, id, &argc);
   if (argc == 0 && sp_streq(name, "frozen?")) { buf_printf(b, "sp_poly_frozen(%s)", tvref); return 1; }
   if (argc == 0 && sp_streq(name, "nil?"))    { buf_printf(b, "sp_poly_nil_p(%s)", tvref); return 1; }
+  if (argc == 0 && sp_streq(name, "zero?"))     { buf_printf(b, "sp_poly_zero_p(%s)", tvref); return 1; }
+  if (argc == 0 && sp_streq(name, "positive?")) { buf_printf(b, "sp_poly_positive_p(%s)", tvref); return 1; }
+  if (argc == 0 && sp_streq(name, "negative?")) { buf_printf(b, "sp_poly_negative_p(%s)", tvref); return 1; }
   if (argc == 1 && sp_streq(name, "eql?"))    { buf_printf(b, "sp_poly_eql(%s, %s)", tvref, argref); return 1; }
   if (argc == 1 && sp_streq(name, "equal?"))  { buf_printf(b, "sp_poly_equal(%s, %s)", tvref, argref); return 1; }
   int is_isa = argc == 1 && (sp_streq(name, "is_a?") || sp_streq(name, "kind_of?"));
@@ -16464,17 +16474,19 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     else { buf_puts(b, "(~"); emit_expr(c, recv, b); buf_puts(b, ")"); }
     return;
   }
-  /* poly numeric predicates: coerce the poly value to int and test. */
+  /* poly parity predicates: Integer-only in Ruby, so truncation cannot lose a
+     value that legally reaches them and the int coercion stays correct.
+     zero?/positive?/negative? are NOT handled here: this arm ran ahead of
+     emit_poly_call and shadowed sp_poly_zero_p and friends, which dispatch on
+     the runtime tag. Truncating first answered every |v| < 1 as zero (0.004
+     came back zero? -> true, positive? -> false), read a bigint through a
+     wrapped int64, and hid a user class's own zero?. */
   if (recv >= 0 && rt == TY_POLY && argc == 0 &&
-      (sp_streq(name, "even?") || sp_streq(name, "odd?") || sp_streq(name, "zero?") ||
-       sp_streq(name, "positive?") || sp_streq(name, "negative?"))) {
+      (sp_streq(name, "even?") || sp_streq(name, "odd?"))) {
     int t = ++g_tmp;
     buf_printf(b, "({ mrb_int _t%d = sp_poly_to_i(", t); emit_expr(c, recv, b); buf_puts(b, "); ");
     if (sp_streq(name, "even?")) buf_printf(b, "(_t%d %% 2 == 0); })", t);
-    else if (sp_streq(name, "odd?")) buf_printf(b, "(_t%d %% 2 != 0); })", t);
-    else if (sp_streq(name, "zero?")) buf_printf(b, "(_t%d == 0); })", t);
-    else if (sp_streq(name, "positive?")) buf_printf(b, "(_t%d > 0); })", t);
-    else buf_printf(b, "(_t%d < 0); })", t);
+    else buf_printf(b, "(_t%d %% 2 != 0); })", t);
     return;
   }
 

--- a/test/poly_sign_predicate_float.rb
+++ b/test/poly_sign_predicate_float.rb
@@ -1,0 +1,37 @@
+# zero?/positive?/negative? on a POLY receiver must test the number itself, not
+# its integer truncation. A parameter widened to poly by one call site reading an
+# element off a heterogeneous array answered as though every value with |v| < 1
+# were zero: 0.004.zero? came back true and 0.004.positive? false. That poisoned
+# EVERY call site of the widened method, including ones passing a float literal.
+
+def sign(v) = "#{v.zero?} #{v.positive?} #{v.negative?}"
+
+# Widens `sign`'s parameter to poly: [Symbol, Float] has a union element type.
+def sign_via(pair) = sign(pair[1])
+
+puts sign(0.004) # the monomorphic call site is poisoned too
+puts sign_via([:t, 0.004])
+puts sign_via([:t, -0.004])
+puts sign_via([:t, 0.0])
+puts sign_via([:t, 2.5])
+puts sign_via([:t, 7])
+puts sign_via([:t, -7])
+puts sign_via([:t, 0])
+
+# A bigint reports its own sign rather than a wrapped int64's.
+puts sign_via([:t, 10**30])
+puts sign_via([:t, -(10**30)])
+
+# A Rational answers from its numerator, exactly: a ratio too small to survive
+# a double would otherwise round to zero and lose its sign.
+puts sign_via([:t, Rational(1, 2)])
+puts sign_via([:t, Rational(0, 5)])
+puts sign_via([:t, Rational(-3, 4)])
+
+# even?/odd? stay integer predicates - a Float does not answer them in Ruby - so
+# truncation cannot lose a value that legally reaches them.
+def parity(n) = "#{n.even?} #{n.odd?}"
+def parity_via(pair) = parity(pair[1])
+
+puts parity_via([:n, 4])
+puts parity_via([:n, 7])

--- a/test/poly_sign_predicate_float.rb.expected
+++ b/test/poly_sign_predicate_float.rb.expected
@@ -1,0 +1,15 @@
+false true false
+false true false
+false false true
+true false false
+false true false
+false true false
+false false true
+true false false
+false true false
+false false true
+false true false
+true false false
+false false true
+true false
+false true

--- a/test/poly_sign_predicate_user_zero.rb
+++ b/test/poly_sign_predicate_user_zero.rb
@@ -1,0 +1,26 @@
+# A user class defining zero? claims the name, so every call on a poly receiver
+# goes through the class dispatch. A Float or Integer arriving at that same call
+# site still has to answer its own sign from the runtime tag - the dispatch used
+# to fall through to the empty default and report false for every number.
+
+class Meter
+  def initialize(n) = @n = n
+  def zero? = @n == 0
+end
+
+def zero(v) = v.zero?
+def zero_via(pair) = zero(pair[1])
+
+puts zero_via([:m, Meter.new(5)])
+puts zero_via([:m, Meter.new(0)])
+puts zero_via([:m, 0.004])
+puts zero_via([:m, 0.0])
+puts zero_via([:m, 3])
+puts zero_via([:m, 0])
+
+# A tag with no sign raises NoMethodError, the same as CRuby.
+begin
+  puts zero_via([:m, "abc"])
+rescue NoMethodError
+  puts "NoMethodError"
+end

--- a/test/poly_sign_predicate_user_zero.rb.expected
+++ b/test/poly_sign_predicate_user_zero.rb.expected
@@ -1,0 +1,7 @@
+false
+true
+false
+true
+false
+true
+NoMethodError


### PR DESCRIPTION
## The bug

The poly predicate arm coerced its receiver with `sp_poly_to_i` before testing,
so a poly holding a `Float` was truncated first. Every value with an absolute
value below 1 then answered as though it were zero:

```ruby
0.004.zero?         # => true   (expected false)
0.004.positive?     # => false  (expected true)
(-0.004).negative?  # => false  (expected true)
```

## Why it is easy to miss

`Float#zero?` is correct in isolation — the receiver has to be poly-typed for the
arm to fire at all. A method needs only ONE call site passing a poly for its
parameter to widen, and the widened predicate is then wrong at **every other call
site too**, including ones handing it a plain float literal:

```ruby
def step(dt) = dt.zero? ? 0.016 : dt
def via(pair) = step(pair[1])   # widens step's parameter to poly

step(0.004)             # => 0.016   <- poisoned by the OTHER call site
via([:tick, 0.004])     # => 0.016
```

A guard of the shape `step = dt.zero? ? DEFAULT : dt` silently stops seeing the
value it was handed and substitutes its fallback forever, with no error and no
diagnostic. Arithmetic, `==`, `<`, `to_s`, `to_f` and `class` on the same poly
value are all correct, so the value looks intact everywhere except through these
three predicates.

## The fix

The runtime already answers these three by dispatching on the value's tag
(`sp_poly_zero_p` and friends), but the truncating arm ran ahead of
`emit_poly_call` and shadowed it. Drop the three names from that arm and let the
existing dispatch serve them. That also stops reading a bigint through a wrapped
int64, restores CRuby's `NoMethodError` for a tag that has no sign (a `String`
answered `zero?` → true), and stops the arm from hiding a user class's own
`zero?`.

Reusing the dispatch exposed two gaps in it, both fixed here:

- The runtime predicates did not know `Rational`. A boxed Rational or big
  Rational now answers from its numerator's sign, read exactly — through a
  double, a ratio below `DBL_MIN` would round to zero and lose its sign.
- A user class defining `zero?` makes the class dispatch the only path, and that
  switch had no default arm for a numeric tag, so a `Float` or `Integer` reaching
  the same call site reported false. The three predicates now take the builtin
  default arm `frozen?`/`nil?` already take.

`even?`/`odd?` keep the integer coercion: a `Float` does not answer them in Ruby,
so truncation cannot lose a value that legally arrives.

## Tests

`test/poly_sign_predicate_float.rb` covers the three predicates over positive,
negative and zero values of `Float`, `Integer`, bigint and `Rational`, through
both the poly-widened parameter and the monomorphic call site, plus `even?`/`odd?`
to pin that they still take the integer path.
`test/poly_sign_predicate_user_zero.rb` covers the user-override path: the
class's own `zero?`, numbers answering their own sign at that same call site, and
the `NoMethodError` for a `String`. Both `.expected` files are the output of real
Ruby.

Full suite green.
