### PR TITLE
Preserve `nil` when nullable scalar results cross into generic values

### DIFF
--- a/lib/sp_alloc.h
+++ b/lib/sp_alloc.h
@@ -790,9 +790,11 @@ static inline const char*sp_encoding_inspect(sp_Encoding e){return sp_sprintf("#
 static inline sp_bool sp_encoding_eq(sp_Encoding a,sp_Encoding b){const char*an=sp_encoding_name(a);const char*bn=sp_encoding_name(b);return strcmp(an,bn)==0;}
 
 /* ---- Box helper prototypes (0 optcarrot uses; bodies in lib/sp_cold.c). ---- */
-sp_RbVal sp_box_int_or_nil(sp_int v);
+/* An int? / float? value crossing into a poly slot: the sentinel is nil, never
+   a number. Inline because every boxed element read goes through here. */
+static inline sp_RbVal sp_box_int_or_nil(sp_int v) { return v == SP_INT_NIL ? sp_box_nil() : sp_box_int(v); }
+static inline sp_RbVal sp_box_float_or_nil(sp_float v) { return sp_float_is_nil(v) ? sp_box_nil() : sp_box_float(v); }
 sp_RbVal sp_unsentinel(sp_RbVal v);
-sp_RbVal sp_box_float_or_nil(sp_float v);
 sp_RbVal sp_box_bigint(sp_Bigint *b);
 sp_RbVal sp_box_encoding(sp_Encoding e);
 sp_RbVal sp_box_nullable_str(const char *v);

--- a/lib/sp_cold.c
+++ b/lib/sp_cold.c
@@ -2749,15 +2749,6 @@ sp_int sp_float_to_i_checked(sp_float f) {
 
 /* ---- Box helpers (0 optcarrot uses) -- relocated from spinel_rt.h. ---- */
 
-/* Boxing a nullable-int value (int?): SP_INT_NIL is the reserved nil sentinel
-   and never a legitimate integer, so a sentinel must surface as Ruby nil rather
-   than a boxed INT_MIN. Used when an int? value (hash miss, rindex, nonzero?,
-   ...) flows into a poly slot. */
-sp_RbVal sp_box_int_or_nil(sp_int v) { return v == SP_INT_NIL ? sp_box_nil() : sp_box_int(v); }
-/* The float counterpart. A float slot spells nil with its own reserved
-   sentinel, and boxing that as an ordinary Float made it a Hash key that no
-   literal nil could match (#3493). */
-sp_RbVal sp_box_float_or_nil(sp_float v) { return sp_float_is_nil(v) ? sp_box_nil() : sp_box_float(v); }
 /* An element read back out of a TYPED array boxes at the runtime read, which
    has no room for the sentinel check the hot path cannot afford. Where analyze
    knows a particular receiver's elements can hold one, it wraps that read in

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -10404,8 +10404,9 @@ static int elem_miss_call(Compiler *c, int v) {
   }
   if (sp_streq(nm, "[]") || sp_streq(nm, "at")) return argc == 1 && blk < 0;
   if (sp_streq(nm, "dig")) return argc >= 1;
-  if (sp_streq(nm, "first") || sp_streq(nm, "last") || sp_streq(nm, "min") ||
-      sp_streq(nm, "max") || sp_streq(nm, "sample")) return argc == 0 && blk < 0;
+  if (sp_streq(nm, "first") || sp_streq(nm, "last") || sp_streq(nm, "sample"))
+    return argc == 0 && blk < 0;
+  if (sp_streq(nm, "min") || sp_streq(nm, "max")) return argc == 0;
   if (sp_streq(nm, "min_by") || sp_streq(nm, "max_by")) return argc == 0 && blk >= 0;
   if (sp_streq(nm, "find") || sp_streq(nm, "detect")) return blk >= 0;
   return 0;

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -10387,6 +10387,30 @@ int nullable_int_elem_read(Compiler *c, int call) {
          nullable_int_elem_expr(c, recv, 0);
 }
 
+/* A call that answers one element of its receiver, or nil when there is none
+   (`a[i]`, `h[k]`, `[].max`, `a.find { }`), plus `Integer(s, exception: false)`. */
+static int elem_miss_call(Compiler *c, int v) {
+  const NodeTable *nt = c->nt;
+  const char *nm = nt_str(nt, v, "name");
+  if (!nm) return 0;
+  int recv = nt_ref(nt, v, "receiver");
+  int args = nt_ref(nt, v, "arguments");
+  int argc = 0; const int *argv = args >= 0 ? nt_arr(nt, args, "arguments", &argc) : NULL;
+  int blk = nt_ref(nt, v, "block");
+  if (recv < 0) {
+    if ((sp_streq(nm, "Integer") || sp_streq(nm, "Float")) && argc >= 2 && argv &&
+        nt_kind(nt, argv[argc - 1]) == NK_KeywordHashNode) return 1;
+    return 0;
+  }
+  if (sp_streq(nm, "[]") || sp_streq(nm, "at")) return argc == 1 && blk < 0;
+  if (sp_streq(nm, "dig")) return argc >= 1;
+  if (sp_streq(nm, "first") || sp_streq(nm, "last") || sp_streq(nm, "min") ||
+      sp_streq(nm, "max") || sp_streq(nm, "sample")) return argc == 0 && blk < 0;
+  if (sp_streq(nm, "min_by") || sp_streq(nm, "max_by")) return argc == 0 && blk >= 0;
+  if (sp_streq(nm, "find") || sp_streq(nm, "detect")) return blk >= 0;
+  return 0;
+}
+
 /* Can this expression leave the sentinel in an int slot? */
 int nullable_int_value(Compiler *c, int v) {
   const NodeTable *nt = c->nt;
@@ -10465,6 +10489,9 @@ int nullable_int_value(Compiler *c, int v) {
   }
   if (nt_kind(nt, v) == NK_CallNode) {
     if (nullable_int_call_name(nt_str(nt, v, "name"))) return 1;
+    /* a missed element read is the sentinel in an int slot; only boxing is
+       affected, typed reads keep their inline arms */
+    if (elem_miss_call(c, v)) return 1;
     /* a method whose --rbs signature pins `Integer?`, or whose own return
        expression can be the sentinel: either way its nil is the sentinel and a
        caller that boxes the value has to answer nil. Resolved the way emission

--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -4181,7 +4181,11 @@ int emit_minmax_cmp_expr(Compiler *c, int id, Buf *b) {
   emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre); buf_printf(g_pre, " _t%d = ", trv); buf_puts(g_pre, rb.p ? rb.p : ""); buf_puts(g_pre, ";\n"); free(rb.p);
   emit_indent(g_pre, g_indent); buf_printf(g_pre, "sp_int _t%d = sp_%sArray_length(_t%d);\n", tn, k, trv);
   emit_indent(g_pre, g_indent); emit_ctype(c, et, g_pre);
-  buf_printf(g_pre, " _t%d = _t%d > 0 ? sp_%sArray_get(_t%d, 0) : %s;\n", tmin, tn, k, trv, et == TY_RANGE ? "(sp_Range){0}" : default_value(et));
+  /* An empty comparator reduction returns nil, so use the carrier's nil
+     sentinel rather than the ordinary zero default for scalar elements. */
+  buf_printf(g_pre, " _t%d = _t%d > 0 ? sp_%sArray_get(_t%d, 0) : %s;\n", tmin, tn, k, trv,
+             et == TY_INT ? "SP_INT_NIL" : et == TY_FLOAT ? "sp_float_nil()" :
+             et == TY_RANGE ? "(sp_Range){0}" : default_value(et));
   emit_indent(g_pre, g_indent); emit_ctype(c, et, g_pre); buf_printf(g_pre, " _t%d = _t%d;\n", tmax, tmin);
   emit_indent(g_pre, g_indent); buf_printf(g_pre, "for (sp_int _t%d = 1; _t%d < _t%d; _t%d++) {\n", ti, ti, tn, ti);
   emit_indent(g_pre, g_indent + 1); emit_ctype(c, et, g_pre); buf_printf(g_pre, " _t%d = sp_%sArray_get(_t%d, _t%d);\n", te, k, trv, ti);

--- a/test/int_nil_boxing_at_poly_boundary.rb
+++ b/test/int_nil_boxing_at_poly_boundary.rb
@@ -1,0 +1,32 @@
+# A missed element read from an int container boxes as nil, not as an Integer.
+def klass(v) = v.class.name
+def isnil(v) = v.nil?
+
+a = [1, 2]
+h = { "a" => 1 }
+ih = { 1 => 2 }
+fa = [1.5]
+
+p klass(a[5]), klass(a[0])
+p klass(h["zz"]), klass(h["a"])
+p klass(ih[3]), klass(ih[1])
+p klass([].max), klass([].min), klass(a.max)
+p klass(a.find { false }), klass(a.detect { |v| v == 2 })
+p klass([].first), klass([].last), klass(a.first)
+p klass(a.at(9)), klass([[1]].dig(0, 5))
+p klass(fa[3]), klass(fa[0])
+p klass(Integer("x", exception: false)), klass(Integer("7", exception: false))
+p klass(Float("x", exception: false)), klass(Float("1.5", exception: false))
+p isnil(a[5]), isnil(a[0]), isnil("s")
+
+x = h["zz"]
+y = a[1]
+p isnil(x), isnil(y), klass(x), klass(y)
+
+def pick(arr, i) = arr[i]
+p klass(pick(a, 7)), klass(pick(a, 0))
+
+out = []
+out << a[5] << a[0] << h["q"]
+p out
+p [a[9], h["zz"], a[0]]

--- a/test/int_nil_boxing_at_poly_boundary.rb.expected
+++ b/test/int_nil_boxing_at_poly_boundary.rb.expected
@@ -1,0 +1,33 @@
+"NilClass"
+"Integer"
+"NilClass"
+"Integer"
+"NilClass"
+"Integer"
+"NilClass"
+"NilClass"
+"Integer"
+"NilClass"
+"Integer"
+"NilClass"
+"NilClass"
+"Integer"
+"NilClass"
+"NilClass"
+"NilClass"
+"Float"
+"NilClass"
+"Integer"
+"NilClass"
+"Float"
+true
+false
+false
+true
+false
+"NilClass"
+"Integer"
+"NilClass"
+"Integer"
+[nil, 1, nil]
+[nil, nil, 1]

--- a/test/int_nil_boxing_min_max_block.rb
+++ b/test/int_nil_boxing_min_max_block.rb
@@ -1,0 +1,23 @@
+# Empty collections return nil from min/max even when a comparator block is
+# supplied. Keep nonempty and argument-taking forms covered at the same time.
+class EmptyInts
+  include Enumerable
+  def each; end
+end
+
+plain_array = []
+array = [1].first(0)
+enum = EmptyInts.new
+
+p plain_array.min { |a, b| a <=> b }
+p plain_array.max { |a, b| a <=> b }
+p array.min { |a, b| a <=> b }
+p array.max { |a, b| a <=> b }
+p enum.min { |a, b| a <=> b }
+p enum.max { |a, b| a <=> b }
+
+values = [3, 1, 2]
+p values.min { |a, b| a <=> b }
+p values.max { |a, b| a <=> b }
+p values.min(2) { |a, b| a <=> b }
+p values.max(2) { |a, b| a <=> b }

--- a/test/int_nil_boxing_min_max_block.rb.expected
+++ b/test/int_nil_boxing_min_max_block.rb.expected
@@ -1,0 +1,10 @@
+nil
+nil
+nil
+nil
+nil
+nil
+1
+3
+[1, 2]
+[3, 2]


### PR DESCRIPTION

## The bug

Ruby returns `nil` when a read or search has no result:

```ruby
def class_name(value) = value.class.name

a = [1, 2]
h = { "a" => 1 }

p class_name(a[5])
p class_name(h["missing"])
p class_name([].max)
```

Ruby returns:

```text
NilClass
NilClass
NilClass
```

Spinel returned `Integer` for these values. Spinel represents `nil` from typed integer and float operations with internal sentinel values. When such a result crossed into a generic Ruby value, ordinary boxing exposed the sentinel as a real number.

## The fix

Use nil-aware boxing whenever a nullable integer or float result crosses into a generic value, including array and hash reads, searches, selectors, `dig`, numeric conversions, locals, parameters, returns, and polymorphic collections.

Typed results continue to use their existing fast paths.

## Tests

Added `test/int_nil_boxing_at_poly_boundary.rb`, covering missed reads, integer and float arrays, searches, selectors, `dig`, numeric conversions, locals, returns, and polymorphic collections.

## Verification

The focused regression matches Ruby 4.0.6 for missed reads, searches, selectors, `dig`, numeric conversions, and generic-value boundaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 配列やハッシュの範囲外アクセス、空コレクション操作などの結果が、数値ではなく正しく `nil` として扱われるようになりました。
  - `first`、`last`、`find`、`detect`、`at`、`dig` などの呼び出しで、`nil` 判定や配列への追加が正しく機能します。
  - ブロック付きの `min`／`max` や空の `min`／`max`／`minmax` でも、結果が適切に `nil` として扱われます。
  - `Integer`／`Float` の非例外変換で返される `nil` も適切に処理されます。

- **テスト**
  - 整数・浮動小数点コンテナの `nil` 処理と、`min`／`max` の動作確認を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->