### PR TITLE
Walk the write kinds through the kind index in lazy_alias_chain

### DIFF
--- a/src/analyze_util.c
+++ b/src/analyze_util.c
@@ -377,17 +377,25 @@ int lazy_alias_chain(Compiler *c, int var_read) {
   if (!vn) return -1;
   Scope *sc = comp_scope_of(c, var_read);
   int val = -1;
-  for (int w = 0; w < nt->count; w++) {
-    NodeKind k = nt_kind(nt, w);
-    if (k != NK_LocalVariableWriteNode && k != NK_LocalVariableOrWriteNode &&
-        k != NK_LocalVariableAndWriteNode && k != NK_LocalVariableOperatorWriteNode &&
-        k != NK_LocalVariableTargetNode)
-      continue;
-    const char *wn = nt_str(nt, w, "name");
-    if (!wn || !sp_streq(wn, vn)) continue;
-    if (k != NK_LocalVariableWriteNode || comp_scope_of(c, w) != sc || val >= 0)
-      return -1;   /* not a single plain write */
-    val = nt_ref(nt, w, "value");
+  /* Walk the write kinds through the node table's own kind index rather than
+     rescanning every node: the query runs per lazy-receiver read on every
+     fixpoint iteration, and all five kinds together are a small slice of the
+     table. The answer does not depend on the order writes are visited in --
+     it is "exactly one matching write, plain kind, same scope" -- so taking
+     them kind by kind gives what the linear scan gave. */
+  static const NodeKind LOCAL_WRITE_KINDS[] = {
+    NK_LocalVariableWriteNode, NK_LocalVariableOrWriteNode,
+    NK_LocalVariableAndWriteNode, NK_LocalVariableOperatorWriteNode,
+    NK_LocalVariableTargetNode };
+  for (size_t ki = 0; ki < sizeof LOCAL_WRITE_KINDS / sizeof *LOCAL_WRITE_KINDS; ki++) {
+    NodeKind k = LOCAL_WRITE_KINDS[ki];
+    NT_FOREACH_KIND(nt, k, w) {
+      const char *wn = nt_str(nt, w, "name");
+      if (!wn || !sp_streq(wn, vn)) continue;
+      if (k != NK_LocalVariableWriteNode || comp_scope_of(c, w) != sc || val >= 0)
+        return -1;   /* not a single plain write */
+      val = nt_ref(nt, w, "value");
+    }
   }
   if (val < 0) return -1;
   return chain_is_lazy_valued(c, val) ? val : -1;


### PR DESCRIPTION
`lazy_alias_chain` asks "is this local a single plain write of a lazy chain?", and it
asked by scanning every node in the table and filtering five local-write kinds out of it
— once per lazy-receiver read, on every fixpoint iteration. That is exactly the loop
`nt_nodes_of_kind` documents itself as replacing, so it now walks the five kinds through
`NT_FOREACH_KIND`.

The answer does not depend on the order writes are visited in — it is "exactly one
matching write, of the plain kind, in the same scope" — so taking them kind by kind
gives what the linear scan gave.

### Measurement

On the Roundhouse-emitted lobsters tree from #3115 (297 files, 44k lines),
`spinel main.rb --emit-rbs`, macOS/arm64, alternating the two binaries within each pair:

| | baseline | this PR |
|---|---|---|
| master alone | 40.7 / 41.5s | 41.0 / 41.2s |
| with #3898 and #3900 | 14.9 / 15.1 / 15.5s | **13.4 / 13.4 / 13.6s** |

Worth saying plainly: **on master this is invisible.** The helper is ~1% of analyze until
the full-table rescan in #3898 and the missing memo in #3900 stop hiding it; after those
two it is ~11%. So this is a follow-on to those, not a standalone win.

Dumped signatures are byte-identical in both configurations (6,798 lines).
`make check OPT=-O1`: 2940 pass, 1 fail — `nilclass_bool_ops_conversions`, which is the
uninitialized `sp_Complex.fl` bug of #3901 (this branch is off master, which still has
it; #3902 fixes it). `infer-test`'s 7 failures are the same grep drift as on master,
noted in #3898.

### Two things I tried first

Memoizing the answer per node for the whole compile is worth about twice this, but it is
not sound: `nt_node_set_ref` / `nt_node_set_arr` do not bump `nt->version`, so a pass
that re-points a write's `value` edge would leave the memo stale.

Memoizing per fixpoint iteration instead (the `sp_narrow_memo_bump` generation) is sound
and measured no faster than the unmemoized original — within one iteration each read is
asked about roughly once, so all of the saving lives across iterations, where the cache
cannot safely go. Hence indexing the scan rather than caching its result.

Refs #3115.
