### PR TITLE
Ask clang for the caret flag it actually has

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -538,10 +538,28 @@ int main(int argc, char **argv) {
      true (#4097). The caret goes with it -- cc draws it from the same column,
      so it points at nothing and pads to that width whatever the location says;
      the source-quote line is cc's only way to carry it and goes too, leaving
-     the file and line the message already names. Both gcc and clang take the
-     flags. */
-  if (debug || line_map)
-    s_add(&cmd, "-fno-show-column -fno-diagnostics-show-caret ");
+     the file and line the message already names. */
+  if (debug || line_map) {
+    s_add(&cmd, "-fno-show-column ");
+    /* clang spells the caret flag -fno-caret-diagnostics and REFUSES the
+       gcc spelling outright: Apple clang 21 answers "unknown argument:
+       '-fno-diagnostics-show-caret'" and stops, so on macOS every build
+       fails -- including spinel's own tools, which it compiles with itself.
+       Its own spelling gives exactly what is wanted here:
+       `e.c:1: error: ...`, no column, no quoted line, no caret.
+
+       Chosen by the compiler that BUILT spinel, since that is the same
+       toolchain it then drives as `cc` wherever the spelling differs. The
+       gcc arm is left exactly as it was, so this cannot regress it. A
+       one-time probe of the configured cc would also cover a build whose
+       CC differs from its host compiler, at the cost of a compile per
+       run. */
+#if defined(__clang__)
+    s_add(&cmd, "-fno-caret-diagnostics ");
+#else
+    s_add(&cmd, "-fno-diagnostics-show-caret ");
+#endif
+  }
   if (fiber_frame_guard) s_add(&cmd, "-Wframe-larger-than=65536 ");
   snprintf(tmp, sizeof tmp, "-I\"%s\" -I\"%s%cregexp\" ", lib_dir, lib_dir, PATH_SEP); s_add(&cmd, tmp);
   /* Compile the generated TU with the same threading define as the mt runtime


### PR DESCRIPTION
Since 9e818906 (`Stop printing a C column against a Ruby line`), `make` fails on a clang host.

`-fno-diagnostics-show-caret` is gcc's spelling. clang does not ignore it — it refuses the argument and stops:

```
clang: error: unknown argument: '-fno-diagnostics-show-caret'
```

That is every build on such a host, spinel's own tools included: `make` gets as far as `bin/spinel` and then dies compiling `spin`, `spinel-flatten`, `spinel-doctor` and `spinel-reduce`, since those are compiled by the compiler that just grew the flag.

```
$ make -j8
...
clang: error: unknown argument: '-fno-diagnostics-show-caret'
spinel: C compilation failed
make: *** [bin/spin] Error 1
```

Measured on Apple clang 21.0.0 (clang-2100.1.1.101), arm64-apple-darwin25.5.0.

## The flag clang has does the same job

```
$ clang -c e.c
e.c:1:24: error: use of undeclared identifier 'undefined_thing'
    1 | int main(void){ return undefined_thing; }
      |                        ^~~~~~~~~~~~~~~

$ clang -fno-show-column -fno-caret-diagnostics -c e.c
e.c:1: error: use of undeclared identifier 'undefined_thing'
```

No column, no quoted line, no caret — the file and line the message already names, which is what 9e818906 was after. `-fno-show-column` is common to both compilers and stays where it is.

## The choice this makes

The spelling is picked by the compiler that **built** spinel, since that is the same toolchain it then drives as `cc` wherever the spelling differs. The gcc arm is untouched, so this cannot regress it.

A one-time probe of the configured `cc` would also cover a build whose `CC` differs from its host compiler, at the cost of one compile per run. Happy to write that instead if that combination is meant to be supported — I went with the smaller change since it restores the build without touching the gcc path.

## Verification

`make test` on this branch: **3228 pass, 0 fail, 0 error.**

No test in the diff: the harness compiles and runs Ruby, and this is a choice made about the `cc` command line before any of that. The seam that would hold one is a way to assert on the command `compile_cmd` builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - Apple clang 使用時の診断メッセージ表示を調整しました。
  - コンパイラに応じて適切な診断抑制オプションを選択し、不要な列・ソース引用・キャレット表示を抑制します。
  - デバッグまたは行番号マッピングが有効な場合にのみ適用されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->