### PR TITLE
Freeze the scope index across the two phases that only read it

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -11455,10 +11455,15 @@ void analyze_program(Compiler *c) {
   /* after the arg/receiver marks: a bare `{}` with no other context takes its
      variant from the peer it is compared against (#3040) or from the key it is
      indexed with (#3028, #3029) */
+  /* Same argument, for the four passes mark_empty_literal_args is called
+     alongside: none of them creates or renames a scope either, and each crosses
+     the node table with method lookups underneath. */
+  comp_scope_index_set_frozen(1);
   mark_mixed_key_hash_locals(c);
   mark_empty_hash_cmp_peers(c);
   (void)mark_empty_hash_key_ctx(c);
   mark_empty_hash_const_writes(c);
+  comp_scope_index_set_frozen(0);
 
   /* A bare identifier inside a class method that names a `class << self`
      attr reader is an implicit-self read of that singleton attribute; give it
@@ -11659,6 +11664,14 @@ void analyze_program(Compiler *c) {
       blk_fwd_callee[fe] = fmi;
     }
   }
+  /* The yield-inlining analysis below reads scope shape but never creates or
+     renames a scope, so the shape index is stable across it -- the same argument
+     mark_empty_literal_args makes for its own body. Frozen, the method lookups
+     underneath it (per scope * per node, through a_block_is_lifted -> infer_type
+     -> infer_call) take the O(1) hash index instead of the unfrozen O(nscopes)
+     reverse scan, and the name-keyed memo in an_user_defines_or_reads -- which
+     stands down while the index is unfrozen -- is live for them. */
+  comp_scope_index_set_frozen(1);
   char *inline_cand = (char *)calloc((size_t)(c->nscopes > 0 ? c->nscopes : 1), 1);
   int cfwd = 64, nfwd = 0;
   int *fwd_from = (int *)malloc(sizeof(int) * (size_t)cfwd);
@@ -11749,6 +11762,7 @@ void analyze_program(Compiler *c) {
   }
   for (int mi = 0; mi < c->nscopes; mi++)
     if (inline_cand[mi]) c->scopes[mi].yields = 1;
+  comp_scope_index_set_frozen(0);
   free(inline_cand); free(fwd_from); free(fwd_to);
   free(blk_call_recv);
   free(blk_arg_expr);


### PR DESCRIPTION
`sm_lookup` has two paths: an O(1) hash index when the scope shape is frozen,
and an O(nscopes) reverse scan when it is not. Counting both on the
Roundhouse-emitted lobsters tree (#3115's tree, now 304 files / 46.7k lines):

| path | calls | scope comparisons | per call |
|---|---|---|---|
| unfrozen | 4,058,525 | **17,436,349,763** | 4,296 |
| frozen | 299,034,086 | 315,835,918 | 1.06 |

1.3% of the lookups do 55× the work. All but 7,055 of the unfrozen ones fall
between `mark_empty_literal_args` and the freeze at the head of the fixpoint, in
two phases that read scope shape but never change it:

| phase | calls | steps |
|---|---|---|
| the four `mark_*` passes called alongside `mark_empty_literal_args` | 1.4M | 6.0B |
| the yield-inlining analysis | 2.6M | 11.4B |

`mark_empty_literal_args` already freezes for its own body, for exactly this
reason and with the measurement in its comment ("the dominant analyze cost on
large apps"). Its neighbours never got the same treatment. Freezing is sound for
them on the same argument: neither phase creates or renames a scope, which is
what the `(count, class_id, name, is_cmethod)` stamp tracks.

A second win folds in. `an_user_defines_or_reads` keeps a name-keyed memo
(#3900) that deliberately stands down while the index is unfrozen, since a
rename can move its answer without moving the counts. So these two phases were
paying the linear scan **and** re-deriving every answer from scratch. After this
change:

| path | calls | steps |
|---|---|---|
| unfrozen | 7,878 | 28,610,156 |
| frozen | 299,095,380 | 315,907,888 |

The frozen counts barely move, so the work went onto the index rather than
somewhere else.

### Measurement

`spinel main.rb --emit-rbs`, macOS/arm64, alternating the two binaries within
each pair:

| | analyze |
|---|---|
| master `c5dc365a` | 40.7 / 42.0s |
| this PR | **29.6 / 28.5s** |

The dumped signatures are byte-identical (7121 lines) and the emitted C is
identical modulo the `#line` paths, which name each binary's own
bundled-packages directory. The fixpoint converges in the same 11 iterations
either way. `make check`: 3178 pass, 0 fail, 0 error; `spin-e2e` green.

Independent of #4074, which indexes a different rescan in one of these same
`mark_*` passes. Stacked, the two take this tree from 40.7s to **20.3s**.

Refs #3115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **パフォーマンス改善**
  * 特定のコード解析処理におけるメソッド検索を最適化し、解析時間の短縮が期待できるようになりました。
  * 解析結果や既存機能の動作に影響を与えず、内部処理の効率を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->