### PR TITLE
Refuse \p{...}/\P{...} inside a character class instead of matching nothing

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -482,9 +482,12 @@ something in CRuby that this engine does not do. Left as unknown escapes each
 was simply its own letter, so `/\R/` matched an `R` rather than a newline and
 `/\p{Alpha}/` answered a request for a letter with the text of the request.
 They raise `RegexpError` at compile time instead. Inside a character class
-CRuby reads them as the letter too, and so does the class parser here, so
-`[\R]` still matches an `R`. `\G` and `\g<name>` ARE carried and behave as
-CRuby does.
+CRuby reads `\K`, `\R` and `\X` as the letter too, and so does the class
+parser here, so `[\R]` still matches an `R`. `\p{...}` / `\P{...}` differ:
+CRuby reads a property escape inside a class as a property test there too
+(`[\p{Alpha}]` matches letters), so the class parser refuses it the same way
+the bare form is refused, rather than reading it as the letters `p{Alpha}`.
+`\G` and `\g<name>` ARE carried and behave as CRuby does.
 
 The same applies inside a character class, where a `[` never stands for
 itself: `[[a][b]]` (a nested class), `[[.a.]]` (a collating element) and

--- a/lib/regexp/re_compile.c
+++ b/lib/regexp/re_compile.c
@@ -738,6 +738,14 @@ read_class_atom(re_compiler *c, re_charclass *cc)
       }
       return cp;
     }
+    /* Unlike `\K`/`\R`/`\X`, CRuby reads a property escape inside a class as
+       a property test there too, not as its literal letters -- `[\p{Alpha}]`
+       matches letters, it doesn't hold the text "p{Alpha}". The engine
+       carries no property table, so this is refused the same way the
+       top-level dispatcher already refuses the bare form. */
+    if ((peek(c) == 'p' || peek(c) == 'P') && c->p + 1 < c->src_end && c->p[1] == '{') {
+      compile_error(c, "character property is not supported");
+    }
     return (uint32_t)parse_escape(c);
   }
   uint8_t b = (uint8_t)*c->p;

--- a/test/regexp_unsupported_escapes.rb
+++ b/test/regexp_unsupported_escapes.rb
@@ -31,7 +31,13 @@ t("bare-g")    { Regexp.new("\\g").match("g")[0] }
 t("bare-p")    { Regexp.new("\\p").match("p")[0] }
 t("pL")        { Regexp.new("\\pL").match("pL")[0] }
 
-# inside a character class CRuby reads them as the letter, and so does the
-# class parser here
+# inside a character class CRuby reads \R and \K as the letter, and so does
+# the class parser here
 t("class-R")   { Regexp.new("[\\R]").match("R")[0] }
 t("class-K")   { Regexp.new("[\\K]").match("K")[0] }
+
+# \p/\P differ: CRuby reads a property escape inside a class as a property
+# test there too, not as its literal letters, so the class parser refuses it
+# the same way the bare form is refused rather than matching "p{Alpha}"
+t("class-p")     { Regexp.new("[\\p{Alpha}]") =~ "a" }
+t("class-P-neg") { Regexp.new("[^\\p{Word}\\- \\t]").match("a d_1") }

--- a/test/regexp_unsupported_escapes.rb.expected
+++ b/test/regexp_unsupported_escapes.rb.expected
@@ -12,3 +12,5 @@ bare-p | "p"
 pL | "pL"
 class-R | "R"
 class-K | "K"
+class-p | RegexpError
+class-P-neg | RegexpError


### PR DESCRIPTION
## What

```ruby
"abc def.1_2".scan(/[\p{Alpha}]/).join
"abc def.1_2".gsub(/[^\p{Word}\- \t]/, "")
```

Under CRuby these give `"abcdef"` and `"abc def1_2"`. Compiled with spinel,
both compile silently and give the wrong answer: `"a"` and `" d"` — the
negated form deletes almost the whole string. `\p{...}`/`\P{...}` used
*outside* a character class already raises `RegexpError` ("character
property is not supported") at compile time; only the in-class form was
still silently wrong.

## Why

`fcf1bcca784e6f2bbc1b19c77fa91c11645cfd8e` added the refusal for `\p`/`\P`
only to the top-level escape dispatcher in `lib/regexp/re_compile.c`. The
character-class parser has its own, separate escape path:
`read_class_atom` falls through to `parse_escape` for any escape it doesn't
special-case, which reads `\p` as the literal letter `p` — so `\p{Word}`
inside `[...]` parsed as the seven literal characters `p`, `{`, `W`, `o`,
`r`, `d`, `}`. That path was never updated to match the top-level one.

`docs/limitations.md` also documented this wrong: it grouped `\p`/`\P` in
with `\K`/`\R`/`\X` as escapes CRuby reads as their literal letters inside a
class. That's true for `\K`/`\R`/`\X`, but not for `\p`/`\P` — CRuby treats a
property escape inside a class as a property test there too (`/[\p{Alpha}]/`
matches letters, it doesn't hold the text `p{Alpha}`).

## The fix

`read_class_atom` now checks for `p`/`P` followed by `{` right after
consuming the backslash, before falling through to `parse_escape`, and
raises the same `"character property is not supported"` `compile_error`
the top-level dispatcher already raises for the bare form. `docs/limitations.md`
is updated to describe `\p`/`\P` separately from `\K`/`\R`/`\X`: the class
parser now refuses them too, rather than reading them as literal letters.

## What the test pins

`test/regexp_unsupported_escapes.rb` gains two cases, alongside the existing
in-class `\R`/`\K` cases that document the letter-reading behavior:

- `[\p{Alpha}]` raises `RegexpError`, the same as the bare `\p{Alpha}` case
  above it, instead of matching nothing
- `[^\p{Word}\- \t]` (the negated, sanitizing-gsub spelling from the original
  report) also raises `RegexpError` instead of silently stripping most of the
  string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 文字クラス内の `\p{...}` および `\P{...}` を、文字列として誤解釈せず、未対応の正規表現エスケープとして適切に拒否するよう改善しました。
  - 該当時にコンパイルエラーが発生し、誤った正規表現が受け入れられなくなりました。
- **ドキュメント**
  - 文字クラス内で利用できないエスケープの挙動を明確化しました。
- **テスト**
  - `\p` および `\P` のエラー処理を確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->