### PR TITLE
Count a generated writer as a write the nil scan cannot see

### DIFF
--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -1488,12 +1488,32 @@ int static_isa_cond(Compiler *c, int pred) {
   return 0;
 }
 
+/* Does any class expose a GENERATED writer for this ivar? attr_writer /
+   attr_accessor synthesize the setter, so `obj.w = v` is a CallNode against a
+   body that has no AST: the scan below cannot see the value it stores, and an
+   ivar written only as `@w = nil` in the constructor read as "every write is
+   nil" even though the program assigns it an Array from outside. A
+   hand-written `def w=(v); @w = v; end` is unaffected -- its body holds a real
+   InstanceVariableWriteNode that the scan already counts. */
+static int ivar_has_generated_writer(Compiler *c, const char *nm) {
+  const char *base = nm + 1;                  /* skip the '@' */
+  for (int i = 0; i < c->nclasses; i++) {
+    ClassInfo *ci = &c->classes[i];
+    for (int w = 0; w < ci->nwriters; w++)
+      if (ci->writers[w] && sp_streq(ci->writers[w], base)) return 1;
+    for (int w = 0; w < ci->nsg_writers; w++)
+      if (ci->sg_writers[w] && sp_streq(ci->sg_writers[w], base)) return 1;
+  }
+  return 0;
+}
+
 /* Scan every program-wide write to ivar `nm` ("@foo"): returns 0 when at least
    one write exists and all of them assign nil (statically falsy), -1 otherwise
    (no writes seen, a non-nil write, or an opaque write form). */
 static int ivar_all_writes_nil(Compiler *c, const char *nm) {
   const NodeTable *nt = c->nt;
   if (!nm) return -1;
+  if (ivar_has_generated_writer(c, nm)) return -1;
   int saw_write = 0;
   for (int id = 0; id < nt->count; id++) {
     const char *ty = nt_type(nt, id);

--- a/test/nil_only_ivar_generated_writer.rb
+++ b/test/nil_only_ivar_generated_writer.rb
@@ -1,0 +1,92 @@
+# An ivar whose only `@x = ...` in the source is `nil` is treated as statically
+# falsy, and `if @x` / `if obj.x` has its live branch dropped at compile time.
+# That scan counts InstanceVariableWriteNodes, and a GENERATED writer leaves
+# none behind: attr_writer / attr_accessor synthesize the setter, so `obj.x = v`
+# is a call against a body with no AST. An object built with `@x = nil` and then
+# assigned from outside therefore read as "every write is nil", and the branch
+# was dropped -- silently, since `.nil?`, `is_a?` and assigning to a local all
+# still emitted a real check and reported the value as present.
+#
+# The fold itself is wanted (optcarrot's `if @conf.stackprof_mode`), so the last
+# two cases pin the boundary the fix draws: a setter whose body is real source
+# keeps the branch, and an ivar with no writer at all still folds.
+#
+# Each case uses a DISTINCT ivar name on purpose. The scan is keyed on the name
+# across the whole program, so sharing one name would let the hand-written
+# setter's `@x = v` suppress the fold for the other cases and hide the bug.
+
+class ViaAccessor
+  attr_accessor :acc
+  def initialize
+    @acc = nil
+  end
+end
+
+class ViaWriter
+  attr_writer :wrt
+  def initialize
+    @wrt = nil
+  end
+  def check
+    if @wrt
+      "truthy"
+    else
+      "falsy"
+    end
+  end
+end
+
+class HandWritten
+  attr_reader :hnd
+  def initialize
+    @hnd = nil
+  end
+  def hnd=(v)
+    @hnd = v
+  end
+end
+
+class NeverSet
+  attr_reader :nvr
+  def initialize
+    @nvr = nil
+  end
+end
+
+def acc_truthy(o)
+  if o.acc
+    "truthy"
+  else
+    "falsy"
+  end
+end
+
+def hnd_truthy(o)
+  if o.hnd
+    "truthy"
+  else
+    "falsy"
+  end
+end
+
+def nvr_truthy(o)
+  if o.nvr
+    "truthy"
+  else
+    "falsy"
+  end
+end
+
+a = ViaAccessor.new
+a.acc = [0.5, 0.25]
+puts "accessor, reader call: " + acc_truthy(a)
+
+b = ViaWriter.new
+b.wrt = [1.0]
+puts "writer, direct ivar:   " + b.check
+
+h = HandWritten.new
+h.hnd = [2.0]
+puts "hand-written setter:   " + hnd_truthy(h)
+
+puts "no writer at all:      " + nvr_truthy(NeverSet.new)

--- a/test/nil_only_ivar_generated_writer.rb.expected
+++ b/test/nil_only_ivar_generated_writer.rb.expected
@@ -1,0 +1,4 @@
+accessor, reader call: truthy
+writer, direct ivar:   truthy
+hand-written setter:   truthy
+no writer at all:      falsy


### PR DESCRIPTION
Fixes #4107.

`emit_if` drops a branch whose guard is statically decidable, and `ivar_all_writes_nil` decides one of those guards: an ivar every one of whose writes assigns nil is falsy, so `if @mode` / `if conf.mode` is dead. It finds those writes by walking the AST for `InstanceVariableWriteNode`s.

`attr_writer` / `attr_accessor` synthesize the setter, so `obj.w = v` is a `CallNode` against a body with no AST and the scan never sees the value it stores. An object built with `@w = nil` and assigned from outside read as "every write is nil", and the live branch was dropped:

```ruby
class Ctx
  attr_accessor :w
  def initialize
    @w = nil
  end
end
c = Ctx.new
c.w = [0.5]
if c.w then "truthy" else "falsy" end   # answered "falsy"
```

Only `emit_if` consults this predicate, so the ternary and every explicit form (`.nil?`, `is_a?`, assigning to a local first) still emitted a real check and reported the value as present — which is what made it silent and confusing rather than obviously broken. The ivar's inferred type was never wrong; it comes out as `sp_FloatArray *`.

The fix declines the fold when any class exposes a **generated** writer for the name.

## What is deliberately still folded

The optimisation is wanted, so the fix is scoped rather than removing it:

- A hand-written `def w=(v); @w = v; end` keeps folding — its body holds a real write node the scan already counts, so nothing is lost where the writes genuinely are all visible.
- The motivating case for the fold (c8403fdd, optcarrot's `if @conf.stackprof_mode`) declares `stackprof_mode` via `attr_reader` with no writer anywhere. It still folds, so the dead StackProf branch is still dropped and no unresolvable `nil.sub` is emitted. **optcarrot builds unchanged, checksum 59662.**

Both are pinned as negative cases in the test.

## Second entry point

`static_nil_ivar_cond` shares the same scan, so `attr_writer` plus a direct `@w` read inside the class was the same bug by another route. Fixing the shared helper covers both; both are in the test.

## Test

`test/nil_only_ivar_generated_writer.rb`, four cases, verified against a pre-fix build of this tree:

| case | pre-fix | with fix | CRuby |
|---|---|---|---|
| `attr_accessor`, read through the reader | falsy | truthy | truthy |
| `attr_writer`, direct `@x` read in the class | falsy | truthy | truthy |
| hand-written setter | truthy | truthy | truthy |
| no writer at all | falsy | falsy | falsy |

Each case uses a **distinct ivar name** on purpose, with a comment saying why: the scan is keyed on the name across the whole program with no owner, so sharing one name lets the hand-written setter's write suppress the fold for the other cases and hide the bug. That happened in my first draft — the test passed against the unfixed compiler until I separated the names.

## Checks

- `make test` — 3245 pass, 1 fail
- `make bench` — 61 pass, 0 fail, 0 error
- `make optcarrot` — OK, checksum 59662
- `make rubyspec-gate` — all expected-PASS examples still pass across all six legs

The single test failure is `sp_net_write_partial`, which is **pre-existing and unrelated**: it produces no output at all, identically, with and without this change (checked by rebuilding the tree both ways). It is the UNIX-socket FFI test added by the tip commit.

There is no `gen2.c == gen3.c` closure target on master, so nothing to run for that item.

Found in a weighted-regression tree path that silently ran its unweighted arithmetic — well-formed but wrong, and it survived a unit-weight self-test because with equal weights the two branches agree by construction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * `attr_writer` や `attr_accessor` で生成されたセッター経由のインスタンス変数が常に `nil` と誤判定される問題を修正しました。
  * 条件分岐が誤って削除されず、実行時の値に基づいて正しく評価されるようになりました。
  * 明示的な代入がないインスタンス変数については、従来どおり最適化されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->