### PR TITLE
Implement CRuby's implicit conversion protocol (#to_str / #to_int) at builtin boundaries

### DIFF
--- a/lib/sp_gc.c
+++ b/lib/sp_gc.c
@@ -57,6 +57,9 @@ int (*sp_obj_is_data_fn)(int) = NULL;
 sp_RbVal (*sp_obj_with_fn)(sp_RbVal, sp_RbVal) = NULL;
 const char *(*sp_obj_inspect_fn)(int cls_id, void *p) = NULL;
 const char *(*sp_obj_to_s_fn)(int cls_id, void *p) = NULL;
+sp_int (*sp_obj_to_int_fn)(int cls_id, void *p, int *ok) = NULL;
+const char *(*sp_obj_to_str_fn)(int cls_id, void *p) = NULL;
+const char *(*sp_obj_cls_name_fn)(int cls_id) = NULL;
 sp_marshal_vt sp_marshal_v = {0};   /* filled by the generated TU (sp_re_init) */
 
 /* ---- Collector-private globals ---- */

--- a/lib/sp_gc.h
+++ b/lib/sp_gc.h
@@ -349,6 +349,15 @@ extern const char *(*sp_obj_inspect_fn)(int cls_id, void *p);
 /* Same shape for user #to_s: sp_poly_to_s's OBJ default consults it so a
    boxed user object with a custom to_s renders through it. */
 extern const char *(*sp_obj_to_s_fn)(int cls_id, void *p);
+/* CRuby's implicit conversion protocol on BOXED user objects: the runtime's
+   Integer/String conversion sites (pack, typed-slot coercions) reach a
+   compiled #to_int / #to_str through these. A class without the method is
+   the default arm (*ok = 0 / NULL) and the caller raises CRuby's TypeError. */
+extern sp_int (*sp_obj_to_int_fn)(int cls_id, void *p, int *ok);
+extern const char *(*sp_obj_to_str_fn)(int cls_id, void *p);
+/* Ruby class name for a user cls_id (the generated id->name table), so a
+   runtime TU can word a TypeError the way CRuby does. */
+extern const char *(*sp_obj_cls_name_fn)(int cls_id);
 
 /* ---- Hot inline mark helpers (inlined into both sides) ----
  * String tag bytes: 0xfe heap-unmarked -> 0xfc marked; others skipped. */

--- a/lib/sp_pack.c
+++ b/lib/sp_pack.c
@@ -220,15 +220,42 @@ static int64_t pk_flt_to_int(double dv) {
   return (int64_t)(dv < 0 ? 0 - u : u);
 }
 
+/* The wording CRuby uses when a value cannot become an Integer: special
+   constants by their inspect (nil / true / false), everything else by class. */
+static const char *pk_val_name(sp_RbVal v) {
+  switch (v.tag) {
+    case SP_TAG_NIL:  return "nil";
+    case SP_TAG_BOOL: return v.v.b ? "true" : "false";
+    case SP_TAG_STR:  return "String";
+    case SP_TAG_SYM:  return "Symbol";
+    case SP_TAG_OBJ:
+      if (v.cls_id >= 0 && sp_obj_cls_name_fn) return sp_obj_cls_name_fn((int)v.cls_id);
+      return "Object";
+    default:          return "Object";
+  }
+}
+
+int64_t sp_bigint_to_int(sp_Bigint *b);  /* wraps mod 2^64, as pack does */
+
 static int64_t pk_poly_to_int(sp_RbVal v) {
   switch (v.tag) {
-    case SP_TAG_INT:  return v.v.i;
-    case SP_TAG_BOOL: return v.v.b ? 1 : 0;
-    case SP_TAG_FLT:  return pk_flt_to_int(v.v.f);
-    case SP_TAG_STR:  return v.v.s ? strtoll(v.v.s, NULL, 0) : 0;
-    case SP_TAG_NIL:  return 0;
-    default:          return 0;
+    case SP_TAG_INT:    return v.v.i;
+    case SP_TAG_FLT:    return pk_flt_to_int(v.v.f);
+    case SP_TAG_BIGINT: return sp_bigint_to_int((sp_Bigint *)v.v.p);
+    case SP_TAG_OBJ:
+      /* a user object converts through its compiled #to_int (the generated
+         bridge); one without the method falls through to CRuby's TypeError */
+      if (v.cls_id >= 0 && v.v.p && sp_obj_to_int_fn) {
+        int ok = 0;
+        int64_t r = sp_obj_to_int_fn((int)v.cls_id, v.v.p, &ok);
+        if (ok) return r;
+      }
+      break;
+    default: break;
   }
+  sp_raise_cls("TypeError",
+               sp_sprintf("no implicit conversion of %s into Integer", pk_val_name(v)));
+  return 0;
 }
 
 static double pk_poly_to_flt(sp_RbVal v) {
@@ -794,6 +821,11 @@ const char *sp_StrArray_pack(sp_StrArray *arr, const char *fmt) {
     }
     else if (spec == 'H' || spec == 'h' || spec == 'B' || spec == 'b' || spec == 'u') {
       pk_str_bytes_directive(spec, count, s, sl, &buf, &len, &cap);
+    }
+    else if (strchr("cCsSlLqQnNvVjJiIfdeEgGUw", spec)) {
+      /* a numeric directive cannot take a String element: CRuby's TypeError
+         (the directive was silently dropped before) */
+      sp_raise_cls("TypeError", "no implicit conversion of String into Integer");
     }
   }
   char *r = sp_str_alloc(len);

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -5380,6 +5380,52 @@ static void emit_obj_with_dispatch(Compiler *c, Buf *b) {
    so nested containers, strings (quoted), nil and nested objects (via the
    sp_obj_inspect_fn hook recursion) all render like CRuby's
    #<Name:0xADDR @a=1, @b="x">. Mirrors sp_marshal_obj_dump's shape. */
+/* One conversion-bridge switch (see the caller's comment): forward decls for
+   every callee it names, then the cls_id switch. `with_ok` adds the *ok
+   out-flag the sp_int form needs (NULL can carry "no method" for a string). */
+static int conv_bridge_callee(Compiler *c, int i, const char *mname, TyKind want,
+                              int *out_mi) {
+  ClassInfo *ci2 = &c->classes[i];
+  if (is_builtin_reopen(ci2->name) || ci2->is_native_class) return -1;
+  if (comp_ty_value_obj(c, ty_object(i))) return -1;
+  int dn = ci2->def_node;
+  const char *dt = dn >= 0 ? nt_type(c->nt, dn) : NULL;
+  if (dt && sp_streq(dt, "ModuleNode")) return -1;   /* no instances */
+  int tdef = -1;
+  int tmi = comp_method_in_chain(c, i, mname, &tdef);
+  if (tmi < 0 || !c->scopes[tmi].reachable || c->scopes[tmi].ret != want ||
+      c->scopes[tmi].nparams != 0) return -1;
+  int ddn = c->classes[tdef].def_node;
+  const char *ddt = ddn >= 0 ? nt_type(c->nt, ddn) : NULL;
+  *out_mi = tmi;
+  /* a module def is copied into the includer; an ancestor CLASS def is one
+     real function the child casts into */
+  return (ddt && sp_streq(ddt, "ModuleNode")) ? i : tdef;
+}
+static void emit_conv_bridge(Compiler *c, Buf *b, const char *mname, TyKind want,
+                             const char *rett, const char *sig, int with_ok,
+                             const char *dflt) {
+  for (int i = 0; i < c->nclasses; i++) {
+    int tmi = -1;
+    int callee = conv_bridge_callee(c, i, mname, want, &tmi);
+    if (callee != i) continue;   /* an ancestor's own row declares it */
+    buf_printf(b, "%s%s sp_%s_%s(sp_%s *self);\n", g_debug ? "" : "static ",
+               rett, c->classes[callee].c_name, mc(c->scopes[tmi].name),
+               c->classes[callee].c_name);
+  }
+  buf_printf(b, "%s {\n  switch (cls_id) {\n", sig);
+  for (int i = 0; i < c->nclasses; i++) {
+    int tmi = -1;
+    int callee = conv_bridge_callee(c, i, mname, want, &tmi);
+    if (callee < 0) continue;
+    buf_printf(b, "    case %d: %sreturn sp_%s_%s((sp_%s *)p);\n",
+               i, with_ok ? "*ok = 1; " : "",
+               c->classes[callee].c_name, mc(c->scopes[tmi].name),
+               c->classes[callee].c_name);
+  }
+  buf_printf(b, "    default: %s\n  }\n}\n", dflt);
+}
+
 static int class_inspectable(Compiler *c, int i) {
   ClassInfo *ci = &c->classes[i];
   if (is_builtin_reopen(ci->name)) return 0;
@@ -5425,6 +5471,22 @@ static void emit_obj_inspect_dispatch(Compiler *c, Buf *b) {
                i, c->classes[tdef].c_name, mc(c->scopes[tmi].name), c->classes[tdef].c_name);
   }
   buf_puts(b, "    default: return NULL;\n  }\n}\n");
+  /* user #to_int / #to_str bridges: the runtime's implicit-conversion sites
+     (pack and friends) reach a compiled conversion method on a BOXED object
+     through these; a class without one falls to the default (not-ok / NULL)
+     and the caller raises CRuby's TypeError. Same shape as the #to_s
+     dispatcher above, with two extra rules: a module row has no instances
+     (and no standalone body -- module methods are copied per includer), so
+     module rows are skipped, and a def that RESOLVES to a module calls the
+     includer's own copy. */
+  emit_conv_bridge(c, b, "to_int", TY_INT,
+                   "sp_int", "static sp_int sp_obj_to_int_sw(int cls_id, void *p, int *ok)",
+                   1, "*ok = 0; return 0;");
+  emit_conv_bridge(c, b, "to_str", TY_STRING,
+                   "const char *", "static const char *sp_obj_to_str_sw(int cls_id, void *p)",
+                   0, "return NULL;");
+  buf_puts(b, "static const char *sp_obj_cls_name_rt(int cls_id) {\n"
+              "  sp_Class _c = {cls_id}; return sp_class_to_s(_c);\n}\n");
   buf_puts(b, "static const char *sp_obj_inspect_sw(int cls_id, void *p) {\n");
   buf_puts(b, "  switch (cls_id) {\n");
   for (int i = 0; i < c->nclasses; i++) {
@@ -6442,6 +6504,9 @@ void emit_regex_section(Compiler *c, Buf *b) {
   if (g_emit_obj_dispatch) {
     buf_puts(b, "  sp_obj_inspect_fn = sp_obj_inspect_sw;\n");
     buf_puts(b, "  sp_obj_to_s_fn = sp_obj_to_s_sw;\n");
+    buf_puts(b, "  sp_obj_to_int_fn = sp_obj_to_int_sw;\n");
+    buf_puts(b, "  sp_obj_to_str_fn = sp_obj_to_str_sw;\n");
+    buf_puts(b, "  sp_obj_cls_name_fn = sp_obj_cls_name_rt;\n");
   }
   if (g_uses_marshal) {
     buf_puts(b,
@@ -8029,6 +8094,9 @@ char *codegen_program(const NodeTable *nt) {
   if (g_emit_obj_dispatch) {
     buf_puts(&b, "static const char *sp_obj_inspect_sw(int cls_id, void *p) __attribute__((cold, noinline));\n");
     buf_puts(&b, "static const char *sp_obj_to_s_sw(int cls_id, void *p) __attribute__((cold, noinline));\n");
+    buf_puts(&b, "static sp_int sp_obj_to_int_sw(int cls_id, void *p, int *ok) __attribute__((cold, noinline));\n");
+    buf_puts(&b, "static const char *sp_obj_to_str_sw(int cls_id, void *p) __attribute__((cold, noinline));\n");
+    buf_puts(&b, "static const char *sp_obj_cls_name_rt(int cls_id) __attribute__((cold, noinline));\n");
   }
   /* The #message / #to_s dispatchers below call these bodies unconditionally,
      so a program that defines an override without ever querying it left the

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -245,6 +245,41 @@ TyKind yield_site_type(Compiler *c, int node) {
   return (t == TY_UNKNOWN || t == TY_VOID || t == TY_NIL) ? u : t;
 }
 
+/* A user object in a concretely-typed slot: CRuby's implicit conversion
+   protocol. The argument's class is static here, so a class defining the
+   conversion method (#to_str for a const char* slot, #to_int for sp_int)
+   converts through a DIRECT call to the compiled method; a class without it
+   is CRuby's TypeError ("no implicit conversion of X into Y") -- where the
+   raw object pointer previously went into the scalar slot and stopped the C
+   build. Handles only a conversion method taking no parameters whose static
+   return type is the slot's type; anything else keeps the prior behavior.
+   Returns 1 when it emitted, 0 to fall through. */
+static int emit_obj_conv(Compiler *c, int node, const char *conv, TyKind want,
+                         const char *into, const char *zero, Buf *b) {
+  TyKind t = comp_ntype(c, node);
+  if (!ty_is_object(t)) return 0;
+  int cid = ty_object_class(t);
+  if (cid < 0 || cid >= c->nclasses) return 0;
+  int def = -1, mi = comp_method_in_chain(c, cid, conv, &def);
+  if (mi >= 0) {
+    Scope *um = &c->scopes[mi];
+    if (um->ret != want || um->nparams != 0) return 0;
+    buf_printf(b, "sp_%s_%s(", c->classes[def].c_name, mc(conv));
+    if (!comp_ty_value_obj(c, t)) buf_printf(b, "(sp_%s *)", c->classes[def].c_name);
+    buf_puts(b, "(");
+    emit_expr(c, node, b);
+    buf_puts(b, "))");
+    return 1;
+  }
+  const char *cn = class_ruby_name(c, cid);
+  buf_puts(b, "({ (void)(");
+  emit_expr(c, node, b);
+  buf_printf(b, "); sp_raise_cls(\"TypeError\","
+                " (&(\"\\xff\" \"no implicit conversion of %s into %s\")[1])); %s; })",
+             cn ? cn : "Object", into, zero);
+  return 1;
+}
+
 void emit_int_expr(Compiler *c, int node, Buf *b) {
   const char *nty = nt_type(c->nt, node);
   /* `*a` forwarded into a scalar int slot (a builtin arg): the value is the
@@ -274,6 +309,7 @@ void emit_int_expr(Compiler *c, int node, Buf *b) {
     buf_puts(b, "(sp_int)("); emit_scalar_operand(c, node, "0", b); buf_puts(b, ")");
     return;
   }
+  if (emit_obj_conv(c, node, "to_int", TY_INT, "Integer", "(sp_int)0", b)) return;
   emit_scalar_operand(c, node, "0", b);
 }
 
@@ -320,6 +356,7 @@ void emit_str_expr(Compiler *c, int node, Buf *b) {
     buf_puts(b, "sp_poly_to_s("); emit_expr(c, node, b); buf_puts(b, ")");
     return;
   }
+  if (emit_obj_conv(c, node, "to_str", TY_STRING, "String", "(const char *)0", b)) return;
   /* The unresolved-call gate's sp_raise_nomethod(...) is a side-effecting poly
      value (it raises): coerce it to the const char* slot, keeping the call,
      rather than passing the sp_RbVal through raw (doom's

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -19706,7 +19706,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
         (sp_streq(name, "match?") || sp_streq(name, "match"))) {
       int ts = ++g_tmp;
       const char *fn = sp_streq(name, "match?") ? "sp_re_match_p" : "sp_re_matchdata";
-      buf_printf(b, "({ const char *_t%d = ", ts); emit_expr(c, argv[0], b);
+      buf_printf(b, "({ const char *_t%d = ", ts); emit_str_expr(c, argv[0], b);
       buf_printf(b, "; mrb_regexp_pattern *_t%dp = re_compile(_t%d, (int64_t)strlen(_t%d ? _t%d : \"\"), 0); ",
                  ts, ts, ts, ts);
       buf_printf(b, "%s(_t%dp, ", fn, ts); emit_expr(c, recv, b); buf_puts(b, "); })");

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -5468,6 +5468,11 @@ void native_arg_check(Compiler *c, int id, const char *what, NativeMethod *m,
                       got == TY_SYMBOL || got == TY_BIGINT);
     int bad = (want_scalar && !got_scalar) ||
               (want == TY_STRING && got != TY_STRING && got != TY_STRBUF);
+    /* a user object reaches a string/int slot through the typed-slot
+       emitters, which carry the implicit conversion protocol: #to_str /
+       #to_int converts, anything else raises CRuby's TypeError at run
+       time -- either way the emitted C is well-typed */
+    if (bad && ty_is_object(got) && (want == TY_STRING || want == TY_INT)) bad = 0;
     if (!bad) continue;
     char msg[256];
     snprintf(msg, sizeof msg, "%s `%s` argument %d (declared :%s, given %s)",
@@ -5492,10 +5497,12 @@ int emit_native_ctor(Compiler *c, int id, int ci, int argc, const int *argv, Buf
   buf_printf(b, "%s(%d", m->csym, ci);
   for (int ai = 0; ai < m->nargs && ai < argc; ai++) {
     buf_puts(b, ", ");
+    TyKind aw = ffi_spec_to_ty(m->args[ai]);
     if (sp_streq(m->args[ai], "any")) emit_boxed(c, argv[ai], b);
-    else if (sp_streq(m->args[ai], "string") && comp_ntype(c, argv[ai]) == TY_POLY) {
-      buf_puts(b, "sp_poly_to_s("); emit_expr(c, argv[ai], b); buf_puts(b, ")");
-    }
+    /* the typed-slot emitters carry the implicit conversion protocol
+       (poly unboxing, #to_str / #to_int on a user object) */
+    else if (aw == TY_STRING) emit_str_expr(c, argv[ai], b);
+    else if (aw == TY_INT) emit_int_expr(c, argv[ai], b);
     else emit_expr(c, argv[ai], b);
   }
   buf_puts(b, ")");

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -18547,10 +18547,10 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       buf_puts(b, "sp_dir_glob("); emit_str_expr(c, argv[0], b); buf_puts(b, ")"); return;
     }
     if ((sp_streq(name, "entries") || sp_streq(name, "children")) && argc == 1) {
-      buf_printf(b, "sp_dir_%s(", name); emit_expr(c, argv[0], b); buf_puts(b, ")"); return;
+      buf_printf(b, "sp_dir_%s(", name); emit_str_expr(c, argv[0], b); buf_puts(b, ")"); return;
     }
     if ((sp_streq(name, "mkdir") || sp_streq(name, "rmdir") || sp_streq(name, "chdir")) && argc >= 1) {
-      buf_printf(b, "sp_dir_%s(", name); emit_expr(c, argv[0], b); buf_puts(b, ")"); return;
+      buf_printf(b, "sp_dir_%s(", name); emit_str_expr(c, argv[0], b); buf_puts(b, ")"); return;
     }
   }
 

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -6559,9 +6559,8 @@ static int emit_class_new_call(Compiler *c, int id, Buf *b) {
           }
           else {
             buf_puts(b, "sp_Random_new(");
-            if (is_big) buf_puts(b, "sp_bigint_to_int(");
-            emit_expr(c, argv[0], b);
-            if (is_big) buf_puts(b, ")");
+            if (is_big) { buf_puts(b, "sp_bigint_to_int("); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+            else emit_int_expr(c, argv[0], b);
             buf_puts(b, ")");
           }
         }
@@ -13368,7 +13367,7 @@ void emit_call(Compiler *c, int id, Buf *b) {
         emit_int_expr(c, argv[0], b);
         buf_printf(b, "); lv_%s = _t%d; _t%d; })", bnm ? rename_local(bnm) : "?", trd, trd);
       }
-      else { buf_puts(b, "sp_File_read_n("); buf_puts(b, r); buf_puts(b, ", "); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+      else { buf_puts(b, "sp_File_read_n("); buf_puts(b, r); buf_puts(b, ", "); emit_int_expr(c, argv[0], b); buf_puts(b, ")"); }
       free(rb.p); return;
     }
     if (sp_streq(name, "gets") || sp_streq(name, "readline")) {
@@ -18175,12 +18174,12 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     }
     if ((sp_streq(name, "fnmatch") || sp_streq(name, "fnmatch?")) && argc >= 2) {
       buf_puts(b, "sp_file_fnmatch("); emit_str_expr(c, argv[0], b); buf_puts(b, ", ");
-      emit_expr(c, argv[1], b); buf_puts(b, ")"); return;
+      emit_str_expr(c, argv[1], b); buf_puts(b, ")"); return;
     }
     if (sp_streq(name, "dirname") && argc == 2) {
       /* File.dirname(path, level): apply dirname `level` times (#2787) */
       int td = ++g_tmp, ti2 = ++g_tmp;
-      buf_printf(b, "({ const char *_t%d = ", td); emit_expr(c, argv[0], b);
+      buf_printf(b, "({ const char *_t%d = ", td); emit_str_expr(c, argv[0], b);
       buf_printf(b, "; sp_int _tl%d = ", td); emit_int_expr(c, argv[1], b);
       buf_printf(b, "; for (sp_int _t%d = 0; _t%d < _tl%d; _t%d++) _t%d = sp_file_dirname(_t%d); _t%d; })",
                  ti2, ti2, td, ti2, td, td, td);
@@ -18189,7 +18188,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     /* chmod / truncate (#2778) */
     if (sp_streq(name, "chmod") && argc == 2) {
       buf_puts(b, "sp_file_chmod("); emit_int_expr(c, argv[0], b); buf_puts(b, ", ");
-      emit_expr(c, argv[1], b); buf_puts(b, ")"); return;
+      emit_str_expr(c, argv[1], b); buf_puts(b, ")"); return;
     }
     if (sp_streq(name, "truncate") && argc == 2) {
       buf_puts(b, "sp_file_truncate("); emit_str_expr(c, argv[0], b); buf_puts(b, ", ");
@@ -18203,7 +18202,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
         if (mv >= 0) {
           buf_puts(b, "sp_file_write_mode("); emit_str_expr(c, argv[0], b); buf_puts(b, ", ");
           emit_str_expr(c, argv[1], b); buf_puts(b, ", ");
-          emit_expr(c, mv, b); buf_puts(b, ")");
+          emit_str_expr(c, mv, b); buf_puts(b, ")");
           return;
         }
       }
@@ -18216,7 +18215,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     }
     if ((sp_streq(name, "write") || sp_streq(name, "binwrite")) && argc == 2) {
       /* runtime write is void; Ruby returns the byte count */
-      buf_puts(b, "({ const char *_wp = "); emit_expr(c, argv[0], b);
+      buf_puts(b, "({ const char *_wp = "); emit_str_expr(c, argv[0], b);
       buf_puts(b, "; const char *_wd = ");
       if (comp_ntype(c, argv[1]) == TY_POLY) {
         buf_puts(b, "sp_poly_to_s("); emit_expr(c, argv[1], b); buf_puts(b, ")");
@@ -18239,7 +18238,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     if ((sp_streq(name, "readable_real?") || sp_streq(name, "writable_real?") ||
          sp_streq(name, "executable_real?")) && argc == 1) {
       buf_printf(b, "sp_file_%.*s_real(", (int)(strlen(name) - 6), name);
-      emit_expr(c, argv[0], b); buf_puts(b, ")"); return;
+      emit_str_expr(c, argv[0], b); buf_puts(b, ")"); return;
     }
     if (sp_streq(name, "directory?") && argc == 1) {
       buf_puts(b, "sp_file_directory("); emit_str_expr(c, argv[0], b); buf_puts(b, ")"); return;
@@ -18302,7 +18301,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       buf_printf(b, "(sp_int)%d; })", argc - 2); return;
     }
     if (sp_streq(name, "file?") && argc == 1) {
-      buf_puts(b, "(!sp_file_directory("); emit_expr(c, argv[0], b); buf_puts(b, ") && sp_file_exist("); emit_expr(c, argv[0], b); buf_puts(b, "))"); return;
+      buf_puts(b, "(!sp_file_directory("); emit_str_expr(c, argv[0], b); buf_puts(b, ") && sp_file_exist("); emit_str_expr(c, argv[0], b); buf_puts(b, "))"); return;
     }
     if ((sp_streq(name, "delete") || sp_streq(name, "unlink")) && argc >= 1) {
       buf_puts(b, "({ ");
@@ -18312,7 +18311,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       buf_printf(b, "(sp_int)%d; })", argc); return;
     }
     if (sp_streq(name, "rename") && argc == 2) {
-      buf_puts(b, "({ sp_file_rename("); emit_expr(c, argv[0], b); buf_puts(b, ", ");
+      buf_puts(b, "({ sp_file_rename("); emit_str_expr(c, argv[0], b); buf_puts(b, ", ");
       emit_expr(c, argv[1], b); buf_puts(b, "); (sp_int)0; })"); return;
     }
     if (sp_streq(name, "mtime") && argc == 1) {
@@ -18362,14 +18361,14 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       }
       if (csep >= 0) {
         buf_puts(b, "sp_file_readlines_sep(");
-        emit_expr(c, argv[0], b); buf_puts(b, ", ");
-        emit_expr(c, csep, b);
+        emit_str_expr(c, argv[0], b); buf_puts(b, ", ");
+        emit_str_expr(c, csep, b);
         buf_printf(b, ", %d)", chomp);
         return;
       }
       if (chomp) buf_puts(b, "sp_file_readlines_chomp(");
       else buf_puts(b, "sp_file_readlines(");
-      emit_expr(c, argv[0], b); buf_puts(b, ")"); return;
+      emit_str_expr(c, argv[0], b); buf_puts(b, ")"); return;
     }
     /* File.open(path, mode) / File.new(path, mode) without block -> TY_IO
        handle. The mode may be a string, an integer flag word (#2788), or a
@@ -18505,7 +18504,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       int dscalar = is_scalar_ret(dres) && dres != TY_VOID && dres != TY_NIL && dres != TY_UNKNOWN;
       int td = ++g_tmp, tdv = ++g_tmp;
       buf_puts(b, "({ ");
-      buf_printf(b, "sp_Dir *_t%d = sp_Dir_new(", td); emit_expr(c, argv[0], b); buf_puts(b, "); ");
+      buf_printf(b, "sp_Dir *_t%d = sp_Dir_new(", td); emit_str_expr(c, argv[0], b); buf_puts(b, "); ");
       buf_printf(b, "SP_GC_ROOT(_t%d); ", td);
       if (dpn) buf_printf(b, "sp_Dir *lv_%s = _t%d; ", dpn, td);
       for (int k = 0; k < dbn - 1; k++) emit_stmt(c, dbb[k], b, 0);
@@ -19367,7 +19366,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     if (rre >= 0 && sp_streq(name, "match?") && argc == 1) {
       /* /re/.match?(str): a match boolean that leaves $~ alone (CRuby) */
       if (a0 == TY_POLY) { buf_printf(b, "sp_re_match_p(sp_re_pat_%d, sp_poly_to_s(", rre); emit_expr(c, argv[0], b); buf_puts(b, "))"); }
-      else { buf_printf(b, "sp_re_match_p(sp_re_pat_%d, ", rre); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+      else { buf_printf(b, "sp_re_match_p(sp_re_pat_%d, ", rre); emit_str_expr(c, argv[0], b); buf_puts(b, ")"); }
       return;
     }
     if (rre >= 0 && sp_streq(name, "===") && argc == 1) {
@@ -19877,7 +19876,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
         if (rp_ok && rp.p) {
           if ((sp_streq(name, "match?") || sp_streq(name, "===")) && argc == 1) {
             if (a0 == TY_POLY) { buf_printf(b, "sp_re_match_p(%s, sp_poly_to_s(", rp.p); emit_expr(c, argv[0], b); buf_puts(b, "))"); }
-            else { buf_printf(b, "sp_re_match_p(%s, ", rp.p); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+            else { buf_printf(b, "sp_re_match_p(%s, ", rp.p); emit_str_expr(c, argv[0], b); buf_puts(b, ")"); }
             free(rp.p); return;
           }
           if (sp_streq(name, "=~") && argc == 1) {

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -8501,12 +8501,14 @@ int emit_object_call(Compiler *c, int id, Buf *b) {
         buf_puts(b, m->csym); buf_puts(b, "("); emit_expr(c, recv, b);
         for (int ai = 0; ai < m->nargs && ai < argc; ai++) {
           buf_puts(b, ", ");
+          TyKind aw = ffi_spec_to_ty(m->args[ai]);
           if (sp_streq(m->args[ai], "any")) emit_boxed(c, argv[ai], b);
           else if (sp_streq(m->args[ai], "regexp"))
             buf_printf(b, "sp_re_pat_%d", re_lit_index(c, argv[ai]));
-          else if (sp_streq(m->args[ai], "string") && comp_ntype(c, argv[ai]) == TY_POLY) {
-            buf_puts(b, "sp_poly_to_s("); emit_expr(c, argv[ai], b); buf_puts(b, ")");
-          }
+          /* the typed-slot emitters carry the implicit conversion protocol
+             (poly unboxing, #to_str / #to_int on a user object) */
+          else if (aw == TY_STRING) emit_str_expr(c, argv[ai], b);
+          else if (aw == TY_INT) emit_int_expr(c, argv[ai], b);
           else emit_expr(c, argv[ai], b);
         }
         buf_puts(b, ")");

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -5965,14 +5965,16 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
       else if ((sp_streq(name, "gsub") || sp_streq(name, "sub")) && argc == 2 && re_lit_index(c, argv[0]) >= 0) {
         const char *suf = comp_ntype(c, argv[1]) == TY_STR_STR_HASH ? "_str_str_hash" : "";
         buf_printf(b, "sp_re_%s%s(sp_re_pat_%d, %s, ", name, suf, re_lit_index(c, argv[0]), r);
-        emit_expr(c, argv[1], b); buf_puts(b, ")");
+        if (comp_ntype(c, argv[1]) == TY_STR_STR_HASH) emit_expr(c, argv[1], b);
+        else emit_str_expr(c, argv[1], b);
+        buf_puts(b, ")");
       }
       else if ((sp_streq(name, "gsub") || sp_streq(name, "sub")) && argc == 2 &&
                nt_type(nt, argv[0]) && sp_streq(nt_type(nt, argv[0]), "InterpolatedRegularExpressionNode")) {
         Buf rp; memset(&rp, 0, sizeof rp);
         emit_regex_pat_to_buf(c, argv[0], &rp);
         buf_printf(b, "sp_re_%s(%s, %s, ", name, rp.p ? rp.p : "NULL", r);
-        emit_expr(c, argv[1], b); buf_puts(b, ")");
+        emit_str_expr(c, argv[1], b); buf_puts(b, ")");
         free(rp.p);
       }
       else if ((sp_streq(name, "gsub") || sp_streq(name, "sub")) && argc == 2 &&
@@ -5983,7 +5985,9 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
         const char *suf = comp_ntype(c, argv[1]) == TY_STR_STR_HASH ? "_str_str_hash" : "";
         buf_printf(b, "sp_re_%s%s(", name, suf);
         emit_expr(c, argv[0], b); buf_printf(b, ", %s, ", r);
-        emit_expr(c, argv[1], b); buf_puts(b, ")");
+        if (comp_ntype(c, argv[1]) == TY_STR_STR_HASH) emit_expr(c, argv[1], b);
+        else emit_str_expr(c, argv[1], b);
+        buf_puts(b, ")");
       }
       else if (sp_streq(name, "split") && argc == 1 && re_lit_index(c, argv[0]) >= 0) {
         buf_printf(b, "sp_re_split(sp_re_pat_%d, %s)", re_lit_index(c, argv[0]), r);
@@ -6289,7 +6293,7 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
       }
       else if ((sp_streq(name, "partition") || sp_streq(name, "rpartition")) && argc == 1 &&
                re_lit_index(c, argv[0]) < 0) {
-        buf_printf(b, "sp_str_%s(%s, ", name, r); emit_expr(c, argv[0], b); buf_puts(b, ")");
+        buf_printf(b, "sp_str_%s(%s, ", name, r); emit_str_expr(c, argv[0], b); buf_puts(b, ")");
       }
       else if (sp_streq(name, "partition") && argc == 1 && re_lit_index(c, argv[0]) >= 0) {
         /* [before, match, after] from the first regex match, else [s, "", ""] */
@@ -6403,7 +6407,7 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
         int ws = nil_arg || (aty && sp_streq(aty, "StringNode") && nt_str(c->nt, argv[0], "content") &&
                  sp_streq(nt_str(c->nt, argv[0], "content"), " "));
         if (ws) buf_printf(b, "sp_str_split_ws(%s)", r);
-        else { buf_printf(b, "sp_str_split_drop_trailing(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+        else { buf_printf(b, "sp_str_split_drop_trailing(%s, ", r); emit_str_expr(c, argv[0], b); buf_puts(b, ")"); }
       }
       else if (sp_streq(name, "split") && argc == 2) {
         buf_printf(b, "sp_str_split_limit(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ", "); emit_int_expr(c, argv[1], b); buf_puts(b, ")");

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -2431,7 +2431,7 @@ else {
         if (rt == TY_INT_ARRAY) {
           buf_printf(b, "({ sp_IntArray *_t%d = ", t); emit_expr(c, recv, b); buf_puts(b, ";");
           for (int a = argc - 1; a >= 0; a--) {
-            buf_printf(b, " sp_IntArray_unshift(_t%d, ", t); emit_expr(c, argv[a], b); buf_puts(b, ");");
+            buf_printf(b, " sp_IntArray_unshift(_t%d, ", t); emit_int_expr(c, argv[a], b); buf_puts(b, ");");
           }
         }
         else if (rt == TY_STR_ARRAY) {
@@ -3966,7 +3966,7 @@ else {
         return 1;
       }
       if (sp_streq(name, "flatten") && argc <= 1) {
-        if (argc == 1) { buf_puts(b, "sp_PolyArray_flatten_n("); emit_expr(c, recv, b); buf_puts(b, ", "); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+        if (argc == 1) { buf_puts(b, "sp_PolyArray_flatten_n("); emit_expr(c, recv, b); buf_puts(b, ", "); emit_int_expr(c, argv[0], b); buf_puts(b, ")"); }
         else { buf_puts(b, "sp_PolyArray_flatten("); emit_expr(c, recv, b); buf_puts(b, ")"); }
         return 1;
       }
@@ -6243,7 +6243,7 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
       }
       else if (sp_streq(name, "index") && argc == 1) {
         /* nil-on-miss carried as the SP_INT_NIL sentinel (a nullable int) */
-        buf_printf(b, "sp_str_index_opt(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")");
+        buf_printf(b, "sp_str_index_opt(%s, ", r); emit_str_expr(c, argv[0], b); buf_puts(b, ")");
       }
       else if (sp_streq(name, "index") && argc == 2 && re_lit_index(c, argv[0]) >= 0) {
         buf_printf(b, "sp_re_index_from_opt(sp_re_pat_%d, %s, ", re_lit_index(c, argv[0]), r);
@@ -6511,27 +6511,27 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
         buf_printf(b, "sp_str_getbyte_opt(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ")");
       }
       else if (sp_streq(name, "squeeze") && argc == 0) buf_printf(b, "sp_str_squeeze(%s)", r);
-      else if (sp_streq(name, "squeeze") && argc == 1) { buf_printf(b, "sp_str_squeeze_chars(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+      else if (sp_streq(name, "squeeze") && argc == 1) { buf_printf(b, "sp_str_squeeze_chars(%s, ", r); emit_str_expr(c, argv[0], b); buf_puts(b, ")"); }
       else if (sp_streq(name, "squeeze") && argc >= 2) {
         buf_printf(b, "sp_str_squeeze_n(%s, (const char *[]){", r);
-        for (int a = 0; a < argc; a++) { if (a) buf_puts(b, ", "); emit_expr(c, argv[a], b); }
+        for (int a = 0; a < argc; a++) { if (a) buf_puts(b, ", "); emit_str_expr(c, argv[a], b); }
         buf_printf(b, "}, %d)", argc);
       }
       else if ((sp_streq(name, "tr") || sp_streq(name, "tr_s")) && argc == 2) {
-        buf_printf(b, "sp_str_%s(%s, ", name, r); emit_expr(c, argv[0], b); buf_puts(b, ", "); emit_expr(c, argv[1], b); buf_puts(b, ")");
+        buf_printf(b, "sp_str_%s(%s, ", name, r); emit_str_expr(c, argv[0], b); buf_puts(b, ", "); emit_str_expr(c, argv[1], b); buf_puts(b, ")");
       }
       else if (sp_streq(name, "delete") && argc == 0) { buf_printf(b, "(%s)", r); return 1; }
-      else if (sp_streq(name, "delete") && argc == 1) { buf_printf(b, "sp_str_delete(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+      else if (sp_streq(name, "delete") && argc == 1) { buf_printf(b, "sp_str_delete(%s, ", r); emit_str_expr(c, argv[0], b); buf_puts(b, ")"); }
       else if (sp_streq(name, "delete") && argc >= 2) {
         buf_printf(b, "sp_str_delete_n(%s, (const char *[]){", r);
-        for (int a = 0; a < argc; a++) { if (a) buf_puts(b, ", "); emit_expr(c, argv[a], b); }
+        for (int a = 0; a < argc; a++) { if (a) buf_puts(b, ", "); emit_str_expr(c, argv[a], b); }
         buf_printf(b, "}, %d)", argc);
       }
       else if (sp_streq(name, "count") && argc == 0) { buf_printf(b, "(sp_raise_cls(\"TypeError\", \"no implicit conversion of nil into String\"), 0LL)"); return 1; }
-      else if (sp_streq(name, "count") && argc == 1) { buf_printf(b, "sp_str_count(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+      else if (sp_streq(name, "count") && argc == 1) { buf_printf(b, "sp_str_count(%s, ", r); emit_str_expr(c, argv[0], b); buf_puts(b, ")"); }
       else if (sp_streq(name, "count") && argc >= 2) {
         buf_printf(b, "sp_str_count_n(%s, (const char *[]){", r);
-        for (int a = 0; a < argc; a++) { if (a) buf_puts(b, ", "); emit_expr(c, argv[a], b); }
+        for (int a = 0; a < argc; a++) { if (a) buf_puts(b, ", "); emit_str_expr(c, argv[a], b); }
         buf_printf(b, "}, %d)", argc);
       }
       else if (sp_streq(name, "lines") && argc == 0) buf_printf(b, "sp_str_lines(%s)", r);
@@ -6556,7 +6556,7 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
       }
       else if (sp_streq(name, "bytes") && argc == 0)   buf_printf(b, "sp_str_bytes(%s)", r);
       else if (sp_streq(name, "codepoints") && argc == 0) buf_printf(b, "sp_str_codepoints(%s)", r);
-      else if (sp_streq(name, "unpack") && argc == 1)  { buf_printf(b, "sp_str_unpack(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+      else if (sp_streq(name, "unpack") && argc == 1)  { buf_printf(b, "sp_str_unpack(%s, ", r); emit_str_expr(c, argv[0], b); buf_puts(b, ")"); }
       /* unpack(fmt, offset: n): a trailing KeywordHashNode carries the offset. */
       else if ((sp_streq(name, "unpack") || sp_streq(name, "unpack1")) && argc == 2 &&
                nt_type(nt, argv[1]) && sp_streq(nt_type(nt, argv[1]), "KeywordHashNode") &&

--- a/src/codegen_iter.c
+++ b/src/codegen_iter.c
@@ -2161,7 +2161,7 @@ int emit_iteration_stmt(Compiler *c, int id, Buf *b, int indent) {
       int t = ++g_tmp, tl = ++g_tmp, ts = ++g_tmp;
       emit_indent(b, indent); buf_printf(b, "sp_int _t%d = ", tl); emit_int_expr(c, sargv[0], b); buf_puts(b, ";\n");
       emit_indent(b, indent); buf_printf(b, "sp_int _t%d = ", ts);
-      if (sargc >= 2) emit_expr(c, sargv[1], b); else buf_puts(b, "1");
+      if (sargc >= 2) emit_int_expr(c, sargv[1], b); else buf_puts(b, "1");
       buf_puts(b, ";\n");
       emit_indent(b, indent);
       buf_printf(b, "if (_t%d == 0) sp_raise_cls(\"ArgumentError\", \"step can't be 0\");\n", ts);

--- a/test/implicit_conversion_args.rb
+++ b/test/implicit_conversion_args.rb
@@ -1,0 +1,60 @@
+# CRuby's implicit conversion protocol at builtin argument boundaries: a user
+# object defining #to_str / #to_int converts where a String / Integer is
+# wanted; one that defines neither raises CRuby's TypeError. The raw object
+# pointer previously went into the typed C slot and stopped the generated-C
+# build.
+class Stringish
+  def to_str
+    "conv-target.txt"
+  end
+end
+
+class Mode
+  def to_str
+    "w"
+  end
+end
+
+class Idx
+  def to_int
+    1
+  end
+end
+
+class Inert
+end
+
+path = "conv-target.txt"
+begin
+  # to_str at File path and mode slots (with and without a block)
+  File.open(Stringish.new, Mode.new) { |f| f.write("hello\n") }
+  p File.read(Stringish.new)
+  p File.readlines(Stringish.new)
+  p File.exist?(Stringish.new)
+  p File.file?(Stringish.new)
+
+  # to_int at index and count slots
+  p [10, 20, 30][Idx.new]
+  p [10, 20, 30].take(Idx.new)
+  p [10, 20, 30].first(Idx.new)
+  p "abc".getbyte(Idx.new)
+
+  # to_str at string-method argument slots
+  p "hello world".include?(Mode.new.to_str)
+  p "wow".delete(Mode.new)
+  p "hello=world".partition(Mode.new.to_str + "orl")
+
+  # no conversion method: CRuby's TypeError
+  begin
+    File.read(Inert.new)
+  rescue TypeError => e
+    p [e.class, e.message]
+  end
+  begin
+    [10, 20, 30].take(Inert.new)
+  rescue TypeError => e
+    p [e.class, e.message]
+  end
+ensure
+  File.delete(path) if File.exist?(path)
+end

--- a/test/implicit_conversion_args.rb
+++ b/test/implicit_conversion_args.rb
@@ -58,3 +58,33 @@ begin
 ensure
   File.delete(path) if File.exist?(path)
 end
+
+# the runtime bridge: a BOXED user object converts inside a generic runtime
+# walk (pack), including a conversion method that arrives through a mixin
+module IntLike
+  def to_int
+    7
+  end
+end
+
+class Mixed
+  include IntLike
+end
+
+p [Idx.new].pack("C").bytes
+p [Mixed.new, Idx.new].pack("C2").bytes
+begin
+  [Inert.new].pack("C")
+rescue TypeError => e
+  p [e.class, e.message]
+end
+begin
+  [nil].pack("C")
+rescue TypeError => e
+  p [e.class, e.message]
+end
+p [2**64 + 65].pack("Q")[0]
+
+# native package bindings: a declared :string argument converts too
+require "stringio"
+p StringIO.new(Stringish.new).read

--- a/test/implicit_conversion_args.rb.expected
+++ b/test/implicit_conversion_args.rb.expected
@@ -1,0 +1,13 @@
+"hello\n"
+["hello\n"]
+true
+true
+20
+[10]
+[10]
+98
+true
+"o"
+["hello=", "worl", "d"]
+[TypeError, "no implicit conversion of Inert into String"]
+[TypeError, "no implicit conversion of Inert into Integer"]

--- a/test/implicit_conversion_args.rb.expected
+++ b/test/implicit_conversion_args.rb.expected
@@ -11,3 +11,9 @@ true
 ["hello=", "worl", "d"]
 [TypeError, "no implicit conversion of Inert into String"]
 [TypeError, "no implicit conversion of Inert into Integer"]
+[1]
+[7, 1]
+[TypeError, "no implicit conversion of Inert into Integer"]
+[TypeError, "no implicit conversion of nil into Integer"]
+"A"
+"conv-target.txt"


### PR DESCRIPTION

## Summary

A user object flowing into a builtin's String- or Integer-typed slot never
consulted CRuby's implicit conversion protocol. The failure took three forms:

1. **Build-stopping ill-typed C** — the object's raw struct pointer was emitted
   into a `const char *` / `sp_int` slot, and clang refused the TU:

   ```ruby
   class Mode; def to_str; "r"; end; end
   File.open("README.md", Mode.new) { |f| f.read(1) }   # C compilation failed
   ```

2. **Silently skipped conversions** — generic runtime paths absorbed the object:

   ```ruby
   class N; def to_int; 65; end; end
   [N.new].pack("C")    # spinel: "\x00"; CRuby: "A"
   ```

3. **Missing TypeError** — a class with *no* conversion method should raise
   `TypeError: no implicit conversion of X into Y`; several paths returned a
   wrong value instead.

After this series all three behave as CRuby 4.0.6 does.

## How

**The typed-slot emitters carry the protocol.** `emit_str_expr` /
`emit_int_expr` are the shared boundary where arguments become `const char *` /
`sp_int`. A statically-typed user object now converts there through a *direct
call* to its compiled `#to_str` / `#to_int` (the class is known at compile
time — no dynamic dispatch), and a class without the method gets CRuby's
TypeError, message and all. Every call site that routes through those helpers
inherited the protocol at once; a sweep moved the historical stragglers
(File/Dir paths and modes, sub/gsub replacements, split separators,
partition patterns, char-set arguments, counts, seeds) onto them.

**A runtime bridge for boxed objects.** A user object inside a poly container
is met by generic runtime code (`pack`), which cannot name compiled methods.
The generated TU already bridges `#to_s` / `#inspect` to the runtime through
per-class switches installed into function pointers; this series adds
`sp_obj_to_int_sw` / `sp_obj_to_str_sw` (and `sp_obj_cls_name_fn`, so a
runtime TU can word the TypeError with the real class name). Pack's numeric
directives and the native package bindings — every declared `:string` /
`:int` argument in StringIO, StrScan, JSON, Base64, CSV — consult it.

Two rules the new switches follow that the older `#to_s` switch predates
(it has both latent): a **module row is skipped** — a module has no
instances, and its methods compile as per-includer copies, so the includer's
copy is the callable symbol — and every callee is **forward-declared**.

**Pack corrections that fell out.** A String element under a numeric pack
directive raises CRuby's TypeError (it was silently dropped); nil / true /
false raise with CRuby's wording; a Bignum packs mod 2^64 as CRuby does.

## Validation

- Full suite green, including the new `test/implicit_conversion_args.rb`
  (CRuby-generated expected output): conversion at File/String/Array/native
  boundaries, the boxed-object bridge, a mixin-supplied conversion method,
  and the no-method TypeErrors.
- Against a differential corpus of minimized programs run under both CRuby
  4.0.6 and spinel: **163 previously-diverging programs now behave
  identically, zero regressions** across the ~2,100-program corpus.

## Not in this series (deliberately)

- `coerce` (the numeric protocol) — lives in the arithmetic emitters, whose
  fast paths deserve their own review.
- `to_ary` / `to_hash` at splat and destructuring boundaries.
- `nil` arguments: nil-validity is per-method (`"x".split(nil)` is legal,
  `File.split(nil)` is not), so it cannot live in the shared emitters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ユーザー定義オブジェクトが `to_int`／`to_str` を実装している場合、整数・文字列を要求する組み込み処理で自動変換できるようになりました。
  - ファイル操作、配列・文字列処理、正規表現、`StringIO` などで暗黙変換を利用できます。

- **バグ修正**
  - 数値変換できない値に対して、型情報を含む `TypeError` を適切に報告するようになりました。
  - 数値 `pack` 処理で不正な文字列を無視せず、エラーとして扱うよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->