### PR TITLE
Make GC stress pin the threshold it seeds

### DIFF
--- a/lib/sp_alloc.c
+++ b/lib/sp_alloc.c
@@ -63,6 +63,12 @@ int sp_ffi_bin_len = 0;   /* see sp_alloc.h: byte count for :binstr / :cbinstr *
 size_t sp_gc_threshold = 256 * 1024;
 size_t sp_gc_threshold_init = 256 * 1024;
 int sp_gc_stress_checked = 0;
+/* Stress pins the threshold instead of merely seeding it: the retunes float
+   the trigger to live*4 with the base as a FLOOR, so on any program whose
+   live set outgrows the base, stress stopped stressing after the first
+   collection -- request-time bugs sat behind a cadence identical to the
+   default's while boot-time ones reproduced instantly (#3513). */
+int sp_gc_stress_pin = 0;
 
 #ifdef SP_THREADS
 pthread_mutex_t sp_heap_lock = PTHREAD_MUTEX_INITIALIZER;   /* see sp_alloc.h */
@@ -79,11 +85,11 @@ void sp_alloc_stress_init(void) {
   int stress = (e && *e && *e != '0');
   if (!sp_str_stress_checked) {
     sp_str_stress_checked = 1;
-    if (stress) { sp_str_threshold = 2048; sp_str_threshold_init = 2048; }
+    if (stress) { sp_str_threshold = 2048; sp_str_threshold_init = 2048; sp_gc_stress_pin = 1; }
   }
   if (!sp_gc_stress_checked) {
     sp_gc_stress_checked = 1;
-    if (stress) { SP_GC_CTR_SET(sp_gc_threshold, 2048); sp_gc_threshold_init = 2048; }
+    if (stress) { SP_GC_CTR_SET(sp_gc_threshold, 2048); sp_gc_threshold_init = 2048; sp_gc_stress_pin = 1; }
   }
 }
 
@@ -130,6 +136,7 @@ void sp_alloc_worker_tune(int workers) {
 /* Re-tune the object / string GC thresholds from the pre-collect live bytes
    (the heuristic mirrors the original inline code in sp_gc_alloc / sp_str_alloc). */
 void sp_gc_retune_object(size_t before) {
+  if (sp_gc_stress_pin) { sp_gc_threshold = sp_gc_threshold_init; return; }
   size_t freed = before - sp_gc_bytes;
   if (freed < before / 4) { sp_gc_threshold = before * 2; }
   else if (sp_gc_bytes > 0) { sp_gc_threshold = sp_gc_bytes * 4; if (sp_gc_threshold < sp_gc_threshold_init) sp_gc_threshold = sp_gc_threshold_init; }
@@ -142,6 +149,7 @@ void sp_gc_retune_object(size_t before) {
    cycle -- retuning on the aggregate would grow it geometrically for long-lived
    strings. The single-threaded build works in absolute bytes (N == 1). */
 static void sp_str_retune(size_t before, size_t promoted) {
+  if (sp_gc_stress_pin) { sp_str_threshold = sp_str_threshold_init; return; }
 #ifdef SP_THREADS
   int nw = sp_active_workers; if (nw < 1) nw = 1;
   size_t after = (sp_str_bytes_total() + promoted) / (size_t)nw;
@@ -213,7 +221,7 @@ void *sp_gc_alloc(size_t sz, void (*fin)(void *), void (*scn)(void *)) {
      moved off it. Removals happen only under stop-the-world with every mutator
      parked, so a push never races the sweep. The stress-threshold one-shot is
      idempotent under a race. */
-  if (!sp_gc_stress_checked) { sp_gc_stress_checked = 1; const char *e = getenv("SPINEL_GC_STRESS"); if (e && *e && *e != '0') { SP_GC_CTR_SET(sp_gc_threshold, 2048); sp_gc_threshold_init = 2048; } }
+  if (!sp_gc_stress_checked) { sp_gc_stress_checked = 1; const char *e = getenv("SPINEL_GC_STRESS"); if (e && *e && *e != '0') { SP_GC_CTR_SET(sp_gc_threshold, 2048); sp_gc_threshold_init = 2048; sp_gc_stress_pin = 1; } }
   if (SP_GC_CTR_GET(sp_gc_bytes) > SP_GC_CTR_GET(sp_gc_threshold)) sp_stw_collect();
   size_t need = sizeof(sp_gc_hdr) + sz;
   sp_gc_hdr *h = (sp_gc_hdr *)calloc(1, need);
@@ -227,7 +235,7 @@ void *sp_gc_alloc(size_t sz, void (*fin)(void *), void (*scn)(void *)) {
   /* The threshold store is atomic: sp_gc_collection_wanted reads it without
      the heap lock. threshold_init stays plain -- only retune reads it, under
      stop-the-world, ordered after this by the writer's park. */
-  if (!sp_gc_stress_checked) { sp_gc_stress_checked = 1; const char *e = getenv("SPINEL_GC_STRESS"); if (e && *e && *e != '0') { SP_GC_CTR_SET(sp_gc_threshold, 2048); sp_gc_threshold_init = 2048; } }
+  if (!sp_gc_stress_checked) { sp_gc_stress_checked = 1; const char *e = getenv("SPINEL_GC_STRESS"); if (e && *e && *e != '0') { SP_GC_CTR_SET(sp_gc_threshold, 2048); sp_gc_threshold_init = 2048; sp_gc_stress_pin = 1; } }
   if (SP_GC_CTR_GET(sp_gc_bytes) > sp_gc_threshold) {
     sp_gc_collect_retune();
   }

--- a/lib/sp_alloc.h
+++ b/lib/sp_alloc.h
@@ -93,6 +93,7 @@ extern size_t sp_str_old_threshold_init; /* recompute floor for the above */
 extern size_t sp_str_threshold;          /* string-GC trigger (own heuristic) */
 extern size_t sp_str_threshold_init;     /* recompute floor */
 extern int    sp_str_stress_checked;     /* one-shot SPINEL_GC_STRESS check */
+extern int    sp_gc_stress_pin;          /* stress caps the retunes at the 2048 base (#3513) */
 #ifdef SP_THREADS
 void sp_alloc_stress_init(void);         /* race-free one-shot stress check (pre-helpers) */
 void sp_alloc_worker_tune(int workers); /* size the collection budget for N workers (pre-helpers) */
@@ -177,7 +178,7 @@ static inline char *sp_str_alloc(size_t len) {
      so. Threshold recompute mirrors sp_gc_alloc's. */
 #ifdef SP_THREADS
   int wid = sp_worker_id;
-  if (!sp_str_stress_checked) { sp_str_stress_checked = 1; const char *e = getenv("SPINEL_GC_STRESS"); if (e && *e && *e != '0') { sp_str_threshold = 2048; sp_str_threshold_init = 2048; } }
+  if (!sp_str_stress_checked) { sp_str_stress_checked = 1; const char *e = getenv("SPINEL_GC_STRESS"); if (e && *e && *e != '0') { sp_str_threshold = 2048; sp_str_threshold_init = 2048; sp_gc_stress_pin = 1; } }
   /* Per-worker trigger: the fast path reads only this worker's own byte count,
      no shared state. Each worker fires at the full threshold, so the aggregate
      bound scales with the worker count -- keeping the stop-the-world frequency
@@ -198,7 +199,7 @@ static inline char *sp_str_alloc(size_t len) {
   SP_GC_CTR_ADD(sp_str_wslot[wid].young_bytes, total);
 #else
   SP_HEAP_LOCK();
-  if (!sp_str_stress_checked) { sp_str_stress_checked = 1; const char *e = getenv("SPINEL_GC_STRESS"); if (e && *e && *e != '0') { SP_GC_CTR_SET(sp_str_threshold, 2048); sp_str_threshold_init = 2048; } }
+  if (!sp_str_stress_checked) { sp_str_stress_checked = 1; const char *e = getenv("SPINEL_GC_STRESS"); if (e && *e && *e != '0') { SP_GC_CTR_SET(sp_str_threshold, 2048); sp_str_threshold_init = 2048; sp_gc_stress_pin = 1; } }
   if (SP_GC_CTR_GET(sp_str_heap_bytes) > sp_str_threshold) {
     sp_str_collect_retune();         /* sp_gc_collect runs sp_str_sweep */
   }


### PR DESCRIPTION
`SPINEL_GC_STRESS` sets the collection threshold to 2048 bytes — but as a *base*, and the post-collection retunes (`sp_gc_retune_object`, `sp_str_retune`) float the threshold to `live*4` with that base only as a floor. So on any program whose live set outgrows ~512 bytes, stress stops stressing after the first collection: the cadence retunes to within a whisker of the default's. This explains a pattern that runs through #3513 — stress reproduced every *boot-time* defect deterministically (the first collection fires at 2 KB, before anything is live) and never once touched a *request-time* one, and a minor-path bug could sit green on two CI legs and red on the third.

This change makes stress pin what it seeds: a `sp_gc_stress_pin` flag set wherever `SPINEL_GC_STRESS` is detected, and an early-out in both retunes that resets the threshold to its base. Nothing changes unless the env var is set.

**Why now: it turns the #3513 heisenbug into a deterministic repro.** On lobsters (the full frozen sequence, `-O2`, spinel HEAD + this change):

| configuration | result |
|---|---|
| `SPINEL_GC_MINOR=1` alone | dies ~1 run in 12 at 576e3f06, ~14 in 20 at 4b099a1a — layout luck, minutes-to-hours to catch |
| minor + stress, **pinned** | **dies at the first collections during boot, 3/3 runs, ~1 s** (`can't modify frozen Array` — a swept header reused) |
| minor + stress + `SPINEL_GC_VERIFY=1 SPINEL_GC_VERIFY_GEN=1`, pinned | deterministic abort, first collection, `phase=globals`, corrupt object `scan=0x0 size=0` |
| default GC + stress, pinned | **full sequence clean**, exit 0 — the corruption is minor-path only |
| minor + stress, *unpinned* (same tree, pre-change binary) | boot, parity, verify, warmup all pass; dies later at the natural rate — the pin is what determinizes |

The boot-time failure the pin surfaces is not necessarily the same member of the lost-object class as the `int_to_s` crash in the issue thread — pinned stress surfaces members in deterministic order starting from boot. That is the point: it converts "rerun the app N times and hope" into a worklist — fix the first member, rerun, the next appears, each step seconds. It should also let the existing suite catch minor-path holes directly: under the old semantics the suite's stress leg was only stressing programs with sub-kilobyte live sets.

**Cost.** Pinned stress is affordable where it matters: the full lobsters sequence completes under default+stress in under two minutes, and under the minor mark each pinned collection marks only the ~2 KB young set. Suite impact under `SPINEL_GC_MINOR=1 SPINEL_GC_STRESS=1 SPINEL_GC_VERIFY_GEN=1`:

**98 failures against 37 baseline** (macOS/arm64). The delta is the finding, not a cost: **all 63 newly failing tests also fail under pinned stress on the *default* collector** — none are minor-mark regressions. They are pre-existing unrooted locals of the `MatchData#named_captures` kind, concentrated in the Enumerator machinery (`enumerator_ops`, `to_enum_enum_for`, `with_index_enumerator`, the Set family; full list in a comment below), and each reproduces in isolation in under a second, e.g.:

    bin/spinel test/enumerator_ops.rb -c --no-line-map -o /tmp/eo.c
    cc -O2 -Ilib /tmp/eo.c lib/libspinel_rt.a -lm -o /tmp/eo
    SPINEL_GC_STRESS=1 /tmp/eo   # SIGSEGV; passes without the env var

Two tests flip the other way (`bignum_downto_upto_to_a`, `hash_each_value_key_enumerator` fail baseline-only) — flaky under the gate env, not pin-related as far as I can tell.

If the new reds are unwelcome on the stress CI leg until they're fixed, the leg can pin the old behavior by also setting `SPINEL_GC_THRESHOLD_KB` — but red is arguably what that leg is for.

Refs #3513.
