### PR TITLE
Hand back a marked empty string, not a bare literal

### DIFF
--- a/lib/sp_runtime.h
+++ b/lib/sp_runtime.h
@@ -7389,7 +7389,10 @@ static inline const char *sp_poly_pack(sp_RbVal recv, const char *fmt) {
     return sp_PolyArray_pack((sp_PolyArray *)recv.v.p, fmt);
   if (recv.tag == SP_TAG_OBJ && recv.cls_id == SP_BUILTIN_STR_ARRAY)
     return sp_StrArray_pack((sp_StrArray *)recv.v.p, fmt);
-  return "";
+  /* Marked, like every other string this can return: a bare "" literal
+     has no 0xff marker byte, and a caller that roots the result would
+     have the collector mark a rodata pointer. */
+  return sp_str_empty;
 }
 
 /* StringScanner is a native-bound spin package (packages/strscan). */
@@ -7405,7 +7408,7 @@ static inline const char *sp_poly_pack(sp_RbVal recv, const char *fmt) {
    referenced-but-undefined static even when the referring function is dead --
    so supply inert fallbacks that the optimizer prunes with everything else. */
 #ifdef SP_TU_NO_POLY_RENDER
-static const char *sp_sym_to_s(sp_sym id) { (void)id; return ""; }
+static const char *sp_sym_to_s(sp_sym id) { (void)id; return sp_str_empty; }
 static const char *sp_class_to_s(sp_Class c) { return c.name ? c.name : ""; }
 static sp_sym sp_sym_intern(const char *s) { (void)s; return (sp_sym)0; }
 #endif

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -5430,10 +5430,19 @@ char *codegen_program(const NodeTable *nt) {
     /* dynamic intern pool: symbols minted at runtime (Symbol#upcase,
        :"interp", String#to_sym) get ids >= the static count. */
     buf_puts(&b, "static const char *sp_dyn_syms[SP_DYN_SYMS_MAX]; static int sp_ndyn = 0;\n");
+    /* Every arm must hand back a MARKED string. sp_sym_names[] entries
+       carry the 0xff rodata marker, but a bare "" literal does not, and
+       callers root the result (`const char *t = sp_sym_to_s(x);
+       SP_GC_ROOT(t);`). sp_gc_mark then reads the arbitrary rodata byte
+       before the literal, fails to recognise a marker, treats it as a
+       heap object and writes its mark word. A nil Symbol lands on the
+       out-of-range arm (id -1), so this was reachable from ordinary
+       Ruby. sp_str_empty is the marked empty string. */
     buf_printf(&b, "static const char *sp_sym_to_s(sp_sym id){"
                    "if(id>=0&&id<%d)return %s;"
                    "if(id>=%d&&id<%d+sp_ndyn)return sp_dyn_syms[id-%d];"
-                   "return \"\";}\n", ns, ns > 0 ? "sp_sym_names[id]" : "\"\"", ns, ns, ns);
+                   "return sp_str_empty;}\n",
+                   ns, ns > 0 ? "sp_sym_names[id]" : "sp_str_empty", ns, ns, ns);
     buf_printf(&b, "static sp_sym sp_sym_intern(const char *s){"
                    "for(int i=0;i<%d;i++)if(strcmp(%s,s)==0)return (sp_sym)i;"
                    "for(int i=0;i<sp_ndyn;i++)if(strcmp(sp_dyn_syms[i],s)==0)return (sp_sym)(%d+i);"


### PR DESCRIPTION
Every string spinel produces carries a marker byte at `[-1]`. `sp_sym_names[]` entries are emitted as `(&("\xff" "name")[1])`, and `sp_gc_mark` reads that byte to decide whether a pointer is a rodata literal to skip or a heap object whose mark word it should write.

Three functions returned a bare `""` instead, which has no such byte — and callers root the result.

## What goes wrong

A **nil Symbol compiles to id `-1`**, so it takes `sp_sym_to_s`'s out-of-range arm and gets the unmarked literal. The generated code then roots it. From a Rails layout where a nil CSS class reaches `html_escape(title_class.to_s)`:

```c
const char * _t5294 = sp_sym_to_s(lv_title_class); SP_GC_ROOT(_t5294);

const char * sp_ViewHelpers_s_html_escape(const char * lv_s) {
    SP_GC_SAVE();
    SP_GC_ROOT(lv_s);
    return sp_re_gsub_str_str_hash(sp_re_pat_3, lv_s, cst_HTML_ESCAPES);
```

Any collection while that root is live has `sp_gc_mark` read whatever rodata precedes the literal, fail to recognise a marker, conclude it is a heap object, and write its mark word — a protection fault on read-only memory:

```
EXC_BAD_ACCESS (code=2, address=0x1030846d7)
  sp_gc_mark + 176            ->  stur w8, [x0, #-0x10]
  sp_gc_mark_all + 408
  sp_gc_collect + 160
  sp_re_gsub_str_str_hash + 684
  sp_Layouts_s_application + 38684
```

`SPINEL_GC_VERIFY=1` names it before the fault, which is how it was found:

```
[phase=root ctx=0x16d0ed9f0]
*** SPINEL_GC_VERIFY: collector reached a non-heap/corrupt object ***
  obj = 0x1030846d7
```

and `frame variable -L` in a `--debug` build shows the rooted slot holding a rodata pointer, with `lv_title_class = -1` one frame up:

```
0x16fdf9118: (const char *) lv_s = 0x1004e397d ""
0x16fdf9114: (int) _gc_saved    = 120
0x16fdf9110: (int) _sp_gcr_1161 = 1
```

The rooting is **not** the bug — spinel strings are `const char *` carrying a marker, so `SP_GC_ROOT` on one is by design. Only these returns are.

## The change

`sp_str_empty` (`&sp_str_empty_data[1]`) is the marked empty string.

- `src/codegen.c` — the emitted `sp_sym_to_s`: the out-of-range arm, and the arm used when a program has no static symbols.
- `lib/sp_runtime.h` — the no-symbol-table default, and the `pack` dispatcher's fallback (reachable and equally rootable). The bare `""` at the top of the format-string helper is after `sp_raise_cls` and unreachable, so it is left alone.

## Verification

The application that hit this died after ~20 requests by default, and on the very first under `SPINEL_GC_STRESS=1` — in a different place each run depending on where the collection landed, which is what made it look flaky.

| | before | after |
|---|---|---|
| render loop, plain | crash at iteration 59 | 200/200 |
| render loop, `SPINEL_GC_STRESS=1` | crash at iteration 0 | 200/200 |
| render loop, stress + `GC_VERIFY` | abort at iteration 0 | 200/200, verifier silent |
| 49-route HTTP sweep | dead at route 23 | all 49 complete |
| 200 HTTP requests | died on #21 | survived |

`make test`: **2512 pass, 0 fail, 0 error**.

No standalone reproducer, and the reason is worth stating: a small program's symbols are all in range, so they get marked table entries. Reaching the fallback needs an out-of-range symbol whose `to_s` result is rooted across a collection, which depends on whole-program inference typing the slot `sp_sym`. Several attempts at a synthetic case all compiled to something that never calls the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
