### PR TITLE
The fixpoint stopped converging: promote_append_accumulators and infer_write_types trade a slot forever (lobsters front end 224s -> 13.4s)

### DIFF
--- a/src/analyze_pass.c
+++ b/src/analyze_pass.c
@@ -2148,6 +2148,24 @@ int infer_write_types(Compiler *c) {
     if (pr != TY_UNKNOWN && (TyKind)lv->proc_ret != pr) { lv->proc_ret = (int)pr; changed = 1; }
   }
 
+  /* A slot already promoted to the append handle keeps that REPRESENTATION
+     across the recompute frame. The reset above re-derives `out = +""` as a
+     plain TY_STRING, and promote_append_accumulators -- which fires on a
+     TY_STRING slot -- then re-promotes it, so the two passes trade the slot
+     back and forth and the fixpoint never converges: every compile ran to the
+     128-iteration cap. TY_STRBUF *is* a String; only the storage differs, so
+     re-deriving the Ruby-level type must not clobber the choice. Same reason
+     infer_bigint_loop_locals re-seeds inside this frame. If the re-derived
+     type is neither String nor the handle, the promotion's precondition is
+     genuinely gone and the flag goes with it. */
+  for (int s = 0; s < c->nscopes; s++)
+    for (int i = 0; i < c->scopes[s].nlocals; i++) {
+      LocalVar *lv = &c->scopes[s].locals[i];
+      if (!lv->str_append) continue;
+      if (lv->type == TY_STRING) lv->type = TY_STRBUF;
+      else if (lv->type != TY_STRBUF) lv->str_append = 0;
+    }
+
   /* detect change vs the stashed old types */
   for (int s = 0; s < c->nscopes; s++)
     for (int i = 0; i < c->scopes[s].nlocals; i++) {


### PR DESCRIPTION
## Repro

Three lines, on master:

```ruby
out = +""
10.times { |i| out << "x" }
puts out
```

The inference fixpoint **never converges** — it runs to the 128-iteration cap. Same on any tree containing that shape; on roundhouse's lobsters emit (41k lines) it caps on *both* `pf_round`s and the front end takes 224s.

## Bisect

Fixed input, front end only (`spinel --rbs . main.rb -c`) on the lobsters emit:

| commit | landed | front end | fixpoint |
|---|---|---|---|
| `8dd45c27` | Jul 25 | 8.4s | converges at iteration 6 |
| `baaeba58` | Jul 30 14:36 | 13.1s | — |
| `bdf60528` | Jul 30 16:45 | **223.9s** | hits the 128 cap |

## Cause

`bdf60528` added `promote_append_accumulators`, which fires on a slot whose type is exactly `TY_STRING` and sets it to `TY_STRBUF` + `str_append`.

`infer_write_types` opens with a recompute frame: every non-param local is reset to `TY_UNKNOWN` (old type stashed in `gc_root`) and re-derived from its write sites, then it reports change if the new type differs from the stashed one. For an accumulator, the write is `out = +""`, so the re-derivation lands on `TY_STRING` — clobbering the handle.

So the two passes trade the slot back and forth, both reporting change, forever. Instrumented, the last iterations before the cap report exactly two passes changing, every iteration:

```
[pre-iwt]  iter=124 out type=STRBUF append=1
[post-iwt] iter=124 out type=STRING append=1     <- recompute frame demotes
[post-paa] iter=124 out type=STRBUF append=1     <- promotion re-fires
```

This is the #3134 shape: a pass measuring against its own per-iteration reset, and a promotion that keeps re-deriving what another pass keeps undoing.

## Fix

The recompute frame already has precedent for both halves of this. `rbs_seeded` slots are excluded from the reset (#2723), and `infer_bigint_loop_locals` is re-seeded *inside* the frame with the comment "the reset above would otherwise wipe the promotion each iteration."

`TY_STRBUF` is a String — only the storage differs — so re-deriving the Ruby-level type must not clobber the representation the promotion chose. This restores it after the write-type loop, and drops the flag if the re-derived type is genuinely neither String nor the handle (the promotion's precondition is gone).

## Result

| | fixpoint | front end | full `spin build` |
|---|---|---|---|
| master `c728bfad` | 128 cap × 2 rounds | 223.9s | 223.07s / 228.54s |
| this branch | converges at 7, then 3 | **13.4s** | **34.74s / 35.34s** |

13.4s matches `baaeba58` (13.1s), the commit before the regression — so this restores the prior curve rather than papering over it. (The `spin build` totals include ~21s of `cc` on a 13.2 MB translation unit.)

## Verification

- `make test`: **2564 pass, 0 fail, 0 error**.
- **The generated C for the whole lobsters app is byte-identical to master's.** The compiler was already reaching the right answer — it just took 256 iterations to stop. Same program out, 6× faster in.
- **`bm_huffman` and `bm_str_concat` — the two benchmarks `bdf60528` was written for — also emit byte-identical C.** The append-handle optimization is fully preserved; this only stops the slot being re-decided every iteration.

## Note

`#3456` (the `strbuf_mut_kind` / `strbuf_ivar_mut_kind` quadratic) was measured against this regressed baseline and I've said so on that PR. It is independent and still worth having, but this one should land first — it is worth ~17×, that one ~1.35×.
