### PR TITLE
Drain once: sp_net_write_partial's test parks where the pair buffers under 128K

### DIFF
--- a/test/sp_net_write_partial.rb
+++ b/test/sp_net_write_partial.rb
@@ -53,7 +53,6 @@ puts "accepted some first: #{sent > 0}"
 # Draining the far end makes room, and the write resumes -- the caller keeps
 # the remainder and retries, which is the whole point of the contract.
 Net.sp_net_recv_some(afd, 65536)
-Net.sp_net_recv_some(afd, 65536)
 puts "resumes: #{Net.sp_net_write_partial(cfd, 'more', 4) > 0}"
 
 Net.sp_net_close(afd)


### PR DESCRIPTION
`sp_net_write_partial`'s test fills the socket until the write reports 0,
then drains the far end with two fixed 64K reads before checking that the
write resumes. Only `cfd` is set non-blocking; `afd` is left blocking, so
a read with nothing behind it parks rather than returning empty.

How much is behind it is a platform property. On a macOS UNIX-domain pair
the whole exchange is 8192 bytes:

    backpressure: true
    accepted some first: true
    SENT BYTES: 8192
    drain1: 8192          <- the first read takes all of it
    drain2                <- nothing left; recvfrom blocks forever

The file's own header asks for better than that ("deterministic on any
POSIX target"), and `make test`'s 10s timeout turns the hang into a FAIL
whose diff reads "7 lines expected, 0 produced" — the six lines that did
run are lost in an unflushed stdout buffer, so it reads like an immediate
crash rather than a park.

One drain is enough to make the point either way: freeing 64K leaves room
for the 4-byte write whatever the buffer size, so the second read adds no
coverage and costs portability.

`sp_net_write_partial` itself is not implicated — backpressure is
detected, a partial is accepted, and the write resumes after draining.
The contract holds; only the test's assumption about the far end does not.

## Verification

`build/test-results/sp_net_write_partial.ok` reports PASS with this
change and hangs to the timeout without it, on macOS 26.0 / arm64,
spinel 556389860149.

Caveat worth stating: I can only run this on macOS. The Linux case is
reasoning, not measurement — freeing 64K leaves room for 4 bytes at any
buffer size — so if that lane is where the two reads came from, it is
worth a second look before merging.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * バックプレッシャー発生後の送信再開テストを更新し、受信側のドレイン処理を行わない構成に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->