### PR TITLE
Ask the write index, not the whole table, for a slot's array evidence

### DIFF
--- a/src/analyze_pass.c
+++ b/src/analyze_pass.c
@@ -107,20 +107,31 @@ static int recv_has_array_write(Compiler *c, int recv) {
     if (rargc != 0 || !gname) return 0;
     char ivn[300];
     snprintf(ivn, sizeof ivn, "@%s", gname);
-    for (int k = 0; k < c->nclasses; k++) {
-      int rdcls = k;
-      if (!comp_reader_in_chain(c, k, gname, &rdcls)) continue;
-      if (rdcls < 0 || rdcls >= c->nclasses) continue;
-      if (comp_ivar_index(&c->classes[rdcls], ivn) < 0) continue;
-      for (int id = 0; id < nt->count; id++) {
-        if (nt_kind(nt, id) != NK_InstanceVariableWriteNode) continue;
-        const char *wnm = nt_str(nt, id, "name");
-        if (!wnm || !sp_streq(wnm, ivn)) continue;
-        Scope *ws = comp_scope_of(c, id);
-        if (!ws || ws->class_id != rdcls) continue;
-        int v = nt_ref(nt, id, "value");
-        if (v < 0) continue;
-        if (nt_kind(nt, v) == NK_ArrayNode || ty_is_array(infer_type(c, v))) return 1;
+    /* Drive from the WRITES to `@gname` (the name-keyed index above), not from
+       every class crossed with every node: the two loops asked one question --
+       is there an array write to the backing ivar in the class that defines
+       the reader -- and the writes are the small side of it. */
+    if (wrn_nt != nt || wrn_ntc != nt->count) wrn_build(c);
+    if (!wrn_buckets) return 0;
+    unsigned rb = wrn_key(ivn, -1) % (unsigned)wrn_buckets;
+    for (int id = wrn_head[rb]; id >= 0; id = wrn_next[id]) {
+      if (nt_kind(nt, id) != NK_InstanceVariableWriteNode) continue;
+      const char *wnm = nt_str(nt, id, "name");
+      if (!wnm || !sp_streq(wnm, ivn)) continue;
+      Scope *ws = comp_scope_of(c, id);
+      if (!ws) continue;
+      int wc = ws->class_id;
+      if (wc < 0 || wc >= c->nclasses) continue;
+      if (comp_ivar_index(&c->classes[wc], ivn) < 0) continue;
+      int v = nt_ref(nt, id, "value");
+      if (v < 0) continue;
+      if (nt_kind(nt, v) != NK_ArrayNode && !ty_is_array(infer_type(c, v))) continue;
+      /* The write only counts when some class really does reach this defining
+         class through a reader named `gname` (alias resolution is per-class,
+         so this asks every class, exactly as the outer loop did). */
+      for (int k = 0; k < c->nclasses; k++) {
+        int rdcls = k;
+        if (comp_reader_in_chain(c, k, gname, &rdcls) && rdcls == wc) return 1;
       }
     }
     return 0;
@@ -132,7 +143,12 @@ static int recv_has_array_write(Compiler *c, int recv) {
   if (!rnm) return 0;
   Scope *rscope = is_local ? comp_scope_of(c, recv) : NULL;
   const char *wkind = is_ivar ? "InstanceVariableWriteNode" : "LocalVariableWriteNode";
-  for (int id = 0; id < nt->count; id++) {
+  /* Same index, same query shape as recv_has_scalar_numeric_write above. */
+  if (wrn_nt != nt || wrn_ntc != nt->count) wrn_build(c);
+  if (!wrn_buckets) return 0;
+  int qscope = is_local ? (int)(rscope - c->scopes) : -1;
+  unsigned b = wrn_key(rnm, qscope) % (unsigned)wrn_buckets;
+  for (int id = wrn_head[b]; id >= 0; id = wrn_next[id]) {
     const char *ty = nt_type(nt, id);
     if (!ty || !sp_streq(ty, wkind)) continue;
     const char *wnm = nt_str(nt, id, "name");


### PR DESCRIPTION
`recv_has_array_write` (src/analyze_pass.c) answers "does this receiver's slot have a
write that is definitely an array?" by scanning the whole node table — once per `<<`
call site, once per fixpoint iteration. Its reader arm (`obj.list << x`, #3781) crosses
every class with every node, so each such site costs O(classes × nodes) per iteration.

Three functions above it, `recv_has_scalar_numeric_write` asks the same question about
numeric writes and already goes through the name-keyed write index (`wrn_build`). This
PR points `recv_has_array_write` at that same index:

* **ivar/local arm** — walk the `(name, scope)` bucket instead of the table; identical
  query shape to the numeric sibling.
* **reader arm** — drive from the `@<gname>` write bucket (the small side of the join)
  and keep the per-class `comp_reader_in_chain` walk for the "which class defines this
  reader" test, since alias resolution is per-class.

No behavior change intended, and none observed — see below.

### Measurement

On the Roundhouse-emitted lobsters tree from #3115 (297 files, 44k lines of plain Ruby),
macOS/arm64, `spinel main.rb --emit-rbs`:

| | analyze |
|---|---|
| master `79249df8` | 45.5s |
| this PR | **20.3s** |

(A second machine-state pair on the same two commits: 40.1s → 18.3s; the ratio holds
at ~2.2× either way.)

A `sample` profile of master puts 41% of all samples on this helper's call site
(`analyze_pass.c:1902`); after the change it does not appear. Per-pass timing agrees:
`infer_write_types`, which hosts the call, was 15.0s of the 26.1s fixpoint.

The fixpoint converges in the same 17 iterations before and after, so this is pass cost,
not iteration count.

### Equivalence

On that tree, `spinel main.rb -c --rbs .` produces **byte-identical C** before and after
(121,761 lines), and `--emit-rbs` produces byte-identical signatures (6,798 lines).

`make check OPT=-O1`: 2941 pass, 0 fail. `infer-test` reports 7 failures on this branch
and the same 7 on clean `79249df8` — they are grep drift, not inference drift (the greps
want `static mrb_int sp_F_s_add(mrb_int, mrb_int)` and codegen now emits
`static inline __attribute__((always_inline)) mrb_int sp_F_s_add(mrb_int, mrb_int)`; the
inferred types are the ones the test asks for). The two tests that pin this helper's
semantics —
`user_operator_on_block_param.rb` (#3501/#3502) and `narrowed_element_local_pin.rb`
(#3781) — pass.

Refs #3115.
