### PR TITLE
Give each rescue clause its own saved cls/msg buffers (#4052)

### DIFF
--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -5244,7 +5244,13 @@ void emit_rescue(Compiler *c, int id, Buf *b, int indent, int fr, const char *re
   }
 
   const char *save_cls = g_rescue_cls, *save_msg = g_rescue_msg;
-  static char clsbuf[32], msgbuf[32];
+  /* NOT static: a rescue body containing its own begin/rescue re-enters this
+     function, and shared buffers meant the inner clause's numbering overwrote
+     the outer one's in place. The save/restore below puts back the POINTER, so
+     the outer bare `raise` then emitted the inner frame's _rcls_N / _rmsg_N,
+     which is out of scope by then and failed the C build (#4052). One buffer
+     per clause, alive for as long as its body is emitted, is the fix. */
+  char clsbuf[32], msgbuf[32];
   snprintf(clsbuf, sizeof clsbuf, "_rcls_%d", rc);
   snprintf(msgbuf, sizeof msgbuf, "_rmsg_%d", rc);
 

--- a/test/reraise_nested_rescue.rb
+++ b/test/reraise_nested_rescue.rb
@@ -1,0 +1,85 @@
+# A bare `raise` re-raises the exception its own rescue caught, even when the
+# rescue body ran another begin/rescue first. The saved class/message buffers
+# were shared across clauses, so the inner clause overwrote the outer one's
+# numbering and the re-raise named temporaries that were out of scope by then
+# -- the C build failed (#4052).
+
+def inner = raise(ArgumentError, "inner boom")
+
+def cleanup_that_raises
+  yield
+rescue StandardError
+  begin
+    inner
+  rescue StandardError => e
+    puts "swallowed: #{e.class}: #{e.message}"
+  end
+  raise
+end
+
+begin
+  cleanup_that_raises { raise "outer boom" }
+rescue StandardError => e
+  puts "caught: #{e.class}: #{e.message}"
+end
+
+# the same with an ensure on the inner handler
+def cleanup_with_ensure
+  yield
+rescue StandardError
+  begin
+    inner
+  rescue StandardError
+    nil
+  ensure
+    puts "ensured"
+  end
+  raise
+end
+
+begin
+  cleanup_with_ensure { raise TypeError, "typed boom" }
+rescue StandardError => e
+  puts "caught: #{e.class}: #{e.message}"
+end
+
+# two levels of nesting inside one rescue body
+def two_levels
+  yield
+rescue StandardError
+  begin
+    begin
+      inner
+    rescue StandardError => e
+      puts "inner: #{e.message}"
+    end
+    raise "middle boom"
+  rescue StandardError => e
+    puts "middle: #{e.message}"
+  end
+  raise
+end
+
+begin
+  two_levels { raise "outermost boom" }
+rescue StandardError => e
+  puts "caught: #{e.message}"
+end
+
+# a nested rescue in the body, then an explicit raise of a NEW exception
+def replaces
+  yield
+rescue StandardError
+  begin
+    inner
+  rescue StandardError
+    nil
+  end
+  raise RuntimeError, "replacement"
+end
+
+begin
+  replaces { raise "original" }
+rescue StandardError => e
+  puts "caught: #{e.message}"
+end

--- a/test/reraise_nested_rescue.rb.expected
+++ b/test/reraise_nested_rescue.rb.expected
@@ -1,0 +1,8 @@
+swallowed: ArgumentError: inner boom
+caught: RuntimeError: outer boom
+ensured
+caught: TypeError: typed boom
+inner: inner boom
+middle: middle boom
+caught: outermost boom
+caught: replacement


### PR DESCRIPTION
Fixes #4052.

A bare `raise` re-raises what its own rescue caught. `emit_rescue` holds that
clause's saved class and message in two buffers, filled before the body is
emitted — and those buffers were `static`, one pair for the whole
compilation.

A rescue body containing its own `begin`/`rescue` re-enters `emit_rescue`, so
the inner clause overwrote the outer one's numbering in place. The
save/restore around the body puts back the *pointer*, which by then addressed
the inner frame's text, and the outer bare `raise` emitted `_rcls_N` /
`_rmsg_N` for a frame that had already closed:

```
rr_nested.rb:10:53: error: use of undeclared identifier '_rcls_6'; did you mean '_rcls_4'?
   10 |               (sp_reraise_current = 1, sp_raise_cls(_rcls_6, _rmsg_6));
```

Dropping `static` gives each clause its own buffers, alive for exactly as long
as its body is emitted, which is what the save/restore assumed all along.

A bare `raise` on its own was never affected; it takes a nested handler ahead
of it to collide. That is the shape cleanup-then-re-raise has: roll back a
partial mount, close a handle, warn that a teardown failed, then let the
original exception out. I hit it compiling a real plugin loader, and this
patch is what lets that file through unedited.

## Tests

`test/reraise_nested_rescue.rb` covers a nested `rescue` before the re-raise,
a nested `rescue`/`ensure`, two levels of nesting in one body, and a body that
raises a new exception instead of re-raising (so the fix is not just "the
build succeeds" — the right exception has to come out).

`make test`: 3145 pass, 0 fail, 0 error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - ネストした例外処理で、bare `raise` が外側の例外を正しく再送出できない問題を修正しました。
  - ネストした `rescue` や `ensure` を含む処理で、コード生成時のビルドエラーを防止しました。

- **テスト**
  - ネストした例外処理、例外の置換、`ensure` の実行を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->