### PR TITLE
spin tool: realpath fix for PATH-resolved compiler

### DIFF
--- a/tools/spin.rb
+++ b/tools/spin.rb
@@ -252,7 +252,13 @@ def spinel_hdr_dir
   env = ENV["SPINEL_HDR_DIR"].to_s
   return env if env != "" && File.exist?(File.join(env, "spinel_rt.h"))
   bin = spinel_bin
-  bin = which("spinel") if bin == "spinel"
+  if bin == "spinel"
+    found = which("spinel")
+    # PATH returns the symlink as-is; the lib probe below then walks
+    # relative to a symlinked path and misses the install tree.
+    found = File.realpath(found) if found != "" && File.symlink?(found)
+    bin = found
+  end
   return "" if bin == ""
   d = File.expand_path("..", bin)
   a = File.join(d, "lib")


### PR DESCRIPTION
`tools/spin.rb`: in `spinel_hdr_dir` (line ~255), after the PATH walk via `which("spinel")`, add `File.realpath` on the found path when it's a symlink. This resolves symlinked installations (e.g. `~/bin/spin -> ~/spinel/bin/spin`, `spin install` output) to their real install root so the downstream `lib` probe finds the runtime headers.

`spinel_bin` first tries `$0`-sibling resolution (`$0` = binary path). When that fails (e.g. `spin` invoked from a different cwd), it falls back to the string `"spinel"`. Previously `spinel_hdr_dir` then called `which("spinel")` and used the raw result - which is the symlink itself. The install layout probe (`File.expand_path("..", bin)` + `lib/`) then walked from the symlink target's parent, missing the real `../lib` that sits beside the compiler binary.
`File.realpath` collapses the symlink chain so the walk lands in the correct install tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * シンボリックリンク経由で起動された場合でも、ランタイムヘッダーを正しいインストール先から探索できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->