### PR TITLE
Collect the tap/then receivers once, not once per key site

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -7942,6 +7942,36 @@ static int mark_empty_hash_key_ctx(Compiler *c) {
   int changed = 0;
   if (!c->hash_want) return 0;
   const NodeTable *nt = c->nt;
+  /* The `tap` / `then` / `yield_self` block parameters, collected once. The hop
+     loop below follows a key operation written on such a parameter back to the
+     call's own receiver (#4026), and it asked by scanning the whole node table
+     -- per key site, per hop, and this pass runs on every fixpoint iteration.
+     Ascending id order is the order the scan visited in, so the first match
+     here is the match it found. */
+  int tp_n = 0, ncall = 0;
+  const char **tp_name = NULL;
+  int *tp_recv = NULL;
+  (void)nt_nodes_of_kind(nt, NK_CallNode, &ncall);
+  if (ncall > 0) {
+    /* One CallNode is the most entries this can take, so size to that and fill
+       in a single walk: no growth step to get an allocation failure half way
+       through, which would leave SOME blocks followed and the rest not. */
+    tp_name = (const char **)malloc(sizeof(*tp_name) * (size_t)ncall);
+    tp_recv = (int *)malloc(sizeof(*tp_recv) * (size_t)ncall);
+    if (!tp_name || !tp_recv) { fprintf(stderr, "spinel: out of memory\n"); exit(1); }
+    NT_FOREACH_KIND(nt, NK_CallNode, tcid) {
+      const char *cn = nt_str(nt, tcid, "name");
+      if (!cn || (!sp_streq(cn, "tap") && !sp_streq(cn, "then") &&
+                  !sp_streq(cn, "yield_self"))) continue;
+      int blk = nt_ref(nt, tcid, "block");
+      if (blk < 0 || nt_kind(nt, blk) != NK_BlockNode) continue;
+      const char *pn = block_param_name(c, blk, 0);
+      if (!pn) continue;
+      tp_name[tp_n] = pn;
+      tp_recv[tp_n] = nt_ref(nt, tcid, "receiver");
+      tp_n++;
+    }
+  }
   for (int id = 0; id < nt->count; id++) {
     NodeKind idk = nt_kind(nt, id);
     /* `h[k] ||= v` and friends select a variant by their key exactly like a
@@ -7968,18 +7998,8 @@ static int mark_empty_hash_key_ctx(Compiler *c) {
       const char *rn2 = nt_str(nt, recv, "name");
       if (!rn2) break;
       int outer = -1;
-      for (int cid2 = 0; cid2 < nt->count; cid2++) {
-        if (nt_kind(nt, cid2) != NK_CallNode) continue;
-        const char *cn2 = nt_str(nt, cid2, "name");
-        if (!cn2 || (!sp_streq(cn2, "tap") && !sp_streq(cn2, "then") &&
-                     !sp_streq(cn2, "yield_self"))) continue;
-        int blk2 = nt_ref(nt, cid2, "block");
-        if (blk2 < 0 || nt_kind(nt, blk2) != NK_BlockNode) continue;
-        const char *p0n = block_param_name(c, blk2, 0);
-        if (!p0n || !sp_streq(p0n, rn2)) continue;
-        outer = nt_ref(nt, cid2, "receiver");
-        break;
-      }
+      for (int t = 0; t < tp_n; t++)
+        if (sp_streq(tp_name[t], rn2)) { outer = tp_recv[t]; break; }
       if (outer < 0) break;
       recv = outer;
     }
@@ -8130,6 +8150,8 @@ static int mark_empty_hash_key_ctx(Compiler *c) {
       }
     }
   }
+  free((void *)tp_name);
+  free(tp_recv);
   return changed;
 }
 /* `TBL = {}` followed by `TBL[k] = v` elsewhere: an empty literal bound to a


### PR DESCRIPTION
`mark_empty_hash_key_ctx` follows a key operation written on a `tap` / `then` /
`yield_self` block parameter back to the call's own receiver, so that
`{}.tap { |h| h[[]] }` takes the variant its key selects (#4026). It finds that
outer call by scanning every node in the table — once per key site, once per hop
of up to eight, and the pass itself runs on every fixpoint iteration.

The calls it is looking for are a small fixed set: those named `tap`, `then` or
`yield_self` that carry a block. Collecting them once at the top of the pass,
through the `NK_CallNode` kind index, turns each hop from a walk of the table
into a walk of that set. Ascending id order is the order the old scan visited
in, so the first match here is the match it found.

### Measurement

On the Roundhouse-emitted lobsters tree (#3115's tree, now 304 files / 46.7k
lines), `spinel main.rb --emit-rbs`, macOS/arm64, alternating the two binaries
within each pair:

| | analyze |
|---|---|
| master `c5dc365a` | 40.7 / 42.0s |
| this PR | **31.0 / 30.1s** |

The dumped signatures are byte-identical (7121 lines) and the emitted C is
identical modulo the `#line` paths, which name each binary's own
bundled-packages directory. The fixpoint converges in the same 11 iterations
either way, so this is pass cost, not extra rounds. `make check`: 3178 pass,
0 fail, 0 error; `spin-e2e` green.

### Provenance

Bisecting this tree's analyze time over the last nine days lands on 9309c09f,
which added the hop — on this tree that commit took analyze from 18.4s to 28.6s.
`test/empty_hash_key_through_tap.rb` still passes, so the behaviour it added is
kept; only the lookup changes.

Refs #4026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * `tap`、`then`、`yield_self` を使用した処理で、キー操作の対象を正しく追跡できるよう改善しました。
  * 複雑なブロックチェーンを含むコード解析の精度と処理効率を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->