### PR TITLE
Type empty literals from their use context

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -7538,6 +7538,16 @@ static void mark_empty_array_operands(Compiler *c) {
       TyKind at = infer_type(c, av[0]);
       if (ty_is_array(at) && at != TY_POLY_ARRAY) { c->arr_want[recv] = at; continue; }
     }
+    /* When both operands are bare `[]`, the receiver becomes a poly array but
+       the argument has no independently inferred kind. Give that argument the
+       same poly layout before codegen; otherwise `[] == []` / `[] | []` pass
+       the default sp_IntArray* into a path expecting sp_PolyArray*. Seeds keep
+       their existing back-fill behavior through the block parameter. */
+    if (!seed) {
+      for (int k = 0; k < an; k++)
+        if (is_empty_array_literal(nt, av[k], c->node_cap) && c->arr_want[av[k]] == TY_UNKNOWN)
+          c->arr_want[av[k]] = TY_POLY_ARRAY;
+    }
     /* ... any other bare `[]` receiver is an empty poly array */
     c->empty_arr_recv[recv] = 1;
     /* The marking gives the receiver an element type, but a block parameter is
@@ -14106,4 +14116,3 @@ void analyze_program(Compiler *c) {
      uncelled, and the emit refuses. Only sets is_cell, and is idempotent. */
   mark_proc_captures(c);
 }
-

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -7485,69 +7485,60 @@ static void narrow_nil_guard_params(Compiler *c) {
   }
 }
 
-/* Mark every empty `[]` literal used as the receiver of a whitelisted iterator
-   (`[].each { }`, `[].map { }`, ...), so infer_uncached types it TY_POLY_ARRAY
-   and the iterator dispatches over an empty poly array instead of aborting on an
-   unresolved receiver. Restricted to iterators whose empty-poly-array codegen is
-   known-good; the non-block empty-literal folds (`[].sum(n)`, `[].reduce(i,:s)`)
-   and the `x = []` element back-fill are on other nodes, so both are untouched. */
-static int empty_arr_iter_ok(const char *nm) {
+/* An empty `[]` infers TY_UNKNOWN so `x = []; x << 1` can back-fill from the
+   writes. A literal consumed on the spot has no writes to wait for, so it takes
+   its kind from the use: a receiver or interpolation is a poly array; an
+   argument to a typed-array method is that array's kind when the method
+   combines arrays (`+`, `concat`, `==`, ...) and a poly array otherwise.
+   Runs after the fixpoint, where receiver kinds are settled. */
+static int empty_arr_same_kind_method(const char *nm) {
   static const char *const ok[] = {
-    "each", "map", "collect", "select", "filter", "reject", "filter_map",
-    "find", "detect", "each_with_object",
-    "group_by", "sort_by", "min_by", "max_by", "flat_map",
-    "reduce", "inject",
-    /* the block forms that were still refusing an empty literal receiver */
-    "partition", "take_while", "drop_while", "each_with_index",
-    /* the cycling block forms, which were refused for the same reason: an
-       empty literal receiver has no array kind for the loop (#3852) */
-    "cycle", "each_slice", "each_cons", "each_entry",
-    /* tap / then yield the receiver itself rather than an element, but they
-       need its kind for the same reason: without one the block parameter had
-       no type and the binding declared a `void` temp (#3929). */
-    "tap", "then", "yield_self", NULL };
+    "+", "-", "&", "|", "==", "!=", "<=>", "eql?", "concat", "replace",
+    "union", "intersection", "difference", "intersect?", "equal?", NULL };
   for (int i = 0; ok[i]; i++) if (sp_streq(nm, ok[i])) return 1;
   return 0;
 }
-static void mark_empty_array_receivers(Compiler *c) {
-  if (!c->empty_arr_recv) return;
+static int is_empty_array_literal(const NodeTable *nt, int id, int cap) {
+  if (id < 0 || id >= cap || nt_kind(nt, id) != NK_ArrayNode) return 0;
+  int en = 0; nt_arr(nt, id, "elements", &en);
+  return en == 0;
+}
+static void mark_empty_array_operands(Compiler *c) {
+  if (!c->empty_arr_recv || !c->arr_want) return;
   const NodeTable *nt = c->nt;
-  for (int id = 0; id < nt->count; id++) {
-    const char *ty = nt_type(nt, id);
-    if (!ty || !sp_streq(ty, "CallNode")) continue;
+  NT_FOREACH_KIND(nt, NK_EmbeddedStatementsNode, es) {
+    int st = nt_ref(nt, es, "statements");
+    int bn = 0; const int *bb = st >= 0 ? nt_arr(nt, st, "body", &bn) : NULL;
+    if (bn == 1 && is_empty_array_literal(nt, bb[0], c->node_cap)) c->empty_arr_recv[bb[0]] = 1;
+  }
+  NT_FOREACH_KIND(nt, NK_CallNode, id) {
     const char *nm = nt_str(nt, id, "name");
-    /* product takes no block; max/min/sample WITH a count arg take no block
-       but return an array (via the PolyArray sort/shuffle path) -- an empty
-       int-array literal there would be passed to sp_PolyArray_* as an
-       sp_IntArray* (#2864). Everything else on the list is block-gated so the
-       non-block empty-literal folds (sum, inject(:sym), first) keep their arms. */
-    int has_block = nt_ref(nt, id, "block") >= 0;
-    int count_form = 0;
-    if (nm && (sp_streq(nm, "max") || sp_streq(nm, "min") || sp_streq(nm, "sample"))) {
-      int an = nt_ref(nt, id, "arguments"); int ac = 0;
-      if (an >= 0) nt_arr(nt, an, "arguments", &ac);
-      count_form = (ac == 1);
-    }
-    /* blockless zip pairs elementwise into a PolyArray of PolyArrays: an
-       untyped empty literal receiver had no array kind, so the call fell
-       through to the set-op arm and emitted sp_<T>Array_difference (#3332) */
-    int zip_form = nm && sp_streq(nm, "zip") && !has_block;
-    /* blockless forms that answer an Enumerator (or a plain value) over the
-       elements: with no array kind on the receiver, no arm claimed them and
-       the call was refused outright (#3618) */
-    int enum_form = nm && !has_block &&
-                    (sp_streq(nm, "each_with_index") ||
-                     sp_streq(nm, "each_entry") || sp_streq(nm, "frozen?"));
-    if (!has_block && !(nm && sp_streq(nm, "product")) && !count_form && !zip_form &&
-        !enum_form) continue;
-    if (!nm || (!empty_arr_iter_ok(nm) && !sp_streq(nm, "product") && !count_form &&
-                !zip_form && !enum_form)) continue;
     int recv = nt_ref(nt, id, "receiver");
     if (recv < 0 || recv >= c->node_cap) continue;
-    const char *rty = nt_type(nt, recv);
-    if (!rty || !sp_streq(rty, "ArrayNode")) continue;
-    int en = 0; nt_arr(nt, recv, "elements", &en);
-    if (en != 0) continue;
+    int anode = nt_ref(nt, id, "arguments");
+    int an = 0; const int *av = anode >= 0 ? nt_arr(nt, anode, "arguments", &an) : NULL;
+    int recv_empty = is_empty_array_literal(nt, recv, c->node_cap);
+    /* an inject / each_with_object seed is written through the block param
+       and back-fills like a local: leave it */
+    int seed = nt_ref(nt, id, "block") >= 0 && nm &&
+               (sp_streq(nm, "each_with_object") || sp_streq(nm, "inject") || sp_streq(nm, "reduce"));
+    if (an > 0 && nm && !recv_empty) {
+      TyKind rt = infer_type(c, recv);
+      if ((ty_is_array(rt) && !seed) || ty_is_hash(rt)) {
+        TyKind want = (ty_is_array(rt) && rt != TY_POLY_ARRAY && empty_arr_same_kind_method(nm))
+                      ? rt : TY_POLY_ARRAY;
+        for (int k = 0; k < an; k++)
+          if (is_empty_array_literal(nt, av[k], c->node_cap) && c->arr_want[av[k]] == TY_UNKNOWN)
+            c->arr_want[av[k]] = want;
+      }
+    }
+    if (!recv_empty) continue;
+    /* `[] + a` takes a's kind ... */
+    if (an == 1 && nm && empty_arr_same_kind_method(nm) && c->arr_want[recv] == TY_UNKNOWN) {
+      TyKind at = infer_type(c, av[0]);
+      if (ty_is_array(at) && at != TY_POLY_ARRAY) { c->arr_want[recv] = at; continue; }
+    }
+    /* ... any other bare `[]` receiver is an empty poly array */
     c->empty_arr_recv[recv] = 1;
     /* The marking gives the receiver an element type, but a block parameter is
        interned only where something reads it. With neither -- `[].map { |x| 1 }`
@@ -7568,9 +7559,6 @@ static void mark_empty_array_receivers(Compiler *c) {
     }
   }
 }
-/* A direct empty `{}` literal receiver of a block method (`{}.select { }`)
-   infers TY_UNKNOWN and can't dispatch; mark it so infer types it as the
-   bare-{} hash (STR_POLY), the same fallback a never-narrowed `{}` local uses. */
 /* A method whose body TAIL is a bare empty `[]` / `{}` literal returns that
    container, but an unmarked empty literal infers TY_UNKNOWN (its element
    type normally back-fills from usage), so the method collapsed to a void C
@@ -7982,15 +7970,18 @@ static int mark_empty_hash_key_ctx(Compiler *c) {
        read does, but they are not CallNodes, so the name gate below never saw
        them and an Integer key fell back to StrPolyHash (#3353) */
     int is_idx_write = (idk == NK_IndexOrWriteNode || idk == NK_IndexAndWriteNode ||
-                        idk == NK_IndexOperatorWriteNode);
+                        idk == NK_IndexOperatorWriteNode || idk == NK_IndexTargetNode);
     if (idk != NK_CallNode && !is_idx_write) continue;
     const char *nm = is_idx_write ? "[]" : nt_str(nt, id, "name");
     /* `[]=` / `store` name the key in arg 0 exactly as the reads do, and say
-       the same thing about which variant the literal has to be (#4026). */
-    if (!nm || (!sp_streq(nm, "fetch") && !sp_streq(nm, "[]") &&
-                !sp_streq(nm, "[]=") && !sp_streq(nm, "store") &&
-                !sp_streq(nm, "key?") && !sp_streq(nm, "has_key?") &&
-                !sp_streq(nm, "include?") && !sp_streq(nm, "dig"))) continue;
+       the same thing about which variant the literal has to be (#4026), as do
+       the other key-taking methods. */
+    static const char *const key_ops[] = {
+      "fetch", "[]", "[]=", "store", "key?", "has_key?", "include?", "member?",
+      "dig", "slice", "except", "values_at", "fetch_values", "assoc", "delete", NULL };
+    int is_key_op = 0;
+    for (int k = 0; nm && key_ops[k] && !is_key_op; k++) if (sp_streq(nm, key_ops[k])) is_key_op = 1;
+    if (!is_key_op) continue;
     int recv = nt_ref(nt, id, "receiver");
     if (recv < 0 || recv >= c->node_cap) continue;
     /* A `tap` / `then` block parameter is another name for the call's own
@@ -8225,15 +8216,6 @@ static void mark_empty_hash_enum_locals(Compiler *c) {
     if (!hit) continue;
     int recv = nt_ref(nt, id, "receiver");
     if (recv < 0) continue;
-    /* the same call on a direct empty literal: the receiver marking only
-       covered the block forms, so a blockless `{}.each_slice(2)` had no hash
-       to build an Enumerator from (#3856) */
-    if ((nt_kind(nt, recv) == NK_HashNode || nt_kind(nt, recv) == NK_KeywordHashNode) &&
-        recv < c->node_cap) {
-      int en0 = 0; nt_arr(nt, recv, "elements", &en0);
-      if (en0 == 0) c->empty_hash_recv[recv] = 1;
-      continue;
-    }
     if (nt_kind(nt, recv) != NK_LocalVariableReadNode) continue;
     const char *lname = nt_str(nt, recv, "name");
     Scope *rs = comp_scope_of(c, recv);
@@ -8268,19 +8250,26 @@ static void mark_empty_hash_enum_locals(Compiler *c) {
     if (ok && lit >= 0 && lit < c->node_cap) c->empty_hash_recv[lit] = 1;
   }
 }
+static int is_empty_hash_literal(const NodeTable *nt, int id, int cap) {
+  if (id < 0 || id >= cap) return 0;
+  NodeKind k = nt_kind(nt, id);
+  if (k != NK_HashNode && k != NK_KeywordHashNode) return 0;
+  int en = 0; nt_arr(nt, id, "elements", &en);
+  return en == 0;
+}
+/* A bare `{}` receiver or interpolation takes the bare-hash default (see
+   mark_empty_array_operands); a key operation refines it in mark_empty_hash_key_ctx. */
 static void mark_empty_hash_receivers(Compiler *c) {
   if (!c->empty_hash_recv) return;
   const NodeTable *nt = c->nt;
-  for (int id = 0; id < nt->count; id++) {
-    const char *ty = nt_type(nt, id);
-    if (!ty || !sp_streq(ty, "CallNode")) continue;
-    if (nt_ref(nt, id, "block") < 0) continue;
+  NT_FOREACH_KIND(nt, NK_CallNode, id) {
     int recv = nt_ref(nt, id, "receiver");
-    if (recv < 0 || recv >= c->node_cap) continue;
-    const char *rty = nt_type(nt, recv);
-    if (!rty || (!sp_streq(rty, "HashNode") && !sp_streq(rty, "KeywordHashNode"))) continue;
-    int en = 0; nt_arr(nt, recv, "elements", &en);
-    if (en == 0) c->empty_hash_recv[recv] = 1;
+    if (is_empty_hash_literal(nt, recv, c->node_cap)) c->empty_hash_recv[recv] = 1;
+  }
+  NT_FOREACH_KIND(nt, NK_EmbeddedStatementsNode, es) {
+    int st = nt_ref(nt, es, "statements");
+    int bn = 0; const int *bb = st >= 0 ? nt_arr(nt, st, "body", &bn) : NULL;
+    if (bn == 1 && is_empty_hash_literal(nt, bb[0], c->node_cap)) c->empty_hash_recv[bb[0]] = 1;
   }
 }
 
@@ -13129,7 +13118,7 @@ void analyze_program(Compiler *c) {
     for (int i = 0; i < c->scopes[s].nlocals; i++)
       c->scopes[s].locals[i].gc_root = (c->scopes[s].locals[i].type == TY_STRING);
 
-  mark_empty_array_receivers(c);
+  mark_empty_array_operands(c);
   for (int id = 0; id < c->nt->count; id++)
     infer_type(c, id);
 

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -3971,11 +3971,6 @@ else {
   }
 
   /* array receiver methods */
-  /* a bare [] literal receiver types UNKNOWN until pushes promote it, but
-     its blockless each is still an Enumerator */
-  if (recv >= 0 && rt == TY_UNKNOWN && nt_type(nt, recv) && sp_streq(nt_type(nt, recv), "ArrayNode") &&
-      nt_ref(nt, id, "block") < 0 && argc == 0 &&
-      (sp_streq(name, "each") || sp_streq(name, "reverse_each"))) return TY_ENUMERATOR;
   /* Array receivers: the array face of infer_call (analyze_infer_recv.c). */
   { TyKind rr; if (infer_array_call(c, id, rt, &rr)) return rr; }
 

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -6172,10 +6172,10 @@ TyKind infer_uncached(Compiler *c, int id) {
     int n = 0;
     const int *els = nt_arr(nt, id, "elements", &n);
     if (n == 0) {
-      /* An empty `[]` used as a whitelisted iterator's receiver must still
-         dispatch (`[].each { }`): type it as an empty poly array. Elsewhere it
-         stays UNKNOWN so `x = []; x << 1` can back-fill the element type and the
-         non-block empty-literal folds keep working. */
+      /* An empty `[]` consumed directly as a receiver or interpolation has no
+         writes to infer from, so mark_empty_array_operands types it as a poly
+         array. An argument may instead take a specific layout through arr_want.
+         Elsewhere it stays UNKNOWN so `x = []; x << 1` can back-fill its kind. */
       if (c->empty_arr_recv && id < c->node_cap && c->empty_arr_recv[id])
         return TY_POLY_ARRAY;
       /* kind fixed by the use context (mark_empty_array_operands) */

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -6183,6 +6183,9 @@ TyKind infer_uncached(Compiler *c, int id) {
          non-block empty-literal folds keep working. */
       if (c->empty_arr_recv && id < c->node_cap && c->empty_arr_recv[id])
         return TY_POLY_ARRAY;
+      /* kind fixed by the use context (mark_empty_array_operands) */
+      if (c->arr_want && id < c->node_cap && ty_is_array(c->arr_want[id]))
+        return c->arr_want[id];
       return TY_UNKNOWN;  /* empty: element type comes from usage */
     }
     TyKind e = TY_UNKNOWN;

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -3464,7 +3464,18 @@ else {
                    k, o, k, k, o, k, t, k, o, k, t, o);
         return 1;
       }
+      /* a typed array never holds an element of another kind: include? is
+         false and index is nil, with both operands still evaluated */
+      int elem_mismatch = 0;
+      if (argc == 1 && rt == TY_STR_ARRAY && a0 != TY_STRING && a0 != TY_UNKNOWN && a0 != TY_POLY) elem_mismatch = 1;
+      if (argc == 1 && (rt == TY_INT_ARRAY || rt == TY_FLOAT_ARRAY) &&
+          a0 != TY_INT && a0 != TY_FLOAT && a0 != TY_UNKNOWN && a0 != TY_POLY) elem_mismatch = 1;
       if ((sp_streq(name, "index") || sp_streq(name, "find_index") || sp_streq(name, "rindex")) && argc == 1 && (rt == TY_INT_ARRAY || rt == TY_STR_ARRAY)) {
+        if (elem_mismatch) {
+          buf_puts(b, "((void)("); emit_expr(c, recv, b);
+          buf_puts(b, "), (void)("); emit_expr(c, argv[0], b); buf_puts(b, "), sp_box_nil())");
+          return 1;
+        }
         /* nil-on-miss -> poly */
         const char *fn = sp_streq(name, "rindex") ? "rindex_poly" : "index_poly";
         buf_printf(b, "sp_%sArray_%s(", k, fn);
@@ -3473,15 +3484,8 @@ else {
         buf_puts(b, ")");
         return 1;
       }
-      if (sp_streq(name, "include?") && argc == 1) {
-        /* a typed array can never contain an element of an incompatible
-           type (numeric vs string), so the answer is statically false;
-           still evaluate both operands for any side effects. */
-        int mismatch = 0;
-        if (rt == TY_STR_ARRAY && a0 != TY_STRING && a0 != TY_UNKNOWN && a0 != TY_POLY) mismatch = 1;
-        if ((rt == TY_INT_ARRAY || rt == TY_FLOAT_ARRAY) &&
-            a0 != TY_INT && a0 != TY_FLOAT && a0 != TY_UNKNOWN && a0 != TY_POLY) mismatch = 1;
-        if (mismatch) {
+      if ((sp_streq(name, "include?") || sp_streq(name, "member?")) && argc == 1) {
+        if (elem_mismatch) {
           buf_puts(b, "((void)("); emit_expr(c, recv, b);
           buf_puts(b, "), (void)("); emit_expr(c, argv[0], b); buf_puts(b, "), 0)");
           return 1;
@@ -3988,7 +3992,13 @@ else {
         buf_puts(b, "sp_PolyArray_get("); emit_expr(c, recv, b); buf_puts(b, ", 0)");
         return 1;
       }
-      if ((sp_streq(name, "to_a") || sp_streq(name, "entries")) && argc == 0) { emit_expr(c, recv, b); return 1; }
+      if ((sp_streq(name, "to_a") || sp_streq(name, "entries") || sp_streq(name, "to_ary") ||
+           sp_streq(name, "deconstruct")) && argc == 0) { emit_expr(c, recv, b); return 1; }
+      if ((sp_streq(name, "union") || sp_streq(name, "difference") || sp_streq(name, "intersection")) &&
+          argc == 0) {
+        buf_puts(b, "sp_PolyArray_dup("); emit_expr(c, recv, b); buf_puts(b, ")");
+        return 1;
+      }
       if (sp_streq(name, "fetch") && (argc == 1 || argc == 2)) {
         int blk = nt_ref(nt, id, "block");
         int ta = ++g_tmp, ti = ++g_tmp, tn = ++g_tmp, tnorm = ++g_tmp;

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -1729,8 +1729,7 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
     if (rt == TY_POLY_ARRAY && sp_streq(name, "sum") && argc == 1 && nt_ref(nt, id, "block") < 0) {
       TyKind init_t = comp_ntype(c, argv[0]);
       /* an Array initial value concatenates one level ([[1],[2]].sum([])) */
-      if (ty_is_array(init_t) ||
-          (init_t == TY_UNKNOWN && nt_type(nt, argv[0]) && sp_streq(nt_type(nt, argv[0]), "ArrayNode"))) {
+      if (ty_is_array(init_t)) {
         buf_puts(b, "sp_PolyArray_sum_concat("); emit_expr(c, recv, b); buf_puts(b, ", ");
         emit_boxed(c, argv[0], b); buf_puts(b, ")");
         return 1;
@@ -2478,12 +2477,11 @@ else {
         }
         return 1;
       }
-      if (sp_streq(name, "+") && argc == 1 && (a0 == rt || a0 == TY_UNKNOWN)) {
-        /* array + array of the same kind -> a fresh concatenation. An empty
-           literal `[]` arg (TY_UNKNOWN) concatenates a null (copies recv). */
+      if (sp_streq(name, "+") && argc == 1 && a0 == rt) {
+        /* array + array of the same kind -> a fresh concatenation */
         buf_printf(b, "sp_%sArray_concat(", k);
         emit_expr(c, recv, b); buf_puts(b, ", ");
-        if (a0 == TY_UNKNOWN) buf_puts(b, "NULL"); else emit_expr(c, argv[0], b);
+        emit_expr(c, argv[0], b);
         buf_puts(b, ")");
         return 1;
       }
@@ -2669,13 +2667,6 @@ else {
         int tb[16]; TyKind at[16]; int nargs = argc < 16 ? argc : 16;
         for (int j = 0; j < nargs; j++) {
           tb[j] = ++g_tmp; at[j] = comp_ntype(c, argv[j]);
-          /* an empty [] argument slots into a PolyArray (kj below); pin its
-             cached type so emit_expr emits sp_PolyArray_new() rather than the
-             sp_IntArray_new() default (#3223) */
-          if (at[j] == TY_UNKNOWN && nt_type(nt, argv[j]) && sp_streq(nt_type(nt, argv[j]), "ArrayNode")) {
-            int aen = 0; nt_arr(nt, argv[j], "elements", &aen);
-            if (aen == 0) { c->ntype[argv[j]] = TY_POLY_ARRAY; at[j] = TY_POLY_ARRAY; }
-          }
         }
         const char *ka = (rt == TY_POLY_ARRAY) ? "Poly" : k;
         buf_printf(b, "({ sp_%sArray *_t%d = ", ka, ta); emit_expr(c, recv, b); buf_puts(b, ";");
@@ -2819,13 +2810,6 @@ else {
       }
       if (sp_streq(name, "product") && argc == 1) {
         TyKind at = comp_ntype(c, argv[0]);
-        /* an empty [] argument defaults to a PolyArray slot (kb below); pin its
-           cached type so emit_expr emits sp_PolyArray_new() rather than the
-           sp_IntArray_new() default, keeping the C well-typed (#3223) */
-        if (at == TY_UNKNOWN && nt_type(nt, argv[0]) && sp_streq(nt_type(nt, argv[0]), "ArrayNode")) {
-          int aen = 0; nt_arr(nt, argv[0], "elements", &aen);
-          if (aen == 0) { c->ntype[argv[0]] = TY_POLY_ARRAY; at = TY_POLY_ARRAY; }
-        }
         const char *kb = (at == TY_POLY_ARRAY) ? "Poly" : (array_kind(at) ? array_kind(at) : "Poly");
         int ta = ++g_tmp, tb = ++g_tmp, tr = ++g_tmp, ti = ++g_tmp, tj = ++g_tmp, tpair = ++g_tmp;
         Buf ra; memset(&ra, 0, sizeof ra); Buf rb2; memset(&rb2, 0, sizeof rb2);
@@ -4036,13 +4020,6 @@ else {
         int tb[16]; TyKind at[16]; int nargs = argc < 16 ? argc : 16;
         for (int j = 0; j < nargs; j++) {
           tb[j] = ++g_tmp; at[j] = comp_ntype(c, argv[j]);
-          /* an empty [] argument slots into a PolyArray (kj below); pin its
-             cached type so emit_expr emits sp_PolyArray_new() rather than the
-             sp_IntArray_new() default (#3223) */
-          if (at[j] == TY_UNKNOWN && nt_type(nt, argv[j]) && sp_streq(nt_type(nt, argv[j]), "ArrayNode")) {
-            int aen = 0; nt_arr(nt, argv[j], "elements", &aen);
-            if (aen == 0) { c->ntype[argv[j]] = TY_POLY_ARRAY; at[j] = TY_POLY_ARRAY; }
-          }
         }
         Buf ra = expr_buf(c, recv);
         buf_printf(b, "({ sp_PolyArray *_t%d = %s;", ta, ra.p ? ra.p : "NULL"); free(ra.p);

--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -276,13 +276,6 @@ void emit_interp(Compiler *c, int id, Buf *b) {
         buf_printf(&conv, "sp_poly_to_s(sp_box_obj(");
         EMIT_IV(); buf_printf(&conv, ", %d))", cid2);
       }
-      else if (t == TY_UNKNOWN && ety && sp_streq(ety, "ArrayNode") &&
-               (nt_arr(nt, expr, "elements", (int[]){0}), 1)) {
-        /* a bare empty array literal interpolates as "[]" */
-        int en = 0; nt_arr(nt, expr, "elements", &en);
-        if (en == 0) { buf_puts(&conv, "(&(\"\\xff\" \"[]\")[1])"); }
-        else { free(conv.p); free(lits.p); free(decls.p); free(wp); free(flat); unsupported(c, pid, "interpolation value"); }
-      }
       else if (t == TY_UNKNOWN) {
         /* An untyped value (e.g. a method resolved only through an included
            module) is already emitted as a boxed sp_RbVal, so stringify it the

--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -3073,7 +3073,12 @@ int emit_inject_expr(Compiler *c, int id, Buf *b) {
       {
         TyKind want = comp_ntype(c, id);
         char accs[24]; snprintf(accs, sizeof accs, "_t%d", tacc);
-        if (want != TY_POLY && want != TY_UNKNOWN && is_scalar_ret(want))
+        /* no initial value and an empty receiver: nil, as the slot's sentinel */
+        if (init_node < 0 && want == TY_INT)
+          buf_printf(b, "sp_poly_as_int_or_nil(%s)", accs);
+        else if (init_node < 0 && want == TY_FLOAT)
+          buf_printf(b, "sp_poly_as_float_or_nil(%s)", accs);
+        else if (want != TY_POLY && want != TY_UNKNOWN && is_scalar_ret(want))
           emit_unbox_text(c, want, accs, b);
         else
           buf_puts(b, accs);

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -8766,6 +8766,7 @@ else {
           buf_printf(b, "sp_%sHash_set(", hn);
           emit_expr(c, recv_id, b); buf_puts(b, ", ");
           if (ty_hash_key(recv_t) == TY_INT) emit_int_expr(c, idx_argv[0], b);
+          else if (ty_hash_key(recv_t) == TY_POLY) emit_boxed(c, idx_argv[0], b);
           else emit_expr(c, idx_argv[0], b);
           buf_puts(b, ", ");
           if (recv_t == TY_SYM_POLY_HASH || recv_t == TY_STR_POLY_HASH || recv_t == TY_POLY_POLY_HASH) {

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -58,6 +58,7 @@ Compiler *comp_new(const NodeTable *nt) {
   c->empty_hash_recv = calloc((size_t)n, 1);
   c->empty_hash_arg = calloc((size_t)n, 1);
   c->hash_want = calloc((size_t)n, sizeof(TyKind));
+  c->arr_want = calloc((size_t)n, sizeof(TyKind));
   c->poly_builtin_ty = calloc((size_t)n, sizeof(TyKind));
   c->node_cap = n;
   return c;
@@ -77,8 +78,9 @@ void comp_grow_node_arrays(Compiler *c) {
   c->empty_hash_recv = realloc(c->empty_hash_recv, (size_t)n);
   c->empty_hash_arg = realloc(c->empty_hash_arg, (size_t)n);
   c->hash_want = realloc(c->hash_want, sizeof(TyKind) * (size_t)n);
+  c->arr_want = realloc(c->arr_want, sizeof(TyKind) * (size_t)n);
   c->poly_builtin_ty = realloc(c->poly_builtin_ty, sizeof(TyKind) * (size_t)n);
-  for (int i = c->node_cap; i < n; i++) { c->ntype[i] = TY_UNKNOWN; c->nilnarrow[i] = TY_UNKNOWN; c->nscope[i] = 0; c->node_cbody[i] = -1; c->empty_arr_recv[i] = 0; c->empty_hash_recv[i] = 0; c->empty_hash_arg[i] = 0; c->hash_want[i] = TY_UNKNOWN; c->poly_builtin_ty[i] = TY_UNKNOWN; c->strbuf_box[i] = 0; }
+  for (int i = c->node_cap; i < n; i++) { c->ntype[i] = TY_UNKNOWN; c->nilnarrow[i] = TY_UNKNOWN; c->nscope[i] = 0; c->node_cbody[i] = -1; c->empty_arr_recv[i] = 0; c->empty_hash_recv[i] = 0; c->empty_hash_arg[i] = 0; c->hash_want[i] = TY_UNKNOWN; c->arr_want[i] = TY_UNKNOWN; c->poly_builtin_ty[i] = TY_UNKNOWN; c->strbuf_box[i] = 0; }
   c->node_cap = n;
 }
 
@@ -141,6 +143,7 @@ void comp_free(Compiler *c) {
   free(c->empty_arr_recv);
   free(c->empty_hash_recv);
   free(c->hash_want);
+  free(c->arr_want);
   free(c->poly_builtin_ty);
   free(c);
 }

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -423,8 +423,8 @@ typedef struct {
                         slot at the read site); TY_UNKNOWN = not narrowed */
   int *nscope;      /* [node_cap] node id -> owning scope index */
   int *node_cbody;  /* [node_cap] node id -> enclosing class/module-body class id, or -1 */
-  char *empty_arr_recv; /* [node_cap] empty `[]` used as a safe-iterator receiver -> TY_POLY_ARRAY */
-  char *empty_hash_recv; /* [node_cap] empty `{}` used as a hash block-method receiver -> TY_STR_POLY_HASH */
+  char *empty_arr_recv; /* [node_cap] empty `[]` used as a direct receiver/interpolation -> TY_POLY_ARRAY */
+  char *empty_hash_recv; /* [node_cap] empty `{}` used as a direct receiver/interpolation -> TY_STR_POLY_HASH */
   char *empty_hash_arg;  /* [node_cap] empty `{}` passed as a user-method arg -> TY_POLY_POLY_HASH */
   TyKind *hash_want; /* [node_cap] variant a hash literal should take from its use context (#3040) */
   TyKind *arr_want;  /* [node_cap] array kind an empty `[]` literal should take from its use context */

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -427,6 +427,7 @@ typedef struct {
   char *empty_hash_recv; /* [node_cap] empty `{}` used as a hash block-method receiver -> TY_STR_POLY_HASH */
   char *empty_hash_arg;  /* [node_cap] empty `{}` passed as a user-method arg -> TY_POLY_POLY_HASH */
   TyKind *hash_want; /* [node_cap] variant a hash literal should take from its use context (#3040) */
+  TyKind *arr_want;  /* [node_cap] array kind an empty `[]` literal should take from its use context */
   TyKind *poly_builtin_ty; /* [node_cap] for a container read on a poly receiver a
                               user class also owns: the type the builtin surface
                               alone would give, so codegen can shape its arm (#3459) */

--- a/test/empty_literal_operand_coercion.rb
+++ b/test/empty_literal_operand_coercion.rb
@@ -70,6 +70,11 @@ p([] + c)
 p([] == a)
 p([] <=> a)
 
+# --- when both operands are bare [], they share the poly-array layout
+p([] == [])
+p([] != [])
+p([] | [])
+
 # --- an empty [] argument on a hash receiver is a poly array
 p({}.each_with_object([]) { })
 p({"a" => 1}.each_with_object([]) { |(k, v), m| m << k })

--- a/test/empty_literal_operand_coercion.rb
+++ b/test/empty_literal_operand_coercion.rb
@@ -1,0 +1,112 @@
+# An empty `[]` / `{}` used as a receiver, argument, or interpolation takes
+# its kind from that use.
+
+# --- receivers: any method on a bare [] runs over an empty poly array
+p([] * 2)
+p([] * ",")
+p([].dup)
+p([].cycle.first(2))
+p([].chunk_while { |x, y| x == y }.to_a)
+p([].each.class)
+p([].reverse_each.class)
+p([].inject(:+))
+p([].reduce(1, :+))
+p([].sum)
+p([].max)
+p([].assoc(1))
+
+# --- receivers: any method on a bare {} runs over the bare hash
+p({}.slice(1))
+p({}.except(1))
+p({}.values_at(1))
+p({}.assoc(1))
+p({}.each_with_object([]) { |(k, v), m| m << k })
+p({}.reduce(0) { |s, (k, v)| s + v })
+p({}.each_pair.to_a)
+p({}.each.class)
+p({}.delete(:x))
+
+# --- arguments: an empty literal handed to a typed-array method takes that
+#     array's kind for the combining methods, and stays a boxed array otherwise
+a = [1, 2].sort
+b = [1.5].sort
+c = %w[x y].sort
+a.concat([]); p a
+b.concat([]); p b
+c.concat([]); p c
+p(a + [])
+p(a - [])
+p(a & [])
+p(a | [])
+p(a == [])
+p(a <=> [])
+p(a.union([]))
+p(a.difference([]))
+p(a.intersect?([]))
+p a.include?([])
+p a.index([])
+p a.rindex([])
+p a.find_index([])
+p a.member?([])
+p b.include?([])
+p c.include?([])
+p c.index([])
+p a.zip([])
+p a.product([])
+p([[1], [2]].sum([]))
+r = [3, 4].sort
+r.replace([]); p r
+
+# --- a bare [] receiver combined with a typed array takes that array's kind
+p([] + a)
+p([] - a)
+p([] & a)
+p([] | a)
+p([].union(a))
+p([].intersection(a))
+p([].difference(a))
+p([] + b)
+p([] + c)
+p([] == a)
+p([] <=> a)
+
+# --- an empty [] argument on a hash receiver is a poly array
+p({}.each_with_object([]) { })
+p({"a" => 1}.each_with_object([]) { |(k, v), m| m << k })
+
+# --- the same mismatch with a non-empty array argument
+p a.include?([1])
+p a.index([1])
+p c.include?(1)
+p c.index(1)
+
+# --- interpolation
+p "#{{}}"
+p "#{[]}"
+p "x#{{}}y#{[]}z"
+
+# --- `h[k], h[j] = ...` on a bare {} picks the variant from its keys, like
+#     `h[k] = v` does
+hh = {}
+hh[:a], hh[:b] = 1, 2
+p hh
+hi = {}
+hi[1], hi[2] = "x", "y"
+p hi
+
+# --- the local back-fill is untouched
+x = []
+x << 1
+p x
+p x.sum
+y = {}
+y["k"] = 2
+p y
+
+# --- the seed of an array's each_with_object / inject / reduce is written
+#     through the block parameter and back-fills like a local
+z = [1, 2, 3].each_with_object([]) { |v, m| m << v * 2 }
+p z
+p z[0] + 1
+p [1, 2, 3].inject([]) { |m, v| m << v }
+p [1, 2, 3].reduce([]) { |m, v| m.push(v) }

--- a/test/empty_literal_operand_coercion.rb.expected
+++ b/test/empty_literal_operand_coercion.rb.expected
@@ -54,6 +54,9 @@ nil
 ["x", "y"]
 false
 -1
+true
+false
+[]
 []
 ["a"]
 false

--- a/test/empty_literal_operand_coercion.rb.expected
+++ b/test/empty_literal_operand_coercion.rb.expected
@@ -1,0 +1,74 @@
+[]
+""
+[]
+[]
+[]
+Enumerator
+Enumerator
+nil
+1
+0
+nil
+nil
+{}
+{}
+[nil]
+nil
+[]
+0
+[]
+Enumerator
+nil
+[1, 2]
+[1.5]
+["x", "y"]
+[1, 2]
+[1, 2]
+[]
+[1, 2]
+false
+1
+[1, 2]
+[1, 2]
+false
+false
+nil
+nil
+nil
+false
+false
+false
+nil
+[[1, nil], [2, nil]]
+[]
+[1, 2]
+[]
+[1, 2]
+[]
+[]
+[1, 2]
+[1, 2]
+[]
+[]
+[1.5]
+["x", "y"]
+false
+-1
+[]
+["a"]
+false
+nil
+false
+nil
+"{}"
+"[]"
+"x{}y[]z"
+{a: 1, b: 2}
+{1 => "x", 2 => "y"}
+[1]
+1
+{"k" => 2}
+[2, 4, 6]
+3
+[1, 2, 3]
+[1, 2, 3]


### PR DESCRIPTION
## The bug

Ruby can consume an empty array or hash immediately even though the literal has no elements from which to infer a storage layout:

```ruby
p([] * 2)
p([].dup)

a = [1.5].sort
a.concat([])

p({}.slice(1))
p "#{{}}"

h = {}
h[:a], h[:b] = 1, 2
```

On current master these receiver, Float/String-array argument, interpolation, and indexed-assignment shapes still produce invalid C. The empty literal remains `TY_UNKNOWN`, so codegen either has no receiver layout or emits the default layout into a differently typed slot.

## The fix

After inference settles, type an empty literal from the operation that consumes it. A direct receiver or interpolation uses the corresponding polymorphic container. An empty array argument follows a concrete array receiver for operations that require matching element storage and otherwise uses a poly array. Hash key operations continue to select the hash variant from their key.

The change removes the per-consumer empty-array pins that this generalized pass replaces and closes the poly-array dispatch gaps exposed by routing through the normal paths.

Locals and accumulator seeds that are filled later remain open for back-filling:

```ruby
x = []
x << 1
```

This does not replace the branch-result or ivar-slot empty-literal handling already on master.

## Tests

Added `test/empty_literal_operand_coercion.rb`, covering direct receivers, typed-array and empty/empty operands, hash receivers, interpolation, indexed multiple assignment, local/seed back-filling, and the related poly-array dispatch paths.

Verification on the rebased branch:

- Current `origin/master` reproduces the receiver, Float/String `concat([])`, hash/interpolation, multiple-assignment, and full-regression compile failures; the branch passes them.
- The focused regression and the four existing upstream empty-literal regressions pass.
- Focused output matches Ruby 4.0.6 byte-for-byte.
- `make test`: 3,271 pass, one `connect_nonblock_sockaddr_1arg` failure that reproduces three-for-three on unmodified `origin/master` on the same host.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * 空の配列・ハッシュリテラルが、受信側や引数などの使用 context に応じて適切な型・形式で扱われるようになりました。
  * 配列の結合、検索、集合演算、複製、変換で型の整合性が向上しました。
  * 空の配列・ハッシュの文字列化、補間、出力結果がより正確になりました。
  * `printf`、`warn`、配列パターンマッチなどの出力・判定処理を改善しました。

* **バグ修正**
  * 空のリダクション結果で `nil` が失われる問題を修正しました。
  * 複合代入や型変換時の不正な処理、要素型不一致時の誤動作を修正しました。

* **テスト**
  * 空リテラルの多様な利用場面を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->