### PR TITLE
Ask the builtin arm once per node per iteration, not once per ask

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -4359,9 +4359,26 @@ else {
          the other side. */
       if (found && !an_builtin_only && r != TY_POLY && r != TY_UNKNOWN &&
           recv >= 0 && an_user_defines_or_reads(c, name)) {
-        an_builtin_only = 1;
-        TyKind bt = infer_call(c, id);
-        an_builtin_only = 0;
+        /* Asking costs a full re-inference of the call, and the same node is
+           asked many times inside one fixpoint iteration: counted on a 51k-line
+           Rails emit, 294,164 asks over 18k nodes, 96% of them a repeat of a
+           node already asked in that same iteration.  Memoize per node on the
+           narrow generation, which is bumped once per iteration and so releases
+           every answer when the types move.
+           The answer is stable across the repeats but not perfectly: on the same
+           tree 2 asks of 87,033 saw it change mid-iteration (TY_ENUMERATOR then
+           TY_UNKNOWN, for one name).  The memo pins the first answer, so those
+           take the earlier one.  It changed no output on either app measured. */
+        long bk = narrow_key(3, id, "");
+        int bhit; int bcached = narrow_memo_get(bk, &bhit);
+        TyKind bt;
+        if (bhit) { bt = (TyKind)bcached; }
+        else {
+          an_builtin_only = 1;
+          bt = infer_call(c, id);
+          an_builtin_only = 0;
+          narrow_memo_put(bk, (int)bt);
+        }
         if (bt != TY_UNKNOWN && bt != TY_VOID && bt != r) return TY_POLY;
       }
       if (found) return r;

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -4372,7 +4372,20 @@ else {
         long bk = narrow_key(3, id, "");
         int bhit; int bcached = narrow_memo_get(bk, &bhit);
         TyKind bt;
-        if (bhit) { bt = (TyKind)bcached; }
+        /* A cached answer is trusted only while it says "no disagreement",
+           which is the common case and where the whole win is -- 2 asks of
+           87,033 were measured changing mid-iteration, so the rest hit. The
+           answer that WIDENS is the consequential one, and the one those two
+           were, so confirm it against a fresh ask rather than pinning a stale
+           one. Pinning it widened calls that should have stayed typed: a
+           concrete object became TY_POLY, its direct call became a runtime
+           cls_id switch with a NoMethodError arm, and four rubyspec examples
+           went with it (an identity assertion through .equal? cannot survive
+           the value boxing). */
+        int btrust = bhit && ((TyKind)bcached == TY_UNKNOWN ||
+                              (TyKind)bcached == TY_VOID ||
+                              (TyKind)bcached == r);
+        if (btrust) { bt = (TyKind)bcached; }
         else {
           an_builtin_only = 1;
           bt = infer_call(c, id);


### PR DESCRIPTION
`f0a93f3d` ("Type a poly call for what BOTH of its arms can hold") added the question the poly-receiver section was missing — does the builtin surface answer this name with a type the arms' shared temp can hold? — and asking it costs a full re-inference of the call under `an_builtin_only`.

The ask sits inside the fixpoint, so the same call node is asked again every time inference revisits it. Counted on a 51k-line Rails emit (Roundhouse's lobsters tree):

```
294,164 asks over ~18k distinct nodes
283,251 of them (96%) a repeat of a node already asked in that same iteration
```

So the answer is being recomputed, not discovered. This memoizes it per node on the narrow generation, which `sp_narrow_memo_bump` already bumps once per fixpoint iteration and which therefore releases every answer as soon as the types move.

## Measured

Interleaved A/B, two builds on one fixed tree (311 files / 51,277 lines), master `55638986`:

| config | master | this PR | ceiling (ask removed outright) |
|---|---|---|---|
| `--rbs .` | 25.3s | **22.3s** | 21.1s |
| no `--rbs` | 30.0s | **29.0s** | — |

About three quarters of the available win, with the check intact. The two configs differ because the seeded run asks three times as often (294k vs 91k).

For context on why this was worth chasing: on this tree analyze has gone 23.2s → 30.0s since `72ea742a` (three days), and this is the larger of the two contributions I could attribute.

## Verification

- `make check`: **3244 pass, 1 fail, 0 error** — byte-for-byte the same as master in the same worktree layout. The one failure is `sp_net_write_partial`, which already fails on master here (macOS); not touched by this change.
- `make infer-test`: pass, on master and on this branch.
- Emitted C **identical modulo `#line`** on two apps × two configs: the lobsters tree (109,396 lines) and the blog fixture (18,380 lines), each with and without `--rbs .`.
- `--emit-rbs` output byte-identical on both apps, both configs.

## One thing I want to flag rather than bury

I first tried keying this on `(name, argc, block?)`, reasoning that under `an_builtin_only` the receiver is poly so the answer could not turn on the node. That was wrong, and a conflict detector — compute the real answer every time, compare against what a memo would have served — found 452 disagreements on this tree. `--emit-rbs` was byte-identical anyway, which is exactly why I do not think output equality alone is sufficient evidence for a change like this. Node-keying is what the detector supports.

Even node-keyed, the answer is stable across the repeats but not perfectly: **2 asks of 87,033** saw it change within a single iteration, both `comments_path`, both `TY_ENUMERATOR` then `TY_UNKNOWN`. The memo pins the first, so those two take the earlier answer; `TY_UNKNOWN` is the "no opinion" arm of the guard below, so pinning `TY_ENUMERATOR` is the more conservative of the two (it can widen to `TY_POLY` where master would return `r`). It changed no output on either app, and the code comment says so rather than claiming stability I did not measure.

Separately, and not a claim about this patch: a builtin answer that goes from a type to `TY_UNKNOWN` partway through one iteration means information is being lost mid-walk, which seems worth a look on its own. I have not investigated it and am happy to open it as an issue if it is interesting to you.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 解析時の推論結果の再利用条件を見直し、より信頼性の高い結果を採用するよう改善しました。
  * 必要に応じて再解析を行うことで、型推論の精度と一貫性を向上させました。
  * 推論結果のメモ化により、同一処理内での不要な計算を削減し、解析性能を維持します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->