### PR TITLE
Do not compile impossible `is_a?` branches for known scalars

### DIFF
--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -2470,16 +2470,15 @@ else {
       else_stmts = nt_ref(nt, sub, "statements");
     int en = 0;
     const int *eb = else_stmts >= 0 ? nt_arr(nt, else_stmts, "body", &en) : NULL;
-    /* A statically-answered defined? predicate folds to its live arm alone:
-       the dead arm may reference the very constant defined? reported on (and
-       its NameError-raise value would not type-unify with the live arm), and
-       CRuby never evaluates it. Mirrors emit_if's statement-form fold and
-       the matching inference fold. */
+    /* A statically-answered defined? or is_a? predicate folds to its live arm:
+       the dead arm may not even type-check against the receiver's storage
+       type. Mirrors emit_if's statement-form fold and the inference fold. */
     {
       int df = comp_defined_guard_false(c, pred);
       int dt = df ? 0 : comp_defined_guard_true(c, pred);
-      if (df || dt) {
-        int take_then = is_unless ? df : dt;
+      int known = df ? 0 : (dt ? 1 : static_isa_cond(c, pred));
+      if (known >= 0) {
+        int take_then = is_unless ? !known : known;
         if (!take_then && !is_unless && sub >= 0 && nt_type(nt, sub) &&
             sp_streq(nt_type(nt, sub), "IfNode")) {
           emit_expr(c, sub, b);  /* the elsif chain continues as the value */

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -518,6 +518,7 @@ const char *sp_re_literal_error(const char *src, int len, int flags);
    or 0 if the name is not a recognized builtin class. */
 int builtin_class_id(const char *name);
 int is_builtin_class_name(const char *n);
+int is_builtin_module_name(const char *n);
 int is_builtin_exception_name(const char *n);
 const char *c_type_name(TyKind t);
 int is_scalar_ret(TyKind t);

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -1461,8 +1461,19 @@ int static_isa_cond(Compiler *c, int pred) {
   int args = nt_ref(nt, pred, "arguments");
   int ac = 0; const int *av = args >= 0 ? nt_arr(nt, args, "arguments", &ac) : NULL;
   if (ac != 1 || !av || !nt_type(nt, av[0]) || !sp_streq(nt_type(nt, av[0]), "ConstantReadNode")) return -1;
-  const char *tname = nt_str(nt, av[0], "name");
-  int target = comp_class_index(c, tname);
+  const char *target_name = nt_str(nt, av[0], "name");
+  if (!target_name) return -1;
+  /* A scalar local against a builtin class is answered from its type. Not a
+     bool (TrueClass/FalseClass depends on the value), not a Queue (shares its
+     runtime object with SizedQueue), and only a local read so no receiver
+     evaluation is dropped. */
+  if (!ty_is_object(rt) && rt != TY_BOOL && rt != TY_QUEUE && rt != TY_UNKNOWN &&
+      (is_builtin_class_name(target_name) || is_builtin_module_name(target_name))) {
+    const char *rnt = nt_type(nt, recv);
+    if (!rnt || !sp_streq(rnt, "LocalVariableReadNode")) return -1;
+    return ty_matches_class(rt, target_name, sp_streq(nm, "instance_of?"));
+  }
+  int target = comp_class_index(c, target_name);
   if (target < 0) return -1;
   /* A number/symbol/bool is never an instance of a user class, so the arm that
      reads it as one is dead -- and it is the only place a call like
@@ -1473,7 +1484,7 @@ int static_isa_cond(Compiler *c, int pred) {
   if (!ty_is_object(rt) && !ty_is_array(rt) && !ty_is_hash(rt) &&
       (rt == TY_INT || rt == TY_BIGINT || rt == TY_FLOAT || rt == TY_BOOL ||
        rt == TY_SYMBOL || rt == TY_STRING) &&
-      tname && !is_builtin_class_name(tname)) {
+      target_name && !is_builtin_class_name(target_name)) {
     for (int k = 0; k < c->nclasses; k++) {
       if (!c->classes[k].name || !is_builtin_class_name(c->classes[k].name)) continue;
       for (int m = 0; m < c->classes[k].nincluded_mods; m++)

--- a/test/scalar_isa_dead_branch.rb
+++ b/test/scalar_isa_dead_branch.rb
@@ -1,0 +1,23 @@
+h = {}
+h[57] = -4
+
+h.keys.sort.each do |key|
+  value = h[key]
+  puts(key.to_s + "=" + (value.is_a?(Array) ?
+    ("[" + value.map { |item| item.to_s }.join(",") + "]") :
+    (value.is_a?(Hash) ?
+      ("{" + value.keys.sort_by(&:to_s).map { |nested_key| nested_key.to_s + ":" + value[nested_key].to_s }.join(",") + "}") :
+      (value.is_a?(Float) ? format("%.2f", value) : value.to_s))))
+end
+
+# A bool's class depends on its value, and a module target is an ancestor:
+# neither guard may be folded away.
+flag = true
+puts(flag.is_a?(TrueClass) ? "true-class" : "false-class")
+n = 5
+puts(n.is_a?(Comparable) ? "comparable" : "not")
+puts(n.is_a?(Numeric) ? "numeric" : "not")
+puts(n.is_a?(String) ? "string" : "not-string")
+s = "x"
+puts(s.instance_of?(String) ? "exact" : "inexact")
+puts(s.is_a?(Object) ? "object" : "not")

--- a/test/scalar_isa_dead_branch.rb.expected
+++ b/test/scalar_isa_dead_branch.rb.expected
@@ -1,0 +1,7 @@
+57=-4
+true-class
+comparable
+numeric
+not-string
+exact
+object


### PR DESCRIPTION

## The bug

Ruby can answer `is_a?` from a value's known type. That means an impossible branch does not need to be evaluated or compiled:

```ruby
value = h[key]   # known to be an Integer

puts(value.is_a?(Array) ? value.map(&:to_s).join(",") : value.to_s)
```

Ruby takes the `else` branch. Spinel still emitted the `Array` branch, and compilation failed because `map` was being generated for an integer value.

## The fix

Use the known scalar type to fold supported type predicates (`is_a?`, `kind_of?`, and `instance_of?`) in expression-form conditionals, so an impossible branch is not emitted. Cases where the answer depends on the runtime value or receiver identity remain dynamic. Existing user-defined-class handling is unchanged.

## Tests

The regression covers the ternary case above, boolean receivers, module targets, and `instance_of?`, with Ruby 4.0.6 as the reference.

## Verification

The regression passes against Ruby 4.0.6 for scalar ternaries, boolean receivers, module targets, and `instance_of?`.