### PR TITLE
Fix String.new invoked with a poly-typed value

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -6893,10 +6893,13 @@ static int emit_class_new_call(Compiler *c, int id, Buf *b) {
         /* String.new(str = "", capacity:, encoding:): always a mutable heap copy.
            The capacity/encoding keyword arguments are hints that do not change
            the value, so the content is the leading positional argument (when it
-           is not itself the keyword hash). */
+           is not itself the keyword hash). emit_str_expr emits it as a plain
+           `const char *` for sp_str_dup_external, unboxing a poly-typed
+           argument through sp_poly_arg_str_chk (which raises TypeError like
+           CRuby for a non-String, non-to_str value). */
         const char *a0ty = argc >= 1 ? nt_type(nt, argv[0]) : NULL;
         int has_content = argc >= 1 && !(a0ty && sp_streq(a0ty, "KeywordHashNode"));
-        if (has_content) { buf_puts(b, "sp_str_dup_external("); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+        if (has_content) { buf_puts(b, "sp_str_dup_external("); emit_str_expr(c, argv[0], b); buf_puts(b, ")"); }
         else buf_puts(b, "sp_str_dup_external((&(\"\\xff\")[1]))");
         return 1;
       }

--- a/test/string_new_poly_arg.rb
+++ b/test/string_new_poly_arg.rb
@@ -1,0 +1,36 @@
+# String.new(x) where x is a poly value -- an element read out of a nested
+# array, rather than a flat array, a local, or a literal -- previously failed
+# C compilation: the argument reached sp_str_dup_external (which takes a
+# plain `const char *`) still boxed as an sp_RbVal.
+nested = [["class", "x"]]
+p String.new(nested[0][1])             # "x"
+
+# A flat array element already worked; keep it covered alongside the nested
+# case so a future regression shows up as a diff, not a silent narrowing.
+flat = ["class", "y"]
+p String.new(flat[1])                  # "y"
+
+# The copy is independent of the source.
+def mutable_from_nested(pairs)
+  s = String.new(pairs[0][1])
+  s << "!"
+  s
+end
+p mutable_from_nested([["k", "z"]])    # "z!"
+p [["k", "z"]][0][1]                   # "z" (unchanged)
+
+# A poly value that cannot convert to a String still raises TypeError, same as
+# a plain String.new(nil) / String.new(5). A variable index into a
+# heterogeneous array keeps the element poly-typed rather than narrowed.
+mixed = [nil, 5, "z"]
+def poly_at(arr, i); arr[i]; end
+begin
+  String.new(poly_at(mixed, 0))
+rescue TypeError => e
+  puts e.message
+end
+begin
+  String.new(poly_at(mixed, 1))
+rescue TypeError => e
+  puts e.message
+end

--- a/test/string_new_poly_arg.rb.expected
+++ b/test/string_new_poly_arg.rb.expected
@@ -1,0 +1,6 @@
+"x"
+"y"
+"z!"
+"z"
+no implicit conversion of nil into String
+no implicit conversion of Integer into String


### PR DESCRIPTION

## What

`String.new(x)` fails C compilation when `x` is a poly value — an element
read out of a nested array, rather than a flat array, a local, or a literal.
The diagnostic names generated runtime internals, not the Ruby expression at
fault:

```ruby
nested = [["class", "x"]]
::String.new(nested[0][1])
```

```
error: passing 'sp_RbVal' to parameter of incompatible type 'const char *'
  ... sp_String_new_shared(sp_str_dup_external(sp_poly_arr_get_hash(...)))
note: passing argument to parameter 's' here
  static inline const char *sp_str_dup_external(const char *s)
```

A flat array element, a local, and a literal all compiled fine — only a
value that stayed poly-typed through codegen hit this.

## Why

`String.new`'s codegen emitted its content argument with `emit_expr`, which
passes the argument through however it is statically represented. A flat
value is a plain `const char *`, matching `sp_str_dup_external`'s parameter.
A value that reaches codegen still poly-typed (e.g. an element pulled out of
a nested array, where inference doesn't narrow past the first level) is
represented at runtime as a boxed `sp_RbVal`, which has no implicit
conversion to `const char *` — hence the C type error.

## The fix

Emit the argument with `emit_str_expr` instead of `emit_expr`
(`src/codegen_call.c`). `emit_str_expr` already handles exactly this
argument-boundary case elsewhere in the codebase (`codegen_call_recv.c`'s
other `const char *`-typed builtin arguments): a plain `TY_STRING` value
still emits directly, unchanged from before, while a poly value is unboxed
through `sp_poly_arg_str_chk` — which raises `TypeError` for a non-String,
non-`to_str` argument the same way CRuby does for `String.new(nil)` /
`String.new(5)`.

## What the test pins

`test/string_new_poly_arg.rb`, golden-checked against CRuby's own output:

- `String.new` on an element read from a **nested** array (the bug) —
  `["class", "x"]` two levels down still compiles and returns `"x"`.
- The same for a **flat** array element, so the already-working case stays
  covered and a future regression shows up as a diff, not a silent
  narrowing.
- The result is an independent mutable copy, not aliased to the source.
- `String.new` on a poly-typed `nil` / `Integer` (reached through a
  variable-indexed heterogeneous array, so the element stays poly rather
  than being narrowed) still raises `TypeError`, with CRuby's exact message.

Confirmed the test actually catches the bug: `ERR` (C compilation failure)
with `emit_expr` reverted, `PASS` with the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * `String.new` が配列要素などの多様な値を適切に文字列化できるようになりました。
  * 変換できない値を渡した場合、CRuby と同様に `TypeError` が発生するようになりました。

* **テスト**
  * ネストされた配列、文字列の独立性、変換不能な値に関する検証を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->