### PR TITLE
Set the int/float flags when a poly receiver converts to a Complex

### DIFF
--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -6208,9 +6208,14 @@ static sp_RbVal sp_poly_to_r_m(sp_RbVal v) {
   sp_raise_cls("NoMethodError", sp_sprintf("undefined method 'to_r' for %s", sp_poly_class_name(v)));
 }
 static sp_RbVal sp_poly_to_c_m(sp_RbVal v) {
-  if (v.tag == SP_TAG_NIL) { sp_Complex z; z.re = 0; z.im = 0; return sp_box_complex(z); }
+  /* fl carries the per-component int/float flag inspect renders from, so it has
+     to be set, not left as whatever the stack held. The typed path is the
+     oracle here: `n.to_c` emits `(sp_Complex){n, 0, <1 for a Float, 0 for an
+     Integer>}`, and a nil receiver answers the all-integer (0+0i). */
+  if (v.tag == SP_TAG_NIL) { sp_Complex z = {0, 0, 0}; return sp_box_complex(z); }
   if (v.tag == SP_TAG_INT || v.tag == SP_TAG_FLT) {
-    sp_Complex z; z.re = sp_poly_to_f(v); z.im = 0; return sp_box_complex(z);
+    sp_Complex z = {sp_poly_to_f(v), 0, (unsigned char)(v.tag == SP_TAG_FLT ? SP_CPLX_RE_F : 0)};
+    return sp_box_complex(z);
   }
   if (v.tag == SP_TAG_STR) return sp_box_complex(sp_str_to_c(v.v.s ? v.v.s : sp_str_empty));
   if (v.tag == SP_TAG_OBJ && v.cls_id == SP_BUILTIN_COMPLEX) return v;


### PR DESCRIPTION
Fixes #3901.

`sp_poly_to_c_m` built its `sp_Complex` by assigning `re` and `im`, leaving `fl` — the
per-component int/float flag `sp_complex_inspect` renders from — holding whatever the
stack held. So whether `nil.to_c` prints `(0+0i)` or `(0.0+0i)` was decided by
uninitialized memory:

```ruby
x = nil
p(x.to_c)    # -O0 → (0+0i)   |  -O1/-O2/-O3 → (0.0+0i)   |  ruby → (0+0i)
p(nil.to_c)  # right everywhere
```

The literal on the second line is unaffected because codegen folds it to
`(sp_Complex){0, 0}`, and a compound literal zero-fills the member the assignments miss.

The typed path is the oracle for what the flags should be — `n.to_c` emits
`(sp_Complex){n, 0, 1}` for a Float receiver and `{n, 0, 0}` for an Integer
(src/codegen_call.c), and a nil receiver answers the all-integer `(0+0i)`. Both arms now
say so, in the same `{re, im, fl}` initializer form the rest of sp_format.c uses.

### Verification

`test/nilclass_bool_ops_conversions.rb` already covers this line, so it is the
regression test rather than a new one:

| | `make OPT=-O1 build/test-results/nilclass_bool_ops_conversions.ok` |
|---|---|
| master `79249df8` | FAIL — 8 runs, 8 failures |
| this PR | PASS — 3 runs |

`make check OPT=-O1`: 2941 pass, 0 fail. (`infer-test` reports its 7 grep-drift failures,
identical on clean `79249df8` — the greps want `static mrb_int f(...)` where codegen now
emits `static inline __attribute__((always_inline)) mrb_int f(...)`; noted in #3898 too.)

That the same test passes on master at `-O2` is what let this sit: an uninitialized byte
moves with unrelated build state, so the failure reads as a flaky test rather than as a
bug. I chased it as a flake first.

I could not build a small program that catches the `SP_TAG_INT` / `SP_TAG_FLT` arm
misrendering — the shapes I tried leave a zero in that stack slot — so those arms are
fixed on the same reasoning rather than on a repro.
