### PR TITLE
Keep every build target when `--` comes first

### DIFF
--- a/tools/spin.rb
+++ b/tools/spin.rb
@@ -1602,7 +1602,12 @@ when "build", "run", "test", "clean"
     if rest.include?("--")
       di = rest.index("--").to_i
       extra = rest[(di + 1)..-1].join(" ")
-      rest = rest[0..(di - 1)]
+      # `rest[0, di]`, not `rest[0..(di - 1)]`: with `--` first (`spin build --
+      # --profile`, no target named) di is 0 and `rest[0..-1]` is the WHOLE
+      # array, so `--` survives as a build target and the run dies with
+      # "no such executable: bin/--.rb" instead of building every bin with the
+      # extra flag.
+      rest = rest[0, di]
     end
     cmd_build(prj, rest, extra)
   when "run"


### PR DESCRIPTION
`spin build -- --profile` — pass a compiler flag, name no target — dies with:

```
spin: no such executable: bin/--.rb
```

The `--` index is 0 in that case, and `rest[0..(di - 1)]` is `rest[0..-1]`: the whole array, `--` included, which then becomes the first build target. `rest[0, di]` is empty at `di == 0`, which is what "no target named" should mean — build them all.

Naming a target (`spin build blog -- --profile`) works today and still does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)