### PR TITLE
Preserve outer exception handlers across `ensure` exits

### DIFF
--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -5097,10 +5097,10 @@ void emit_return(Compiler *c, int id, Buf *b, int indent) {
       }
     }
     {
+      /* inside a rescue/else clause the region's frame is already popped, so
+         0 is a valid count; popping one anyway takes a caller's handler */
       int pops = g_exc_frame_depth - ctx->exc_base;
-      if (pops < 1) pops = 1;   /* at least the ensure frame itself */
-      /* pop the handlers for rescue bodies inside this ensure region we are
-         leaving; rescues outside it are popped at the ensure re-dispatch. */
+      if (pops < 0) pops = 0;
       emit_cur_exc_restore(b, ctx->exc_base);
       buf_printf(b, "_retf%d = 1; sp_exc_top -= %d; goto _ensure%d; }\n",
                  ctx->lid, pops, ctx->lid);
@@ -9072,7 +9072,7 @@ else {
     if (g_ensure_depth > g_loop_ensure_base) {
       EnsureCtx *nctx = &g_ensure_stack[g_ensure_depth - 1];
       int npops = g_exc_frame_depth - nctx->exc_base;
-      if (npops < 1) npops = 1;
+      if (npops < 0) npops = 0;   /* see emit_return */
       emit_indent(b, indent);
       buf_puts(b, "{ ");
       emit_cur_exc_restore(b, nctx->exc_base);

--- a/test/rescue_return_with_ensure.rb
+++ b/test/rescue_return_with_ensure.rb
@@ -1,0 +1,61 @@
+# `return` / `next` from a rescue or else clause under `ensure` leaves the
+# handler stack intact for later rescues.
+def ret_from_rescue
+  raise "x"
+rescue => e
+  return "r:#{e.message}"
+ensure
+  puts "ensure ran"
+end
+
+def ret_from_else
+  1
+rescue
+  return "rescued"
+else
+  return "else"
+ensure
+  puts "ensure ran"
+end
+
+def next_from_rescue(xs)
+  out = []
+  xs.each do |x|
+    begin
+      raise "odd" if x.odd?
+      out << x
+    rescue
+      next
+    ensure
+      out << -x
+    end
+  end
+  out
+end
+
+def nested_ret
+  begin
+    raise "inner"
+  rescue
+    return "inner-rescue"
+  ensure
+    puts "inner ensure"
+  end
+ensure
+  puts "outer ensure"
+end
+
+p ret_from_rescue
+p ret_from_else
+p next_from_rescue([1, 2, 3])
+p nested_ret
+
+# every later rescue must still catch
+begin
+  raise "boom"
+rescue => e
+  p e.message
+end
+p((Integer("zz") rescue -1))
+x = (raise "mod" rescue "modifier")
+p x

--- a/test/rescue_return_with_ensure.rb.expected
+++ b/test/rescue_return_with_ensure.rb.expected
@@ -1,0 +1,11 @@
+ensure ran
+"r:x"
+ensure ran
+"else"
+[-1, 2, -2, -3]
+inner ensure
+outer ensure
+"inner-rescue"
+"boom"
+-1
+"modifier"


### PR DESCRIPTION

## The bug

Ruby runs an `ensure` clause when a `return` or `next` leaves a rescue or else clause, without removing exception handlers belonging to the caller:

```ruby
def evaluate
  raise "x"
rescue
  return "r"
ensure
  puts "always"
end

p evaluate

begin
  raise "boom"
rescue => error
  p error.message
end
```

Ruby prints:

```text
always
"r"
"boom"
```

Spinel printed the first two results, but then treated the final exception as uncaught. While performing the deferred return, it removed the caller's exception handler.

## The fix

Deferred exits now remove only the frames that still belong to the exited `ensure` region. When a rescue or else clause has already removed that region's frame, the exit may remove zero additional frames instead of forcibly popping the caller's handler.

## Tests

Added `test/rescue_return_with_ensure.rb`, covering returns from rescue and else clauses, `next` from rescue inside a loop, nested `ensure` regions, and later rescue clauses.

## Verification

The focused regression matches Ruby 4.0.6 for returns and `next` through rescue, else, and `ensure`, including nested handlers.