### PR TITLE
[BLOCKED on #4134] Take a URI and an initheader, and open a connection #request needs

### DIFF
--- a/packages/net/net/http.rb
+++ b/packages/net/net/http.rb
@@ -85,19 +85,46 @@ module Net
     attr_reader :method, :path
     attr_accessor :body
 
-    def initialize(method, path)
+    # `path` is a request path, or a URI -- CRuby takes either, and
+    # `Net::HTTP::Post.new(uri, "Content-Type" => "application/json")` is the
+    # spelling a caller reaches for when it already parsed the URL. A URI
+    # contributes its `request_uri` (the path with the query), not its `to_s`,
+    # which is the whole URL and would go out as an absolute request line.
+    def initialize(method, path, initheader = nil)
       @method = method
-      @path = (path.nil? || path.to_s.empty?) ? "/" : path.to_s
+      @path = if path.is_a?(URI::Generic)
+        path.request_uri
+      else
+        (path.nil? || path.to_s.empty?) ? "/" : path.to_s
+      end
       @headers = {}
       @body = ""
+      initheader.each { |k, v| @headers[k.to_s] = v.to_s } unless initheader.nil?
     end
 
+    # Header names are case-insensitive on the wire, and CRuby's
+    # Net::HTTPHeader is case-insensitive on both halves -- as the response
+    # half here already is. What is kept, rather than downcased the way the
+    # response stores them, is the caller's spelling: for a request that is
+    # what goes out on the wire.
     def []=(name, value)
+      existing = header_name(name)
+      @headers.delete(existing) unless existing.nil?
       @headers[name.to_s] = value.to_s
     end
 
     def [](name)
-      @headers[name.to_s]
+      k = header_name(name)
+      k.nil? ? nil : @headers[k]
+    end
+
+    # The stored spelling of a header, in whatever case the caller asks for it,
+    # or nil when it is not set.
+    def header_name(name)
+      want = name.to_s.downcase
+      found = nil
+      @headers.each_key { |k| found = k if k.to_s.downcase == want }
+      found
     end
 
     def each_header
@@ -120,32 +147,32 @@ module Net
     # CRuby builds requests as Net::HTTP::Get.new(path) and friends. Same
     # spelling here, so the same code compiles.
     class Get < HTTPRequest
-      def initialize(path)
-        super("GET", path)
+      def initialize(path, initheader = nil)
+        super("GET", path, initheader)
       end
     end
 
     class Post < HTTPRequest
-      def initialize(path)
-        super("POST", path)
+      def initialize(path, initheader = nil)
+        super("POST", path, initheader)
       end
     end
 
     class Put < HTTPRequest
-      def initialize(path)
-        super("PUT", path)
+      def initialize(path, initheader = nil)
+        super("PUT", path, initheader)
       end
     end
 
     class Delete < HTTPRequest
-      def initialize(path)
-        super("DELETE", path)
+      def initialize(path, initheader = nil)
+        super("DELETE", path, initheader)
       end
     end
 
     class Head < HTTPRequest
-      def initialize(path)
-        super("HEAD", path)
+      def initialize(path, initheader = nil)
+        super("HEAD", path, initheader)
       end
     end
 
@@ -259,7 +286,20 @@ module Net
     end
 
     def request(req)
-      raise HTTPError, "not started" unless @started
+      # CRuby opens a connection for a #request on an unstarted Net::HTTP, runs
+      # the request over it and closes it again -- so `Net::HTTP.new(host,
+      # port).request(req)` works without a `start`, and is the spelling a
+      # caller writes when the connection is configured somewhere other than
+      # where the request is sent. Doing that here rather than raising keeps
+      # the two spellings interchangeable, as they are there.
+      unless @started
+        start
+        begin
+          return request(req)
+        ensure
+          finish
+        end
+      end
       # Every request goes out with `Connection: close`, so the server hangs
       # up after answering and the socket a second request would use is dead.
       # CRuby reconnects transparently in that situation, and a caller writing

--- a/packages/net/net/http.rb
+++ b/packages/net/net/http.rb
@@ -99,7 +99,7 @@ module Net
       end
       @headers = {}
       @body = ""
-      initheader.each { |k, v| @headers[k.to_s] = v.to_s } unless initheader.nil?
+      initheader.each { |k, v| self[k] = v } unless initheader.nil?
     end
 
     # Header names are case-insensitive on the wire, and CRuby's
@@ -107,15 +107,24 @@ module Net
     # half here already is. What is kept, rather than downcased the way the
     # response stores them, is the caller's spelling: for a request that is
     # what goes out on the wire.
+    # EVERY write goes through here -- `initheader`, `content_type=` and
+    # `set_form_data` included. Writing to `@headers` directly is how the same
+    # header ends up stored twice under two spellings and goes out on the wire
+    # twice: `Post.new(uri, "content-type" => "text/plain")` followed by
+    # `req.content_type = "application/json"` sent BOTH, and a server is free
+    # to believe either one.
     def []=(name, value)
-      existing = header_name(name)
-      @headers.delete(existing) unless existing.nil?
+      delete_header(name)
       @headers[name.to_s] = value.to_s
     end
 
     def [](name)
       k = header_name(name)
       k.nil? ? nil : @headers[k]
+    end
+
+    def key?(name)
+      !header_name(name).nil?
     end
 
     # The stored spelling of a header, in whatever case the caller asks for it,
@@ -127,18 +136,29 @@ module Net
       found
     end
 
+    # Remove EVERY spelling of a header, not just one: a collision that
+    # predates this write needs clearing whole, or the duplicate survives the
+    # overwrite that was supposed to replace it.
+    def delete_header(name)
+      want = name.to_s.downcase
+      doomed = []
+      @headers.each_key { |k| doomed << k if k.to_s.downcase == want }
+      doomed.each { |k| @headers.delete(k) }
+      nil
+    end
+
     def each_header
       @headers.each { |k, v| yield k, v }
       nil
     end
 
     def content_type=(v)
-      @headers["Content-Type"] = v.to_s
+      self["Content-Type"] = v
     end
 
     def set_form_data(hash)
       @body = URI.encode_www_form(hash)
-      @headers["Content-Type"] = "application/x-www-form-urlencoded"
+      self["Content-Type"] = "application/x-www-form-urlencoded"
       @body
     end
   end
@@ -293,8 +313,12 @@ module Net
       # where the request is sent. Doing that here rather than raising keeps
       # the two spellings interchangeable, as they are there.
       unless @started
-        start
+        # `start` is INSIDE the begin: `open_connection` assigns @socket and
+        # only then completes the TLS handshake, so a handshake failure raises
+        # with a live socket that nothing else will close. `finish` is a no-op
+        # when there is nothing open, which is the other way start can fail.
         begin
+          start
           return request(req)
         ensure
           finish

--- a/packages/net/net/http.rb
+++ b/packages/net/net/http.rb
@@ -97,7 +97,13 @@ module Net
       else
         (path.nil? || path.to_s.empty?) ? "/" : path.to_s
       end
+      # Downcased name => value, with the caller's spelling kept beside it for
+      # the wire. One key per header name makes a duplicate impossible to
+      # construct, which is what "keep the spelling, scan for case variants on
+      # every write" was doing by hand. The response half of this file has
+      # stored them downcased all along.
       @headers = {}
+      @header_names = {}
       @body = ""
       initheader.each { |k, v| self[k] = v } unless initheader.nil?
     end
@@ -107,48 +113,44 @@ module Net
     # half here already is. What is kept, rather than downcased the way the
     # response stores them, is the caller's spelling: for a request that is
     # what goes out on the wire.
-    # EVERY write goes through here -- `initheader`, `content_type=` and
-    # `set_form_data` included. Writing to `@headers` directly is how the same
-    # header ends up stored twice under two spellings and goes out on the wire
-    # twice: `Post.new(uri, "content-type" => "text/plain")` followed by
-    # `req.content_type = "application/json"` sent BOTH, and a server is free
-    # to believe either one.
+    # Header names are case-insensitive on the wire, and CRuby's
+    # Net::HTTPHeader is case-insensitive on both halves. Storing under the
+    # downcased name makes that a lookup rather than a scan, and makes it
+    # impossible to hold one header twice under two spellings -- which is what
+    # `Post.new(uri, "content-type" => …)` followed by `req.content_type = …`
+    # used to do, sending both and leaving the server to pick.
     def []=(name, value)
-      delete_header(name)
-      @headers[name.to_s] = value.to_s
+      k = name.to_s.downcase
+      # An Array joins with ", ", the way CRuby serves a multi-valued header:
+      # `req["Accept"] = %w[a b]` reads back "a, b" and goes out as one line.
+      # `to_s` on an Array is its INSPECT form, so without this the wire got
+      # `Accept: ["a", "b"]`.
+      #
+      # CRuby only reaches that path through `#[]=`; its initheader half calls
+      # `value.strip` per value and so raises NoMethodError for an Array. This
+      # package routes initheader through `#[]=` and therefore accepts one -- a
+      # deliberate divergence, in the permissive direction, and one rule for one
+      # value shape rather than two.
+      @headers[k] = value.is_a?(Array) ? value.map { |v| v.to_s }.join(", ") : value.to_s
+      @header_names[k] = name.to_s
+      value
     end
 
     def [](name)
-      k = header_name(name)
-      k.nil? ? nil : @headers[k]
+      @headers[name.to_s.downcase]
     end
 
     def key?(name)
-      !header_name(name).nil?
+      @headers.key?(name.to_s.downcase)
     end
 
-    # The stored spelling of a header, in whatever case the caller asks for it,
-    # or nil when it is not set.
-    def header_name(name)
-      want = name.to_s.downcase
-      found = nil
-      @headers.each_key { |k| found = k if k.to_s.downcase == want }
-      found
-    end
-
-    # Remove EVERY spelling of a header, not just one: a collision that
-    # predates this write needs clearing whole, or the duplicate survives the
-    # overwrite that was supposed to replace it.
-    def delete_header(name)
-      want = name.to_s.downcase
-      doomed = []
-      @headers.each_key { |k| doomed << k if k.to_s.downcase == want }
-      doomed.each { |k| @headers.delete(k) }
-      nil
-    end
-
+    # Yields the spelling the caller wrote, not the downcased key: for a
+    # request that is what goes out on the wire.
     def each_header
-      @headers.each { |k, v| yield k, v }
+      @headers.each do |k, v|
+        name = @header_names[k]
+        yield (name.nil? ? k : name), v
+      end
       nil
     end
 

--- a/packages/net/test/net_http_client.rb
+++ b/packages/net/test/net_http_client.rb
@@ -14,7 +14,7 @@ port = server.addr[1]
 
 t = Thread.new do
   seen = []
-  6.times do
+  7.times do
     c = server.accept
     req = c.gets.to_s.strip                 # the request line
     headers = {}
@@ -81,6 +81,17 @@ Net::HTTP.start("127.0.0.1", port) do |http|
   p http.get("/one").body
   p http.get("/two").body
 end
+
+# A request object built from a URI with an initial header hash, sent through a
+# Net::HTTP that was never started -- both are CRuby spellings, and together
+# they are how a caller that already parsed the URL writes a POST.
+uri = URI("http://127.0.0.1:#{port}/hook?k=v")
+post = Net::HTTP::Post.new(uri, "Content-Type" => "application/json")
+post.body = "{}"
+p post.path                    # the URI's request_uri, not its whole to_s
+p post["content-type"]
+r5 = Net::HTTP.new(uri.host, uri.port).request(post)
+p [r5.code, r5.body]
 
 t.value.each { |line| puts line }
 server.close

--- a/packages/net/test/net_http_client.rb
+++ b/packages/net/test/net_http_client.rb
@@ -36,7 +36,8 @@ t = Thread.new do
     # `headers` is keyed downcased, so two spellings of one name collapse
     # here; count the raw lines instead or a duplicate goes unseen.
     ctypes = raw.count { |l| l.downcase.start_with?("content-type:") }
-    seen << "#{req}|host-has-port=#{hostok}|content-type-lines=#{ctypes}|body=#{body}"
+    multi = raw.find { |l| l.downcase.start_with?("x-multi:") }.to_s
+    seen << "#{req}|host-has-port=#{hostok}|content-type-lines=#{ctypes}|#{multi}|body=#{body}"
 
     if req.include?("/chunked")
       c.write("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n")
@@ -106,6 +107,15 @@ dup = Net::HTTP::Post.new(uri2, "content-type" => "text/plain")
 dup.content_type = "application/json"
 p dup["Content-Type"]
 p dup["content-type"]          # either spelling finds the one value
+# A multi-valued header is ONE line, joined with ", ". `to_s` on an Array is
+# its inspect form, so getting this wrong puts `["a", "b"]` on the wire. Set
+# through `#[]=`, which is the path CRuby supports for an Array: its
+# initheader half calls `value.strip` per value and raises NoMethodError.
+# Folded onto this request rather than a fresh one on purpose -- a request
+# built WITHOUT the optional initheader, beside these that have it, is the
+# arity pair that segfaults (#4134).
+dup["X-Multi"] = [ "one", "two" ]
+p dup["X-Multi"]
 dup.body = "{}"
 r6 = Net::HTTP.new(uri2.host, uri2.port).request(dup)
 p r6.code

--- a/packages/net/test/net_http_client.rb
+++ b/packages/net/test/net_http_client.rb
@@ -14,13 +14,15 @@ port = server.addr[1]
 
 t = Thread.new do
   seen = []
-  7.times do
+  8.times do
     c = server.accept
     req = c.gets.to_s.strip                 # the request line
     headers = {}
+    raw = []
     while (line = c.gets)
       line = line.strip
       break if line.empty?
+      raw << line
       ci = line.index(":")
       headers[line[0, ci].downcase] = line[(ci + 1)..-1].to_s.strip unless ci.nil?
     end
@@ -31,7 +33,10 @@ t = Thread.new do
     end
     # The port is random, so record whether Host carried it rather than its value.
     hostok = headers["host"] == "127.0.0.1:#{port}"
-    seen << "#{req}|host-has-port=#{hostok}|body=#{body}"
+    # `headers` is keyed downcased, so two spellings of one name collapse
+    # here; count the raw lines instead or a duplicate goes unseen.
+    ctypes = raw.count { |l| l.downcase.start_with?("content-type:") }
+    seen << "#{req}|host-has-port=#{hostok}|content-type-lines=#{ctypes}|body=#{body}"
 
     if req.include?("/chunked")
       c.write("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n")
@@ -92,6 +97,18 @@ p post.path                    # the URI's request_uri, not its whole to_s
 p post["content-type"]
 r5 = Net::HTTP.new(uri.host, uri.port).request(post)
 p [r5.code, r5.body]
+
+# A header set twice under two spellings is ONE header. `initheader` takes the
+# caller's lowercase spelling, `content_type=` then overwrites it; sending both
+# leaves the server to pick, which is not a choice it should have.
+uri2 = URI("http://127.0.0.1:#{port}/dup")
+dup = Net::HTTP::Post.new(uri2, "content-type" => "text/plain")
+dup.content_type = "application/json"
+p dup["Content-Type"]
+p dup["content-type"]          # either spelling finds the one value
+dup.body = "{}"
+r6 = Net::HTTP.new(uri2.host, uri2.port).request(dup)
+p r6.code
 
 t.value.each { |line| puts line }
 server.close

--- a/packages/net/test/net_http_client.rb.expected
+++ b/packages/net/test/net_http_client.rb.expected
@@ -14,12 +14,13 @@ true
 ["200", "ok:{}"]
 "application/json"
 "application/json"
+"one, two"
 "200"
-GET /a?x=1 HTTP/1.1|host-has-port=true|content-type-lines=0|body=
-GET /chunked HTTP/1.1|host-has-port=true|content-type-lines=0|body=
-POST /f HTTP/1.1|host-has-port=true|content-type-lines=1|body=a=1&b=x+y
-GET /notfound HTTP/1.1|host-has-port=true|content-type-lines=0|body=
-GET /one HTTP/1.1|host-has-port=true|content-type-lines=0|body=
-GET /two HTTP/1.1|host-has-port=true|content-type-lines=0|body=
-POST /hook?k=v HTTP/1.1|host-has-port=true|content-type-lines=1|body={}
-POST /dup HTTP/1.1|host-has-port=true|content-type-lines=1|body={}
+GET /a?x=1 HTTP/1.1|host-has-port=true|content-type-lines=0||body=
+GET /chunked HTTP/1.1|host-has-port=true|content-type-lines=0||body=
+POST /f HTTP/1.1|host-has-port=true|content-type-lines=1||body=a=1&b=x+y
+GET /notfound HTTP/1.1|host-has-port=true|content-type-lines=0||body=
+GET /one HTTP/1.1|host-has-port=true|content-type-lines=0||body=
+GET /two HTTP/1.1|host-has-port=true|content-type-lines=0||body=
+POST /hook?k=v HTTP/1.1|host-has-port=true|content-type-lines=1||body={}
+POST /dup HTTP/1.1|host-has-port=true|content-type-lines=1|X-Multi: one, two|body={}

--- a/packages/net/test/net_http_client.rb.expected
+++ b/packages/net/test/net_http_client.rb.expected
@@ -9,9 +9,13 @@ true
 [true, true, false]
 "ok:"
 "ok:"
+"/hook?k=v"
+"application/json"
+["200", "ok:{}"]
 GET /a?x=1 HTTP/1.1|host-has-port=true|body=
 GET /chunked HTTP/1.1|host-has-port=true|body=
 POST /f HTTP/1.1|host-has-port=true|body=a=1&b=x+y
 GET /notfound HTTP/1.1|host-has-port=true|body=
 GET /one HTTP/1.1|host-has-port=true|body=
 GET /two HTTP/1.1|host-has-port=true|body=
+POST /hook?k=v HTTP/1.1|host-has-port=true|body={}

--- a/packages/net/test/net_http_client.rb.expected
+++ b/packages/net/test/net_http_client.rb.expected
@@ -12,10 +12,14 @@ true
 "/hook?k=v"
 "application/json"
 ["200", "ok:{}"]
-GET /a?x=1 HTTP/1.1|host-has-port=true|body=
-GET /chunked HTTP/1.1|host-has-port=true|body=
-POST /f HTTP/1.1|host-has-port=true|body=a=1&b=x+y
-GET /notfound HTTP/1.1|host-has-port=true|body=
-GET /one HTTP/1.1|host-has-port=true|body=
-GET /two HTTP/1.1|host-has-port=true|body=
-POST /hook?k=v HTTP/1.1|host-has-port=true|body={}
+"application/json"
+"application/json"
+"200"
+GET /a?x=1 HTTP/1.1|host-has-port=true|content-type-lines=0|body=
+GET /chunked HTTP/1.1|host-has-port=true|content-type-lines=0|body=
+POST /f HTTP/1.1|host-has-port=true|content-type-lines=1|body=a=1&b=x+y
+GET /notfound HTTP/1.1|host-has-port=true|content-type-lines=0|body=
+GET /one HTTP/1.1|host-has-port=true|content-type-lines=0|body=
+GET /two HTTP/1.1|host-has-port=true|content-type-lines=0|body=
+POST /hook?k=v HTTP/1.1|host-has-port=true|content-type-lines=1|body={}
+POST /dup HTTP/1.1|host-has-port=true|content-type-lines=1|body={}


### PR DESCRIPTION
Three places where a request written in the CRuby spelling did not run under
the `net` package. All three sit in the same four lines a caller writes to POST
to a URL it has already parsed — this is [once-campfire's
`Webhook#deliver`](https://github.com/basecamp/once-campfire/blob/main/app/models/webhook.rb),
reduced:

```ruby
require "net/http"
require "uri"

uri = URI("http://127.0.0.1:9/hook")
req = Net::HTTP::Post.new(uri, "Content-Type" => "application/json")
req.body = "{}"
p req.path
p req["content-type"]
http = Net::HTTP.new(uri.host, uri.port)
begin
  http.request(req)
rescue => e
  puts "#{e.class}: #{e.message}"
end
```

| | before | CRuby |
|---|---|---|
| `Post.new(uri, hdrs)` | `ArgumentError: wrong number of arguments (given 2, expected 1)` | `"/hook"` |
| `req["content-type"]` | `nil` | `"application/json"` |
| `#request` unstarted | `Net::HTTPError: not started` | `Errno::ECONNREFUSED` |

### What changed

* **`HTTPRequest#initialize` takes an `initheader`**, and the five verb
  subclasses forward it. A URI argument contributes its `request_uri` — the
  path with the query — not its `to_s`, which is the whole URL and would go
  out as an absolute request line.

* **`#request` opens a connection when there is none.** CRuby's `#request` on
  an unstarted `Net::HTTP` starts it, runs the request and finishes, which is
  what a caller writes when the connection is configured somewhere other than
  where the request is sent. Doing that here rather than raising keeps the two
  spellings interchangeable, as they are there.

* **Request header lookup is case-insensitive.** A header stored as
  `"Content-Type"` read back as `nil` through `req["content-type"]`. Names are
  case-insensitive on the wire, CRuby's `Net::HTTPHeader` is case-insensitive
  on both halves, and the *response* half of this file already was — the
  request half was the odd one out. The caller's spelling is still what is
  stored, because for a request that is what goes on the wire.

### Test

`packages/net/test/net_http_client.rb` grows the four lines above end to end
against the server it already stands up, so all three are gated. `.expected`
is CRuby's own output for the same file, and the pre-existing lines in it are
unchanged. Reverting `net/http.rb` alone takes the test to FAIL (it was worth
checking — `make`'s exit status is 0 either way; the verdict is the contents of
`build/test-results/pkg.net.net_http_client.ok`).

`make test`: **3254 pass, 0 fail, 0 error** on macOS.

### Not in this PR

Two things this same call site wants that are not package-level fixes, noted
here so the gap is visible rather than filed as a surprise later:

* `open_timeout` / `read_timeout` are stored in `initialize` and never read
  again, and `Net::OpenTimeout` / `Net::ReadTimeout` do not exist — so a
  timeout is accepted and silently does nothing, and the `rescue` campfire
  writes around it cannot be written. That needs a socket-level timeout, so it
  wants its own issue.
* The streaming surface (`#request` with a block, `#read_body` with a block,
  `start(ipaddr:)`) — deliberately absent per the package header. It matters
  for fetching an *untrusted* URL, where reading the body whole is unbounded
  and connecting by hostname re-resolves past a DNS check; I'd rather raise
  that as a use case than assume it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ヘッダー名を大文字・小文字にかかわらず同一のものとして扱えるようになりました。
  - 複数の値を持つヘッダーを、カンマ区切りで送信・取得できるようになりました。
  - ヘッダーを設定しても、送信時には指定した表記を保持します。

- **バグ修正**
  - 同名ヘッダーの上書きや取得が正しく行われるようになりました。
  - ヘッダーの重複送信を防ぎ、HTTPリクエストの動作を安定させました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->