### PR TITLE
codegen: add :ptr type for native_c_type() raw pointer passthrough

### DIFF
--- a/src/codegen_util.c
+++ b/src/codegen_util.c
@@ -998,6 +998,7 @@ int ty_is_struct_valued(TyKind t) {
 const char *native_c_type(const char *spec) {
   if (!spec) return "void";
   if (sp_streq(spec, "any"))    return "sp_RbVal";
+  if (sp_streq(spec, "ptr"))    return "void *";   /* raw pointer passthrough */
   if (sp_streq(spec, "string")) return "const char *";
   if (sp_streq(spec, "string?")) return "const char *";  /* nullable; call site wraps */
   if (sp_streq(spec, "nstring")) return "const char *";   /* NULL-able string, unboxed */


### PR DESCRIPTION
Currently `native_c_type()` in `src/codegen_util.c` lacks a case for the `:ptr` type spec, causing it to fall through to the default `sp_RbVal` return. This breaks native FFI calls that need to pass raw pointers (e.g., `:ptr` args for `native_new`/`native_method`).

When a package declares:
```ruby
native_new [:ptr, :ptr], "sp_SSLSocket_new"
```

The generated C extern declares `sp_SSLSocket_new(mrb_int, sp_RbVal, sp_RbVal)` instead of `sp_SSLSocket_new(mrb_int, void *, void *)`. On x86_64 System V ABI, passing two 16-byte `sp_RbVal` structs by value causes register/stack layout mismatches between caller and callee - the callee reads garbage pointer values.

This change adds:
```c
if (sp_streq(spec, "ptr"))    return "void *";   /* raw pointer passthrough */
```

so `:ptr` arguments generate correct `void *` parameters, matching how the generated call site passes unboxed pointers
(e.g., `sp_SSLSocket_new(8, lv_sock, lv_ctx)` where `lv_sock` is `sp_File*` and `lv_ctx` is `sp_SSLContext*`).