### PR TITLE
A regex in argument position may be any expression

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -5294,7 +5294,16 @@ else {
       if (aty && sp_streq(aty, "RegularExpressionNode")) {
         const char *src = nt_str(nt, argv[0], "unescaped");
         if (src && an_re_has_captures(src)) return TY_POLY_ARRAY;
+        return TY_STR_ARRAY;
       }
+      /* A regex whose source is not visible here -- an interpolated literal, a
+         local holding one, an inline `Regexp.new(s)` -- can only be asked at
+         run time whether it captures, so take the shape that answers both:
+         sp_re_scan_poly pushes the whole match when the pattern has no groups
+         and a captures row when it does. Statically visible literals stay on
+         the narrower arms above (#3389). */
+      if (infer_type(c, argv[0]) == TY_REGEX && !an_regex_lit_src(c, argv[0]))
+        return TY_POLY_ARRAY;
       return TY_STR_ARRAY;
     }
     if (sp_streq(name, "upto") && argc == 1) return TY_STR_ARRAY;  /* blockless: materialized sequence */

--- a/src/analyze_internal.h
+++ b/src/analyze_internal.h
@@ -121,6 +121,7 @@ int builtin_class_id(const char *name);
 int builtin_object_method_known(const char *m);
 int class_inherits_builtin_exception(Compiler *c, int ci);
 int an_re_has_captures(const char *src);
+const char *an_regex_lit_src(Compiler *c, int nid);
 int str_in(const char *s, const char *const *set);
 int is_arith_op(const char *op);
 int is_cmp_op(const char *op);

--- a/src/analyze_util.c
+++ b/src/analyze_util.c
@@ -104,6 +104,42 @@ int an_re_has_captures(const char *src) {
   }
   return 0;
 }
+/* The source text of the regex literal behind `nid`, or NULL when the pattern
+   is only known at run time (an interpolated literal, a `Regexp.new(s)` call,
+   a method's return). Deliberately mirrors codegen's re_lit_index resolution
+   -- a bare literal, a constant bound to one (`PAT = /re/[.freeze]`), or a
+   regex-typed local bound to one -- so a type rule here and the emit arm there
+   agree on which patterns are statically visible. Unlike re_lit_index this
+   only looks, never registers a pattern slot, so it is safe to call during
+   inference. */
+const char *an_regex_lit_src(Compiler *c, int nid) {
+  const NodeTable *nt = c->nt;
+  if (nid < 0) return NULL;
+  const char *ty = nt_type(nt, nid);
+  if (!ty) return NULL;
+  if (sp_streq(ty, "RegularExpressionNode")) return nt_str(nt, nid, "unescaped");
+  int want_const = sp_streq(ty, "ConstantReadNode") || sp_streq(ty, "ConstantPathNode");
+  int want_local = sp_streq(ty, "LocalVariableReadNode") && infer_type(c, nid) == TY_REGEX;
+  if (!want_const && !want_local) return NULL;
+  const char *nm = nt_str(nt, nid, "name");
+  if (!nm) return NULL;
+  for (int k = 0; k < nt->count; k++) {
+    const char *kt = nt_type(nt, k);
+    if (!kt) continue;
+    if (want_const ? (!sp_streq(kt, "ConstantWriteNode") && !sp_streq(kt, "ConstantPathWriteNode"))
+                   : !sp_streq(kt, "LocalVariableWriteNode"))
+      continue;
+    const char *kn = nt_str(nt, k, "name");
+    if (!kn || !sp_streq(kn, nm)) continue;
+    int v = nt_ref(nt, k, "value");
+    if (want_const && v >= 0 && nt_type(nt, v) && sp_streq(nt_type(nt, v), "CallNode") &&
+        nt_str(nt, v, "name") && sp_streq(nt_str(nt, v, "name"), "freeze"))
+      v = nt_ref(nt, v, "receiver");
+    if (v >= 0 && nt_type(nt, v) && sp_streq(nt_type(nt, v), "RegularExpressionNode"))
+      return nt_str(nt, v, "unescaped");
+  }
+  return NULL;
+}
 int str_in(const char *s, const char *const *set) {
   if (!s) return 0;
   for (int i = 0; set[i]; i++) if (sp_streq(s, set[i])) return 1;

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -16332,15 +16332,27 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     if (recv >= 0 && argc >= 1) {
       const char *a0ty = nt_type(nt, argv[0]);
       int is_interp_arg = a0ty && sp_streq(a0ty, "InterpolatedRegularExpressionNode");
-      int is_regex_lv_arg = !is_interp_arg && argc >= 1 && comp_ntype(c, argv[0]) == TY_REGEX
-                            && nt_type(nt, argv[0])
-                            && (sp_streq(nt_type(nt, argv[0]), "LocalVariableReadNode") ||
-                                sp_streq(nt_type(nt, argv[0]), "ConstantReadNode"));
-      if (is_interp_arg || is_regex_lv_arg) {
+      /* Any regex-typed argument EXPRESSION, not just a local or constant read:
+         an inline `Regexp.new(s)` / `Regexp.union(..)` / a method returning a
+         regex is the same mrb_regexp_pattern* in argument position, so
+         `str.match(Regexp.new(s))` belongs here rather than falling through to
+         the unresolved-call gate and raising NoMethodError on the String
+         (#3389). Two shapes stay out. A bare regex literal is already served
+         by the precompiled arms above; routing it here would pull e.g. a
+         Symbol receiver off its own handler. And an Object receiver -- a user
+         class, or a native-bound one like StringScanner -- dispatches its OWN
+         match/match?, the same exclusion those precompiled arms carry: without
+         it `matcher.match?(re_local)` fed the object into sp_re_match_p's
+         const char* slot and the generated C did not compile. */
+      const char *a0nt = nt_type(nt, argv[0]);
+      int is_regex_val_arg = !is_interp_arg && argc >= 1 && comp_ntype(c, argv[0]) == TY_REGEX
+                             && a0nt && !sp_streq(a0nt, "RegularExpressionNode")
+                             && !ty_is_object(rt);
+      if (is_interp_arg || is_regex_val_arg) {
         Buf rp; memset(&rp, 0, sizeof rp);
         int rp_ok = emit_regex_pat_to_buf(c, argv[0], &rp) && rp.p;
         /* Fallback: TY_REGEX local/constant/inline Regexp.new -- value IS the mrb_regexp_pattern* */
-        if (!rp_ok && is_regex_lv_arg) {
+        if (!rp_ok && is_regex_val_arg) {
           int tv = ++g_tmp;
           Buf eb; memset(&eb, 0, sizeof eb);
           emit_expr(c, argv[0], &eb);  /* may itself append pre-code to g_pre */
@@ -16366,11 +16378,19 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
                        name, tn9, dv9 ? dv9 : "sp_box_nil()");
             free(rp.p); return;
           }
-          if (sp_streq(name, "match?") && argc == 1) {
+          if (sp_streq(name, "match?") && (argc == 1 || argc == 2)) {
             /* A symbol receiver matches over its name, so feed the runtime
                pattern the symbol's string rather than the raw sp_sym. */
             if (rt == TY_SYMBOL) { buf_printf(b, "sp_re_match_p(%s, sp_sym_to_s(", rp.p); emit_expr(c, recv, b); buf_puts(b, "))"); }
-            else { buf_printf(b, "sp_re_match_p(%s, ", rp.p); emit_expr(c, recv, b); buf_puts(b, ")"); }
+            /* emit_str_expr, not emit_expr: a poly receiver (a String read out
+               of a widened container) needs coercing into the const char* slot
+               the same way the precompiled-literal arms do it (#3389). */
+            else if (argc == 1) { buf_printf(b, "sp_re_match_p(%s, ", rp.p); emit_str_expr(c, recv, b); buf_puts(b, ")"); }
+            /* match?(re, pos) starts the scan at pos */
+            else {
+              buf_printf(b, "sp_str_re_match_p_at(%s, ", rp.p); emit_str_expr(c, recv, b);
+              buf_puts(b, ", "); emit_int_expr(c, argv[1], b); buf_puts(b, ")");
+            }
             free(rp.p); return;
           }
           if (sp_streq(name, "=~") && rt == TY_STRING) {
@@ -16394,8 +16414,14 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
             buf_printf(b, "(!sp_re_match_p(%s, ", rp.p); emit_expr(c, recv, b); buf_puts(b, "))");
             free(rp.p); return;
           }
-          if (sp_streq(name, "match") && argc == 1) {
-            buf_printf(b, "sp_re_matchdata(%s, ", rp.p); emit_expr(c, recv, b); buf_puts(b, ")");
+          if (sp_streq(name, "match") && (argc == 1 || argc == 2)) {
+            /* emit_str_expr, not emit_expr: a poly receiver needs coercing into
+               the const char* slot, as the precompiled-literal arms do (#3389) */
+            if (argc == 1) { buf_printf(b, "sp_re_matchdata(%s, ", rp.p); emit_str_expr(c, recv, b); buf_puts(b, ")"); }
+            else {
+              buf_printf(b, "sp_re_matchdata_at(%s, ", rp.p); emit_str_expr(c, recv, b);
+              buf_puts(b, ", "); emit_int_expr(c, argv[1], b); buf_puts(b, ")");
+            }
             free(rp.p); return;
           }
           free(rp.p);

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -5343,7 +5343,8 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
         buf_printf(b, ", %s, ", r); emit_expr(c, argv[1], b); buf_puts(b, ")");
       }
       else if (sp_streq(name, "scan") && argc == 1 &&
-               (re_lit_index(c, argv[0]) >= 0 || comp_ntype(c, argv[0]) == TY_STRING) &&
+               (re_lit_index(c, argv[0]) >= 0 || comp_ntype(c, argv[0]) == TY_STRING ||
+                comp_ntype(c, argv[0]) == TY_REGEX) &&
                nt_ref(nt, id, "block") >= 0) {
         /* value-form scan { }: iterate in the prelude; the value is the
            receiver string (CRuby returns self from the block form). With
@@ -5366,6 +5367,21 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
         else if (re_idx >= 0)
           buf_printf(g_pre, "sp_StrArray *_t%d = sp_re_scan(sp_re_pat_%d, _t%d); SP_GC_ROOT(_t%d);\n",
                      tm, re_idx, tr, tm);
+        /* pattern only known at run time (an inline `Regexp.new(s)`, a local
+           holding one): the value already IS the mrb_regexp_pattern*. has_cap
+           is 0 for such a pattern, so the block param stays a whole-match
+           String -- the same shape a local bound to a capturing literal
+           already yields here (#3389). */
+        else if (comp_ntype(c, argv[0]) == TY_REGEX) {
+          /* render the pattern to a scratch buffer: `Regexp.new(s)` roots its
+             own argument, and those decls go to g_pre, which must receive them
+             as whole statements rather than spliced into this initializer */
+          Buf eb; memset(&eb, 0, sizeof eb);
+          emit_expr(c, argv[0], &eb);
+          buf_printf(g_pre, "sp_StrArray *_t%d = sp_re_scan(%s, _t%d); SP_GC_ROOT(_t%d);\n",
+                     tm, eb.p ? eb.p : "NULL", tr, tm);
+          free(eb.p);
+        }
         else {
           buf_printf(g_pre, "sp_StrArray *_t%d = sp_str_scan(_t%d, ", tm, tr);
           emit_expr(c, argv[0], g_pre);
@@ -5408,6 +5424,20 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
       }
       else if (sp_streq(name, "scan") && argc == 1 && comp_ntype(c, argv[0]) == TY_STRING) {
         buf_printf(b, "sp_str_scan(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")");
+      }
+      /* scan against a regex VALUE the arms above could not resolve to a
+         precompiled literal (an interpolated pattern, a local holding one, an
+         inline `Regexp.new(s)`): the value already IS the
+         mrb_regexp_pattern*. Without this arm the call fell through to the
+         unresolved-call gate and raised NoMethodError on the String (#3389).
+         The result shape follows the type analyze settled on, so the two stay
+         in step: an unresolvable pattern is typed poly_array and
+         sp_re_scan_poly decides per match whether the row is the whole match
+         or its captures. */
+      else if (sp_streq(name, "scan") && argc == 1 && comp_ntype(c, argv[0]) == TY_REGEX &&
+               nt_ref(nt, id, "block") < 0) {
+        buf_printf(b, "%s(", comp_ntype(c, id) == TY_POLY_ARRAY ? "sp_re_scan_poly" : "sp_re_scan");
+        emit_expr(c, argv[0], b); buf_printf(b, ", %s)", r);
       }
       else if (sp_streq(name, "to_sym") || sp_streq(name, "intern")) buf_printf(b, "sp_sym_intern(%s)", r);
       else if (sp_streq(name, "to_c") && argc == 0) buf_printf(b, "sp_str_to_c(%s)", r);

--- a/test/regex_value_as_match_arg.rb
+++ b/test/regex_value_as_match_arg.rb
@@ -1,0 +1,84 @@
+# A regex in argument position may be any expression, not just a local or a
+# constant read. An inline `Regexp.new(s)` / `Regexp.union(..)` / a method
+# returning a regex is the same pattern value, and String#match / #match? /
+# #=~ / #!~ / #scan must take it the way #sub / #gsub / #split already do.
+
+def re
+  /\d/
+end
+
+# --- inline call in argument position
+p "1d".match(Regexp.new("\\d"))
+p "1d".match?(Regexp.new("\\d"))
+p("1d" =~ Regexp.new("\\d"))
+p("1d" !~ Regexp.new("\\d"))
+p "1d".scan(Regexp.new("\\d"))
+p "a1b2".match(Regexp.union("b", "1"))
+p "a1b2".scan(Regexp.union("1", "2"))
+
+# a call returning a plain literal is still a call
+p "1d".match(re)
+p "1d".match?(re)
+p("1d" =~ re)
+p "a1b2".scan(re)
+
+# --- the same expression bound to a local keeps working
+r = Regexp.new("\\d")
+p "1d".match(r)
+p "1d".match?(r)
+p("1d" =~ r)
+p("1d" !~ r)
+p "a1b2".scan(r)
+
+# --- literals and constant-bound literals stay on their own paths
+LIT = /\d/
+p "1d".match(/\d/)
+p "1d".match?(/\d/)
+p("1d" =~ /\d/)
+p "a1b2".scan(/\d/)
+p "a1b2".scan(/(\d)(\w)/)
+p "1d".match(LIT)
+
+# --- interpolated literal in argument position
+sep = "d"
+p "1d".match(/#{sep}/)
+p "1d".match?(/#{sep}/)
+p "a1b2d".scan(/#{sep}|\d/)
+p "a1b2".scan(/(#{sep}|\d)(\w)/)
+
+# --- a run-time pattern's capture groups are only knowable at run time:
+# no groups yields whole matches, groups yield a row per match
+p "a1b2".scan(Regexp.new("\\d"))
+p "a1b2".scan(Regexp.new("(\\d)(\\w)"))
+p "abc".scan(Regexp.new("\\d"))
+
+# --- scan's block form returns self and yields each whole match
+p("a1b2".scan(Regexp.new("\\d")) { |m| print m })
+
+# --- the reported site: an interpolated pattern built with Regexp.new,
+# consumed directly in an `if` condition
+INTERVALS = { "h" => 3600, "m" => 60 }
+def parse(param)
+  if m = param.to_s.match(Regexp.new("\\A(\\d+)([#{INTERVALS.keys.join}])\\z"))
+    m[1].to_i * INTERVALS[m[2]]
+  end
+end
+p parse("12h")
+p parse("30m")
+p parse("nope")
+
+# --- the start-position form takes a run-time pattern too
+p "a1b2".match(Regexp.new("\\d"), 2)
+p "a1b2".match?(Regexp.new("\\d"), 2)
+p "a1b2".match(r, 2)
+
+# --- a poly receiver (a String read out of a widened container) is coerced
+# into the subject slot rather than passed through raw
+mixed = ["a1b2", 7]
+poly = mixed[0]
+p poly.match(Regexp.new("\\d"))
+p poly.match?(Regexp.new("\\d"))
+
+# --- Regexp on the receiver side is unchanged
+p Regexp.new("\\d").match("1d")
+p Regexp.new("\\d").match?("1d")

--- a/test/regex_value_as_match_arg.rb.expected
+++ b/test/regex_value_as_match_arg.rb.expected
@@ -1,0 +1,40 @@
+#<MatchData "1">
+true
+0
+false
+["1"]
+#<MatchData "1">
+["1", "2"]
+#<MatchData "1">
+true
+0
+["1", "2"]
+#<MatchData "1">
+true
+0
+false
+["1", "2"]
+#<MatchData "1">
+true
+0
+["1", "2"]
+[["1", "b"]]
+#<MatchData "1">
+#<MatchData "d">
+true
+["1", "2", "d"]
+[["1", "b"]]
+["1", "2"]
+[["1", "b"]]
+[]
+12"a1b2"
+43200
+1800
+nil
+#<MatchData "2">
+true
+#<MatchData "2">
+#<MatchData "1">
+true
+#<MatchData "1">
+true

--- a/test/regex_value_as_match_arg_object_recv.rb
+++ b/test/regex_value_as_match_arg_object_recv.rb
@@ -1,0 +1,30 @@
+# Widening which regex arguments reach the string-side match path must not
+# pull an Object receiver off its own methods: a class that defines match /
+# match? answers those itself, whatever the argument expression looks like.
+# Kept apart from regex_value_as_match_arg.rb, which needs a program where
+# nothing defines #match so a poly receiver stays a String.
+
+class Matcher
+  def match(re)
+    "user match #{re.source}"
+  end
+
+  def match?(re)
+    "user match? #{re.source}"
+  end
+end
+
+m = Matcher.new
+
+# inline call in argument position
+p m.match(Regexp.new("\\d"))
+p m.match?(Regexp.new("\\d"))
+
+# a local, and a regex literal
+lv = Regexp.new("\\w")
+p m.match?(lv)
+p m.match(/\s/)
+
+# the String receiver in the same program still takes the regex path
+p "1d".match(Regexp.new("\\d"))
+p "1d".match?(Regexp.new("\\d"))

--- a/test/regex_value_as_match_arg_object_recv.rb.expected
+++ b/test/regex_value_as_match_arg_object_recv.rb.expected
@@ -1,0 +1,6 @@
+"user match \\d"
+"user match? \\d"
+"user match? \\w"
+"user match \\s"
+#<MatchData "1">
+true


### PR DESCRIPTION
Fixes #3389.

## What was wrong

The runtime-pattern path in `emit_call` admitted a regex **argument** only when it was spelled as a `LocalVariableReadNode` or `ConstantReadNode`:

```c
int is_regex_lv_arg = ... && (sp_streq(a0ty, "LocalVariableReadNode") ||
                              sp_streq(a0ty, "ConstantReadNode"));
```

Any call in argument position missed it and fell through to the unresolved-call gate, so `"1d".match(Regexp.new("\\d"))` raised `NoMethodError` on the String while the identical value bound to a local first worked. A method returning a plain `/\d/` failed too — the ingredient was the argument's node shape, not whether the pattern was constructed. The receiver side of the same block never had that restriction, which is why `Regexp#match(str)` was fine.

`sub` / `gsub` / `split` accept any `TY_REGEX` argument in `codegen_call_recv.c`, which is why they took the same source without complaint.

`scan` was a separate hole: it had no runtime-pattern emit at all, so it raised for a local-held `Regexp.new` and for an interpolated literal too, not just for an inline call.

## The fix

- **`codegen_call.c`** — the argument gate takes any regex-typed expression. Covers `match`, `match?`, `=~`, `!~`, and completes the block's `match(re, pos)` / `match?(re, pos)` arms, which previously existed only for `argc == 1`.
- **`codegen_call_recv.c`** — a `scan` arm for a regex-typed argument, blockless and block forms.
- **`analyze_infer.c` / `analyze_util.c`** — a pattern whose source is not statically visible is typed `poly_array`, and `sp_re_scan_poly` decides per match whether the row is the whole match or its captures. `an_regex_lit_src` is a look-only mirror of codegen's `re_lit_index` resolution (it never registers a pattern slot), so the type rule and the emit arm agree on which patterns are statically visible.

Two guards fell out of the widening, both found by testing rather than by reading:

- A bare regex **literal** stays on the precompiled arms above. Their receiver test is narrower than this block's, so routing literals here would pull e.g. a Symbol receiver off its own handler.
- An **Object receiver** dispatches its own `match` / `match?`. The precompiled arms already excluded `ty_is_object`; this block did not. Applying it here also fixes a pre-existing miscompile — `matcher.match?(re_local)` fed the object straight into `sp_re_match_p`'s `const char *` slot and the generated C did not compile, and `matcher.match(re_local)` answered `nil` instead of calling the user's method.

A poly receiver now reaches the subject slot through `emit_str_expr`, as the precompiled arms do; previously an `sp_RbVal` went into the `const char *` slot.

## Verification

Every shape below is diffed against CRuby.

| argument form | before | after |
|---|---|---|
| `match` / `match?` / `=~` / `!~`, inline `Regexp.new(s)` | NoMethodError | ok |
| same, inline `Regexp.union(..)` | NoMethodError | ok |
| same, method returning a literal | NoMethodError | ok |
| `match(re, pos)` / `match?(re, pos)`, run-time pattern | NoMethodError | ok |
| `scan`, inline / local / interpolated pattern | NoMethodError | ok |
| `scan` with capture groups, run-time pattern | NoMethodError | rows, as CRuby |
| poly receiver + run-time pattern | C compile error | ok |
| Object receiver + regex local | C compile error / `nil` | dispatches own method |
| literal, const-bound literal, local-bound literal | ok | unchanged |

The reported real-world site now works:

```ruby
if m = param.to_s.match(Regexp.new("\\A(\\d+)([#{TIME_INTERVALS.keys.join}])\\z"))
```

Two regression tests, kept apart on purpose — `regex_value_as_match_arg.rb` needs a program where nothing defines `#match`, so a poly receiver stays a String; `regex_value_as_match_arg_object_recv.rb` pins the Object-receiver dispatch.

`make test`: 2510 pass, 0 fail, 0 error (2508 before, plus the two new tests). `make optcarrot`: 359 fps, checksum 59662, OK.

## Not fixed here

Two adjacent bugs turned up while testing and are left alone and filed separately:

- **#3391** — `PAT = /(\d)(\w)/; "a1b2".scan(PAT)` — codegen resolves the constant to a capturing literal and emits `sp_re_scan_poly`, but analyze types the call `str_array`, so the C does not compile. A local bound to the same literal has the mirror-image problem: it silently yields whole matches rather than capture rows.
- **#3392** — `poly.scan(Regexp.new(s))` — the poly-receiver `scan` handler (#3368) still requires a statically resolvable literal, so it raises `NoMethodError`. String receivers are what #3389 reports; the poly arm would need the same analyze/codegen pair on its own path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
