### PR TITLE
Add a failing test for [] defined in a Struct/Data block being ignored

### DIFF
--- a/test/struct_block_overrides_bracket.rb
+++ b/test/struct_block_overrides_bracket.rb
@@ -1,0 +1,55 @@
+# A method defined in a Struct.new / Data.define block overrides the built-in
+# member accessor of the same name, as it does in CRuby. `[]` written in the
+# block was ignored: the call went to the generated member lookup, so a key
+# that is not a member raised
+#
+#   NameError: no member 'text' in struct
+#
+# instead of running the user's body. The same applies to any built-in the
+# block redefines (`to_s`, `==`, ...).
+#
+# Found porting tobi/try, which wraps a Hash payload in a Data and defines
+# `[]` to forward unknown keys into that Hash.
+Item = Data.define(:data, :score) do
+  def [](key)
+    if key == :score
+      score
+    else
+      data[key]
+    end
+  end
+end
+
+i = Item.new(data: { text: "hello", path: "/tmp/x" }, score: 1.5)
+p i[:score]
+p i[:text]
+p i[:path]
+
+# The generated readers still work alongside the override.
+p i.score
+p i.data[:text]
+
+# Struct.new takes the same treatment.
+Pair = Struct.new(:a, :b) do
+  def [](key)
+    "custom:#{key}"
+  end
+end
+s = Pair.new(1, 2)
+p s[:a]
+p s[:zzz]
+p s.a
+p s.b
+
+# A Struct that does NOT override [] keeps the built-in member lookup,
+# including the integer-offset form and the NameError for an unknown name.
+Plain = Struct.new(:x, :y)
+pl = Plain.new(7, 8)
+p pl[:x]
+p pl[1]
+p pl[-1]
+begin
+  pl[:nope]
+rescue NameError => e
+  puts "NameError: #{e.message}"
+end

--- a/test/struct_block_overrides_bracket.rb.expected
+++ b/test/struct_block_overrides_bracket.rb.expected
@@ -1,0 +1,13 @@
+1.5
+"hello"
+"/tmp/x"
+1.5
+"hello"
+"custom:a"
+"custom:zzz"
+1
+2
+7
+8
+8
+NameError: no member 'nope' in struct


### PR DESCRIPTION
## Status: this test is intentionally failing (RED). It documents the bug; no fix is included.

## What

A method defined in a `Struct.new` / `Data.define` block overrides the built-in member accessor of the same name in CRuby. `[]` written in the block is ignored: the call goes to the generated member lookup, so a key that is not a member raises instead of running the user's body.

```ruby
Item = Data.define(:data, :score) do
  def [](key)
    key == :score ? score : data[key]
  end
end

i = Item.new(data: { text: "hello" }, score: 1.5)
i[:score]   # 1.5 — happens to agree, it IS a member
i[:text]    # CRuby: "hello"    Spinel: NameError: no member 'text' in struct
```

The same applies to any built-in the block redefines (`to_s`, `==`, ...); `[]` is just where it bit us.

## What the test pins

Both directions, so a fix cannot simply drop the generated accessor:

- the override **is** called, for a member key, a non-member key, and via `Struct.new` as well as `Data.define`;
- the generated readers still work alongside it;
- a Struct that does **not** override `[]` keeps the built-in member lookup — including the integer-offset form, the negative-offset form, and the `NameError` for an unknown name.

## Context

Found while porting [tobi/try](https://github.com/tobi/try) — a ~1300-line Ruby CLI + fuzzy-matching TUI — to Spinel, under a deliberately strict constraint: **one source tree that runs unchanged under both CRuby and Spinel**, no `RUBY_ENGINE` branching, byte-identical output.

try wraps a Hash payload in a Data and defines `[]` to forward unknown keys into that Hash — a pretty common shape for "struct with a bag of extra attributes". The workaround in the port was to rename the method (`fetch`) and dispatch each key to a named reader, which changes every call site.
