### PR TITLE
Memoize the "does any user class own this name?" question

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -50,19 +50,74 @@ static int an_nonblock_no_exception(Compiler *c, int id) {
 static int an_builtin_only = 0;
 int an_builtin_only_p(void) { return an_builtin_only; }
 
+/* Name-keyed answer memo, the same shape (and the same staleness argument) as
+   udm_ in an_user_defines_method: the question below crosses every class with
+   the ancestor chain, and infer_call asks it for every poly-receiver call node
+   on every fixpoint iteration -- on a 40k-line program that is hundreds of
+   millions of chain walks for a few thousand distinct answers. The answer only
+   moves when scope or class shape does, which the (gen, nscopes, nclasses)
+   stamp tracks. */
+static char **udr_names = NULL;
+static signed char *udr_ans = NULL;
+static int *udr_next = NULL, *udr_head = NULL;
+static int udr_n = 0, udr_cap = 0;
+static unsigned udr_gen = (unsigned)-1;
+static int udr_nscopes = -1, udr_nclasses = -1;
+static unsigned udr_hash(const char *s) {
+  unsigned h = 2166136261u;
+  while (*s) { h ^= (unsigned char)*s++; h *= 16777619u; }
+  return h;
+}
+
 int an_user_defines_or_reads(Compiler *c, const char *name) {
   if (an_builtin_only) return 0;
   if (!name) return 0;
-  for (int k = 0; k < c->nclasses; k++) {
-    if (comp_method_in_chain(c, k, name, NULL) >= 0) return 1;
-    if (comp_is_reader(&c->classes[k], name)) return 1;
+  /* Outside the frozen fixpoint scope shape can still change without the counts
+     moving (a rename), so neither consult nor populate the memo there. */
+  int memo = comp_scope_index_is_frozen();
+  unsigned b = 0;
+  if (memo) {
+    unsigned gen = comp_scope_index_gen();
+    if (gen != udr_gen || c->nscopes != udr_nscopes || c->nclasses != udr_nclasses) {
+      for (int i = 0; i < udr_n; i++) free(udr_names[i]);
+      udr_n = 0;
+      if (!udr_cap) {
+        udr_cap = 4096;
+        udr_names = malloc(sizeof(char *) * (size_t)udr_cap);
+        udr_ans = malloc((size_t)udr_cap);
+        udr_next = malloc(sizeof(int) * (size_t)udr_cap);
+        udr_head = malloc(sizeof(int) * (size_t)udr_cap);
+        if (!udr_names || !udr_ans || !udr_next || !udr_head) udr_cap = 0;
+      }
+      for (int i = 0; i < udr_cap; i++) udr_head[i] = -1;
+      udr_gen = gen; udr_nscopes = c->nscopes; udr_nclasses = c->nclasses;
+    }
+    if (udr_cap) {
+      b = udr_hash(name) & (unsigned)(udr_cap - 1);
+      for (int i = udr_head[b]; i >= 0; i = udr_next[i])
+        if (sp_streq(udr_names[i], name)) return udr_ans[i];
+    }
+    else memo = 0;
+  }
+  int ans = 0;
+  for (int k = 0; k < c->nclasses && !ans; k++) {
+    if (comp_method_in_chain(c, k, name, NULL) >= 0) ans = 1;
+    else if (comp_is_reader(&c->classes[k], name)) ans = 1;
   }
   /* A CLASS method of the same name is deliberately not consulted: it is only
      reachable through a Class-valued receiver, so it cannot be the answer to
      an instance call. Counting it made `k.downcase` on a String bind to a
      `def self.downcase(s)` elsewhere in the program and compile to the arity
      raise (#3520). */
-  return comp_method_index(c, name) >= 0;
+  if (!ans) ans = comp_method_index(c, name) >= 0;
+  if (memo && udr_n < udr_cap) {
+    udr_names[udr_n] = strdup(name);
+    if (udr_names[udr_n]) {
+      udr_ans[udr_n] = (signed char)ans;
+      udr_next[udr_n] = udr_head[b]; udr_head[b] = udr_n; udr_n++;
+    }
+  }
+  return ans;
 }
 
 void sp_narrow_memo_bump(void) { g_narrow_gen++; }


### PR DESCRIPTION
`an_user_defines_or_reads` (src/analyze_infer.c) answers "does any user class define
or read this name?" by crossing every class with the ancestor chain. `infer_call` asks
it for every poly-receiver call node, on every fixpoint iteration — on the
Roundhouse-emitted lobsters tree from #3115 that comes to **388.7 million**
`comp_method_in_chain` calls for a few thousand distinct answers.

Its sibling `an_user_defines_method` (src/analyze_util.c) already keeps a name-keyed
memo (`udm_`) stamped with (scope-index generation, `nscopes`, `nclasses`), on the
argument that the answer only moves when scope or class shape does. This PR gives
`an_user_defines_or_reads` the same memo, with the same stamp and the same
"not while unfrozen" guard — a rename leaves the counts unchanged, so outside the
frozen fixpoint the memo is neither consulted nor populated. The computation itself is
unchanged.

### Measurement

`spinel main.rb --emit-rbs` on that tree (297 files, 44k lines), macOS/arm64:

| | analyze |
|---|---|
| master `79249df8` | 45.5s → **39.2s** |
| with #3898 also applied | 18.1s → **14.8s** |

The second pair is the more interesting one: #3898 removes a full-table rescan that was
hiding this, and together they take the tree back under the 14.3s it analyzed in at
`b67a1266` (2026-07-22).

### Equivalence

Dumped signatures are byte-identical before and after in both configurations
(6,798 lines).

`make check OPT=-O1`: 2940 pass, 1 fail — `nilclass_bool_ops_conversions`. That test is
**flaky on clean master**: same commit, same command, four runs gave FAIL/FAIL/PASS/FAIL
(and FAIL/PASS on this branch). The emitted C for it is deterministic — two compiles of
the same source byte-match — so the flip is below codegen. Happy to open a separate issue
with the loop if it is not already known.

### One dead end, for the record

Memoizing `comp_method_in_chain` itself — the leaf that topped the profile — was worth
only 6%: at that call volume, hashing the name for the memo lookup becomes the cost.
The saving is in not asking the question, not in answering it faster.

Refs #3115.
