### PR TITLE
Give an --rbs nilable scalar somewhere to put nil

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -690,6 +690,14 @@ rbs-seed-test: $(SPINEL) $(RBS_EXTRACT_BIN) $(SP_RT_LIB)
 	  "$$tmp/yu" > "$$tmp/yu.out" 2>/dev/null; \
 	  cmp -s "$$tmp/yu.out" test/rbs-seed/yield_union_hash_obj.expected || { echo "rbs-seed-test: FAIL (#3278 yield-union output mismatch)"; diff -u test/rbs-seed/yield_union_hash_obj.expected "$$tmp/yu.out" || true; ok=0; }; \
 	else echo "rbs-seed-test: FAIL (#3278 yield-union: C did not compile)"; ok=0; fi; \
+	$(SPINEL) test/rbs-seed/nilable_scalar_ivar.rb --rbs test/rbs-seed/sig \
+	  -c --no-line-map -o "$$tmp/ns.c" 2>/dev/null; \
+	grep -Eq 'sp_RbVal[[:space:]]+iv_f;' "$$tmp/ns.c" || { echo "rbs-seed-test: FAIL (#3412: bool? pinned a slot with no nil)"; ok=0; }; \
+	grep -Eq 'sp_RbVal[[:space:]]+iv_y;' "$$tmp/ns.c" || { echo "rbs-seed-test: FAIL (#3412: Symbol? pinned a slot with no nil)"; ok=0; }; \
+	if $(CC) -O0 -Ilib "$$tmp/ns.c" $(SP_RT_LIB) $(LDFLAGS) -lm -o "$$tmp/ns" 2>"$$tmp/ns.err"; then \
+	  "$$tmp/ns" > "$$tmp/ns.out" 2>/dev/null; \
+	  cmp -s "$$tmp/ns.out" test/rbs-seed/nilable_scalar_ivar.expected || { echo "rbs-seed-test: FAIL (#3412 nilable-scalar ivar output mismatch)"; diff -u test/rbs-seed/nilable_scalar_ivar.expected "$$tmp/ns.out" || true; ok=0; }; \
+	else echo "rbs-seed-test: FAIL (#3412 nilable-scalar ivar: C did not compile)"; ok=0; fi; \
 	rm -rf "$$tmp"; \
 	if [ $$ok -eq 1 ]; then echo "rbs-seed-test: pass"; else exit 1; fi
 endif

--- a/docs/rbs-extract.md
+++ b/docs/rbs-extract.md
@@ -120,6 +120,26 @@ ivar <name> <type>
 
 Lines whose first token isn't a keyword are treated as comments.
 
+### How the analyzer reads a `<T>?` token
+
+`parse_seed_type` pins a nilable token to the base type only where that
+type's C slot still has an inhabitant left to spell nil with:
+
+| Token                         | Pinned to        | nil is        |
+|-------------------------------|------------------|---------------|
+| `int?`                        | `mrb_int`        | `SP_INT_NIL`  |
+| `float?`                      | `mrb_float`      | a NaN payload |
+| `string?`, `obj_X?`, `*_array?`, `*_hash?` | the pointer | `NULL`   |
+| `bool?`, `symbol?`            | `sp_RbVal`       | `SP_TAG_NIL`  |
+
+`mrb_bool` and `sp_sym` have no spare inhabitant — `0` is `false`, and
+symbol `0` is a real symbol — so `bool?` and `Symbol?` pin to the boxed
+tagged union rather than collapsing nil onto `false` / `:""` (#3412).
+A poly value narrowed into one of the sentinel-carrying slots goes
+through `sp_poly_as_int_or_nil` / `sp_poly_as_float_or_nil`, which map
+the nil tag to the sentinel instead of reading the zero payload beneath
+it.
+
 ## Follow-up
 
 Tracked as out-of-scope for the initial spike (see matz/spinel#7 +

--- a/lib/sp_alloc.h
+++ b/lib/sp_alloc.h
@@ -359,6 +359,19 @@ static inline sp_RbVal sp_box_obj(void *p, int cls_id) { sp_RbVal r; r.tag = SP_
 static inline sp_RbVal sp_box_sym(sp_sym v)     { if (v == (sp_sym)-1) { sp_RbVal n; n.tag = SP_TAG_NIL; n.cls_id = 0; n.v.i = 0; return n; } sp_RbVal r; r.tag = SP_TAG_SYM;  r.cls_id = 0; r.v.i = (mrb_int)v; return r; }  /* (sp_sym)-1 is the nilable-symbol sentinel: box it as nil, never as :"" */
 static inline sp_RbVal sp_box_poly_array(void *p) { return sp_box_obj(p, SP_BUILTIN_POLY_ARRAY); }
 
+/* The inverse of sp_box_int_or_nil / the float sentinel: unbox a poly into a
+   flat int / float slot that may hold nil. Reading `.v.i` straight off a
+   nil-tagged value yields the payload underneath the tag -- 0, an ordinary
+   Integer -- so nil silently becomes 0 (or 0.0). These map the nil tag to the
+   slot's reserved sentinel instead, which is what every nil? / to_s / boxing
+   site on a nullable int or float already tests for. */
+static inline mrb_int sp_poly_as_int_or_nil(sp_RbVal v) {
+  return v.tag == SP_TAG_NIL ? SP_INT_NIL : v.v.i;
+}
+static inline mrb_float sp_poly_as_float_or_nil(sp_RbVal v) {
+  return v.tag == SP_TAG_NIL ? sp_float_nil() : v.v.f;
+}
+
 /* GC object allocator. The threshold/stress state is extern (defined in
    sp_alloc.c) so every TU shares it -- the same model as sp_gc_heap/bytes.
    sp_gc_alloc itself is an external function (defined in sp_alloc.c) so the

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -1740,14 +1740,21 @@ static TyKind parse_seed_type(Compiler *c, const char *tok) {
   char buf[128];
   if (n >= sizeof buf) return TY_UNKNOWN;
   memcpy(buf, tok, n + 1);
-  /* A trailing nullable '?' has no C scalar kind (objects are NULL-nullable
-     already); pin to the base type. */
-  if (n > 0 && buf[n - 1] == '?') buf[--n] = '\0';
+  /* A trailing '?' is RBS's nilable form (`Integer?`, `bool?`). Pinning it to
+     the base type is right only where that type's C slot still has an
+     inhabitant left to spell nil with: a pointer kind uses NULL, and int /
+     float / string carry a reserved sentinel every nil? / to_s / boxing site
+     already tests for. `mrb_bool` and `sp_sym` have none -- 0 is `false`, and
+     symbol 0 is a real symbol -- so a `bool?` / `Symbol?` pin has nowhere to
+     put nil and collapses it onto false / :"" (#3412). Those pin to the tagged
+     union, which is what `bool | nil` means anyway. */
+  int nilable = 0;
+  if (n > 0 && buf[n - 1] == '?') { buf[--n] = '\0'; nilable = 1; }
   if (sp_streq(buf, "int"))    return TY_INT;
   if (sp_streq(buf, "float"))  return TY_FLOAT;
   if (sp_streq(buf, "string") || sp_streq(buf, "str")) return TY_STRING;
-  if (sp_streq(buf, "symbol") || sp_streq(buf, "sym")) return TY_SYMBOL;
-  if (sp_streq(buf, "bool"))   return TY_BOOL;
+  if (sp_streq(buf, "symbol") || sp_streq(buf, "sym")) return nilable ? TY_POLY : TY_SYMBOL;
+  if (sp_streq(buf, "bool"))   return nilable ? TY_POLY : TY_BOOL;
   if (sp_streq(buf, "nil"))    return TY_NIL;
   if (sp_streq(buf, "void"))   return TY_VOID;
   /* heterogeneous unions map to the bare poly tag (#1255); accepting the

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -124,6 +124,24 @@ void emit_unbox_text(Compiler *c, TyKind t, const char *expr, Buf *b) {
   else buf_printf(b, "(%s).v.i", expr);
 }
 
+/* Emit `expr` (a poly value that MAY be nil) unboxed into a slot of type `t`,
+   keeping nil as the slot's own nil rather than as the union payload sitting
+   under the nil tag. `.v.i` / `.v.f` on a boxed nil read 0 / 0.0 -- ordinary
+   values -- so the plain unbox turns nil into zero, silently: the C is
+   well-formed and nothing downstream can tell the two apart (#3412).
+
+   Only int and float need the guard. A pointer-backed slot takes NULL from the
+   zeroed payload, which IS its nil; bool and symbol have no nil inhabitant at
+   all, so a slot that must hold nil is never given those types (see
+   parse_seed_type). Use this wherever a poly whose nil-ness is not already
+   ruled out is narrowed to a concrete slot; emit_unbox_text stays the
+   unguarded form for the many sites that have. */
+void emit_unbox_nilable_text(Compiler *c, TyKind t, const char *expr, Buf *b) {
+  if (t == TY_INT)   { buf_printf(b, "sp_poly_as_int_or_nil(%s)", expr); return; }
+  if (t == TY_FLOAT) { buf_printf(b, "sp_poly_as_float_or_nil(%s)", expr); return; }
+  emit_unbox_text(c, t, expr, b);
+}
+
 /* An unresolved constant read lowers to a runtime NameError raise whose C
    value is an sp_Class struct (the class-position shape). In a scalar slot
    that struct fails the C compile ("incompatible types"), so the scalar

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -433,6 +433,9 @@ void emit_frozen_obj_guard(Compiler *c, int cid, const char *selfexpr, Buf *b);
    Such a value must box via sp_box_nullable_obj so a NULL becomes SP_TAG_NIL. */
 const char *ty_nullable_builtin_id(TyKind t);
 void emit_unbox_text(Compiler *c, TyKind t, const char *expr, Buf *b);
+/* emit_unbox_text, but a nil-tagged poly lands on the slot's own nil (an int?
+   or float? sentinel) instead of the zero payload under the tag (#3412). */
+void emit_unbox_nilable_text(Compiler *c, TyKind t, const char *expr, Buf *b);
 void emit_proc_literal(Compiler *c, int create, Buf *b);
 int proc_slot_is_direct(TyKind t);
 const char *proc_rest_name(Compiler *c, int create);

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -5922,10 +5922,13 @@ else {
       buf_puts(b, "sp_bigint_new_int("); emit_int_expr(c, v, b); buf_puts(b, ")");
     }
     else if (ivt != TY_POLY && ivt != TY_UNKNOWN && comp_ntype(c, v) == TY_POLY) {
-      /* poly rhs assigned to a typed ivar: unbox to the concrete type */
+      /* poly rhs assigned to a typed ivar: unbox to the concrete type. The
+         nil-preserving form -- the RHS is a tagged union whose nil-ness is not
+         ruled out here, and an --rbs `Integer?` / `Float?` pin makes this
+         exactly the slot a nil is expected to survive in (#3412). */
       Buf _rb; memset(&_rb, 0, sizeof _rb);
       emit_expr(c, v, &_rb);
-      emit_unbox_text(c, ivt, _rb.p ? _rb.p : "sp_box_nil()", b);
+      emit_unbox_nilable_text(c, ivt, _rb.p ? _rb.p : "sp_box_nil()", b);
       free(_rb.p);
     }
     else if (ivt != TY_POLY && ivt != TY_UNKNOWN && comp_ntype(c, v) == TY_UNKNOWN) {

--- a/test/rbs-seed/nilable_scalar_ivar.expected
+++ b/test/rbs-seed/nilable_scalar_ivar.expected
@@ -1,0 +1,10 @@
+nil nil nil nil nil
+7 1.5 "x" false :a
+0 0.0 "" false :a
+nil nil nil nil nil
+true
+true
+true
+true
+2
+1

--- a/test/rbs-seed/nilable_scalar_ivar.rb
+++ b/test/rbs-seed/nilable_scalar_ivar.rb
@@ -1,0 +1,67 @@
+# An --rbs `Integer?` / `Float?` / `bool?` / `Symbol?` ivar seed must keep nil
+# distinguishable from the type's zero. The seed pins the slot to the unboxed
+# kind, so assigning a poly RHS (here a nil arriving through a setter) unboxes
+# it -- and `.v.i` on a boxed nil reads the payload under the tag, 0. int and
+# float have a reserved sentinel to land on; bool and symbol have none, so
+# their seeds pin to the boxed union instead. #3412.
+class NilRow
+  def initialize
+    @n = nil
+    @r = nil
+    @s = nil
+    @f = nil
+    @y = nil
+  end
+  def n; @n; end
+  def n=(v); @n = v; end
+  def r; @r; end
+  def r=(v); @r = v; end
+  def s; @s; end
+  def s=(v); @s = v; end
+  def f; @f; end
+  def f=(v); @f = v; end
+  def y; @y; end
+  def y=(v); @y = v; end
+end
+
+def show(row)
+  puts [row.n.inspect, row.r.inspect, row.s.inspect,
+        row.f.inspect, row.y.inspect].join(" ")
+end
+
+# a fresh row: every seeded slot starts nil
+row = NilRow.new
+show(row)
+
+# real values round-trip through the same slots
+row.n = 7
+row.r = 1.5
+row.s = "x"
+row.f = false
+row.y = :a
+show(row)
+
+# and the zero of each type stays distinct from nil
+row.n = 0
+row.r = 0.0
+row.s = ""
+show(row)
+
+# assigning nil back through the setter must restore nil, not the zero
+row.n = nil
+row.r = nil
+row.s = nil
+row.f = nil
+row.y = nil
+show(row)
+puts row.n.nil?
+puts row.r.nil?
+puts row.f.nil?
+puts row.y.nil?
+
+# the shape that surfaced it: grouping rows by a nilable Integer column must
+# file the nil-keyed ones under nil, not under 0
+rows = [1, nil, 0, nil].map { |v| r = NilRow.new; r.n = v; r }
+groups = rows.group_by { |x| x.n }
+puts groups[nil].length
+puts groups[0].length

--- a/test/rbs-seed/sig/nilable_scalar_ivar.rbs
+++ b/test/rbs-seed/sig/nilable_scalar_ivar.rbs
@@ -1,0 +1,7 @@
+class NilRow
+  attr_accessor n: Integer?
+  attr_accessor r: Float?
+  attr_accessor s: String?
+  attr_accessor f: bool?
+  attr_accessor y: Symbol?
+end


### PR DESCRIPTION
Fixes #3412.

## What the seed actually changed

The pin is what narrows the slot. Without `--rbs`, `@i` sees a nil write and widens to poly, which is why dropping the seed matched CRuby on all four types. An `Integer?` seed pins it to `mrb_int` instead — and a narrow slot needs a coercion the wide one never did.

A poly RHS assigned into a typed ivar unboxed through `emit_unbox_text`, which reads the union member for the target kind — `.v.i` — with no regard for the tag above it. A boxed nil carries zero in that member. So `@i = v` with `v` nil stored 0, and from that point on it *was* the Integer 0: well-formed C, nothing downstream able to tell. `String?` escaped only because the zero it collapses onto **is** a null pointer, which the string paths already read as nil.

## The split, and why it isn't uniform

`int` and `float` each have a reserved sentinel — `SP_INT_NIL`, a NaN payload — that every `nil?` / `to_s` / boxing site on a nullable slot already tests for. The nil-*literal* arm three branches up in the same function writes exactly those, which is why `@i = nil` in `initialize` was already correct and only the assignment through the setter was not. The store was the wrong half, not the pin: routing the coercion through new `sp_poly_as_int_or_nil` / `sp_poly_as_float_or_nil` makes the sentinel survive the round trip.

`bool?` and `Symbol?` have no such sentinel to reach for. `mrb_bool` is a C `bool` — 0 is `false`, and there is no third value — and symbol 0 is an ordinary symbol, so a pinned slot has nowhere to put nil at all. Both now pin to the tagged union, which is what `bool | nil` means anyway.

`Symbol?` turned out worse than the three in the report. Its nil-init *does* write the `(sp_sym)-1` sentinel, but `nil?` on a symbol receiver is in codegen's "value-typed, never nil" fold list, so it constant-folds to false and the read never consults the sentinel — a nil symbol came back as whichever symbol id happened to sit there (`:initialize`, in the fixture below).

| Token | Pinned to | nil is |
|---|---|---|
| `int?` | `mrb_int` | `SP_INT_NIL` |
| `float?` | `mrb_float` | a NaN payload |
| `string?`, `obj_X?`, `*_array?`, `*_hash?` | the pointer | `NULL` |
| `bool?`, `symbol?` | `sp_RbVal` | `SP_TAG_NIL` |

## Verification

The reported repro, after:

```
$ spinel m.rb -o m_rbs --rbs . && ./m_rbs
Integer? nil ->  nil?=true
Float?   nil ->  nil?=true
String?  nil ->  nil?=true
bool?    nil ->  nil?=true
```

Byte-identical to `ruby m.rb`. A wider fixture covering `Symbol?`, `Box?`, `Array[Integer]?` and `Hash[String, Integer]?` also matches CRuby on all eight.

New regression test `test/rbs-seed/nilable_scalar_ivar.rb`, wired into `make rbs-seed-test`. Against the pre-fix compiler it prints

```
-nil nil nil nil nil          +nil nil nil false nil
-nil nil nil nil nil          +0 0.0 nil false :initialize
-2                            +0        # group_by[nil].length
-1                            +3        # group_by[0].length
```

— the last two lines being the `/u` symptom in miniature. It also greps the emitted C for `sp_RbVal iv_f` / `sp_RbVal iv_y`, so a future change that re-pins `bool?` or `Symbol?` to a flat slot fails loudly rather than silently.

`make test` 2528 pass / 0 fail / 0 error, `rbs-test` 13 pass, `rbs-seed-test` pass, `make optcarrot` OK (341 fps, checksum 59662), `make bench` 59 pass / 0 fail.

## Known adjacent gap, not fixed here

A nilable **parameter** still loses nil, through a different mechanism:

```rbs
def take: (Integer? n) -> Integer?
```
```ruby
def take(n); n; end
[1, nil, 3].each { |v| puts take(v).inspect }   # spinel: 1, 0, 3
```

The call site coerces a poly argument with `sp_poly_to_i`, which answers 0 on nil. This PR doesn't touch it: `parse_seed_type` discards the `?` before anything records it, so codegen can't distinguish `Integer` from `Integer?` at the binding, and the plain sentinel unbox can't just be substituted — that path also does the Float/String→int conversions `sp_poly_to_i` exists for. It needs nilability tracked on the seeded param plus a nil-preserving conversion helper.

The Roundhouse shape doesn't reach it (`attr_accessor` emits only `ivar` seed lines, no `meth` lines), and the existing `nilable_arg_group_by` fixture passes because its argument is a literal `nil`, which has its own arm. Worth its own issue if you'd like one.
