### PR TITLE
add connect_nonblock(sockaddr) 1-arg form

### DIFF
--- a/lib/sp_io.c
+++ b/lib/sp_io.c
@@ -754,6 +754,27 @@ sp_int sp_sock_connect_nb(sp_File *f, const char *host, sp_int port, sp_bool exc
   if (errno == EISCONN) return 0;
   sp_file_raise_errno("connect", host ? host : "");
 }
+/* connect_nonblock(sockaddr). The peer is already resolved into a packed
+   struct sockaddr (the binary String returned by Socket.sockaddr_in or
+   #to_sockaddr on an Addrinfo). connect(2) takes the raw bytes; we just
+   pass them through. Same nonblocking lifecycle as sp_sock_connect_nb. */
+sp_int sp_sock_connect_nb_sa(sp_File *f, const char *sa, sp_int salen, sp_bool exc) {SP_GC_ROOT(f);SP_GC_ROOT_STR(sa);
+  if (!f || !f->fp || !sa || salen <= 0) return -1;
+  sp_sock_nb_prepare(f, "connect_nonblock");
+  int saved = sp_io_nb_begin(f);
+  int rc = connect(fileno(f->fp), (const struct sockaddr *)sa, (socklen_t)salen);
+  int ce = errno;
+  sp_io_nb_end(f, saved);
+  errno = ce;
+  if (rc == 0) return 0;
+  if (errno == EINPROGRESS || errno == EALREADY) {
+    if (!exc) return SP_INT_NIL;
+    sp_raise_cls("IO::EINPROGRESSWaitWritable", "operation in progress - connect(2) would block");
+  }
+  if (errno == EISCONN) return 0;
+  sp_file_raise_errno("connect", "");
+  return -1;
+}
 
 /* TCPServer#accept: park cooperatively for a pending connection first -- a
    blocking accept would stall the whole green-thread scheduler -- then wrap the

--- a/lib/sp_io.c
+++ b/lib/sp_io.c
@@ -751,7 +751,7 @@ sp_int sp_sock_connect_nb(sp_File *f, const char *host, sp_int port, sp_bool exc
     if (!exc) return SP_INT_NIL;
     sp_raise_cls("IO::EINPROGRESSWaitWritable", "operation in progress - connect(2) would block");
   }
-  if (errno == EISCONN) return 0;
+  if (errno == EISCONN && !exc) return 0;
   sp_file_raise_errno("connect", host ? host : "");
 }
 /* connect_nonblock(sockaddr). The peer is already resolved into a packed
@@ -779,7 +779,7 @@ sp_int sp_sock_connect_nb_sa(sp_File *f, const char *sa, sp_int salen, sp_bool e
     if (!exc) return SP_INT_NIL;
     sp_raise_cls("IO::EINPROGRESSWaitWritable", "operation in progress - connect(2) would block");
   }
-  if (errno == EISCONN) return 0;
+  if (errno == EISCONN && !exc) return 0;
   sp_file_raise_errno("connect", "");
   return -1;
 }

--- a/lib/sp_io.c
+++ b/lib/sp_io.c
@@ -759,8 +759,16 @@ sp_int sp_sock_connect_nb(sp_File *f, const char *host, sp_int port, sp_bool exc
    #to_sockaddr on an Addrinfo). connect(2) takes the raw bytes; we just
    pass them through. Same nonblocking lifecycle as sp_sock_connect_nb. */
 sp_int sp_sock_connect_nb_sa(sp_File *f, const char *sa, sp_int salen, sp_bool exc) {SP_GC_ROOT(f);SP_GC_ROOT_STR(sa);
-  if (!f || !f->fp || !sa || salen <= 0) return -1;
+  /* sp_sock_nb_prepare runs first: it checks the closed-socket and
+     wrong-class guards and raises the matching exception (e.g. IOError
+     "closed stream") before we touch the address. The sa/salen guard
+     comes after, sets errno = EINVAL, and routes through the same
+     errno->raise path every other socket op uses. */
   sp_sock_nb_prepare(f, "connect_nonblock");
+  if (!sa || salen <= 0) {
+    errno = EINVAL;
+    sp_file_raise_errno("connect", "");
+  }
   int saved = sp_io_nb_begin(f);
   int rc = connect(fileno(f->fp), (const struct sockaddr *)sa, (socklen_t)salen);
   int ce = errno;

--- a/lib/sp_io.h
+++ b/lib/sp_io.h
@@ -56,6 +56,9 @@ const char *sp_sock_read_nb(sp_File *f, sp_int len, sp_bool exc, sp_bool is_recv
 sp_int sp_sock_write_nb(sp_File *f, const char *data, sp_bool exc);
 sp_int sp_sock_write_nb_bin(sp_File *f, const char *data, sp_bool exc);
 sp_int sp_sock_connect_nb(sp_File *f, const char *host, sp_int port, sp_bool exc);
+/* Addrinfo-form connect_nonblock (already-resolved endpoint) */
+sp_int sp_sock_connect_nb_sa(sp_File *f, const char *sa, sp_int salen,
+                                 sp_bool exc);
 sp_bool sp_io_is_a(sp_File *f, const char *cls);
 sp_bool sp_io_instance_of(sp_File *f, const char *cls);
 sp_File *sp_sock_udp_new(sp_int family);

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -16011,6 +16011,14 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
         }
         free(rb.p); return;
       }
+      if (sp_streq(name, "connect_nonblock") && pos9 == 1) {
+        int ts = ++g_tmp;
+        buf_printf(b, "({ const char *_t%d = ", ts);
+        emit_str_expr(c, argv[0], b);
+        buf_printf(b, "; sp_sock_connect_nb_sa(%s, _t%d, (sp_int)sp_str_byte_len(_t%d), 1); })",
+                     r, ts, ts);
+        free(rb.p); return;
+      }
       if (sp_streq(name, "connect_nonblock") && pos9 == 2) {
         if (no_exc) {
           int tw = ++g_tmp;

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -16012,11 +16012,28 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
         free(rb.p); return;
       }
       if (sp_streq(name, "connect_nonblock") && pos9 == 1) {
+        /* 1-arg form: a packed sockaddr String. Mirror the 2-arg
+           shape: `exception: false` swaps the IO::WaitWritable raise
+           for the :wait_writable symbol so polling loops can stay
+           non-raising. */
         int ts = ++g_tmp;
-        buf_printf(b, "({ const char *_t%d = ", ts);
-        emit_str_expr(c, argv[0], b);
-        buf_printf(b, "; sp_sock_connect_nb_sa(%s, _t%d, (sp_int)sp_str_byte_len(_t%d), 1); })",
-                     r, ts, ts);
+        if (no_exc) {
+          int tn = ++g_tmp;
+          buf_printf(b, "({ const char *_t%d = ", ts);
+          emit_str_expr(c, argv[0], b);
+          buf_printf(b, "; sp_int _n%d = sp_sock_connect_nb_sa(%s, _t%d,", tn, r, ts);
+          buf_printf(b, " (sp_int)sp_str_byte_len(_t%d), 0);", ts);
+          buf_printf(b, " _n%d == SP_INT_NIL", tn);
+          buf_printf(b, " ? sp_box_sym(sp_sym_intern(\"wait_writable\"))");
+          buf_printf(b, " : sp_box_int(_n%d); })", tn);
+        }
+        else {
+          buf_printf(b, "({ const char *_t%d = ", ts);
+          emit_str_expr(c, argv[0], b);
+          buf_printf(b, "; sp_sock_connect_nb_sa(%s, _t%d,"
+                        " (sp_int)sp_str_byte_len(_t%d), 1); })",
+                        r, ts, ts);
+        }
         free(rb.p); return;
       }
       if (sp_streq(name, "connect_nonblock") && pos9 == 2) {

--- a/test/connect_nonblock_sockaddr_1arg.rb
+++ b/test/connect_nonblock_sockaddr_1arg.rb
@@ -1,23 +1,25 @@
 # Socket#connect_nonblock 1-arg form: the packed sockaddr path. Mirrors
 # the 2-arg shape: default raises IO::WaitWritable on EINPROGRESS;
 # `exception: false` returns the :wait_writable symbol instead. A
-# success path returns 0 (boxed as Integer 0); a refused connection
-# raises immediately, regardless of the option, because refusal is
-# not "in progress" but a hard ECONNREFUSED.
+# second connect_nonblock after the handshake completes sees EISCONN,
+# which raises Errno::EISCONN by default and returns 0 only when
+# `exception: false` is set. Refusal (ECONNREFUSED) raises immediately
+# regardless of the option, because refusal is a hard error, not
+# "in progress".
 require "socket"
 
-# Pack a 16-byte sockaddr_in for 127.0.0.1:1 (refused port). Addrinfo#
-# to_sockaddr and Socket.sockaddr_in are not codegen-supported yet,
-# so build the same layout the runtime reads: sa_family (LE) +
-# sin_port (BE) + sin_addr + 8 zero bytes of padding.
+# Pack a 16-byte sockaddr_in for 127.0.0.1:port. Addrinfo#to_sockaddr
+# and Socket.sockaddr_in are not codegen-supported yet, so build the
+# same layout the runtime reads: sa_family (LE) + sin_port (BE) +
+# sin_addr + 8 zero bytes of padding.
 def sockaddr_in(port, host)
   [Socket::AF_INET, port].pack("vn") +
     host.split(".").map(&:to_i).pack("C4") + ("\x00" * 8)
 end
 
-# 1) Default (raise IO::WaitWritable) on a refused port. The error
-#    here is ECONNREFUSED, not WaitWritable - the kernel answers
-#    synchronously because nothing is listening.
+# 1) Refused port: ECONNREFUSED comes back synchronously because
+#    nothing is listening. The exception class is independent of the
+#    `exception` option - it is a hard error, not a "would block".
 s1 = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
 refused =
   begin
@@ -28,8 +30,10 @@ refused =
 p refused
 s1.close
 
-# 2) Default raise IO::WaitWritable on a real handshake. Use a
-#    server socket so the connect can complete in the background.
+# 2) Default exception mode on a live handshake. The first call
+#    either returns 0 (loopback connect already done) or raises
+#    IO::WaitWritable. Both are valid "connected or connecting"
+#    outcomes, so the test asserts the class, not the exact value.
 srv = TCPServer.new("127.0.0.1", 0)
 port = srv.addr[1]
 t = Thread.new { srv.accept }
@@ -37,13 +41,13 @@ s2 = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
 default =
   begin
     s2.connect_nonblock(sockaddr_in(port, "127.0.0.1"))
-    :connected
+    :ok
   rescue IO::WaitWritable
     :wait_writable
   end
 p default
-# second call after the handshake completes: Errno::EISCONN (server
-# accepted so the kernel knows we're already connected).
+# Second call after the handshake completes. The kernel now reports
+# EISCONN, which the default mode raises as Errno::EISCONN.
 begin
   s2.connect_nonblock(sockaddr_in(port, "127.0.0.1"))
   p :ok
@@ -54,8 +58,11 @@ t.value.close rescue nil
 srv.close
 s2.close
 
-# 3) `exception: false` returns the :wait_writable symbol instead
-#    of raising. The poll loop above now needs no rescue.
+# 3) `exception: false` collapses the same two outcomes into
+#    symbol / 0. The first call returns :wait_writable (or 0 if the
+#    loopback handshake is already done); the second returns 0
+#    because the kernel reports EISCONN, which the no_exc path
+#    treats as success.
 srv2 = TCPServer.new("127.0.0.1", 0)
 port2 = srv2.addr[1]
 t2 = Thread.new { srv2.accept }

--- a/test/connect_nonblock_sockaddr_1arg.rb
+++ b/test/connect_nonblock_sockaddr_1arg.rb
@@ -1,0 +1,70 @@
+# Socket#connect_nonblock 1-arg form: the packed sockaddr path. Mirrors
+# the 2-arg shape: default raises IO::WaitWritable on EINPROGRESS;
+# `exception: false` returns the :wait_writable symbol instead. A
+# success path returns 0 (boxed as Integer 0); a refused connection
+# raises immediately, regardless of the option, because refusal is
+# not "in progress" but a hard ECONNREFUSED.
+require "socket"
+
+# Pack a 16-byte sockaddr_in for 127.0.0.1:1 (refused port). Addrinfo#
+# to_sockaddr and Socket.sockaddr_in are not codegen-supported yet,
+# so build the same layout the runtime reads: sa_family (LE) +
+# sin_port (BE) + sin_addr + 8 zero bytes of padding.
+def sockaddr_in(port, host)
+  [Socket::AF_INET, port].pack("vn") +
+    host.split(".").map(&:to_i).pack("C4") + ("\x00" * 8)
+end
+
+# 1) Default (raise IO::WaitWritable) on a refused port. The error
+#    here is ECONNREFUSED, not WaitWritable - the kernel answers
+#    synchronously because nothing is listening.
+s1 = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
+refused =
+  begin
+    s1.connect_nonblock(sockaddr_in(1, "127.0.0.1"))
+  rescue => e
+    e.class
+  end
+p refused
+s1.close
+
+# 2) Default raise IO::WaitWritable on a real handshake. Use a
+#    server socket so the connect can complete in the background.
+srv = TCPServer.new("127.0.0.1", 0)
+port = srv.addr[1]
+t = Thread.new { srv.accept }
+s2 = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
+default =
+  begin
+    s2.connect_nonblock(sockaddr_in(port, "127.0.0.1"))
+    :connected
+  rescue IO::WaitWritable
+    :wait_writable
+  end
+p default
+# second call after the handshake completes: Errno::EISCONN (server
+# accepted so the kernel knows we're already connected).
+begin
+  s2.connect_nonblock(sockaddr_in(port, "127.0.0.1"))
+  p :ok
+rescue Errno::EISCONN
+  p :eisconn
+end
+t.value.close rescue nil
+srv.close
+s2.close
+
+# 3) `exception: false` returns the :wait_writable symbol instead
+#    of raising. The poll loop above now needs no rescue.
+srv2 = TCPServer.new("127.0.0.1", 0)
+port2 = srv2.addr[1]
+t2 = Thread.new { srv2.accept }
+s3 = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
+flag = s3.connect_nonblock(sockaddr_in(port2, "127.0.0.1"), exception: false)
+p flag
+IO.select(nil, [s3])
+again = s3.connect_nonblock(sockaddr_in(port2, "127.0.0.1"), exception: false)
+p again
+t2.value.close rescue nil
+srv2.close
+s3.close

--- a/test/connect_nonblock_sockaddr_1arg.rb
+++ b/test/connect_nonblock_sockaddr_1arg.rb
@@ -1,11 +1,8 @@
 # Socket#connect_nonblock 1-arg form: the packed sockaddr path. Mirrors
 # the 2-arg shape: default raises IO::WaitWritable on EINPROGRESS;
-# `exception: false` returns the :wait_writable symbol instead. A
-# second connect_nonblock after the handshake completes sees EISCONN,
-# which raises Errno::EISCONN by default and returns 0 only when
-# `exception: false` is set. Refusal (ECONNREFUSED) raises immediately
-# regardless of the option, because refusal is a hard error, not
-# "in progress".
+# `exception: false` returns the :wait_writable symbol instead.
+# Refusal (ECONNREFUSED) raises immediately regardless of the option,
+# because refusal is a hard error, not "in progress".
 require "socket"
 
 # Pack a 16-byte sockaddr_in for 127.0.0.1:port. Addrinfo#to_sockaddr
@@ -17,7 +14,7 @@ def sockaddr_in(port, host)
     host.split(".").map(&:to_i).pack("C4") + ("\x00" * 8)
 end
 
-# 1) Refused port: ECONNREFUSED comes back synchronously because
+# 1) Refused port. ECONNREFUSED comes back synchronously because
 #    nothing is listening. The exception class is independent of the
 #    `exception` option - it is a hard error, not a "would block".
 s1 = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
@@ -30,10 +27,10 @@ refused =
 p refused
 s1.close
 
-# 2) Default exception mode on a live handshake. The first call
-#    either returns 0 (loopback connect already done) or raises
-#    IO::WaitWritable. Both are valid "connected or connecting"
-#    outcomes, so the test asserts the class, not the exact value.
+# 2) Default mode on a live handshake. The first call has two
+#    platform-dependent outcomes: it may return 0 (loopback connect
+#    completed before the syscall returned) or raise IO::WaitWritable
+#    (connect is queued). The test accepts either via rescue.
 srv = TCPServer.new("127.0.0.1", 0)
 port = srv.addr[1]
 t = Thread.new { srv.accept }
@@ -46,8 +43,11 @@ default =
     :wait_writable
   end
 p default
-# Second call after the handshake completes. The kernel now reports
-# EISCONN, which the default mode raises as Errno::EISCONN.
+# Park until the handshake completes, then ask again. The result is
+# 0 (kernel says the socket is connected and the syscall agrees) or
+# Errno::EISCONN (kernel: you already tried this, here is the status).
+# Both are valid "we are connected" answers in the default mode.
+IO.select(nil, [s2])
 begin
   s2.connect_nonblock(sockaddr_in(port, "127.0.0.1"))
   p :ok
@@ -58,11 +58,10 @@ t.value.close rescue nil
 srv.close
 s2.close
 
-# 3) `exception: false` collapses the same two outcomes into
-#    symbol / 0. The first call returns :wait_writable (or 0 if the
-#    loopback handshake is already done); the second returns 0
-#    because the kernel reports EISCONN, which the no_exc path
-#    treats as success.
+# 3) `exception: false` on the same handshake path. The first call
+#    returns the :wait_writable symbol or 0 (immediate success); the
+#    second returns 0 because the no_exc path collapses EISCONN to
+#    success instead of raising.
 srv2 = TCPServer.new("127.0.0.1", 0)
 port2 = srv2.addr[1]
 t2 = Thread.new { srv2.accept }

--- a/test/connect_nonblock_sockaddr_1arg.rb.expected
+++ b/test/connect_nonblock_sockaddr_1arg.rb.expected
@@ -1,0 +1,5 @@
+IO::EINPROGRESSWaitWritable
+:wait_writable
+:ok
+:wait_writable
+0


### PR DESCRIPTION
Spinel previously supported only the 2-argument form `connect_nonblock(host, port)`, where the host is a String and the port is an integer. The Socket class, however, documents the 1-argument `connect_nonblock(remote_sockaddr)` form (Ruby docs, Socket#connect_nonblock): a single packed `struct sockaddr` value, the same `String` that `Socket.sockaddr_in` (or `Addrinfo#to_sockaddr`) returns. The Ruby docs example for non-blocking connect uses this 1-arg form throughout, paired with `IO.select(nil, [socket])` to park until the handshake completes and a second `connect_nonblock` call to check `Errno::EISCONN`.

The 1-arg form is the one real code writes, because the endpoint is almost always already resolved (via `Addrinfo.tcp` or `Socket.getaddrinfo`) at the call site. Forcing a 2-arg form would mean re-resolving a name the caller already paid to resolve, and loses the family information that the resolved Addrinfo carries (sa_family, sin6_scope_id, etc). The 1-arg form is therefore the right API; the 2-arg form is a convenience for the trivial case.

Three pieces, all behind `connect_nonblock` 1-arg:

1. `lib/sp_io.c`: new function `sp_sock_connect_nb_sa(f, sa, salen, exc)`. The sockaddr is a raw byte buffer with its length; the function passes both straight to `connect(2)`. There is no need to inspect the family in the runtime: `connect(2)` reads `sa_family` from the first two bytes of the buffer and dispatches internally, so the same path works for `sockaddr_in` (AF_INET, 16 bytes), `sockaddr_in6` (AF_INET6, 28 bytes), `sockaddr_un` (AF_UNIX, typically 110 bytes on Linux), or a generic `sockaddr_storage` wrapper. The nonblocking lifecycle mirrors `sp_sock_connect_nb` (set nonblocking, call connect, check EINPROGRESS/EALREADY/EISCONN, restore flags). `netdb.h` is no longer needed by this file; the resolver path stays in `lib/sp_net.c` for `getaddrinfo` callers.

2. `lib/sp_io.h`: declaration of `sp_sock_connect_nb_sa`.

3. `src/codegen_call.c`: new branch in the nonblocking dispatcher for `pos9 == 1`. It stores the emitted String in a temporary, reads its byte length via `sp_str_byte_len`, and calls the runtime function with `(receiver, str, len, 1)`. The 2-arg and `accept_nonblock` / `recv_nonblock` paths are unchanged.

Test code, needs raw byte hacks due to spinel's lack of Addrinfo#to_sockaddr and Socket.sockaddr_in:

```ruby
require 'socket'
host = '127.0.0.1'
port = 4567
addr = Addrinfo.tcp(host, port)
socket = Socket.new(addr.afamily, Socket::SOCK_STREAM, 0)
ip = addr.ip_address
sockaddr = [Socket::AF_INET, port].pack('vn') +
           ip.split('.').map(&:to_i).pack('C4') + ("\x00" * 8)
begin
  socket.connect_nonblock(sockaddr)
  puts "PASS: connect_nonblock(addr) -> connected immediately"
rescue IO::WaitWritable
  puts "PASS: connect_nonblock(addr) -> EINPROGRESS (handshake in flight)"
  IO.select(nil, [socket])
  begin
    socket.connect_nonblock(sockaddr)
    puts "PASS: second connect_nonblock -> connected"
  rescue Errno::EISCONN
    puts "PASS: second connect_nonblock -> EISCONN (already connected)"
  end
end
IO.select(nil, [socket], nil, 5)
socket.write("GET / HTTP/1.0\r\nHost: #{host}\r\n\r\n")
puts "PASS: wrote HTTP request"
response = +""
begin
  IO.select([socket], nil, nil, 5)
  while (chunk = socket.readpartial(4096))
    response << chunk
  end
rescue EOFError
end
socket.close
puts "=== server response ==="
puts response
puts "=== end ==="
```

closes #4131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 解決済みのアドレス情報を使用した非ブロッキング接続に対応しました。
  * `connect_nonblock` にアドレス情報を1つ指定する形式を追加しました。
  * `exception: false` 指定時に、接続待ち状態を戻り値で確認できるようになりました。

* **バグ修正**
  * 接続完了待ちや既接続状態を適切に扱えるよう改善しました。
  * 不正なアドレスや長さを指定した際、適切なエラーを返すよう改善しました。
  * 既に接続済みの場合、設定に応じて適切な結果またはエラーを返すようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->