### PR TITLE
Follow a nilable scalar through yield, an inferred return, and poly dispatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -751,7 +751,7 @@ rbs-seed-test: $(SPINEL) $(RBS_EXTRACT_BIN) $(SP_RT_LIB)
 	     -c --no-line-map -o "$$tmp/sxa.c" >"$$tmp/sxa.out" 2>&1; then \
 	  echo "rbs-seed-test: FAIL (a contradicted seed on an ARGUMENT compiled)"; ok=0; \
 	else grep -q "seed contradicted" "$$tmp/sxa.out" || { echo "rbs-seed-test: FAIL (contradicted argument rejected without saying why)"; sed -n 1,5p "$$tmp/sxa.out"; ok=0; }; fi; \
-	for t in hash_kind_widened_return poly_dispatch_arm_arg_type; do \
+	for t in hash_kind_widened_return poly_dispatch_arm_arg_type nilable_scalar_yield_key; do \
 	  $(SPINEL) test/rbs-seed/$$t.rb --rbs test/rbs-seed/sig -c --no-line-map -o "$$tmp/$$t.c" 2>/dev/null; \
 	  if $(CC) -O0 -Ilib $(RBS_SEED_STRICT) "$$tmp/$$t.c" $(SP_RT_LIB) $(LDFLAGS) -lm -o "$$tmp/$$t" 2>"$$tmp/$$t.err"; then \
 	    "$$tmp/$$t" > "$$tmp/$$t.out" 2>/dev/null; \

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -8236,20 +8236,68 @@ static int nullable_int_call_name(const char *nm) {
   for (int i = 0; N[i]; i++) if (sp_streq(nm, N[i])) return 1;
   return 0;
 }
-/* Mark the int locals that can hold that sentinel, so codegen boxes them as
-   nil rather than as INTPTR_MIN. Boxing every int through the nil check costs
-   ~8% on optcarrot -- every pixel goes through it -- so the marking is static
-   and the hot path keeps the plain box. */
+/* A scalar slot on a class the fixpoint could not pin to a receiver still
+   dispatches at runtime: codegen emits a cls_id switch over every class that
+   defines the name. Ask whether ANY of those targets can answer the sentinel.
+   Over-marking here only costs the boxing branch; missing one is the
+   silent-wrong hash key of #3505, so the conservative direction is `yes`. */
+static int poly_dispatch_nullable(Compiler *c, const char *cn) {
+  if (!cn) return 0;
+  for (int si = 1; si < c->nscopes; si++)
+    if (c->scopes[si].name && sp_streq(c->scopes[si].name, cn) &&
+        c->scopes[si].ret_nullable_int) return 1;
+  /* an attr_reader over a scalar ivar: those slots are sentinel-defaulted
+     (ivar_scalar_nil_init), so the read carries the sentinel like a `return
+     nil` would -- the resolved-receiver twin of this lives in codegen's
+     call_returns_nullable_int */
+  for (int ci = 0; ci < c->nclasses; ci++) {
+    if (!comp_reader_in_chain(c, ci, cn, NULL)) continue;
+    char ivb[300];
+    snprintf(ivb, sizeof ivb, "@%s", comp_resolve_alias(c, ci, cn));
+    int iv = comp_ivar_index(&c->classes[ci], ivb);
+    if (iv >= 0 && (c->classes[ci].ivar_types[iv] == TY_INT ||
+                    c->classes[ci].ivar_types[iv] == TY_FLOAT)) return 1;
+  }
+  return 0;
+}
+
 /* Can this expression leave the sentinel in an int slot? */
-static int nullable_int_value(Compiler *c, int v) {
+int nullable_int_value(Compiler *c, int v) {
   const NodeTable *nt = c->nt;
   if (v < 0) return 0;
   if (nt_kind(nt, v) == NK_NilNode) return 1;
+  /* `return e` / `(e)` carry their inner value unchanged; a block tail can be
+     either, and so can a method's own tail statement. */
+  if (nt_kind(nt, v) == NK_ReturnNode) {
+    int rv = nt_ref(nt, v, "arguments");
+    int rn = 0; const int *ra = rv >= 0 ? nt_arr(nt, rv, "arguments", &rn) : NULL;
+    return ra && rn == 1 ? nullable_int_value(c, ra[0]) : 0;
+  }
+  if (nt_kind(nt, v) == NK_ParenthesesNode) {
+    int pb = nt_ref(nt, v, "body");
+    int pn = 0; const int *pd = pb >= 0 ? nt_arr(nt, pb, "body", &pn) : NULL;
+    return pd && pn == 1 ? nullable_int_value(c, pd[0]) : 0;
+  }
+  /* The value of `yield x` is the BLOCK's, decided per call site. The yield's
+     own type says only TY_INT, which an `Integer?` and an `Integer` share, so
+     ask the blocks themselves (#3505). */
+  if (nt_kind(nt, v) == NK_YieldNode) {
+    Scope *ys = comp_scope_of(c, v);
+    int ymi = ys ? (int)(ys - c->scopes) : -1;
+    if (ymi < 0) return 0;
+    int tails[32];
+    int n = yield_block_tails(c, ymi, tails, (int)(sizeof tails / sizeof tails[0]));
+    /* no literal block in sight (an escaping &blk called through the proc ABI):
+       its value arrives boxed, so nothing unboxed carries a sentinel */
+    for (int i = 0; i < n; i++) if (nullable_int_value(c, tails[i])) return 1;
+    return 0;
+  }
   if (nt_kind(nt, v) == NK_CallNode) {
     if (nullable_int_call_name(nt_str(nt, v, "name"))) return 1;
-    /* a method whose --rbs signature pins `Integer?`: the pin keeps the
-       unboxed kind, so its nil is the sentinel and a caller that boxes the
-       value has to answer nil. Resolved the way emission resolves it. */
+    /* a method whose --rbs signature pins `Integer?`, or whose own return
+       expression can be the sentinel: either way its nil is the sentinel and a
+       caller that boxes the value has to answer nil. Resolved the way emission
+       resolves it. */
     const char *cn = nt_str(nt, v, "name");
     int mi = cn ? comp_method_index(c, cn) : -1;
     int rcv = nt_ref(nt, v, "receiver");
@@ -8265,9 +8313,12 @@ static int nullable_int_value(Compiler *c, int v) {
           int rci = comp_class_index(c, nt_str(nt, rcv, "name"));
           if (rci >= 0) mi = comp_cmethod_in_chain(c, rci, cn, NULL);
         }
+        /* the receiver stayed poly, so no single callee resolves -- fall back
+           to the runtime dispatch set */
+        else if (rt == TY_POLY) return poly_dispatch_nullable(c, cn);
       }
     }
-    return mi >= 0 && c->scopes[mi].ret_rbs_nilable;
+    return mi >= 0 && c->scopes[mi].ret_nullable_int;
   }
   if (nt_kind(nt, v) == NK_LocalVariableReadNode) {
     const char *rn = nt_str(nt, v, "name");
@@ -8278,10 +8329,53 @@ static int nullable_int_value(Compiler *c, int v) {
   return 0;
 }
 
+/* Runaway backstop for the marking fixpoint below, not its exit condition --
+   see the comment on the loop. */
+#define NULLABLE_MARK_ROUNDS 32
+
+/* Mark the int locals that can hold that sentinel, so codegen boxes them as
+   nil rather than as INTPTR_MIN. Boxing every int through the nil check costs
+   ~8% on optcarrot -- every pixel goes through it -- so the marking is static
+   and the hot path keeps the plain box. */
 static void mark_nullable_int_locals(Compiler *c) {
   const NodeTable *nt = c->nt;
-  for (int round = 0; round < 4; round++) {
+  /* An --rbs `Integer?` return is the seeded form of the same property the
+     rounds below infer, so start the propagation from it. */
+  for (int mi = 1; mi < c->nscopes; mi++)
+    if (c->scopes[mi].ret_rbs_nilable) c->scopes[mi].ret_nullable_int = 1;
+  /* Method returns propagate through this fixpoint too (a pass-through method
+     is nilable because its callee is), so the cap has to clear a chain of
+     them rather than the single hop the local marking used to need. Every
+     sub-pass below skips what is already marked and only ever sets a flag, so
+     `changed` is the real exit and the cap is a runaway backstop: measured over
+     the 2636 test + benchmark programs, 2563 settle in one round, 72 in two and
+     one in three. A chain deeper than the cap would stop early and silently
+     under-mark -- the unsafe direction -- hence the wide margin AND the
+     did-not-converge check after the loop rather than a silent stop. */
+  int converged = 0;
+  for (int round = 0; round < NULLABLE_MARK_ROUNDS; round++) {
     int changed = 0;
+    /* A method whose own return expression can be the sentinel hands it to
+       every caller. Without this, only an --rbs-seeded signature made a method
+       nilable, so `def pass(x) = x.p_` silently laundered the sentinel into a
+       plain int at the caller (#3505). */
+    for (int mi = 1; mi < c->nscopes; mi++) {
+      Scope *s = &c->scopes[mi];
+      if (s->ret_nullable_int || (s->ret != TY_INT && s->ret != TY_FLOAT)) continue;
+      int tail = scope_body_last(c, mi);
+      if (tail >= 0 && nullable_int_value(c, tail)) { s->ret_nullable_int = 1; changed = 1; }
+    }
+    /* an explicit `return e` exits the method just as its tail does. Blocks
+       share the enclosing method's scope, so a `return` inside one attributes
+       to the method it returns from. */
+    NT_FOREACH_KIND(nt, NK_ReturnNode, id) {
+      Scope *rs = comp_scope_of(c, id);
+      int rmi = rs ? (int)(rs - c->scopes) : -1;
+      if (rmi < 1 || rmi >= c->nscopes) continue;
+      Scope *s = &c->scopes[rmi];
+      if (s->ret_nullable_int || (s->ret != TY_INT && s->ret != TY_FLOAT)) continue;
+      if (nullable_int_value(c, id)) { s->ret_nullable_int = 1; changed = 1; }
+    }
     for (int id = 0; id < nt->count; id++) {
       if (nt_kind(nt, id) != NK_LocalVariableWriteNode) continue;
       int v = nt_ref(nt, id, "value");
@@ -8351,7 +8445,22 @@ static void mark_nullable_int_locals(Compiler *c) {
         if (tl && (tl->type == TY_INT || tl->type == TY_FLOAT) && !tl->nullable_int) { tl->nullable_int = 1; changed = 1; }
       }
     }
-    if (!changed) break;
+    if (!changed) { converged = 1; break; }
+  }
+  /* Running out of rounds means some slot that CAN hold the sentinel is still
+     unmarked, and codegen would box it as an ordinary number -- a Hash key no
+     literal nil matches, with no error at compile or run time (#3505). That is
+     the exact silent-wrong-output this pass exists to prevent, so refuse to
+     emit rather than emit something quietly wrong. Unreachable for a monotone
+     predicate at any realistic chain depth (the deepest program in the tree
+     settles in 3 rounds), so this firing means either a pathological chain or a
+     marking arm that is not monotone -- both worth a bug report. */
+  if (!converged) {
+    fprintf(stderr, "spinel: internal: nilable-scalar marking did not converge in "
+                    "%d rounds; refusing to emit (a nil sentinel would box as an "
+                    "ordinary number). Please report this with the source.\n",
+            NULLABLE_MARK_ROUNDS);
+    exit(1);
   }
 }
 

--- a/src/analyze.h
+++ b/src/analyze.h
@@ -35,6 +35,13 @@ void analyze_program(Compiler *c);
    reads the cached results via comp_ntype. */
 TyKind infer_type(Compiler *c, int id);
 
+/* True when node `id`'s value, held in an unboxed scalar slot, can be the
+   reserved nil sentinel (SP_INT_NIL / the float twin). The slot type alone
+   cannot say -- an `Integer?` and an `Integer` are both TY_INT -- so codegen
+   asks this before choosing between sp_box_int and sp_box_int_or_nil at a poly
+   boundary. Valid only after analyze_program has settled the marking. */
+int nullable_int_value(Compiler *c, int id);
+
 /* Re-infer every node of the subtree at `id` (children first), refreshing the
    whole type cache under the CURRENT scope-local types. The shadow-typing
    emitters (a block param pinned to the receiver's element type for the body's

--- a/src/analyze_internal.h
+++ b/src/analyze_internal.h
@@ -136,6 +136,8 @@ int is_blk_param_call(Compiler *c, int node, int mi);
 TyKind scan_break_type(Compiler *c, int id, int depth);
 TyKind scan_throw_type(Compiler *c, const char *tag);
 TyKind yield_value_type(Compiler *c, int mi);
+/* Tail expressions of the blocks reaching `mi`'s yield (see analyze_util.c). */
+int yield_block_tails(Compiler *c, int mi, int *out, int max);
 /* The block value reaching `mi` from a child's `super` (see analyze_util.c). */
 TyKind yield_value_type_via_super(Compiler *c, int mi);
 int yield_value_diverges(Compiler *c, int mi);

--- a/src/analyze_util.c
+++ b/src/analyze_util.c
@@ -720,6 +720,53 @@ static void yvt_build(Compiler *c) {
     yvt_ids[yvt_n++] = cid;
   }
 }
+/* Which method does block-passing call site `cid` reach? Shared by
+   yield_value_type and yield_block_tails so the two agree on what counts as a
+   call site of a given method. */
+static int yvt_callee_index(Compiler *c, int cid) {
+  const NodeTable *nt = c->nt;
+  const char *cn = nt_str(nt, cid, "name");
+  int crecv = nt_ref(nt, cid, "receiver");
+  int rmi = -1;
+  if (crecv < 0) {
+    rmi = comp_method_index(c, cn);
+    if (rmi < 0) {
+      Scope *cs = comp_scope_of(c, cid);
+      if (cs->class_id >= 0) {
+        rmi = comp_method_in_chain(c, cs->class_id, cn, NULL);
+        /* an implicit-self call inside a class method resolves to a CLASS
+           method; its block/forward feeds that method's blk_ret too */
+        if (rmi < 0) rmi = comp_cmethod_in_chain(c, cs->class_id, cn, NULL);
+      }
+    }
+  }
+  else {
+    TyKind crt = infer_type(c, crecv);
+    if (ty_is_object(crt)) rmi = comp_method_in_chain(c, ty_object_class(crt), cn, NULL);
+    /* `Klass.new { block }`: the block feeds the class's initialize. A
+       scoped receiver (`NS::Klass`) resolves by its leaf name, the key
+       classes are indexed under. */
+    else if (cn && sp_streq(cn, "new") && nt_type(nt, crecv) &&
+             (sp_streq(nt_type(nt, crecv), "ConstantReadNode") ||
+              sp_streq(nt_type(nt, crecv), "ConstantPathNode"))) {
+      int nci = comp_class_index(c, nt_str(nt, crecv, "name"));
+      if (nci >= 0) rmi = comp_method_in_chain(c, nci, "initialize", NULL);
+    }
+    /* `Klass.m { block }` / `Mod.m { block }` / `NS::Klass.m { block }`: a
+       class/module self-method (singleton). Resolve the constant and look
+       up its singleton method so the block's value type flows back to m's
+       return type -- instance methods resolve via the ty_is_object arm
+       above (#1446). */
+    else if (nt_type(nt, crecv) &&
+             (sp_streq(nt_type(nt, crecv), "ConstantReadNode") ||
+              sp_streq(nt_type(nt, crecv), "ConstantPathNode"))) {
+      int nci = comp_class_index(c, nt_str(nt, crecv, "name"));
+      if (nci >= 0) rmi = comp_cmethod_in_chain(c, nci, cn, NULL);
+    }
+  }
+  return rmi;
+}
+
 TyKind yield_value_type(Compiler *c, int mi) {
   for (int i = 0; i < g_yvt_depth; i++)
     if (g_yvt_mi[i] == mi) return TY_UNKNOWN;
@@ -738,46 +785,7 @@ TyKind yield_value_type(Compiler *c, int mi) {
     /* skip calls that live inside method mi itself (recursive self-calls);
        only external call sites provide a concrete block value type */
     if ((int)(comp_scope_of(c, cid) - c->scopes) == mi) continue;
-    const char *cn = nt_str(nt, cid, "name");
-    int crecv = nt_ref(nt, cid, "receiver");
-    int rmi = -1;
-    if (crecv < 0) {
-      rmi = comp_method_index(c, cn);
-      if (rmi < 0) {
-        Scope *cs = comp_scope_of(c, cid);
-        if (cs->class_id >= 0) {
-          rmi = comp_method_in_chain(c, cs->class_id, cn, NULL);
-          /* an implicit-self call inside a class method resolves to a CLASS
-             method; its block/forward feeds that method's blk_ret too */
-          if (rmi < 0) rmi = comp_cmethod_in_chain(c, cs->class_id, cn, NULL);
-        }
-      }
-    }
-else {
-      TyKind crt = infer_type(c, crecv);
-      if (ty_is_object(crt)) rmi = comp_method_in_chain(c, ty_object_class(crt), cn, NULL);
-      /* `Klass.new { block }`: the block feeds the class's initialize. A
-         scoped receiver (`NS::Klass`) resolves by its leaf name, the key
-         classes are indexed under. */
-      else if (cn && sp_streq(cn, "new") && nt_type(nt, crecv) &&
-               (sp_streq(nt_type(nt, crecv), "ConstantReadNode") ||
-                sp_streq(nt_type(nt, crecv), "ConstantPathNode"))) {
-        int nci = comp_class_index(c, nt_str(nt, crecv, "name"));
-        if (nci >= 0) rmi = comp_method_in_chain(c, nci, "initialize", NULL);
-      }
-      /* `Klass.m { block }` / `Mod.m { block }` / `NS::Klass.m { block }`: a
-         class/module self-method (singleton). Resolve the constant and look
-         up its singleton method so the block's value type flows back to m's
-         return type -- instance methods resolve via the ty_is_object arm
-         above (#1446). */
-      else if (nt_type(nt, crecv) &&
-               (sp_streq(nt_type(nt, crecv), "ConstantReadNode") ||
-                sp_streq(nt_type(nt, crecv), "ConstantPathNode"))) {
-        int nci = comp_class_index(c, nt_str(nt, crecv, "name"));
-        if (nci >= 0) rmi = comp_cmethod_in_chain(c, nci, cn, NULL);
-      }
-    }
-    if (rmi != mi) continue;
+    if (yvt_callee_index(c, cid) != mi) continue;
     /* `mi(&b)` / `mi(...)`: the call forwards the block of its enclosing
        method rather than passing a literal. The value `mi` yields is then
        whatever that forwarded block produces -- the enclosing method's
@@ -816,6 +824,48 @@ else {
   }
   g_yvt_depth--;
   return result;
+}
+
+/* The tail expression of every literal block that can reach `mi`'s yield.
+   This is yield_value_type's call-site scan answering with NODES instead of a
+   unified type, because nilability is a property of the producing EXPRESSION,
+   not of the type it settles on -- an `Integer?` and an `Integer` both arrive
+   as TY_INT, so the type alone cannot say whether the value can be the
+   reserved scalar nil sentinel (#3505). A forwarded block (`m(&b)` / `m(...)`)
+   has no literal of its own and delegates to the enclosing method's tails.
+   Unlike yield_value_type this collects EVERY site rather than stopping at the
+   first concrete one: the caller ORs the results, and a single nilable block
+   anywhere is enough to make the slot nilable. Writes at most `max` ids and
+   returns how many. */
+int yield_block_tails(Compiler *c, int mi, int *out, int max) {
+  if (max <= 0) return 0;
+  for (int i = 0; i < g_yvt_depth; i++)
+    if (g_yvt_mi[i] == mi) return 0;
+  if (g_yvt_depth >= MAX_YVT_DEPTH) return 0;
+  g_yvt_mi[g_yvt_depth++] = mi;
+
+  const NodeTable *nt = c->nt;
+  int n = 0;
+  if (yvt_nt != nt || yvt_ntc != nt->count) yvt_build(c);
+  for (int ii = 0; ii < yvt_n && n < max; ii++) {
+    int cid = yvt_ids[ii];
+    int blk = nt_ref(nt, cid, "block");
+    int fwd_args = yvt_call_forwards_block(nt, cid);
+    if ((int)(comp_scope_of(c, cid) - c->scopes) == mi) continue;
+    if (yvt_callee_index(c, cid) != mi) continue;
+    const char *blkty = blk >= 0 ? nt_type(nt, blk) : NULL;
+    if (fwd_args || (blkty && sp_streq(blkty, "BlockArgumentNode"))) {
+      Scope *encl = comp_scope_of(c, cid);
+      int emi = encl ? (int)(encl - c->scopes) : -1;
+      if (emi >= 0 && emi != mi) n += yield_block_tails(c, emi, out + n, max - n);
+      continue;
+    }
+    int bb = nt_ref(nt, blk, "body");
+    int bn = 0; const int *bd = bb >= 0 ? nt_arr(nt, bb, "body", &bn) : NULL;
+    if (bd && bn > 0) out[n++] = bd[bn - 1];
+  }
+  g_yvt_depth--;
+  return n;
 }
 /* The block value that reaches `mi` from BELOW: a child method whose `super`
    lands on mi forwards its own caller's block down. Only the middle link of a

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -328,6 +328,12 @@ int emit_unresolved_coerced(Compiler *c, int node, TyKind target, Buf *b) {
 static int call_returns_nullable_int(Compiler *c, int node) {
   const NodeTable *nt = c->nt;
   const char *nty = nt_type(nt, node);
+  /* The analyzer's own answer, which knows the shapes only whole-program
+     inference can see: a `yield` (nilable per the block at each call site), a
+     method whose nilable return no RBS signature declared, and a call through a
+     receiver that stayed poly (#3505). The arms below stay as the local,
+     name-based backstop for the builtins analyze does not model. */
+  if (nullable_int_value(c, node)) return 1;
   /* A local that was assigned one of these results carries the sentinel just
      as the call did: `i = s.index("z")` then `i == nil` has to answer true.
      analyze marks the local; boxing an ordinary int stays on the plain path,

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -146,6 +146,13 @@ typedef struct {
                           pinned kind is an unboxed scalar: the return can be
                           the reserved sentinel, so a caller boxing it has to
                           answer nil rather than the raw number (#3493) */
+  int ret_nullable_int; /* the same property, INFERRED rather than seeded: this
+                           method's scalar return can be the reserved sentinel
+                           because its own return expression can be. Seeded from
+                           ret_rbs_nilable, then propagated through pass-through
+                           methods (`def pass(x) = x.p_`) and methods whose value
+                           is their block's (`def key_of(x) = yield x`), which no
+                           RBS signature covers (#3505). */
   TyKind ret_oa_pin;   /* the pointer-array return type the narrowing pass gave
                           this method, re-asserted every round for the same
                           reason LocalVar.oa_pin is. TY_UNKNOWN = not narrowed. */

--- a/test/rbs-seed/nilable_scalar_yield_key.expected
+++ b/test/rbs-seed/nilable_scalar_yield_key.expected
@@ -1,0 +1,11 @@
+yield  len=1 val="literal" cls=NilClass nil?=true
+yield! len=1 val="literal"
+pass   len=1 val="literal" cls=NilClass nil?=true
+pass!  len=1 val="literal"
+poly   len=1 val="literal" cls=NilClass nil?=true
+poly!  len=1 val="literal"
+float  len=1 val="literal" cls=NilClass nil?=true
+groups 3
+roots  [1, 3]
+kids   [2]
+mixed  len=2 seven="seven" nil="literal"

--- a/test/rbs-seed/nilable_scalar_yield_key.rb
+++ b/test/rbs-seed/nilable_scalar_yield_key.rb
@@ -1,0 +1,132 @@
+# The yield/return/dispatch counterparts of #3493. A nilable scalar slot holds
+# nil as the reserved sentinel, and boxing it into a poly context has to spell
+# that nil -- but "can this slot hold the sentinel?" was answered from the
+# syntactic SHAPE of the producing expression, so three shapes went unmarked
+# and their nil became a Hash key no literal nil could match (#3505):
+#
+#   1. `k = yield x`      -- the value is the BLOCK's, decided per call site
+#   2. `k = pass(r)`      -- a method whose nilable return no RBS declares
+#   3. `k = rows[0].p_`   -- a receiver the fixpoint left poly, so no single
+#                            callee resolves and only the dispatch set knows
+#
+# Each is checked twice: once through a local (the slot's own marking) and once
+# boxed straight from the expression (codegen's per-site choice).
+class YkR
+  def initialize(p)
+    @p = p
+  end
+
+  def p_
+    @p
+  end
+end
+
+def yk_key_of(x)
+  yield x
+end
+
+def yk_pass(x)
+  x.p_
+end
+
+# 1. through a block
+h1 = {}
+k1 = yk_key_of(YkR.new(nil)) { |x| x.p_ }
+h1[k1] = "block"
+h1[nil] = "literal"
+puts "yield  len=#{h1.length} val=#{h1[nil].inspect} cls=#{k1.class} nil?=#{k1.nil?}"
+
+h2 = {}
+h2[yk_key_of(YkR.new(nil)) { |x| x.p_ }] = "block"
+h2[nil] = "literal"
+puts "yield! len=#{h2.length} val=#{h2[nil].inspect}"
+
+# 2. through a method whose nilable return is inferred, not seeded
+h3 = {}
+k3 = yk_pass(YkR.new(nil))
+h3[k3] = "pass"
+h3[nil] = "literal"
+puts "pass   len=#{h3.length} val=#{h3[nil].inspect} cls=#{k3.class} nil?=#{k3.nil?}"
+
+h4 = {}
+h4[yk_pass(YkR.new(nil))] = "pass"
+h4[nil] = "literal"
+puts "pass!  len=#{h4.length} val=#{h4[nil].inspect}"
+
+# 3. through a receiver that stayed poly
+rows = [YkR.new(nil), YkR.new(7), YkR.new(nil)]
+rows.each { |x| x.p_ }
+h5 = {}
+k5 = rows[0].p_
+h5[k5] = "poly"
+h5[nil] = "literal"
+puts "poly   len=#{h5.length} val=#{h5[nil].inspect} cls=#{k5.class} nil?=#{k5.nil?}"
+
+h6 = {}
+h6[rows[0].p_] = "poly"
+h6[nil] = "literal"
+puts "poly!  len=#{h6.length} val=#{h6[nil].inspect}"
+
+# A Float? slot has its own reserved sentinel and the same three shapes.
+class YkF
+  def initialize(v)
+    @v = v
+  end
+
+  def val
+    @v
+  end
+end
+
+def yk_fkey_of(x)
+  yield x
+end
+
+hf = {}
+kf = yk_fkey_of(YkF.new(nil)) { |x| x.val }
+hf[kf] = "block"
+hf[nil] = "literal"
+puts "float  len=#{hf.length} val=#{hf[nil].inspect} cls=#{kf.class} nil?=#{kf.nil?}"
+
+# The shape this was found in: group_by a nullable foreign key through a block,
+# then reach for the nil bucket to find the roots of the tree.
+def yk_group_by(arr)
+  out = {}
+  arr.each do |x|
+    k = yield x
+    a = out.fetch(k, nil)
+    if a.nil?
+      a = []
+      out[k] = a
+    end
+    a << x
+  end
+  out
+end
+
+class YkRow
+  def initialize(id, parent)
+    @id = id
+    @parent = parent
+  end
+
+  def id
+    @id
+  end
+
+  def parent_id
+    @parent
+  end
+end
+
+trows = [YkRow.new(1, nil), YkRow.new(2, 1), YkRow.new(3, nil), YkRow.new(4, 2)]
+groups = yk_group_by(trows) { |r| r.parent_id }
+puts "groups #{groups.length}"
+puts "roots  #{groups[nil].map { |r| r.id }.inspect}"
+puts "kids   #{groups[1].map { |r| r.id }.inspect}"
+
+# A real (non-nil) value must still box as itself, not get swept into nil.
+hn = {}
+hn[yk_key_of(YkR.new(7)) { |x| x.p_ }] = "seven"
+hn[nil] = "literal"
+puts "mixed  len=#{hn.length} seven=#{hn[7].inspect} nil=#{hn[nil].inspect}"

--- a/test/rbs-seed/sig/nilable_scalar_yield_key.rbs
+++ b/test/rbs-seed/sig/nilable_scalar_yield_key.rbs
@@ -1,0 +1,15 @@
+class YkR
+  def initialize: (Integer?) -> void
+  def p_: () -> Integer?
+end
+
+class YkF
+  def initialize: (Float?) -> void
+  def val: () -> Float?
+end
+
+class YkRow
+  def initialize: (Integer, Integer?) -> void
+  def id: () -> Integer
+  def parent_id: () -> Integer?
+end


### PR DESCRIPTION
Refs #3505. **Partial — deliberately does not close it.** Tested against the original codebase there are still shapes in this family that get through; this lands the three the issue's repros isolate and leaves the rest open.

## The defect

The nilable-int slot *representation* is correct. `k` is an `mrb_int` holding `SP_INT_NIL`, which is why `k.class` / `k.nil?` / `k.inspect` all read right off the local. What's wrong is only the **box at the poly boundary**:

```c
// two.c:284
sp_PolyPolyHash_set(lv_h, sp_box_int(lv_k), sp_box_str("from-block"));
//                        ^^^^^^^^^^ SP_INT_NIL goes out as Integer(INTPTR_MIN)
sp_PolyPolyHash_set(lv_h, sp_box_nil(),     sp_box_str("from-literal"));
```

`sp_box_int_or_nil` isn't the default because it costs throughput — forcing it on every int box measures ~12% on optcarrot. So nilability is a static marking pass (`mark_nullable_int_locals` / `nullable_int_value`) that enumerates the syntactic **shapes** that can leave the sentinel. That enumeration is the hole factory.

## Three gaps

Each probe is `h[k] = …; h[nil] = …; puts h.length`; CRuby answers 1.

| shape | before | gap |
|---|---|---|
| `k = r.p_` (typed local receiver) | 1 ✅ | — |
| `k = yield x` | **2** | no `NK_YieldNode` arm |
| `k = pass(r)`, `def pass(x) = x.p_` | **2** | inferred nilable return not propagated |
| `k = rows[0].p_`, `rows` widened to poly | **2** | callee unresolvable through a poly receiver |

1. **`yield`** — no `NK_YieldNode` case, so `k = yield x` never marks. New `yield_block_tails` is `yield_value_type`'s call-site scan answering with **nodes** instead of a unified type: nilability is a property of the producing expression, not of the type it settles on — an `Integer?` and an `Integer` are both `TY_INT`. Forwarded blocks (`m(&b)` / `m(...)`) delegate to the enclosing method. The callee resolution both scans need is extracted into `yvt_callee_index` rather than duplicated.

2. **Inferred nilable return** — the `CallNode` arm ended at `ret_rbs_nilable`, which `seed_method` sets *only* from an RBS signature. New `Scope.ret_nullable_int` is the inferred twin, seeded from it and propagated through the marking fixpoint from each method's tail and its explicit `return`s. This is what `two.rb`'s `key_of` needs — that repro fails through this gap, not through the yield one.

3. **Poly receiver** — resolution only handled `ty_is_object` or a constant receiver. When the receiver stays `TY_POLY`, `poly_dispatch_nullable` asks the runtime dispatch set instead: any same-named method with a nilable scalar return, or any `attr_reader` over a scalar ivar. Over-marking costs a branch; missing one is the silent-wrong key.

All three hit `Float?` identically.

## Both box sites

`h[yield x] = v` with no local was wrong the same way, so codegen's `call_returns_nullable_int` now consults the analyzer's predicate first and keeps its own arms as the backstop for builtins analyze doesn't model.

## One correction to the issue's table

The `parents[d]` → OK row was passing by coincidence. `main.c:341` emitted `sp_box_int(lv_d)` — the direct read was plain-boxed too (gap 3), matching only because the stored key was equally wrong. Patching gap 1 alone gives:

```
key     cls=NilClass val=nil nil?=true n=2     <- fixed
[nil]   [#<R:...>, #<R:...>]                   <- fixed
[d]     nil                                    <- REGRESSED
```

So gaps 1 and 3 had to land together.

## Fixpoint cap

Method returns now chain through the marking fixpoint, so a 5-deep pass-through chain would have under-marked at the old cap of 4. Cap goes 4 → 32, and **failing to converge is now an error rather than a silent stop** — running out of rounds leaves a slot unmarked, which is exactly the silent-wrong-key this pass exists to prevent, so it refuses to emit.

Instrumented over the 2636 test + benchmark programs: 2563 settle in **1** round, 72 in 2, one in 3. The cap is ~10× the observed max. Verified the check is live, not dead code, by starving the cap to 1 — it fires with a clear message, and the build then fails compiling spinel's own `tools/spin.rb`, so it bites on real code.

## Cost

**None on the hot path.** optcarrot's generated C is byte-identical to master (200 `sp_box_int`, 11 `sp_box_int_or_nil` both ways) and compile time is unchanged at 0.16s. fps readings moved around inside run-to-run noise — the same binary measured 1818–1960 across runs — so the byte-identical codegen is the real signal.

## Verification

- Both `#3505` repros match CRuby byte-for-byte, including the `parents[d]` row.
- 8 probes: 3 local-slot shapes, 3 direct-expression shapes, `Float?`, plus the plain-read control.
- `make test` 2603 pass / 0 fail · `make bench` 60 pass · `make rubyspec-gate` 2109 examples across 6 suites · optcarrot checksum `59662`.

New fixture `test/rbs-seed/nilable_scalar_yield_key.rb` covers all three gaps through both a local and a direct box, plus `Float?`, the `group_by`-then-`[nil]` shape from the report, and a non-nil control so a real `7` isn't swept into nil. Confirmed it's a real guard: on master it fails all seven lines and returns `roots []`.

## Still open

Issue #3505 should stay open after this merges. The marking pass is still a shape enumeration, so the family's root cause — nilability tracked per-syntactic-form rather than as a property of the slot — survives, and more shapes in this family are known to get through. Post them on the issue and I'll extend the same three seams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
