### PR TITLE
Answer mark_empty_hash_key_ctx's write-site lookups from an index, not a rescan (lobsters front end 43.3s -> 35.5s)

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -6174,7 +6174,11 @@ static int mark_empty_hash_key_ctx(Compiler *c) {
       Scope *rs = comp_scope_of(c, recv);
       int rcid = rs ? rs->class_id : -1;
       if (!ivn || rcid < 0) continue;
-      for (int w = 0; w < nt->count; w++) {
+      /* Walk only the ivar-write nodes named `ivn` (index bucket) instead of
+         rescanning the whole table per read site -- an O(sites * nodes)
+         quadratic on ivar-heavy model graphs otherwise. */
+      for (int r = ivw_shared_first(c, ivn); r >= 0; r = ivw_shared_next(r)) {
+        int w = ivw_shared_node(r);
         if (nt_kind(nt, w) != NK_InstanceVariableWriteNode) continue;
         const char *wn = nt_str(nt, w, "name");
         Scope *ws = comp_scope_of(c, w);
@@ -6193,7 +6197,11 @@ static int mark_empty_hash_key_ctx(Compiler *c) {
     const char *ln = nt_str(nt, recv, "name");
     Scope *sc = comp_scope_of(c, recv);
     if (!ln || !sc || !local_all_writes_empty_hash(c, sc, ln)) continue;
-    for (int w = 0; w < nt->count; w++) {
+    /* Walk only the writes of local `ln` in this scope (index bucket) rather
+       than rescanning the whole table per read site (see the ivar case). */
+    int si = (int)(sc - c->scopes);
+    for (int r = lw_shared_first(c, ln, si); r >= 0; r = lw_shared_next(r)) {
+      int w = lw_shared_node(r);
       if (nt_kind(nt, w) != NK_LocalVariableWriteNode) continue;
       const char *wn = nt_str(nt, w, "name");
       if (!wn || !sp_streq(wn, ln) || comp_scope_of(c, w) != sc) continue;

--- a/src/analyze_internal.h
+++ b/src/analyze_internal.h
@@ -151,6 +151,12 @@ int is_proc_create(Compiler *c, int id);
 int lw_shared_first(Compiler *c, const char *name, int scope);
 int lw_shared_node(int rec);
 int lw_shared_next(int rec);
+/* Shared cached ivar-write index (analyze_pass.c): the ivar analogue of the
+   local-write index, keyed by ivar name only. Callers confirm name (hash
+   collisions), node kind, and defining class on each record. */
+int ivw_shared_first(Compiler *c, const char *name);
+int ivw_shared_node(int rec);
+int ivw_shared_next(int rec);
 TyKind proc_node_ret(Compiler *c, int create);
 TyKind proc_ret_of(Compiler *c, int node);
 TyKind proc_call_ret(Compiler *c, int recv);

--- a/src/analyze_pass.c
+++ b/src/analyze_pass.c
@@ -461,21 +461,23 @@ int lw_shared_next(int rec) { return lw_shared_ix.next[rec]; }
    #1302 from_hash/to_hash shape). Indexes both plain and `||=` ivar writes;
    callers filter by node kind and class. Reuses LWIndex's layout (scope-less,
    so the bucket key is name only). */
-static int ivw_is_write_kind(NodeKind k) {
-  return k == NK_InstanceVariableWriteNode || k == NK_InstanceVariableOrWriteNode;
-}
-
 static unsigned ivw_hash(const char *name) {
   unsigned h = 2166136261u;
   for (const char *p = name; p && *p; p++) { h ^= (unsigned char)*p; h *= 16777619u; }
   return h;
 }
 
+static const NodeKind ivw_write_kinds[2] = {
+  NK_InstanceVariableWriteNode, NK_InstanceVariableOrWriteNode};
+
 static void ivw_index_build(Compiler *c, LWIndex *ix) {
   const NodeTable *nt = c->nt;
+  /* Iterate only the ivar-write kinds (kind-grouped id lists) rather than the
+     whole table -- the write population is a small fraction of the node count,
+     and this build reruns whenever the table grows. Same move as
+     lw_index_build; consumers are order-independent existence walks. */
   int n = 0;
-  for (int id = 0; id < nt->count; id++)
-    if (ivw_is_write_kind(nt_kind(nt, id))) n++;
+  for (int t = 0; t < 2; t++) { int kn; nt_nodes_of_kind(nt, ivw_write_kinds[t], &kn); n += kn; }
   int cap = 16;
   while (cap < n * 2) cap <<= 1;
   ix->cap = cap;
@@ -484,14 +486,17 @@ static void ivw_index_build(Compiler *c, LWIndex *ix) {
   ix->head = (int *)malloc(sizeof(int) * cap);
   for (int i = 0; i < cap; i++) ix->head[i] = -1;
   int k = 0;
-  for (int id = 0; id < nt->count; id++) {
-    if (!ivw_is_write_kind(nt_kind(nt, id))) continue;
-    const char *nm = nt_str(nt, id, "name");
-    unsigned h = ivw_hash(nm) & (unsigned)(cap - 1);
-    ix->node[k] = id;
-    ix->next[k] = ix->head[h];
-    ix->head[h] = k;
-    k++;
+  for (int t = 0; t < 2; t++) {
+    int kn; const int *ids = nt_nodes_of_kind(nt, ivw_write_kinds[t], &kn);
+    for (int j = 0; j < kn; j++) {
+      int id = ids[j];
+      const char *nm = nt_str(nt, id, "name");
+      unsigned h = ivw_hash(nm) & (unsigned)(cap - 1);
+      ix->node[k] = id;
+      ix->next[k] = ix->head[h];
+      ix->head[h] = k;
+      k++;
+    }
   }
 }
 
@@ -500,6 +505,29 @@ static void ivw_index_build(Compiler *c, LWIndex *ix) {
 static int ivw_index_first(const LWIndex *ix, const char *name) {
   return ix->head[ivw_hash(name) & (unsigned)(ix->cap - 1)];
 }
+
+/* Long-lived ivar-write index behind mark_empty_hash_key_ctx's write-site
+   lookups -- the ivar analogue of lw_shared_ix. The bucket key is the ivar
+   name, a syntactic property of the write node that is stable across the
+   frozen fixpoint (the defining class is confirmed by the caller per hit, so
+   scope re-homing needs no re-key). Rebuilt on the same signal lw_shared uses:
+   node-table identity/growth, or a scope-index epoch tick. */
+static LWIndex ivw_shared_ix;
+static const NodeTable *ivw_shared_nt = NULL;
+static int ivw_shared_ntc = -1;
+static unsigned ivw_shared_gen = 0;
+int ivw_shared_first(Compiler *c, const char *name) {
+  unsigned gen = comp_scope_index_gen();
+  if (!comp_scope_index_is_frozen() ||
+      ivw_shared_nt != c->nt || ivw_shared_ntc != c->nt->count || ivw_shared_gen != gen) {
+    if (ivw_shared_nt) lw_index_free(&ivw_shared_ix);
+    ivw_index_build(c, &ivw_shared_ix);
+    ivw_shared_nt = c->nt; ivw_shared_ntc = c->nt->count; ivw_shared_gen = gen;
+  }
+  return ivw_index_first(&ivw_shared_ix, name);
+}
+int ivw_shared_node(int rec) { return ivw_shared_ix.node[rec]; }
+int ivw_shared_next(int rec) { return ivw_shared_ix.next[rec]; }
 
 /* `x, y = obj.m` where the callee's body ends in `return a, b` with statically
    known element types: yields those types so the destructured targets keep


### PR DESCRIPTION
`mark_empty_hash_key_ctx` carries the "empty `{}` indexed with a typed key" context back to the slot's write literal, so the hash variant is chosen off the key rather than defaulted. For an ivar (`@h[sym]`) or local (`h[sym]`) receiver it found those writes by **scanning the entire node table per read site** — twice, one loop for ivar writes and one for locals — and it runs on every fixpoint iteration.

This is the same rescan shape as #3456 / #3457, one loop deeper: the [#3115](https://github.com/matz/spinel/issues/3115) villain again, now the single largest self-time frame left in the front end.

On roundhouse's lobsters emit (142k nodes) that is ~730 read sites × 142k nodes × 13 passes ≈ **1.19 billion inner iterations, 16.7% of the front end**.

## The fix

Both answers are already indexed:

- **locals** — `lw_shared_first(c, ln, si)` is the existing `(scope, name)` local-write index. Drop-in.
- **ivars** — the index existed (`ivw_index_build`, added for the #1302 `from_hash`/`to_hash` shape) but only as a pass-local instance. This exposes it as `ivw_shared_first` / `ivw_shared_node` / `ivw_shared_next`, under the same frozen-cache contract as `lw_shared`: live while the scope index is frozen, stamped with `comp_scope_index_gen()`, rebuilt when the node table grows.

The bucket key is the ivar name only — a syntactic property of the write node — so scope re-homing needs no re-key; the caller already confirms node kind, name (hash collisions), and defining class on every hit, and those checks are unchanged. Each inner scan goes from 142k nodes to O(matches).

**Why the result is identical:** both loops are existence checks over write sites — order-independent and idempotent per write. The bucket contains every node the table scan would have matched and nothing else that survives the caller's filters.

## `ivw_index_build` walks the kind lists now

Secondary, but it matters because the cache rebuilds whenever the growing table invalidates it — once per pass in practice. It now iterates the kind-grouped id lists (`nt_nodes_of_kind` over `NK_InstanceVariableWriteNode` / `NK_InstanceVariableOrWriteNode`) the way `lw_index_build` does, instead of filtering the whole table. Rebuild cost drops from O(nodes) to O(ivar writes), and the pre-existing #1302 consumer at `analyze_pass.c:1026` gets the same speedup for free.

## Measurements

`spin build` of roundhouse's lobsters emit, `spin clean` before each run:

| lane | front end |
|---|---|
| master `7b6fa010^` | 43.3s |
| this branch | **35.5s** |

**−18%**, on top of the #3456 + #3457 wins already landed.

## Verification

- **Generated C for the whole lobsters app is byte-identical** to master's — same program, faster in.
- `make test`: no new failures. The lone `system_argument_list` failure in my sandbox needs `ruby` on `PATH` and fails identically on the unmodified baseline.
