### PR TITLE
Answer IO#tty?, #isatty and #winsize on a poly-carried handle

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -5410,7 +5410,13 @@ else {
       if (sp_streq(name, "resume") || sp_streq(name, "value") || sp_streq(name, "join"))
         return TY_POLY;
       if (sp_streq(name, "alive?") || sp_streq(name, "dead?") || sp_streq(name, "closed?") ||
-          sp_streq(name, "eof?")) return TY_BOOL;
+          sp_streq(name, "eof?") || sp_streq(name, "tty?") || sp_streq(name, "isatty"))
+        return TY_BOOL;
+      /* IO#winsize on a poly-carried handle: [rows, cols], same as the TY_IO
+         arm. Without this the call falls through to a plain poly result and the
+         `size[0]` that follows reads it as an untyped value. */
+      if (sp_streq(name, "winsize") && sp_feature_enabled("io/console"))
+        return TY_INT_ARRAY;
       if (sp_streq(name, "read") || sp_streq(name, "gets") ||
           sp_streq(name, "readline")) return TY_STRING;
       if (sp_streq(name, "write")) return TY_INT;   /* IO#write: the byte count */

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -12929,6 +12929,8 @@ void emit_call(Compiler *c, int id, Buf *b) {
           their own arms. */
        sp_streq(name, "puts") || sp_streq(name, "print") || sp_streq(name, "putc") ||
        sp_streq(name, "eof?") || sp_streq(name, "closed?") || sp_streq(name, "path") ||
+       sp_streq(name, "tty?") || sp_streq(name, "isatty") ||
+       (sp_streq(name, "winsize") && sp_feature_enabled("io/console")) ||
        sp_streq(name, "readlines") || sp_streq(name, "rewind") || sp_streq(name, "sync"))) {
     int iocand = 0;
     for (int k = 0; k < c->nclasses && !iocand; k++)
@@ -12980,6 +12982,9 @@ void emit_call(Compiler *c, int id, Buf *b) {
       }
       else if (sp_streq(name, "eof?")) buf_printf(b, "sp_File_eof_p(_t%d); })", tio2);
       else if (sp_streq(name, "closed?")) buf_printf(b, "sp_File_closed_p(_t%d); })", tio2);
+      else if (sp_streq(name, "tty?") || sp_streq(name, "isatty"))
+        buf_printf(b, "sp_File_tty_p(_t%d); })", tio2);
+      else if (sp_streq(name, "winsize")) buf_printf(b, "sp_File_winsize(_t%d); })", tio2);
       else if (sp_streq(name, "path")) buf_printf(b, "sp_File_path(_t%d); })", tio2);
       else if (sp_streq(name, "readlines")) buf_printf(b, "sp_File_readlines(_t%d); })", tio2);
       else if (sp_streq(name, "rewind")) buf_printf(b, "sp_File_rewind(_t%d); })", tio2);

--- a/test/io_tty_winsize_poly_handle.rb
+++ b/test/io_tty_winsize_poly_handle.rb
@@ -1,0 +1,65 @@
+# IO#tty? and IO#winsize on a poly-carried handle.
+#
+# Both names reach the IO arm only when the receiver is statically typed IO.
+# A handle read out of a container, or a parameter whose call sites disagree,
+# is carried as poly, and the poly-dispatch allowlist has to name the method
+# or the call answers NoMethodError for a value that IS an IO.
+#
+# What is pinned is reachability, not any particular terminal geometry: the
+# test runs with stdout redirected to a file, so it must not depend on a tty
+# existing. winsize is only asserted to answer WITHOUT NoMethodError, because
+# a non-tty answer legitimately differs between the engines (CRuby raises
+# Errno::ENOTTY; Spinel reports zeroes from the ioctl).
+require "io/console"
+
+def winsize_reachable?(stream)
+  size = stream.winsize
+  size.is_a?(Array)
+rescue NoMethodError
+  false          # the bug: an IO that claims not to know the method
+rescue StandardError
+  true           # ENOTTY and friends: reached the method, no tty to measure
+end
+
+File.write("/tmp/sp_ttyws.txt", "x")
+
+# A block parameter over a literal array: the shape that regressed.
+[STDOUT].each { |s| p s.tty?.class }
+
+# A file handle out of a container answers false, not NoMethodError.
+File.open("/tmp/sp_ttyws.txt") do |f|
+  [f].each { |s| p s.tty? }
+  handles = [f, f]
+  p handles[0].tty?
+  p handles.first.tty?
+  [f].each { |s| p winsize_reachable?(s) }
+end
+
+# Two call sites that disagree degrade the parameter to poly. The IO site
+# must keep working: this is what silently broke a winsize probe that also
+# accepted IO.console's (untyped) result.
+def probe_tty(stream)
+  stream.tty?
+rescue NoMethodError
+  :no_method
+end
+
+def untyped
+  IO.console
+rescue StandardError
+  nil
+end
+
+File.open("/tmp/sp_ttyws.txt") do |f|
+  p probe_tty(f)
+  p winsize_reachable?(f)
+end
+other = untyped
+p probe_tty(other).equal?(:no_method) == false || other.nil?
+
+# isatty is the same method under its second name.
+File.open("/tmp/sp_ttyws.txt") do |f|
+  [f].each { |s| p s.isatty }
+end
+
+File.delete("/tmp/sp_ttyws.txt")

--- a/test/io_tty_winsize_poly_handle.rb.expected
+++ b/test/io_tty_winsize_poly_handle.rb.expected
@@ -1,0 +1,9 @@
+FalseClass
+false
+false
+false
+true
+false
+true
+true
+false


### PR DESCRIPTION
`tty?`, `isatty` and `winsize` reach their IO implementation only when the receiver is statically typed IO. A handle that arrives as **poly** — read back out of a container, or a parameter whose call sites disagree — misses the poly-dispatch allowlist entirely, so the call answers

```
undefined method 'tty?' for an instance of IO (NoMethodError)
```

for a value that genuinely *is* an IO.

Smallest reproduction, on current master:

```ruby
[STDOUT].each { |s| p s.tty? }
```

```
undefined method 'tty?' for an instance of IO (NoMethodError)
```

CRuby prints `false`.

## The fix

Two places had to agree, matching how the neighbouring IO predicates (`eof?`, `closed?`, `path`, `rewind`, …) are already handled:

- **`src/codegen_call.c`** — names the three methods in the poly-receiver allowlist and emits the existing `sp_File_tty_p` / `sp_File_winsize` runtime helpers. Both were already present in `lib/sp_io.c` and already reachable from the statically-typed arm; only the poly path could not get to them.
- **`src/analyze_infer.c`** — types them, so a following `size[0]` reads an int array rather than an untyped poly value. `tty?`/`isatty` join the `TY_BOOL` predicates; `winsize` answers `TY_INT_ARRAY` under the `io/console` feature guard, the same shape the `TY_IO` arm gives.

`winsize` needed the inference half specifically: without it the call falls through to a plain poly result and the indexing that almost always follows it reads an untyped value.

## Test

`test/io_tty_winsize_poly_handle.rb` covers the shapes that degrade a handle to poly: a literal-array block parameter, a container read (`handles[0]`, `handles.first`), and a parameter with two disagreeing call sites (one `File`, one `IO.console`). `isatty` is exercised as the second name for the same method.

The test pins **reachability, not terminal geometry**. It runs with stdout redirected to a file, so it must not assume a tty exists — `winsize` is asserted only to answer *without* `NoMethodError`. A non-tty answer legitimately differs between the engines (CRuby raises `Errno::ENOTTY`; Spinel reports zeroes from the ioctl), and the helper accepts either:

```ruby
rescue NoMethodError
  false          # the bug: an IO that claims not to know the method
rescue StandardError
  true           # ENOTTY and friends: reached the method, no tty to measure
```

## Verification

Against master at `e05feeb9`:

- Test is **RED before / GREEN after** — output byte-identical to CRuby (`FalseClass false false false true false true true false`).
- Full corpus with the patch: **2958 pass, 0 fail, 7 error**.
- Those same 7 (`fiber_kill`, `thread_gc_start`, `thread_condvar`, `thread_mutex`, `thread_kill_raise`, `monitor_reentrant`, `block_tail_prelude_inside`) error **identically on unpatched master** — pre-existing and unrelated, all thread/fiber tests.

One caveat on CI, unchanged from my earlier PRs: `make test` aborts at `Makefile:552` because `rbs-seed-test` fails on clean master (#3203) before the corpus runs. The corpus numbers above come from building the `TEST_TARGETS` directly to get past that gate. If the check comes back red, that is the reason, not this change.
