### PR TITLE
Convert, refuse or miss at every typed argument slot the way CRuby does

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -846,6 +846,14 @@ rbs-seed-test: $(SPINEL) $(RBS_EXTRACT_BIN) $(SP_RT_LIB)
 	     -c --no-line-map -o "$$tmp/icnm.c" >"$$tmp/icnm.out" 2>&1; then \
 	  echo "rbs-seed-test: FAIL (an object with no #to_str compiled into a String slot)"; ok=0; \
 	else grep -q "no implicit conversion of Inert into String" "$$tmp/icnm.out" || { echo "rbs-seed-test: FAIL (missing #to_str rejected without saying why)"; sed -n 1,5p "$$tmp/icnm.out"; ok=0; }; fi; \
+	if $(SPINEL) test/rbs-seed/typed_slot_block_key.rb \
+	     -c --no-line-map -o "$$tmp/tsbk.c" >"$$tmp/tsbk.out" 2>&1; then \
+	  echo "rbs-seed-test: FAIL (a foreign key reached a typed block parameter)"; ok=0; \
+	else grep -q "a key of another class than the hash's keys" "$$tmp/tsbk.out" || { echo "rbs-seed-test: FAIL (foreign block key rejected without saying why)"; sed -n 1,5p "$$tmp/tsbk.out"; ok=0; }; fi; \
+	if $(SPINEL) test/rbs-seed/typed_slot_compare_obj.rb \
+	     -c --no-line-map -o "$$tmp/tsco.c" >"$$tmp/tsco.out" 2>&1; then \
+	  echo "rbs-seed-test: FAIL (a comparing user object reached a typed Array slot)"; ok=0; \
+	else grep -q "a user object defining == compared against a typed Array" "$$tmp/tsco.out" || { echo "rbs-seed-test: FAIL (comparing object rejected without saying why)"; sed -n 1,5p "$$tmp/tsco.out"; ok=0; }; fi; \
 	for t in hash_kind_widened_return poly_dispatch_arm_arg_type nilable_scalar_yield_key nilable_scalar_deep_chain nilable_scalar_paths poly_index_hash_dispatch yield_site_scalar_tail poly_container_op_result untyped_param_two_shapes untyped_recv_string_surface seeded_hash_boundary_values seed_hash_value_kind seed_ret_replaced_def seed_ret_empty_literal; do \
 	  $(SPINEL) test/rbs-seed/$$t.rb --rbs test/rbs-seed/sig -c --no-line-map -o "$$tmp/$$t.c" 2>/dev/null; \
 	  if $(CC) -O0 -Ilib $(RBS_SEED_STRICT) "$$tmp/$$t.c" $(SP_RT_LIB) $(LDFLAGS) -lm -o "$$tmp/$$t" 2>"$$tmp/$$t.err"; then \

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -298,6 +298,24 @@ int obj_conv_method(Compiler *c, TyKind t, const char *conv, TyKind want, int *d
   return mi;
 }
 
+/* The container half of the protocol: a class whose #to_ary / #to_hash is a
+   no-parameter method returning a static Array (or Hash) kind converts
+   through a direct call, typed as that container (Array#zip, #product,
+   Hash#merge). Answers the container kind, or TY_UNKNOWN when the class has
+   no such method -- the method's own return type is the answer, so there is
+   nothing to search the kind space for. */
+TyKind obj_container_conv(Compiler *c, TyKind t, const char *conv, int *def) {
+  if (!ty_is_object(t)) return TY_UNKNOWN;
+  int cid = ty_object_class(t);
+  if (cid < 0 || cid >= c->nclasses) return TY_UNKNOWN;
+  int d = -1, mi = comp_method_in_chain(c, cid, conv, &d);
+  if (mi < 0 || c->scopes[mi].nparams != 0) return TY_UNKNOWN;
+  TyKind ret = c->scopes[mi].ret;
+  if (sp_streq(conv, "to_hash") ? !ty_is_hash(ret) : !ty_is_array(ret)) return TY_UNKNOWN;
+  if (def) *def = d;
+  return ret;
+}
+
 /* 1 iff any class in the program defines a usable #to_int / #to_str. A
    NARROWING into a typed slot compiles the conversion in only then: unlike an
    argument slot, a narrowing sits wherever the analysis put it -- including
@@ -397,7 +415,7 @@ static int emit_obj_conv(Compiler *c, int node, const char *conv, TyKind want,
 /* The static Ruby class name of a scalar/container kind, for TypeError
    wording -- NULL for kinds a conversion arm already handles (poly, object,
    unknown) or that are legal in the slot. */
-static const char *conv_wrong_cls_name(TyKind t) {
+const char *conv_wrong_cls_name(TyKind t) {
   if (t == TY_INT || t == TY_BIGINT) return "Integer";
   if (t == TY_FLOAT) return "Float";
   if (t == TY_SYMBOL) return "Symbol";
@@ -409,6 +427,15 @@ static const char *conv_wrong_cls_name(TyKind t) {
   if (ty_is_array(t)) return "Array";
   if (ty_is_hash(t)) return "Hash";
   return NULL;
+}
+
+/* The Ruby class name a TypeError should name for any settled static kind:
+   the scalar and container names above, "nil" for nil, and a user class by
+   its own name. NULL only where the kind is not settled (poly, unknown). */
+const char *conv_cls_name_of(Compiler *c, TyKind t) {
+  if (t == TY_NIL) return "nil";
+  if (ty_is_object(t)) return class_ruby_name(c, ty_object_class(t));
+  return conv_wrong_cls_name(t);
 }
 
 static int emit_nilbool_conv_raise_w(Compiler *c, int node, TyKind want, int nil_ok,
@@ -509,11 +536,33 @@ void emit_int_expr_conv(Compiler *c, int node, Buf *b) {
   emit_int_expr_ex(c, node, 2, b);
 }
 
-/* Emit a node as an sp_float. A poly value is unboxed via sp_poly_to_f; any
-   other (numeric) value is plain-cast, matching the legacy `(sp_float)(...)`. */
+/* Emit a node as an sp_float. A poly value is unboxed via sp_poly_to_f; a
+   numeric value is plain-cast, matching the legacy `(sp_float)(...)`. The
+   slot follows CRuby's rb_to_float, which converts only a Numeric: a String,
+   Symbol, nil, boolean, container or user object (its #to_f is not asked) is
+   "can't convert X into Float" -- where the raw pointer used to be cast to
+   double and stop the C build (Math.sqrt(obj), Float#rationalize("x")). */
 void emit_float_expr(Compiler *c, int node, Buf *b) {
   if (yield_site_type(c, node) == TY_POLY) {
     buf_puts(b, "sp_poly_to_f("); emit_expr(c, node, b); buf_puts(b, ")");
+    return;
+  }
+  TyKind t = comp_ntype(c, node);
+  if (t == TY_BIGINT) {
+    buf_puts(b, "sp_bigint_to_double("); emit_expr(c, node, b); buf_puts(b, ")");
+    return;
+  }
+  const char *cn = conv_cls_name_of(c, t);
+  if (cn && t != TY_INT && t != TY_FLOAT) {
+    buf_puts(b, "({ (void)(");
+    emit_expr(c, node, b);
+    buf_printf(b, "); sp_raise_cls(\"TypeError\", \"can't convert %s into Float\"); 0.0; })", cn);
+    return;
+  }
+  if (t == TY_BOOL) {
+    buf_puts(b, "({ sp_raise_cls(\"TypeError\", (");
+    emit_expr(c, node, b);
+    buf_puts(b, ") ? \"can't convert true into Float\" : \"can't convert false into Float\"); 0.0; })");
     return;
   }
   Buf tmp; memset(&tmp, 0, sizeof tmp);
@@ -524,6 +573,39 @@ void emit_float_expr(Compiler *c, int node, Buf *b) {
     buf_puts(b, ")");
   }
   free(tmp.p);
+}
+
+/* A Float operand of an arithmetic method (Float#quo, #fdiv): a Numeric
+   converts as the float slot does, and any other class is the coercion
+   failure, "X can't be coerced into Float", where X is the value's inspect
+   for nil, true, false and a Symbol and its class name otherwise -- not the
+   conversion slot's "can't convert X into Float". */
+void emit_float_coerce_expr(Compiler *c, int node, Buf *b) {
+  TyKind t = comp_ntype(c, node);
+  if (t == TY_INT || t == TY_BIGINT || t == TY_FLOAT || t == TY_POLY || t == TY_UNKNOWN ||
+      t == TY_RATIONAL) {
+    emit_float_expr(c, node, b);
+    return;
+  }
+  if (t == TY_BOOL) {
+    buf_puts(b, "({ sp_raise_cls(\"TypeError\", (");
+    emit_expr(c, node, b);
+    buf_puts(b, ") ? \"true can't be coerced into Float\" : \"false can't be coerced into Float\"); 0.0; })");
+    return;
+  }
+  if (t == TY_SYMBOL) {
+    buf_puts(b, "({ sp_raise_cls(\"TypeError\", sp_sprintf(\"%s can't be coerced into Float\", sp_sym_inspect(");
+    emit_expr(c, node, b);
+    buf_puts(b, "))); 0.0; })");
+    return;
+  }
+  const char *cn = conv_cls_name_of(c, t);
+  if (!cn) {
+    emit_float_expr(c, node, b);
+    return;
+  }
+  buf_puts(b, "({ (void)("); emit_expr(c, node, b);
+  buf_printf(b, "); sp_raise_cls(\"TypeError\", \"%s can't be coerced into Float\"); 0.0; })", cn);
 }
 
 /* See codegen_internal.h. */

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -3091,10 +3091,11 @@ static int emit_complex_rational_call(Compiler *c, int id, Buf *b) {
       return 1;
     }
     if (crt == TY_FLOAT && sp_streq(name, "quo") && argc == 1) {
-      /* Float#quo == / (float division) */
+      /* Float#quo == / (float division); a non-numeric operand is the
+         arithmetic coercion failure, not the float slot's conversion one */
       buf_puts(b, "((");
       emit_expr(c, recv, b); buf_puts(b, ") / (sp_float)(");
-      emit_float_expr(c, argv[0], b); buf_puts(b, "))");
+      emit_float_coerce_expr(c, argv[0], b); buf_puts(b, "))");
       return 1;
     }
     /* Integer ** <negative literal>: a Rational in CRuby (2 ** -2 == (1/4)).
@@ -6144,7 +6145,7 @@ static int emit_time_civil_ctor(Compiler *c, int id, int is_utc, int is_new, Buf
   if (!is_new && argc == 10) {
     buf_printf(b, "sp_time_new%s(", is_utc ? "_utc" : "");
     for (int i = 5; i >= 0; i--) {
-      emit_expr(c, argv[i], b);
+      emit_int_expr(c, argv[i], b);
       if (i) buf_puts(b, ", ");
     }
     buf_puts(b, ")");
@@ -6166,7 +6167,8 @@ static int emit_time_civil_ctor(Compiler *c, int id, int is_utc, int is_new, Buf
         TyKind fit = comp_ntype(c, argv[i]);
         if (fit == TY_STRING) { buf_puts(b, "(int64_t)strtoll("); emit_expr(c, argv[i], b); buf_puts(b, ", NULL, 10)"); }
         else if (fit == TY_POLY || fit == TY_UNKNOWN) { buf_puts(b, "sp_poly_to_i("); emit_boxed(c, argv[i], b); buf_puts(b, ")"); }
-        else emit_expr(c, argv[i], b);
+        else if (fit == TY_NIL) buf_puts(b, (i == 1 || i == 2) ? "1" : "0");  /* a nil field is its default */
+        else emit_int_expr(c, argv[i], b);
       }
       buf_printf(b, ", (int64_t)_t%d); _t%da.tv_nsec = (int32_t)((_t%d - (double)(int64_t)_t%d) * 1e9 + 0.5); _t%da; })",
                  ts, ts, ts, ts, ts);
@@ -6267,7 +6269,8 @@ else buf_printf(b, "sp_time_new%s(", is_utc ? "_utc" : "");
       if (fit == TY_STRING && i == 1) { buf_puts(b, "sp_time_month_arg("); emit_expr(c, argv[i], b); buf_puts(b, ")"); }
       else if (fit == TY_STRING) { buf_puts(b, "(int64_t)strtoll("); emit_expr(c, argv[i], b); buf_puts(b, ", NULL, 10)"); }
       else if (fit == TY_POLY || fit == TY_UNKNOWN) { buf_puts(b, "sp_poly_to_i("); emit_boxed(c, argv[i], b); buf_puts(b, ")"); }
-      else emit_expr(c, argv[i], b);
+      else if (fit == TY_NIL) buf_puts(b, (i == 1 || i == 2) ? "1" : "0");  /* a nil field is its default */
+      else emit_int_expr(c, argv[i], b);
     }
     else buf_puts(b, (i == 1 || i == 2) ? "1" : "0");
   }
@@ -12200,6 +12203,29 @@ static int emit_operands_in_order(Compiler *c, int id, Buf *b) {
   return 1;
 }
 
+/* File.utime's time operands: a Time's seconds, nil the current time, a
+   number as seconds, and any other class CRuby's "can't convert X into time". */
+static void emit_utime_arg(Compiler *c, int node, Buf *b) {
+  TyKind t = comp_ntype(c, node);
+  if (t == TY_TIME) { buf_puts(b, "(double)("); emit_expr(c, node, b); buf_puts(b, ").tv_sec"); return; }
+  if (t == TY_NIL) { buf_puts(b, "({ (void)("); emit_expr(c, node, b); buf_puts(b, "); (double)time(NULL); })"); return; }  /* nil is now */
+  if (t == TY_INT || t == TY_FLOAT || t == TY_BIGINT || t == TY_POLY || t == TY_UNKNOWN) {
+    buf_puts(b, "(double)("); emit_float_expr(c, node, b); buf_puts(b, ")");
+    return;
+  }
+  if (t == TY_BOOL) {
+    /* CRuby names the class, which a static bool only knows at run time */
+    buf_puts(b, "({ sp_raise_cls(\"TypeError\", (");
+    emit_expr(c, node, b);
+    buf_puts(b, ") ? \"can't convert TrueClass into time\""
+                " : \"can't convert FalseClass into time\"); 0.0; })");
+    return;
+  }
+  const char *cn = conv_cls_name_of(c, t);
+  buf_puts(b, "({ (void)("); emit_expr(c, node, b);
+  buf_printf(b, "); sp_raise_cls(\"TypeError\", \"can't convert %s into time\"); 0.0; })", cn ? cn : "Object");
+}
+
 static void emit_call_body(Compiler *c, int id, Buf *b);
 
 /* Every String a call's operands convert to is declared in a rooted temp in
@@ -12227,7 +12253,7 @@ void emit_call(Compiler *c, int id, Buf *b) {
      is not this call's value */
   const char *head = ob.p ? ob.p : "";
   while (*head == '(') head++;
-  int ok = hold.n > 0 && strncmp(head, "sp_raise_nomethod(", 18) != 0 &&
+  int ok = hold.n > 0 && !hold.guarded && strncmp(head, "sp_raise_nomethod(", 18) != 0 &&
            strncmp(head, "sp_raise_cls(", 13) != 0;
   for (int i = 0; i < hold.n && ok; i++)
     if (g_pre && g_pre->p && g_pre->len > pre_mark && text_uses_tmp(g_pre->p + pre_mark, hold.tmp[i])) ok = 0;
@@ -13295,9 +13321,18 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
 
   /* system(cmd, ...) expr: run and return bool */
   if (recv < 0 && sp_streq(name, "system") && argc >= 1 && !bare_call_class_owned(c, id)) {
+    if (ty_is_hash(comp_ntype(c, argv[0]))) { unsupported_feature(c, id, "system with an environment Hash"); return; }
+    if (ty_is_array(comp_ntype(c, argv[0]))) { unsupported_feature(c, id, "system with a [command, argv0] pair"); return; }
+    /* each argument converts and is rooted before the next converts: a
+       #to_str's answer is a heap String the following conversion may collect */
     int ts = ++g_tmp;
-    buf_printf(b, "({ const char *_sys_%d[] = { ", ts);
-    for (int k = 0; k < argc; k++) { if (k > 0) buf_puts(b, ", "); emit_expr(c, argv[k], b); }
+    buf_puts(b, "({ ");
+    for (int k = 0; k < argc; k++) {
+      buf_printf(b, "const char *_sys_%d_%d = ", ts, k); emit_str_expr(c, argv[k], b);
+      buf_printf(b, "; SP_GC_ROOT_STR(_sys_%d_%d); ", ts, k);
+    }
+    buf_printf(b, "const char *_sys_%d[] = { ", ts);
+    for (int k = 0; k < argc; k++) { if (k > 0) buf_puts(b, ", "); buf_printf(b, "_sys_%d_%d", ts, k); }
     buf_printf(b, ", NULL }; (sp_bool)sp_system_args(%d, _sys_%d); })", argc, ts);
     return;
   }
@@ -13490,7 +13525,7 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
       if (enm && sp_streq(enm, "delete") && eac == 1) {
         int t1 = ++g_tmp, t2 = ++g_tmp;
         int dblk = nt_ref(nt, id, "block");
-        buf_printf(b, "({ const char *_t%d = ", t1); emit_expr(c, eav[0], b);
+        buf_printf(b, "({ const char *_t%d = ", t1); emit_str_expr(c, eav[0], b);
         buf_printf(b, "; const char *_t%d = getenv(_t%d);"
                       " _t%d = _t%d ? sp_str_dup_external(_t%d) : NULL;"
                       " unsetenv(_t%d); ", t2, t1, t2, t2, t2, t1);
@@ -13532,7 +13567,7 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
       /* ENV.store(k, v) is []= */
       if (enm && sp_streq(enm, "store") && eac == 2) {
         buf_puts(b, "sp_env_aset(");
-        emit_expr(c, eav[0], b); buf_puts(b, ", ");
+        emit_str_expr(c, eav[0], b); buf_puts(b, ", ");
         emit_boxed(c, eav[1], b); buf_puts(b, ")");
         return;
       }
@@ -13544,7 +13579,7 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
     if (rty2 && sp_streq(rty2, "ConstantReadNode")) {
       const char *rn = nt_str(nt, recv, "name");
       if (rn && sp_streq(rn, "ENV")) {
-        buf_puts(b, "sp_str_dup_external(getenv("); emit_expr(c, argv[0], b); buf_puts(b, "))");
+        buf_puts(b, "sp_str_dup_external(getenv("); emit_str_expr(c, argv[0], b); buf_puts(b, "))");
         return;
       }
     }
@@ -13599,7 +13634,7 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
     if (rty2 && sp_streq(rty2, "ConstantReadNode")) {
       const char *rn = nt_str(nt, recv, "name");
       if (rn && sp_streq(rn, "ENV")) {
-        buf_puts(b, "(getenv("); emit_expr(c, argv[0], b); buf_puts(b, ") != NULL)");
+        buf_puts(b, "(getenv("); emit_str_expr(c, argv[0], b); buf_puts(b, ") != NULL)");
         return;
       }
     }
@@ -15590,9 +15625,14 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
         buf_puts(b, "sp_bigint_rand(sp_random_default_get(), ");
         emit_expr(c, argv[0], b); buf_puts(b, ")");
       }
+      else if (argc >= 1 && comp_ntype(c, argv[0]) == TY_NIL) {
+        /* rand(nil) is CRuby's ArgumentError, not the int slot's TypeError */
+        buf_puts(b, "({ (void)("); emit_expr(c, argv[0], b);
+        buf_puts(b, "); sp_raise_cls(\"ArgumentError\", \"invalid argument - \"); (sp_int)0; })");
+      }
       else if (argc >= 1) {
         buf_puts(b, "sp_Random_rand_int(sp_random_default_get(), ");
-        emit_expr(c, argv[0], b); buf_puts(b, ")");
+        emit_int_expr(c, argv[0], b); buf_puts(b, ")");
       }
       else buf_puts(b, "sp_Random_rand_float(sp_random_default_get())");
       return;
@@ -15670,9 +15710,13 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
         buf_puts(b, "sp_bigint_rand("); emit_expr(c, recv, b); buf_puts(b, ", ");
         emit_expr(c, argv[0], b); buf_puts(b, ")");
       }
+      else if (argc >= 1 && comp_ntype(c, argv[0]) == TY_NIL) {
+        buf_puts(b, "({ (void)("); emit_expr(c, recv, b); buf_puts(b, "); (void)("); emit_expr(c, argv[0], b);
+        buf_puts(b, "); sp_raise_cls(\"ArgumentError\", \"invalid argument - \"); (sp_int)0; })");
+      }
       else if (argc >= 1) {
         buf_puts(b, "sp_Random_rand_int("); emit_expr(c, recv, b); buf_puts(b, ", ");
-        emit_expr(c, argv[0], b); buf_puts(b, ")");
+        emit_int_expr(c, argv[0], b); buf_puts(b, ")");
       }
       else {
         buf_puts(b, "sp_Random_rand_float("); emit_expr(c, recv, b); buf_puts(b, ")");
@@ -16176,7 +16220,7 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
       if (argc == 0 && !is_rdl) buf_printf(b, "sp_File_gets(%s)", r);
       else {
         buf_printf(b, "sp_File_%s(%s, ", is_rdl ? "readline_sep" : "gets_sep", r);
-        if (gsep >= 0) emit_expr(c, gsep, b); else buf_puts(b, "\"\\n\"");
+        if (gsep >= 0) emit_str_expr_nilable(c, gsep, b); else buf_puts(b, "\"\\n\"");
         buf_puts(b, ", ");
         if (glim >= 0) emit_int_expr(c, glim, b); else buf_puts(b, "0");
         buf_printf(b, ", %d)", gchomp);
@@ -17232,8 +17276,10 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       emit_indent(g_pre, g_indent);
       buf_printf(g_pre, "const char *_t%d = ", tf);
       Buf fb; memset(&fb, 0, sizeof fb);
-      emit_expr(c, av[0], &fb);
-      buf_printf(g_pre, "%s;\n", fb.p ? fb.p : "");
+      emit_str_expr(c, av[0], &fb);
+      /* rooted too: a #to_str's answer lives on the heap, and every arg
+         below boxes */
+      buf_printf(g_pre, "%s; SP_GC_ROOT_STR(_t%d);\n", fb.p ? fb.p : "", tf);
       free(fb.p);
       emit_indent(g_pre, g_indent);
       /* Rooted: every arg below boxes, and a box allocates. */
@@ -17364,7 +17410,26 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     buf_puts(b, "((void)sp_sleep(");
     if (st == TY_INT) { buf_puts(b, "(double)"); emit_expr(c, argv[0], b); }
     else if (st == TY_POLY) { buf_puts(b, "sp_poly_to_f("); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
-    else emit_expr(c, argv[0], b);
+    else if (st == TY_NIL) {
+      /* CRuby's sleep(nil) sleeps forever, as bare sleep does; both take the
+         no-op shape here (sp_sleep returns at once for a non-positive
+         duration), so nil follows the bare form rather than raising */
+      buf_puts(b, "({ (void)("); emit_expr(c, argv[0], b); buf_puts(b, "); 0.0; })");
+    }
+    else if (st == TY_BOOL) {
+      buf_puts(b, "({ sp_raise_cls(\"TypeError\", (");
+      emit_expr(c, argv[0], b);
+      buf_puts(b, ") ? \"can't convert TrueClass into time interval\""
+                  " : \"can't convert FalseClass into time interval\"); 0.0; })");
+    }
+    else if (st != TY_FLOAT && st != TY_BIGINT && conv_cls_name_of(c, st)) {
+      /* rb_time_interval's wording, which names the class -- not the Float
+         slot's ("can't convert String into time interval") */
+      buf_puts(b, "({ (void)("); emit_expr(c, argv[0], b);
+      buf_printf(b, "); sp_raise_cls(\"TypeError\", \"can't convert %s into time interval\"); 0.0; })",
+                 conv_cls_name_of(c, st));
+    }
+    else emit_float_expr(c, argv[0], b);
     buf_puts(b, "), (sp_int)0)");
     return;
   }
@@ -17388,7 +17453,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     TyKind xt = comp_ntype(c, argv[0]);
     if (xt == TY_POLY) { buf_printf(b, "({ %s((int)sp_poly_to_i(", xfn); emit_expr(c, argv[0], b); buf_puts(b, ")); (sp_int)0; })"); }
     else if (xt == TY_BOOL) { buf_printf(b, "({ %s((", xfn); emit_expr(c, argv[0], b); buf_puts(b, ") ? 0 : 1); (sp_int)0; })"); }
-    else { buf_printf(b, "({ %s((int)(", xfn); emit_expr(c, argv[0], b); buf_puts(b, ")); (sp_int)0; })"); }
+    else { buf_printf(b, "({ %s((int)(", xfn); emit_int_expr(c, argv[0], b); buf_puts(b, ")); (sp_int)0; })"); }
     return;
     }
   }
@@ -17399,7 +17464,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       TyKind at2 = comp_ntype(c, argv[0]);
       buf_puts(b, "({ sp_abort_raise(");
       if (at2 == TY_STRING) emit_expr(c, argv[0], b);
-      else { buf_puts(b, "sp_to_s("); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+      else emit_str_expr(c, argv[0], b);
       buf_puts(b, "); (sp_int)0; })");
     }
     else buf_puts(b, "({ sp_abort_raise((const char *)0); (sp_int)0; })");
@@ -18430,7 +18495,13 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       nt_str(nt, recv, "name") && sp_streq(nt_str(nt, recv, "name"), "Regexp")) {
     TyKind _re_at = comp_ntype(c, argv[0]);
     if (_re_at == TY_POLY) { buf_puts(b, "sp_re_escape(sp_poly_to_s("); emit_expr(c, argv[0], b); buf_puts(b, "))"); }
-    else { buf_puts(b, "sp_re_escape("); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+    else if (_re_at == TY_SYMBOL) {
+      /* rb_reg_operand takes a Symbol by its name -- Regexp.escape(:"a.b")
+         is "a\\.b" -- where the #to_str protocol of the String slot would
+         refuse it (Regexp.union really does refuse a Symbol; escape does not) */
+      buf_puts(b, "sp_re_escape(sp_sym_to_s("); emit_expr(c, argv[0], b); buf_puts(b, "))");
+    }
+    else { buf_puts(b, "sp_re_escape("); emit_str_expr(c, argv[0], b); buf_puts(b, ")"); }
     return;
   }
   /* Regexp.union(pat, ...) -> a pattern matching the alternation of its operands.
@@ -21194,12 +21265,8 @@ else {
     if (sp_streq(name, "utime") && argc >= 3) {
       /* File.utime(atime, mtime, *paths): set the times on every path, return
          the count. Time args carry .tv_sec; numeric args are seconds. */
-      buf_puts(b, "({ double _ua = ");
-      if (comp_ntype(c, argv[0]) == TY_TIME) { buf_puts(b, "(double)("); emit_expr(c, argv[0], b); buf_puts(b, ").tv_sec"); }
-      else { buf_puts(b, "(double)("); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
-      buf_puts(b, "; double _um = ");
-      if (comp_ntype(c, argv[1]) == TY_TIME) { buf_puts(b, "(double)("); emit_expr(c, argv[1], b); buf_puts(b, ").tv_sec"); }
-      else { buf_puts(b, "(double)("); emit_expr(c, argv[1], b); buf_puts(b, ")"); }
+      buf_puts(b, "({ double _ua = "); emit_utime_arg(c, argv[0], b);
+      buf_puts(b, "; double _um = "); emit_utime_arg(c, argv[1], b);
       buf_puts(b, "; ");
       for (int k = 2; k < argc; k++) {
         buf_puts(b, "sp_file_utime(_ua, _um, "); emit_path_expr(c, argv[k], b); buf_puts(b, "); ");
@@ -21523,6 +21590,20 @@ else {
         buf_puts(b, "sp_time_at_float(sp_poly_to_f("); emit_expr(c, argv[0], b);
         buf_puts(b, "))");
         return;
+      }
+      if (at != TY_INT && at != TY_FLOAT && at != TY_BIGINT && at != TY_UNKNOWN) {
+        /* an object answering #to_int is its Integer; any other class is
+           CRuby's "can't convert X into an exact number" */
+        if (ty_is_object(at) && obj_conv_method(c, at, "to_int", TY_INT, NULL) >= 0) {
+          buf_puts(b, "sp_time_at_int("); emit_int_expr(c, argv[0], b); buf_puts(b, ")");
+          return;
+        }
+        const char *ocn = conv_cls_name_of(c, at);
+        if (ocn) {
+          buf_puts(b, "({ (void)("); emit_expr(c, argv[0], b);
+          buf_printf(b, "); sp_raise_cls(\"TypeError\", \"can't convert %s into an exact number\"); (sp_Time){0, 0, 0}; })", ocn);
+          return;
+        }
       }
       buf_printf(b, "sp_time_at_%s(", at == TY_FLOAT ? "float" : "int");
       emit_expr(c, argv[0], b); buf_puts(b, ")");
@@ -22320,7 +22401,7 @@ else {
     }
     if (rre >= 0 && sp_streq(name, "match?") && argc == 2) {
       buf_printf(b, "sp_re_match_p_at(sp_re_pat_%d, ", rre); emit_expr(c, argv[0], b);
-      buf_puts(b, ", "); emit_expr(c, argv[1], b); buf_puts(b, ")");
+      buf_puts(b, ", "); emit_int_expr(c, argv[1], b); buf_puts(b, ")");
       return;
     }
     /* /re/ =~ str -> match offset or nil (poly) */
@@ -22629,7 +22710,7 @@ else {
       }
       else {
         buf_printf(b, "sp_re_matchdata_at(sp_re_pat_%d, ", are); emit_str_expr(c, recv, b);
-        buf_puts(b, ", "); emit_expr(c, argv[1], b); buf_puts(b, ")");
+        buf_puts(b, ", "); emit_int_expr(c, argv[1], b); buf_puts(b, ")");
       }
       return;
     }
@@ -22874,7 +22955,7 @@ else {
                untyped block param is enough -- so unbox it into the const
                char * slot the way match? and =~ already do */
             if (argc == 1) { buf_printf(b, "sp_re_matchdata(%s, ", rp.p); emit_str_expr_nilable(c, argv[0], b); buf_puts(b, ")"); }
-            else { buf_printf(b, "sp_re_matchdata_at(%s, ", rp.p); emit_str_expr_nilable(c, argv[0], b); buf_puts(b, ", "); emit_expr(c, argv[1], b); buf_puts(b, ")"); }
+            else { buf_printf(b, "sp_re_matchdata_at(%s, ", rp.p); emit_str_expr_nilable(c, argv[0], b); buf_puts(b, ", "); emit_int_expr(c, argv[1], b); buf_puts(b, ")"); }
             free(rp.p); return;
           }
           free(rp.p);
@@ -23982,7 +24063,7 @@ else {
       buf_puts(b, ", ");
       if (at0 == TY_POLY) { buf_puts(b, "sp_poly_to_i("); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
       else if (at0 == TY_FLOAT) { buf_puts(b, "(sp_int)("); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
-      else emit_expr(c, argv[0], b);
+      else emit_int_expr(c, argv[0], b);
       buf_puts(b, ")");
       return;
     }

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -112,6 +112,77 @@ static void emit_struct_member_by_key(Compiler *c, ClassInfo *sc, const char *rt
                tk0, sc->nivars, tk0, tk0, tk0, tr);
 }
 
+/* 1 when the node is a user object whose class compares -- defines ==, ===
+   or <=> (a Comparable includer) -- so a typed container's lookup would have
+   to call it, and the typed slot has no room for the object. The arms refuse
+   these at compile time, naming the case, rather than hand the C compiler the
+   pointer. */
+static int value_obj_compares(Compiler *c, int node) {
+  TyKind t = comp_ntype(c, node);
+  if (!ty_is_object(t)) return 0;
+  int cid = ty_object_class(t);
+  return cid >= 0 && (comp_method_in_chain(c, cid, "==", NULL) >= 0 ||
+                      comp_method_in_chain(c, cid, "===", NULL) >= 0 ||
+                      comp_method_in_chain(c, cid, "<=>", NULL) >= 0);
+}
+
+/* 1 when a value of the node's static kind can never be == to an element
+   of kind `ek`: a String searched for in an Integer Array, a Symbol in a
+   String Array, nil in either. CRuby compares and finds nothing -- Array#delete
+   answers nil, count 0, all? false -- where the raw value in the typed slot
+   stopped the C build. Integer and Float compare equal across kinds, so they
+   are never a static miss of each other; a user object converts nothing
+   here, and its class may define == (or ===, which the predicates use), so
+   it stays on the comparing path when it does. Also the value slots that
+   compare the same way: Hash#value?, Range#include? and #eql?. */
+static int value_kind_misses(Compiler *c, int node, TyKind ek) {
+  TyKind t = comp_ntype(c, node);
+  if (t == ek || t == TY_POLY || t == TY_UNKNOWN) return 0;
+  int num = ek == TY_INT || ek == TY_FLOAT || ek == TY_BIGINT;
+  if (num && (t == TY_INT || t == TY_FLOAT || (t == TY_BIGINT && ek != TY_INT))) return 0;
+  if (ek == TY_STRING && (t == TY_STRING || t == TY_STRBUF)) return 0;
+  if (!num && ek != TY_STRING) return 0;
+  if (ty_is_object(t)) {
+    /* a class defining <=> is a Comparable includer, whose == the module
+       supplies (the same reading as respond_to?'s) */
+    int cid = ty_object_class(t);
+    return cid >= 0 && comp_method_in_chain(c, cid, "==", NULL) < 0 &&
+           comp_method_in_chain(c, cid, "===", NULL) < 0 &&
+           comp_method_in_chain(c, cid, "<=>", NULL) < 0;
+  }
+  if (ek == TY_INT && t == TY_BIGINT) return 1;  /* no sp_int equals a Bignum */
+  return t == TY_NIL || t == TY_BOOL || t == TY_INT || t == TY_BIGINT || t == TY_FLOAT ||
+         t == TY_SYMBOL || t == TY_STRING || t == TY_STRBUF || t == TY_RANGE ||
+         t == TY_FLOAT_RANGE || t == TY_STR_RANGE || t == TY_TIME || t == TY_REGEX ||
+         ty_is_array(t) || ty_is_hash(t);
+}
+
+/* The direct call of the container conversion obj_container_conv found:
+   the compiled #to_ary / #to_hash of the defining class on the operand. */
+static void emit_obj_container_conv(Compiler *c, int node, int def, const char *conv, Buf *b) {
+  TyKind t = comp_ntype(c, node);
+  buf_printf(b, "sp_%s_%s(", c->classes[def].c_name, mc(conv));
+  if (!comp_ty_value_obj(c, t)) buf_printf(b, "(sp_%s *)", c->classes[def].c_name);
+  buf_puts(b, "("); emit_expr(c, node, b); buf_puts(b, "))");
+}
+
+/* Array#product's operand as an Array: an array passes; an object converts
+   through #to_ary; any other class is CRuby's TypeError. Answers the Array
+   kind the text is typed as. */
+static TyKind emit_product_operand(Compiler *c, int node, TyKind at, Buf *b) {
+  int def = -1;
+  TyKind k = obj_container_conv(c, at, "to_ary", &def);
+  if (k != TY_UNKNOWN) { emit_obj_container_conv(c, node, def, "to_ary", b); return k; }
+  const char *cn = conv_cls_name_of(c, at);
+  if (cn && !ty_is_array(at) && at != TY_POLY_ARRAY) {
+    buf_puts(b, "({ (void)("); emit_expr(c, node, b);
+    buf_printf(b, "); sp_raise_cls(\"TypeError\", \"no implicit conversion of %s into Array\"); (sp_PolyArray *)0; })", cn);
+    return TY_POLY_ARRAY;
+  }
+  emit_expr(c, node, b);
+  return at;
+}
+
 int emit_array_call(Compiler *c, int id, Buf *b) {
   /* The variadic Array mutators accept zero elements and return the receiver
      unchanged; every arm below is written for argc >= 1, so a no-argument call
@@ -810,7 +881,7 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
     buf_printf(b, "; const char *_t%d = sp_str_bytesplice(", tn9);
     emit_expr(c, recv, b);
     buf_printf(b, ", _t%d.first, _t%d.last - _t%d.first + (_t%d.excl ? 0 : 1), ", tr9, tr9, tr9, tr9);
-    emit_expr(c, argv[1], b); buf_puts(b, ")");
+    emit_str_expr(c, argv[1], b); buf_puts(b, ")");
     if (lvw9) { buf_puts(b, "; "); emit_expr(c, recv, b); buf_printf(b, " = _t%d", tn9); }
     buf_printf(b, "; _t%d; })", tn9);
     return 1;
@@ -877,7 +948,7 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
     emit_expr(c, recv, b);
     buf_puts(b, ", "); emit_int_expr(c, argv[0], b);
     buf_puts(b, ", "); emit_int_expr(c, argv[1], b);
-    buf_puts(b, ", "); emit_expr(c, argv[2], b); buf_puts(b, ")");
+    buf_puts(b, ", "); emit_str_expr(c, argv[2], b); buf_puts(b, ")");
     if (lvw) { buf_puts(b, "; "); emit_expr(c, recv, b); buf_printf(b, " = _t%d", tn2); }
     buf_printf(b, "; _t%d; })", tn2);
     return 1;
@@ -1799,7 +1870,7 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
         return 1;
       }
       if (argc == 1) {
-        buf_puts(b, "sp_PolyArray_get("); emit_expr(c, recv, b); buf_puts(b, ", "); emit_expr(c, argv[0], b); buf_puts(b, ")");
+        buf_puts(b, "sp_PolyArray_get("); emit_expr(c, recv, b); buf_puts(b, ", "); emit_int_expr(c, argv[0], b); buf_puts(b, ")");
       }
       else {
         /* each later step goes through the dig-specific helper so a scalar
@@ -1807,7 +1878,7 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
         /* the key goes boxed: a Struct member can be named, and a String or
            Symbol reached the integer offset slot as a pointer (#3575) */
         for (int di = argc - 1; di >= 1; di--) buf_printf(b, "sp_poly_dig_step_key(");
-        buf_puts(b, "sp_PolyArray_get("); emit_expr(c, recv, b); buf_puts(b, ", "); emit_expr(c, argv[0], b); buf_puts(b, ")");
+        buf_puts(b, "sp_PolyArray_get("); emit_expr(c, recv, b); buf_puts(b, ", "); emit_int_expr(c, argv[0], b); buf_puts(b, ")");
         for (int di = 1; di < argc; di++) { buf_puts(b, ", "); emit_boxed(c, argv[di], b); buf_puts(b, ")"); }
       }
       return 1;
@@ -2684,9 +2755,35 @@ else {
              TypeError naming its class. Read as a container regardless, a nil
              became a column of nils, silently, and an Integer or a String
              stopped the C build. */
+          if (ty_is_object(at[j])) {
+            /* an object answering #to_ary zips as that Array; one answering
+               #each enumerates; any other is the scalar's TypeError */
+            int zdef = -1;
+            TyKind zk = obj_container_conv(c, at[j], "to_ary", &zdef);
+            if (zk != TY_UNKNOWN) {
+              const char *kz = zk == TY_POLY_ARRAY ? "Poly" : array_kind(zk);
+              buf_printf(b, " sp_%sArray *_t%d = ", kz ? kz : "Poly", tb[j]);
+              emit_obj_container_conv(c, argv[j], zdef, "to_ary", b);
+              /* rooted: the answer is the conversion's own allocation, read
+                 across every row the loop below allocates */
+              buf_printf(b, "; SP_GC_ROOT(_t%d);", tb[j]);
+              at[j] = kz ? zk : TY_POLY_ARRAY;
+              continue;
+            }
+            int zcid = ty_object_class(at[j]);
+            if (zcid >= 0 && comp_method_in_chain(c, zcid, "each", NULL) < 0) {
+              /* sp_zip_arg would send :each and answer NoMethodError; the
+                 class is settled, so name CRuby's TypeError here */
+              buf_printf(b, " sp_PolyArray *_t%d = ({ (void)(", tb[j]); emit_expr(c, argv[j], b);
+              buf_printf(b, "); sp_raise_cls(\"TypeError\", \"wrong argument type %s (must respond to :each)\"); (sp_PolyArray *)0; });",
+                         class_ruby_name(c, zcid));
+              at[j] = TY_POLY_ARRAY;
+              continue;
+            }
+          }
           if (at[j] == TY_NIL || at[j] == TY_BOOL || at[j] == TY_INT ||
               at[j] == TY_FLOAT || at[j] == TY_STRING || at[j] == TY_STRBUF ||
-              at[j] == TY_SYMBOL || at[j] == TY_VOID ||
+              at[j] == TY_SYMBOL || at[j] == TY_VOID || ty_is_object(at[j]) ||
               /* a Hash or an Enumerator DOES respond to :each; the same helper
                  materializes it, where the typed line below spelled the slot
                  sp_PolyArray* and assigned an sp_SymPolyHash* to it */
@@ -2750,13 +2847,15 @@ else {
             c->ntype[argv[0]] = TY_POLY_ARRAY;
         }
         TyKind at = comp_ntype(c, argv[0]);
+        Buf ra; memset(&ra, 0, sizeof ra);
+        emit_expr(c, recv, &ra);  /* the receiver's prelude first, as Ruby evaluates */
+        Buf rb2; memset(&rb2, 0, sizeof rb2);
+        at = emit_product_operand(c, argv[0], at, &rb2);
         const char *kb = (at == TY_POLY_ARRAY) ? "Poly" : (array_kind(at) ? array_kind(at) : "Poly");
         int bbody = nt_ref(nt, blk, "body");
         int bn = 0; const int *bb = bbody >= 0 ? nt_arr(nt, bbody, "body", &bn) : NULL;
         const char *fp0 = block_param_name(c, blk, 0);
         int ta = ++g_tmp, tb = ++g_tmp, ti = ++g_tmp, tj = ++g_tmp, tpair = ++g_tmp;
-        Buf ra; memset(&ra, 0, sizeof ra); Buf rb2; memset(&rb2, 0, sizeof rb2);
-        emit_expr(c, recv, &ra); emit_expr(c, argv[0], &rb2);
         buf_printf(b, "({ sp_%sArray *_t%d = %s; SP_GC_ROOT(_t%d); sp_%sArray *_t%d = %s; SP_GC_ROOT(_t%d);",
                    k, ta, ra.p ? ra.p : "NULL", ta, kb, tb, rb2.p ? rb2.p : "NULL", tb);
         free(ra.p); free(rb2.p);
@@ -2810,12 +2909,14 @@ else {
       }
       if (sp_streq(name, "product") && argc == 1) {
         TyKind at = comp_ntype(c, argv[0]);
+        Buf ra; memset(&ra, 0, sizeof ra);
+        emit_expr(c, recv, &ra);  /* the receiver's prelude first, as Ruby evaluates */
+        Buf rb2; memset(&rb2, 0, sizeof rb2);
+        at = emit_product_operand(c, argv[0], at, &rb2);
         const char *kb = (at == TY_POLY_ARRAY) ? "Poly" : (array_kind(at) ? array_kind(at) : "Poly");
         int ta = ++g_tmp, tb = ++g_tmp, tr = ++g_tmp, ti = ++g_tmp, tj = ++g_tmp, tpair = ++g_tmp;
-        Buf ra; memset(&ra, 0, sizeof ra); Buf rb2; memset(&rb2, 0, sizeof rb2);
-        emit_expr(c, recv, &ra); emit_expr(c, argv[0], &rb2);
-        buf_printf(b, "({ sp_%sArray *_t%d = %s; sp_%sArray *_t%d = %s;",
-                   k, ta, ra.p ? ra.p : "NULL", kb, tb, rb2.p ? rb2.p : "NULL");
+        buf_printf(b, "({ sp_%sArray *_t%d = %s; SP_GC_ROOT(_t%d); sp_%sArray *_t%d = %s; SP_GC_ROOT(_t%d);",
+                   k, ta, ra.p ? ra.p : "NULL", ta, kb, tb, rb2.p ? rb2.p : "NULL", tb);
         free(ra.p); free(rb2.p);
         buf_printf(b, " sp_PolyArray *_t%d = sp_PolyArray_new(); SP_GC_ROOT(_t%d);", tr, tr);
         buf_printf(b, " sp_PolyArray *_t%d = NULL;", tpair);
@@ -2941,6 +3042,19 @@ else {
         if (dblk >= 0 && nt_type(nt, dblk) && sp_streq(nt_type(nt, dblk), "BlockNode")) {
           int dbody = nt_ref(nt, dblk, "body");
           int dbn = 0; const int *dbb = dbody >= 0 ? nt_arr(nt, dbody, "body", &dbn) : NULL;
+          if (value_obj_compares(c, argv[0])) {
+            unsupported_feature(c, id, "Array#delete of a user object defining == from a typed Array");
+            return 0;
+          }
+          if (dbn >= 1 && value_kind_misses(c, argv[0], ty_array_elem(rt))) {
+            /* nothing to delete: the block, handed the value, supplies the answer */
+            const char *dp0 = block_param_name(c, dblk, 0);
+            buf_puts(b, "({ (void)("); emit_expr(c, recv, b); buf_puts(b, "); ");
+            if (dp0) { buf_printf(b, "lv_%s = ", rename_local(dp0)); emit_boxed(c, argv[0], b); buf_puts(b, "; "); }
+            else { buf_puts(b, "(void)("); emit_expr(c, argv[0], b); buf_puts(b, "); "); }
+            emit_boxed(c, dbb[dbn - 1], b); buf_puts(b, "; })");
+            return 1;
+          }
           if (dbn >= 1) {
             int tdr = ++g_tmp;
             if (rt == TY_INT_ARRAY) {
@@ -2957,6 +3071,15 @@ else {
             buf_puts(b, "; })");
             return 1;
           }
+        }
+        if (value_obj_compares(c, argv[0])) {
+          unsupported_feature(c, id, "Array#delete of a user object defining == from a typed Array");
+          return 0;
+        }
+        if (value_kind_misses(c, argv[0], ty_array_elem(rt))) {
+          buf_puts(b, "({ (void)("); emit_expr(c, recv, b); buf_puts(b, "); (void)("); emit_expr(c, argv[0], b);
+          buf_printf(b, "); %s; })", rt == TY_INT_ARRAY ? "SP_INT_NIL" : rt == TY_STR_ARRAY ? "(const char *)0" : "sp_float_nil()");
+          return 1;
         }
         buf_printf(b, "sp_%sArray_delete(", k); emit_expr(c, recv, b); buf_puts(b, ", "); emit_expr(c, argv[0], b); buf_puts(b, ")");
         return 1;
@@ -2978,7 +3101,7 @@ else {
         /* slice!(start, len): remove and return the subarray (raises
            FrozenError inside the runtime helper when the array is frozen) */
         buf_printf(b, "sp_%sArray_slice_bang(", k); emit_expr(c, recv, b);
-        buf_puts(b, ", "); emit_expr(c, argv[0], b); buf_puts(b, ", "); emit_expr(c, argv[1], b); buf_puts(b, ")");
+        buf_puts(b, ", "); emit_int_expr(c, argv[0], b); buf_puts(b, ", "); emit_int_expr(c, argv[1], b); buf_puts(b, ")");
         return 1;
       }
       if (sp_streq(name, "slice!") && argc == 1 && comp_ntype(c, argv[0]) == TY_RANGE) {
@@ -3293,6 +3416,18 @@ else {
         Buf ra = expr_buf(c, recv);
         buf_printf(b, "({ sp_%sArray *_t%d = %s;", k, ta, ra.p ? ra.p : "NULL"); free(ra.p);
         emit_indent(g_pre, 0);
+        if (value_obj_compares(c, argv[0])) {
+          unsupported_feature(c, id, "a user object defining == compared against a typed Array's elements");
+          return 0;
+        }
+        if (value_kind_misses(c, argv[0], ty_array_elem(rt))) {
+          /* a value no element can equal: only an empty array is all? of it */
+          buf_puts(b, " (void)("); emit_expr(c, argv[0], b); buf_puts(b, ");");
+          if (sp_streq(name, "all?"))       buf_printf(b, " sp_%sArray_length(_t%d) == 0; })", k, ta);
+          else if (sp_streq(name, "none?")) buf_puts(b, " 1; })");
+          else                              buf_puts(b, " 0; })");
+          return 1;
+        }
         buf_printf(b, " "); emit_ctype(c, ty_array_elem(rt), b);
         buf_printf(b, " _t%d = ", tv); emit_expr(c, argv[0], b); buf_puts(b, ";");
         buf_printf(b, " sp_int _t%d = 0;", tc);
@@ -3462,6 +3597,15 @@ else {
         }
         /* nil-on-miss -> poly */
         const char *fn = sp_streq(name, "rindex") ? "rindex_poly" : "index_poly";
+        if (value_obj_compares(c, argv[0])) {
+          unsupported_feature(c, id, "Array#index of a user object defining == in a typed Array");
+          return 0;
+        }
+        if (value_kind_misses(c, argv[0], ty_array_elem(rt))) {
+          buf_puts(b, "({ (void)("); emit_expr(c, recv, b); buf_puts(b, "); (void)("); emit_expr(c, argv[0], b);
+          buf_puts(b, "); sp_box_nil(); })");
+          return 1;
+        }
         buf_printf(b, "sp_%sArray_%s(", k, fn);
         emit_expr(c, recv, b); buf_puts(b, ", ");
         if (sp_streq(k, "Int")) emit_int_expr(c, argv[0], b); else emit_expr(c, argv[0], b);
@@ -4037,9 +4181,35 @@ else {
              TypeError naming its class. Read as a container regardless, a nil
              became a column of nils, silently, and an Integer or a String
              stopped the C build. */
+          if (ty_is_object(at[j])) {
+            /* an object answering #to_ary zips as that Array; one answering
+               #each enumerates; any other is the scalar's TypeError */
+            int zdef = -1;
+            TyKind zk = obj_container_conv(c, at[j], "to_ary", &zdef);
+            if (zk != TY_UNKNOWN) {
+              const char *kz = zk == TY_POLY_ARRAY ? "Poly" : array_kind(zk);
+              buf_printf(b, " sp_%sArray *_t%d = ", kz ? kz : "Poly", tb[j]);
+              emit_obj_container_conv(c, argv[j], zdef, "to_ary", b);
+              /* rooted: the answer is the conversion's own allocation, read
+                 across every row the loop below allocates */
+              buf_printf(b, "; SP_GC_ROOT(_t%d);", tb[j]);
+              at[j] = kz ? zk : TY_POLY_ARRAY;
+              continue;
+            }
+            int zcid = ty_object_class(at[j]);
+            if (zcid >= 0 && comp_method_in_chain(c, zcid, "each", NULL) < 0) {
+              /* sp_zip_arg would send :each and answer NoMethodError; the
+                 class is settled, so name CRuby's TypeError here */
+              buf_printf(b, " sp_PolyArray *_t%d = ({ (void)(", tb[j]); emit_expr(c, argv[j], b);
+              buf_printf(b, "); sp_raise_cls(\"TypeError\", \"wrong argument type %s (must respond to :each)\"); (sp_PolyArray *)0; });",
+                         class_ruby_name(c, zcid));
+              at[j] = TY_POLY_ARRAY;
+              continue;
+            }
+          }
           if (at[j] == TY_NIL || at[j] == TY_BOOL || at[j] == TY_INT ||
               at[j] == TY_FLOAT || at[j] == TY_STRING || at[j] == TY_STRBUF ||
-              at[j] == TY_SYMBOL || at[j] == TY_VOID ||
+              at[j] == TY_SYMBOL || at[j] == TY_VOID || ty_is_object(at[j]) ||
               /* a Hash or an Enumerator DOES respond to :each; the same helper
                  materializes it, where the typed line below spelled the slot
                  sp_PolyArray* and assigned an sp_SymPolyHash* to it */
@@ -4803,6 +4973,7 @@ int emit_hash_call(Compiler *c, int id, Buf *b) {
           TyKind vt = ty_hash_val(rt);
           int t = ++g_tmp;
           buf_printf(b, "({ %s _t%d = ", c_type_name(rt), t); emit_expr(c, recv, b); buf_puts(b, "; ");
+          buf_puts(b, "(void)("); emit_expr(c, argv[0], b); buf_puts(b, "); ");  /* the key still evaluates */
           if (vt == TY_INT) buf_printf(b, "_t%d ? _t%d->default_v : SP_INT_NIL; })", t, t);
           /* absent means the hash's default, which is nil unless one was
              given -- not the empty string (#3790) */
@@ -4839,9 +5010,10 @@ int emit_hash_call(Compiler *c, int id, Buf *b) {
         TyKind arg0t = comp_ntype(c, argv[0]);
         if ((kt == TY_SYMBOL && arg0t == TY_STRING) ||
             (kt == TY_STRING && arg0t == TY_SYMBOL)) {
-          if (vt == TY_INT) buf_puts(b, "SP_INT_NIL");
-          else if (vt == TY_STRING) buf_puts(b, "NULL");
-          else buf_puts(b, "sp_box_nil()");
+          buf_puts(b, "({ (void)("); emit_expr(c, recv, b); buf_puts(b, "); (void)("); emit_expr(c, argv[0], b);
+          if (vt == TY_INT) buf_puts(b, "); SP_INT_NIL; })");
+          else if (vt == TY_STRING) buf_puts(b, "); NULL; })");
+          else buf_puts(b, "); sp_box_nil(); })");
           return 1;
         }
         const char *getter = vt == TY_INT ? "get_opt" : "get";
@@ -4908,7 +5080,7 @@ int emit_hash_call(Compiler *c, int id, Buf *b) {
             }
             else {
               buf_printf(b, " sp_int _t%d = ", tk);
-              emit_expr(c, argv[di], b);
+              emit_int_expr(c, argv[di], b);
               buf_printf(b, "; _t%d = sp_poly_arr_get_hash(_t%d, _t%d);", tr, tr, tk);
             }
           }
@@ -4942,6 +5114,24 @@ int emit_hash_call(Compiler *c, int id, Buf *b) {
             buf_printf(b, " %s _t%d = ", c_type_name(kt), tk);
             if (kt == TY_STRING) buf_printf(b, "sp_poly_to_s(sp_PolyArray_get(_t%d, _t%d));", ts, ti);
             else buf_printf(b, "(%s)sp_poly_to_i(sp_PolyArray_get(_t%d, _t%d));", c_type_name(kt), ts, ti);
+          }
+          else if (hash_key_misses(c, argv[a], kt)) {
+            /* a key of a kind the table cannot hold: values_at answers nil,
+               fetch_values raises naming the key, boxed once here */
+            int fv_blk = nt_ref(nt, id, "block");
+            if (is_fetch && fv_blk >= 0) {
+              unsupported_feature(c, id, "Hash#fetch_values with a block and a key of another class than the hash's keys");
+              return 0;
+            }
+            buf_printf(b, " sp_RbVal _t%d = ", tk); emit_boxed(c, argv[a], b); buf_puts(b, ";");
+            if (is_fetch) {
+              char htmp[32]; snprintf(htmp, sizeof htmp, "_t%d", th);
+              buf_puts(b, " sp_exc_stage_recv(");
+              emit_boxed_text(c, rt, htmp, b);
+              buf_printf(b, "); sp_raise_key_not_found(_t%d);", tk);
+            }
+            else buf_printf(b, " sp_PolyArray_push(_t%d, sp_box_nil());", tr);
+            continue;
           }
           else {
             buf_printf(b, " %s _t%d = ", c_type_name(kt), tk); emit_hash_key(c, argv[a], kt, b); buf_puts(b, ";");
@@ -5001,6 +5191,12 @@ int emit_hash_call(Compiler *c, int id, Buf *b) {
            exactly that rule. */
       if (sp_streq(name, "fetch") && (argc == 1 || (argc == 2 && nt_ref(nt, id, "block") >= 0))) {
         int blk = nt_ref(nt, id, "block");
+        if (blk >= 0 && hash_key_misses(c, argv[0], ty_hash_key(rt))) {
+          /* the block receives the missing key, and its parameter is typed
+             as the table's key kind; a key of another kind has no slot */
+          unsupported_feature(c, id, "Hash#fetch with a block and a key of another class than the hash's keys");
+          return 0;
+        }
         if (blk >= 0) {
           /* fetch(key) { default } -> has_key? ? get : block-default */
           TyKind vt = ty_hash_val(rt);
@@ -5038,13 +5234,23 @@ else {
         /* fetch(key) with no default raises KeyError on a miss */
         TyKind vt = ty_hash_val(rt);
         int th = ++g_tmp, tk = ++g_tmp;
-        buf_printf(b, "({ %s _t%d = ", c_type_name(rt), th); emit_expr(c, recv, b);
-        buf_printf(b, "; %s _t%d = ", c_type_name(ty_hash_key(rt)), tk); emit_hash_key(c, argv[0], ty_hash_key(rt), b);
-        buf_printf(b, "; sp_%sHash_has_key(_t%d, _t%d) ? sp_%sHash_get(_t%d, _t%d) : (",
-                   hn, th, tk, hn, th, tk);
         char keytmp[32], htmp[32];
         snprintf(keytmp, sizeof keytmp, "_t%d", tk);
         snprintf(htmp, sizeof htmp, "_t%d", th);
+        buf_printf(b, "({ %s _t%d = ", c_type_name(rt), th); emit_expr(c, recv, b);
+        if (hash_key_misses(c, argv[0], ty_hash_key(rt))) {
+          /* a key of a kind the table cannot hold: the KeyError names the
+             key itself, so box it once rather than look it up */
+          buf_printf(b, "; sp_RbVal _t%d = ", tk); emit_boxed(c, argv[0], b);
+          buf_puts(b, "; sp_exc_stage_recv(");
+          emit_boxed_text(c, rt, htmp, b);
+          buf_printf(b, "); sp_raise_key_not_found(_t%d); %s; })", tk,
+                     vt == TY_POLY ? "sp_box_nil()" : default_value(vt));
+          return 1;
+        }
+        buf_printf(b, "; %s _t%d = ", c_type_name(ty_hash_key(rt)), tk); emit_hash_key(c, argv[0], ty_hash_key(rt), b);
+        buf_printf(b, "; sp_%sHash_has_key(_t%d, _t%d) ? sp_%sHash_get(_t%d, _t%d) : (",
+                   hn, th, tk, hn, th, tk);
         buf_puts(b, "sp_exc_stage_recv(");
         emit_boxed_text(c, rt, htmp, b);
         buf_puts(b, "), sp_raise_key_not_found(");
@@ -5146,9 +5352,12 @@ else {
            sp_streq(name, "include?") || sp_streq(name, "member?")) && argc == 1) {
         TyKind arg_kt = comp_ntype(c, argv[0]);
         TyKind hash_kt = ty_hash_key(rt);
-        if (hash_kt != TY_POLY && arg_kt != TY_POLY && arg_kt != TY_UNKNOWN && arg_kt != hash_kt) {
-          /* type mismatch (e.g. string arg on sym-keyed hash): always false */
-          buf_puts(b, "0"); return 1;
+        if (hash_key_misses(c, argv[0], hash_kt)) {
+          /* a key of a class the table cannot hold: false, the receiver and
+             the key still evaluated */
+          buf_puts(b, "({ (void)("); emit_expr(c, recv, b); buf_puts(b, "); (void)("); emit_expr(c, argv[0], b);
+          buf_puts(b, "); 0; })");
+          return 1;
         }
         buf_printf(b, "sp_%sHash_has_key(", hn);
         emit_expr(c, recv, b); buf_puts(b, ", "); emit_hash_key(c, argv[0], hash_kt, b); buf_puts(b, ")");
@@ -5157,6 +5366,14 @@ else {
       if ((sp_streq(name, "value?") || sp_streq(name, "has_value?")) && argc == 1) {
         int poly = (rt == TY_SYM_POLY_HASH || rt == TY_STR_POLY_HASH ||
                     rt == TY_POLY_POLY_HASH);  /* boxed-value variants (#2373) */
+        if (!poly && value_obj_compares(c, argv[0])) {
+          unsupported_feature(c, id, "Hash#value? of a user object defining == in a typed Hash");
+          return 0;
+        }
+        if (!poly && value_kind_misses(c, argv[0], ty_hash_val(rt))) {
+          buf_puts(b, "({ (void)("); emit_expr(c, recv, b); buf_puts(b, "); (void)("); emit_expr(c, argv[0], b); buf_puts(b, "); 0; })");
+          return 1;
+        }
         buf_printf(b, "sp_%sHash_has_value(", hn);
         emit_expr(c, recv, b); buf_puts(b, ", ");
         if (poly) emit_boxed(c, argv[0], b); else emit_expr(c, argv[0], b);
@@ -5587,6 +5804,30 @@ else {
           buf_puts(b, ", "); emit_boxed(c, argv[0], b); buf_puts(b, ")");
           return 1;
         }
+        if (!ty_is_hash(at) && at != TY_POLY && at != TY_UNKNOWN) {
+          /* an object answering #to_hash of the receiver's own layout merges
+             as that Hash; any other class is CRuby's TypeError */
+          int mdef = -1;
+          TyKind mk = obj_container_conv(c, at, "to_hash", &mdef);
+          if (mk == rt) {
+            buf_printf(b, "sp_%sHash_merge(", hn); emit_expr(c, recv, b); buf_puts(b, ", ");
+            emit_obj_container_conv(c, argv[0], mdef, "to_hash", b); buf_puts(b, ")");
+            return 1;
+          }
+          if (mk != TY_UNKNOWN) {
+            /* the analysis typed this call as the receiver's layout; a
+               #to_hash of another layout would widen it, which is an
+               inference question, so say so rather than miscompile */
+            unsupported_feature(c, id, "Hash#merge with a #to_hash of another layout than the receiver");
+            return 0;
+          }
+          const char *mcn = conv_cls_name_of(c, at);
+          if (mcn) {
+            buf_puts(b, "({ (void)("); emit_expr(c, recv, b); buf_puts(b, "); (void)("); emit_expr(c, argv[0], b);
+            buf_printf(b, "); sp_raise_cls(\"TypeError\", \"no implicit conversion of %s into Hash\"); (%s)0; })", mcn, c_type_name(rt));
+            return 1;
+          }
+        }
         buf_printf(b, "sp_%sHash_merge(", hn); emit_expr(c, recv, b); buf_puts(b, ", ");
         /* a str_poly receiver may be merged with a concrete str-keyed hash;
            coerce the argument to the receiver's variant first */
@@ -5891,7 +6132,9 @@ else {
           if (rt == TY_POLY_POLY_HASH)
             buf_printf(b, " if (sp_rbval_eql_key(_t%d->keys[_t%d->order[_t%d]], _t%d)) {", th, th, ti, ta);
           else if (kt == TY_STRING)
-            buf_printf(b, " if (!strcmp(_t%d->order[_t%d], _t%d)) {", th, ti, ta);
+            /* sp_str_eq, not strcmp: a key of a class the table cannot hold
+               reaches here as the NULL miss sentinel emit_hash_key answers */
+            buf_printf(b, " if (sp_str_eq(_t%d->order[_t%d], _t%d)) {", th, ti, ta);
           else
             buf_printf(b, " if (_t%d->order[_t%d] == _t%d) {", th, ti, ta);
         }
@@ -5959,6 +6202,11 @@ else {
         /* returns the deleted value (or nil on a miss), then removes the key */
         TyKind vt = ty_hash_val(rt);
         int th = ++g_tmp, tk = ++g_tmp, tv = ++g_tmp;
+        if (nt_ref(nt, id, "block") >= 0 && hash_key_misses(c, argv[0], ty_hash_key(rt))) {
+          /* the block receives the missing key, typed as the table's key kind */
+          unsupported_feature(c, id, "Hash#delete with a block and a key of another class than the hash's keys");
+          return 0;
+        }
         buf_printf(b, "({ %s _t%d = ", c_type_name(rt), th); emit_expr(c, recv, b);
         buf_printf(b, "; if (sp_gc_is_frozen(_t%d)) sp_raise_frozen_hash_at(_t%d, %s);", th, th, hash_box_cls(rt));   /* (#3001) */
         buf_printf(b, " %s _t%d = ", c_type_name(ty_hash_key(rt)), tk); emit_hash_key(c, argv[0], ty_hash_key(rt), b);
@@ -6129,6 +6377,33 @@ int nil_answers_name(const char *n) {
   return 0;
 }
 
+/* A String slot of the pattern family (String#split's separator): a
+   String or nil passes as the String slot does, but a value of any other
+   class -- true and false included -- is CRuby's "wrong argument type X
+   (expected Regexp)", not the implicit-conversion wording. A Regexp is the
+   one class the family is not wrong about, and it belongs to the arm's own
+   Regexp path, never here. */
+void emit_str_pattern_expr(Compiler *c, int node, Buf *b) {
+  TyKind t = comp_ntype(c, node);
+  if (t == TY_REGEX) unsupported_feature(c, node, "a Regexp separator reached the String pattern slot");
+  if (t == TY_BOOL) {
+    int tb = ++g_tmp;
+    buf_printf(b, "({ int _t%d = (", tb); emit_expr(c, node, b);
+    buf_printf(b, "); sp_raise_cls(\"TypeError\", _t%d"
+                  " ? \"wrong argument type true (expected Regexp)\""
+                  " : \"wrong argument type false (expected Regexp)\");"
+                  " (const char *)0; })", tb);
+    return;
+  }
+  const char *cn = conv_wrong_cls_name(t);
+  if (cn && t != TY_STRING && t != TY_STRBUF) {
+    buf_puts(b, "({ (void)("); emit_expr(c, node, b);
+    buf_printf(b, "); sp_raise_cls(\"TypeError\", \"wrong argument type %s (expected Regexp)\"); (const char *)0; })", cn);
+    return;
+  }
+  emit_str_expr_nilable(c, node, b);
+}
+
 int emit_scalar_call(Compiler *c, int id, Buf *b) {
   /* Shared-mutable shim (#3227): setbyte on a strbuf local -- shadow-copy
      re-entry, same as emit_array_call's. */
@@ -6223,6 +6498,11 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
         g_tmpid = ++g_tmp;
         snprintf(g_rname, sizeof g_rname, "_t%d", g_tmpid);
         g_outer_b = b; b = &gbody; r = g_rname;
+        /* conversions the arms emit belong BELOW the guard's nil check --
+           CRuby raises its NoMethodError without asking #to_str -- so the
+           call-level hold, which would hoist them above it, stands down and
+           they render inline inside the guarded body */
+        if (g_conv_hold) g_conv_hold->guarded = 1;
       }
     }
     int handled = 1;
@@ -6230,7 +6510,7 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
     if (rt == TY_STRING) {
       /* blockless "a".upto("c") materializes the succ-sequence as an array */
       if (sp_streq(name, "upto") && argc == 1 && nt_ref(nt, id, "block") < 0) {
-        buf_printf(b, "sp_StrArray_from_string_range(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ", 0)");
+        buf_printf(b, "sp_StrArray_from_string_range(%s, ", r); emit_str_expr(c, argv[0], b); buf_puts(b, ", 0)");
       }
       /* a nil / true / false PATTERN in the regexp-expected family is CRuby's
          TypeError ("wrong argument type nil (expected Regexp)") -- it used to
@@ -6469,7 +6749,7 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
           buf_puts(b, r);
         }
         else {
-          buf_printf(b, "sp_str_chomp_sep(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")");
+          buf_printf(b, "sp_str_chomp_sep(%s, ", r); emit_str_expr(c, argv[0], b); buf_puts(b, ")");
         }
       }
       else if (sp_streq(name, "chomp"))      buf_printf(b, "sp_str_chomp(%s)", r);
@@ -6562,7 +6842,7 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
       }
       else if (sp_streq(name, "index") && argc == 2) {
         buf_printf(b, "sp_str_index_from_opt(%s, ", r);
-        emit_expr(c, argv[0], b); buf_puts(b, ", ");
+        emit_str_expr(c, argv[0], b); buf_puts(b, ", ");
         emit_int_expr(c, argv[1], b); buf_puts(b, ")");
       }
       /* byteindex/byterindex over a String needle: BYTE-offset search (result +
@@ -6619,12 +6899,12 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
       else if (sp_streq(name, "rindex") && argc == 1 && re_lit_index(c, argv[0]) >= 0) {
         buf_printf(b, "sp_re_rindex_opt(sp_re_pat_%d, %s)", re_lit_index(c, argv[0]), r);
       }
-      else if (sp_streq(name, "rindex") && argc == 1) { buf_printf(b, "sp_str_rindex_opt(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+      else if (sp_streq(name, "rindex") && argc == 1) { buf_printf(b, "sp_str_rindex_opt(%s, ", r); emit_str_expr(c, argv[0], b); buf_puts(b, ")"); }
       else if (sp_streq(name, "rindex") && argc == 2 && re_lit_index(c, argv[0]) >= 0) {
         buf_printf(b, "sp_re_rindex_from_opt(sp_re_pat_%d, %s, ", re_lit_index(c, argv[0]), r);
         emit_int_expr(c, argv[1], b); buf_puts(b, ")");
       }
-      else if (sp_streq(name, "rindex") && argc == 2) { buf_printf(b, "sp_str_rindex_from(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ", "); emit_int_expr(c, argv[1], b); buf_puts(b, ")"); }
+      else if (sp_streq(name, "rindex") && argc == 2) { buf_printf(b, "sp_str_rindex_from(%s, ", r); emit_str_expr(c, argv[0], b); buf_puts(b, ", "); emit_int_expr(c, argv[1], b); buf_puts(b, ")"); }
       else if (sp_streq(name, "crypt") && argc == 1) { buf_printf(b, "sp_str_crypt(%s, ", r); emit_str_expr(c, argv[0], b); buf_puts(b, ")"); }
       /* scrub! mutates in place, so a frozen receiver raises -- but only when
          it would actually replace something: CRuby returns a frozen string
@@ -6632,10 +6912,10 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
       else if (sp_streq(name, "scrub!") && argc == 0)
         buf_printf(b, "sp_str_scrub_bang(%s, 0)", r);
       else if (sp_streq(name, "scrub!") && argc == 1) {
-        buf_printf(b, "sp_str_scrub_bang(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")");
+        buf_printf(b, "sp_str_scrub_bang(%s, ", r); emit_str_expr_nilable(c, argv[0], b); buf_puts(b, ")");
       }
       else if (sp_streq(name, "scrub") && argc == 0) buf_printf(b, "sp_str_scrub(%s, 0)", r);
-      else if (sp_streq(name, "scrub") && argc == 1) { buf_printf(b, "sp_str_scrub(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+      else if (sp_streq(name, "scrub") && argc == 1) { buf_printf(b, "sp_str_scrub(%s, ", r); emit_str_expr_nilable(c, argv[0], b); buf_puts(b, ")"); }
       else if ((sp_streq(name, "[]") || sp_streq(name, "slice")) && argc == 1 && re_lit_index(c, argv[0]) >= 0) {
         /* s[/re/] -> the matched substring, or nil (NULL) on no match */
         buf_printf(b, "(sp_re_match(sp_re_pat_%d, %s) >= 0 ? sp_re_match_str : NULL)", re_lit_index(c, argv[0]), r);
@@ -6714,10 +6994,10 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
         int ws = nil_arg || (aty && sp_streq(aty, "StringNode") && nt_str(c->nt, argv[0], "content") &&
                  sp_streq(nt_str(c->nt, argv[0], "content"), " "));
         if (ws) buf_printf(b, "sp_str_split_ws(%s)", r);
-        else { buf_printf(b, "sp_str_split_drop_trailing(%s, ", r); emit_str_expr(c, argv[0], b); buf_puts(b, ")"); }
+        else { buf_printf(b, "sp_str_split_drop_trailing(%s, ", r); emit_str_pattern_expr(c, argv[0], b); buf_puts(b, ")"); }
       }
       else if (sp_streq(name, "split") && argc == 2) {
-        buf_printf(b, "sp_str_split_limit(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ", "); emit_int_expr(c, argv[1], b); buf_puts(b, ")");
+        buf_printf(b, "sp_str_split_limit(%s, ", r); emit_str_pattern_expr(c, argv[0], b); buf_puts(b, ", "); emit_int_expr(c, argv[1], b); buf_puts(b, ")");
       }
       else if (sp_streq(name, "clamp") && (argc == 2 ||
                (argc == 1 && nt_type(c->nt, argv[0]) && sp_streq(nt_type(c->nt, argv[0]), "RangeNode")))) {
@@ -6929,7 +7209,7 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
         if (one && u1t == TY_INT)        buf_puts(b, "sp_poly_to_i(sp_PolyArray_get(");
         else if (one && u1t == TY_FLOAT) buf_puts(b, "sp_poly_to_f_opt(sp_PolyArray_get(");
         else if (one)                    buf_puts(b, "sp_PolyArray_get(");
-        buf_printf(b, "sp_str_unpack_off(%s, ", r); emit_expr(c, argv[0], b);
+        buf_printf(b, "sp_str_unpack_off(%s, ", r); emit_str_expr(c, argv[0], b);
         buf_puts(b, ", "); emit_int_expr(c, offv, b); buf_puts(b, ")");
         if (one) buf_puts(b, (u1t == TY_INT || u1t == TY_FLOAT) ? ", 0))" : ", 0)");
       }
@@ -6942,7 +7222,7 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
         if (u1t == TY_INT)        buf_printf(b, "sp_poly_to_i(sp_PolyArray_get(sp_str_unpack(%s, ", r);
         else if (u1t == TY_FLOAT) buf_printf(b, "sp_poly_to_f_opt(sp_PolyArray_get(sp_str_unpack(%s, ", r);
         else                      buf_printf(b, "sp_PolyArray_get(sp_str_unpack(%s, ", r);
-        emit_expr(c, argv[0], b);
+        emit_str_expr(c, argv[0], b);
         buf_puts(b, (u1t == TY_INT || u1t == TY_FLOAT) ? "), 0))" : "), 0)");
       }
       else if (sp_streq(name, "sum") && argc <= 1) {
@@ -6980,19 +7260,19 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
         buf_printf(b, "sp_str_center(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ")");
       }
       else if (sp_streq(name, "center") && argc == 2) {
-        buf_printf(b, "sp_str_center2(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ", "); emit_expr(c, argv[1], b); buf_puts(b, ")");
+        buf_printf(b, "sp_str_center2(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ", "); emit_str_expr(c, argv[1], b); buf_puts(b, ")");
       }
       else if (sp_streq(name, "ljust") && argc == 1) {
         buf_printf(b, "sp_str_ljust(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ")");
       }
       else if (sp_streq(name, "ljust") && argc == 2) {
-        buf_printf(b, "sp_str_ljust2(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ", "); emit_expr(c, argv[1], b); buf_puts(b, ")");
+        buf_printf(b, "sp_str_ljust2(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ", "); emit_str_expr(c, argv[1], b); buf_puts(b, ")");
       }
       else if (sp_streq(name, "rjust") && argc == 1) {
         buf_printf(b, "sp_str_rjust(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ")");
       }
       else if (sp_streq(name, "rjust") && argc == 2) {
-        buf_printf(b, "sp_str_rjust2(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ", "); emit_expr(c, argv[1], b); buf_puts(b, ")");
+        buf_printf(b, "sp_str_rjust2(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ", "); emit_str_expr(c, argv[1], b); buf_puts(b, ")");
       }
       /* String#eql?(x): byte-equal only when x is itself String-typed (no
          coercion, unlike ==). A poly arg checks its tag; any other concrete
@@ -7185,7 +7465,7 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
           buf_puts(b, "({ (void)("); emit_expr(c, argv[0], b);
           buf_printf(b, "); (sp_int)((%s) < 0 ? 1 : 0); })", r);
         }
-        else { buf_printf(b, "sp_int_bit((%s), ", r); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+        else { buf_printf(b, "sp_int_bit((%s), ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ")"); }
       }
       else if (sp_streq(name, "bit_length") && argc == 0) buf_printf(b, "sp_int_bit_length(%s)", r);
       else if (sp_streq(name, "fdiv") && argc == 1) { buf_printf(b, "((sp_float)(%s) / (", r); emit_float_expr(c, argv[0], b); buf_puts(b, "))"); }
@@ -7947,7 +8227,7 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
                         " sp_FloatArray_push(_t%d, (%s)); _t%d; })", o, o, ta, o, r, o);
         }
       }
-      else if (sp_streq(name, "fdiv") && argc == 1) { buf_printf(b, "((%s) / (", r); emit_float_expr(c, argv[0], b); buf_puts(b, "))"); }
+      else if (sp_streq(name, "fdiv") && argc == 1) { buf_printf(b, "((%s) / (", r); emit_float_coerce_expr(c, argv[0], b); buf_puts(b, "))"); }
       /* Float#eql?(x): true only when x is itself a Float of equal value (no
          numeric coercion, unlike ==). A float-typed arg compares directly; any
          other arg is boxed and rejected unless it is tagged float at runtime. */
@@ -9586,7 +9866,7 @@ int emit_value_recv_call(Compiler *c, int id, Buf *b) {
       #undef SG_EMIT_KEY
       buf_printf(b, " sp_box_obj(_t%d, SP_BUILTIN_SYM_POLY_HASH); })", th);
     }
-    else if (sp_streq(name, "strftime") && argc == 1) { buf_printf(b, "sp_time_strftime(%s, ", r); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+    else if (sp_streq(name, "strftime") && argc == 1) { buf_printf(b, "sp_time_strftime(%s, ", r); emit_str_expr(c, argv[0], b); buf_puts(b, ")"); }
     /* Comparable#between? / #clamp compare a Time with a Time; CRuby raises
        ArgumentError ("comparison of Time with 1 failed") for anything else,
        where reading the operand as an sp_Time did not compile (#3865). */
@@ -9765,7 +10045,8 @@ int emit_value_recv_call(Compiler *c, int id, Buf *b) {
       int by_name = (kt2 == TY_STRING || kt2 == TY_SYMBOL);
       buf_printf(b, "sp_MatchData_%s%s(%s, ", name, by_name ? "_name" : "", r);
       if (kt2 == TY_SYMBOL) { buf_puts(b, "sp_sym_to_s("); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
-      else emit_expr(c, argv[0], b);
+      else if (by_name) emit_expr(c, argv[0], b);
+      else emit_int_expr(c, argv[0], b);
       buf_puts(b, ")");
     }
     else if (sp_streq(name, "values_at") && argc >= 1) {
@@ -9812,7 +10093,7 @@ int emit_value_recv_call(Compiler *c, int id, Buf *b) {
         }
         else {
           buf_printf(b, " sp_PolyArray_push(_t%d, sp_box_nullable_str(sp_MatchData_aref(_t%d, ", at, mt);
-          emit_expr(c, argv[i], b); buf_puts(b, ")));");
+          emit_int_expr(c, argv[i], b); buf_puts(b, ")));");
         }
       }
       buf_printf(b, " _t%d; })", at);
@@ -10568,13 +10849,20 @@ int emit_range_call(Compiler *c, int id, Buf *b) {
           TyKind at0 = comp_ntype(c, argv[0]);
           int arg_is_float = at0 == TY_FLOAT;
           int arg_is_poly = at0 == TY_POLY;
-          buf_printf(b, "sp_range_include(&_t%d, ", t);
-          if (arg_is_float) buf_puts(b, "(sp_int)(");
-          if (arg_is_poly) buf_puts(b, "sp_poly_to_i(");
-          emit_expr(c, argv[0], b);
-          if (arg_is_poly) buf_puts(b, ")");
-          if (arg_is_float) buf_puts(b, ")");
-          buf_puts(b, ")");
+          if (value_obj_compares(c, argv[0])) unsupported_feature(c, id, "Range#include? of a user object defining <=>");
+          if (value_kind_misses(c, argv[0], TY_INT)) {
+            /* an Integer compares with nothing of this class: not covered */
+            buf_puts(b, "({ (void)("); emit_expr(c, argv[0], b); buf_puts(b, "); 0; })");
+          }
+          else {
+            buf_printf(b, "sp_range_include(&_t%d, ", t);
+            if (arg_is_float) buf_puts(b, "(sp_int)(");
+            if (arg_is_poly) buf_puts(b, "sp_poly_to_i(");
+            emit_expr(c, argv[0], b);
+            if (arg_is_poly) buf_puts(b, ")");
+            if (arg_is_float) buf_puts(b, ")");
+            buf_puts(b, ")");
+          }
         }
       }
       else if (sp_streq(name, "min"))  /* smallest enumerated element (direction-aware) */
@@ -10657,7 +10945,12 @@ int emit_range_call(Compiler *c, int id, Buf *b) {
       else if (sp_streq(name, "eql?") || sp_streq(name, "equal?")) {
         /* the unboxed sp_Range has no object identity: equal? compares
            components, like the Complex/Rational value arms */
-        buf_printf(b, "sp_range_eq(_t%d, ", t); emit_expr(c, argv[0], b); buf_puts(b, ")");
+        if (argc == 1 && comp_ntype(c, argv[0]) != TY_RANGE && comp_ntype(c, argv[0]) != TY_POLY &&
+            comp_ntype(c, argv[0]) != TY_UNKNOWN) {
+          /* a value of another class is never eql? to a Range */
+          buf_puts(b, "({ (void)("); emit_expr(c, argv[0], b); buf_puts(b, "); 0; })");
+        }
+        else { buf_printf(b, "sp_range_eq(_t%d, ", t); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
       }
       else if (sp_streq(name, "overlap?")) {
         int t2 = ++g_tmp;

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -403,6 +403,11 @@ int  emit_super_inline(Compiler *c, int id, Buf *b, int indent, int as_expr);
 void emit_args_filled(Compiler *c, int callee_idx, int argsNode, const char *lead, Buf *out);
 /* Emit a hash key, unboxing a poly value to the typed-hash's key type. */
 void emit_hash_key(Compiler *c, int key, TyKind kt, Buf *b);
+int hash_key_misses(Compiler *c, int key, TyKind kt);
+const char *conv_wrong_cls_name(TyKind t);
+const char *conv_cls_name_of(Compiler *c, TyKind t);
+TyKind obj_container_conv(Compiler *c, TyKind t, const char *conv, int *def);
+void emit_str_pattern_expr(Compiler *c, int node, Buf *b);
 void emit_boxed_text(Compiler *c, TyKind t, const char *expr, Buf *b);
 int emit_iter_bind_rest(Compiler *c, int block, int np, TyKind elem_t, const char *elem_src, Buf *b, int indent);
 void emit_frozen_obj_guard(Compiler *c, int cid, const char *selfexpr, Buf *b);
@@ -797,8 +802,12 @@ void emit_int_expr(Compiler *c, int node, Buf *b);
 void emit_str_expr(Compiler *c, int node, Buf *b);
 void emit_path_expr(Compiler *c, int node, Buf *b);
 void emit_to_s_expr(Compiler *c, int node, Buf *b);
-/* Converted String operands held across the call they enter (codegen.c). */
-typedef struct { Buf b; int *tmp; int n, cap; } ConvHold;
+/* Converted String operands held across the call they enter (codegen.c).
+   `guarded` declines the hold: the arm wrapped its body in a nil-receiver
+   dispatch check, and a hoisted conversion would run before that check
+   raises its NoMethodError -- CRuby never asks #to_str for a call that
+   does not dispatch. */
+typedef struct { Buf b; int *tmp; int n, cap; int guarded; } ConvHold;
 extern ConvHold *g_conv_hold;
 extern unsigned g_conv_emitted;  /* implicit conversions emitted so far; read as a delta */
 Buf *conv_hold_begin(Buf *b, int *tmp);
@@ -812,6 +821,7 @@ void emit_int_expr_conv(Compiler *c, int node, Buf *b);
 int emit_unresolved_coerced(Compiler *c, int node, TyKind target, Buf *b);
 void emit_int_divisor(Compiler *c, int node, Buf *b);
 void emit_float_expr(Compiler *c, int node, Buf *b);
+void emit_float_coerce_expr(Compiler *c, int node, Buf *b);
 /* Emit `node` as a scalar operand: like a plain emit_expr, except an
    unresolved-constant read (which lowers to a NameError raise valued as an
    sp_Class struct) is voided and replaced by `zero` ("0" / "0.0"), so the

--- a/src/codegen_iter.c
+++ b/src/codegen_iter.c
@@ -3409,7 +3409,7 @@ int emit_iteration_stmt(Compiler *c, int id, Buf *b, int indent) {
     emit_indent(b, indent);
     if (cyc_argc == 1) {
       buf_printf(b, "sp_int _t%d = ", tn);
-      emit_expr(c, cyc_argv[0], b); buf_puts(b, ";\n");
+      emit_int_expr_nilable(c, cyc_argv[0], b); buf_puts(b, ";\n");
       emit_indent(b, indent);
       buf_printf(b, "for (sp_int _t%d = 0; _t%d < _t%d; _t%d++) {\n", ti, ti, tn, ti);
     }
@@ -3459,7 +3459,7 @@ int emit_iteration_stmt(Compiler *c, int id, Buf *b, int indent) {
     emit_indent(b, indent); emit_ctype(c, rt, b);
     buf_printf(b, " _t%d = %s;\n", ta, rb.p ? rb.p : ""); free(rb.p);
     emit_indent(b, indent); buf_printf(b, "sp_int _t%d = ", ts);
-    emit_expr(c, es_argv[0], b); buf_puts(b, ";\n");
+    emit_int_expr(c, es_argv[0], b); buf_puts(b, ";\n");
     emit_indent(b, indent);
     buf_printf(b, "for (sp_int _t%d = 0; _t%d < sp_%sArray_length(_t%d); _t%d += _t%d) {\n",
                ti, ti, k, ta, ti, ts);
@@ -3516,14 +3516,32 @@ int emit_iteration_stmt(Compiler *c, int id, Buf *b, int indent) {
       int ws = (aty && sp_streq(aty, "NilNode")) ||
                (aty && sp_streq(aty, "StringNode") && nt_str(nt, sp_argv[0], "content") &&
                 sp_streq(nt_str(nt, sp_argv[0], "content"), " "));
+      int reli = re_lit_index(c, sp_argv[0]);
       if (ws) buf_printf(b, "sp_str_split_ws(%s);\n", rb.p ? rb.p : "");
+      /* a Regexp separator splits with the engine, the way the expression
+         arm does; it is the one class the pattern slot must not word as a
+         wrong argument */
+      else if (reli >= 0) buf_printf(b, "sp_re_split(sp_re_pat_%d, %s);\n", reli, rb.p ? rb.p : "");
+      else if (comp_ntype(c, sp_argv[0]) == TY_REGEX) {
+        buf_puts(b, "sp_re_split("); emit_expr(c, sp_argv[0], b);
+        buf_printf(b, ", %s);\n", rb.p ? rb.p : "");
+      }
       else {
-        buf_printf(b, "sp_str_split_drop_trailing(%s, ", rb.p ? rb.p : ""); emit_expr(c, sp_argv[0], b); buf_puts(b, ");\n");
+        buf_printf(b, "sp_str_split_drop_trailing(%s, ", rb.p ? rb.p : ""); emit_str_pattern_expr(c, sp_argv[0], b); buf_puts(b, ");\n");
       }
     }
     else {
-      buf_printf(b, "sp_str_split_limit(%s, ", rb.p ? rb.p : ""); emit_expr(c, sp_argv[0], b);
-      buf_puts(b, ", "); emit_int_expr(c, sp_argv[1], b); buf_puts(b, ");\n");
+      int reli = re_lit_index(c, sp_argv[0]);
+      if (reli >= 0) buf_printf(b, "sp_re_split_limit(sp_re_pat_%d, %s, ", reli, rb.p ? rb.p : "");
+      else if (comp_ntype(c, sp_argv[0]) == TY_REGEX) {
+        buf_puts(b, "sp_re_split_limit("); emit_expr(c, sp_argv[0], b);
+        buf_printf(b, ", %s, ", rb.p ? rb.p : "");
+      }
+      else {
+        buf_printf(b, "sp_str_split_limit(%s, ", rb.p ? rb.p : ""); emit_str_pattern_expr(c, sp_argv[0], b);
+        buf_puts(b, ", ");
+      }
+      emit_int_expr(c, sp_argv[1], b); buf_puts(b, ");\n");
     }
     free(rb.p);
     emit_indent(b, indent); buf_printf(b, "SP_GC_ROOT(_t%d);\n", tm);

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -667,15 +667,22 @@ else if (at == TY_POLY) {
       buf_puts(b, "putchar((int)(sp_poly_to_i("); emit_expr(c, argv[0], b); buf_puts(b, ") & 0xff));\n");
     }
 else {
-      buf_puts(b, "putchar((int)(("); emit_expr(c, argv[0], b); buf_puts(b, ") & 0xff));\n");
+      buf_puts(b, "putchar((int)(("); emit_int_expr(c, argv[0], b); buf_puts(b, ") & 0xff));\n");
     }
     return 1;
   }
   if (sp_streq(name, "system") && argc >= 1) {
+    if (ty_is_hash(comp_ntype(c, argv[0]))) { unsupported_feature(c, id, "system with an environment Hash"); return 0; }
+    if (ty_is_array(comp_ntype(c, argv[0]))) { unsupported_feature(c, id, "system with a [command, argv0] pair"); return 0; }
     int ts = ++g_tmp;
     emit_indent(b, indent);
-    buf_printf(b, "{ const char *_sys_%d[] = { ", ts);
-    for (int k = 0; k < argc; k++) { if (k > 0) buf_puts(b, ", "); emit_expr(c, argv[k], b); }
+    buf_puts(b, "{ ");
+    for (int k = 0; k < argc; k++) {
+      buf_printf(b, "const char *_sys_%d_%d = ", ts, k); emit_str_expr(c, argv[k], b);
+      buf_printf(b, "; SP_GC_ROOT_STR(_sys_%d_%d); ", ts, k);
+    }
+    buf_printf(b, "const char *_sys_%d[] = { ", ts);
+    for (int k = 0; k < argc; k++) { if (k > 0) buf_puts(b, ", "); buf_printf(b, "_sys_%d_%d", ts, k); }
     buf_printf(b, ", NULL }; sp_system_args(%d, _sys_%d); }\n", argc, ts);
     return 1;
   }
@@ -706,7 +713,7 @@ else {
         }
         emit_indent(b, indent);
         buf_puts(b, "  fputs(sp_str_format_polyarr(");
-        emit_expr(c, argv[0], b);
+        emit_str_expr(c, argv[0], b);
         buf_printf(b, ", _t%d), stdout); }\n", tpa);
         return 1;
       }
@@ -762,7 +769,7 @@ else {
       TyKind xt = comp_ntype(c, argv[0]);
       if (xt == TY_POLY) { buf_printf(b, "%s((int)sp_poly_to_i(", xfn); emit_expr(c, argv[0], b); buf_puts(b, "));\n"); }
       else if (xt == TY_BOOL) { buf_printf(b, "%s((", xfn); emit_expr(c, argv[0], b); buf_puts(b, ") ? 0 : 1);\n"); }
-      else { buf_printf(b, "%s((int)(", xfn); emit_expr(c, argv[0], b); buf_puts(b, "));\n"); }
+      else { buf_printf(b, "%s((int)(", xfn); emit_int_expr(c, argv[0], b); buf_puts(b, "));\n"); }
     }
     return 1;
   }
@@ -773,7 +780,7 @@ else {
       buf_puts(b, "sp_abort_raise(");
       TyKind at = comp_ntype(c, argv[0]);
       if (at == TY_STRING) emit_expr(c, argv[0], b);
-      else { buf_puts(b, "sp_to_s("); emit_expr(c, argv[0], b); buf_puts(b, ")"); }
+      else emit_str_expr(c, argv[0], b);
       buf_puts(b, ");\n");
     }
     else buf_puts(b, "sp_abort_raise((const char *)0);\n");

--- a/src/codegen_util.c
+++ b/src/codegen_util.c
@@ -1500,8 +1500,38 @@ int emit_catch_tag(Compiler *c, int id, Buf *b) {
   unsupported(c, id, "catch/throw with a Float, boolean, nil, or Bignum tag (use a Symbol, String, Integer, or object tag)");
   return 0;
 }
+/* A key whose static kind can never be in a typed hash's table: a String
+   or a user object looked up in an Integer-keyed Hash, a Float where
+   1.eql?(1.0) is false, nil in any of them. Hash looks a key up by #hash and
+   #eql? and converts nothing, so the lookup is a plain miss in CRuby, not a
+   TypeError -- and not the raw pointer in the sp_int slot that stopped the C
+   build ({1 => 2}.dig("a"), .fetch("a"), .except(obj)). The same kinds a
+   poly key of another tag already misses on. A user object is a miss
+   without asking whether its class defines #eql? and #hash: a typed table
+   holds no objects, so nothing in it can be eql? to one. */
+int hash_key_misses(Compiler *c, int key, TyKind kt) {
+  TyKind actual = comp_ntype(c, key);
+  if (kt == TY_POLY || actual == kt || actual == TY_POLY || actual == TY_UNKNOWN) return 0;
+  if (kt == TY_STRING && (actual == TY_STRBUF || actual == TY_SYMBOL)) return 0;
+  return actual == TY_NIL || actual == TY_BOOL || actual == TY_INT ||
+         actual == TY_BIGINT || actual == TY_FLOAT || actual == TY_SYMBOL ||
+         actual == TY_STRING || actual == TY_STRBUF || actual == TY_RANGE ||
+         actual == TY_FLOAT_RANGE || actual == TY_STR_RANGE || actual == TY_TIME ||
+         actual == TY_REGEX || ty_is_array(actual) || ty_is_hash(actual) ||
+         ty_is_object(actual);
+}
+
 void emit_hash_key(Compiler *c, int key, TyKind kt, Buf *b) {
   TyKind actual = comp_ntype(c, key);
+  if (hash_key_misses(c, key, kt)) {
+    /* evaluate the key for its effects, then answer the value no key equals */
+    buf_puts(b, "({ (void)(");
+    emit_expr(c, key, b);
+    if (kt == TY_STRING)      buf_puts(b, "); (const char *)0; })");
+    else if (kt == TY_SYMBOL) buf_puts(b, "); (sp_sym)-1; })");
+    else                      buf_puts(b, "); SP_INT_NIL; })");
+    return;
+  }
   /* A symbol key on a string-keyed hash (Hash.new{}'s StrPolyHash models
      symbol keys by their name) coerces to the symbol's string. A literal
      :sym becomes the name string directly; a symbol value uses sp_sym_to_s. */

--- a/test/rbs-seed/typed_slot_block_key.rb
+++ b/test/rbs-seed/typed_slot_block_key.rb
@@ -1,0 +1,9 @@
+# Hash#fetch / #fetch_values / #delete with a BLOCK and a key of a class the
+# table cannot hold: the block's parameter is typed as the table's key kind,
+# so a key of another class has no slot to arrive in. Spinel refuses at
+# compile time and names the case, rather than putting the raw value in the
+# typed slot and stopping the generated-C build. The blockless forms -- which
+# simply miss, the way CRuby's #hash / #eql? lookup does -- are pinned by
+# test/typed_slot_conversion.rb.
+h = { 1 => 2 }
+p h.fetch("a") { |k| k }

--- a/test/rbs-seed/typed_slot_compare_obj.rb
+++ b/test/rbs-seed/typed_slot_compare_obj.rb
@@ -1,0 +1,13 @@
+# A user object whose class defines == (here through Comparable's <=>) looked
+# up in a typed Array: CRuby calls the method against every element, and the
+# typed slot has no room for the object. Spinel refuses at compile time and
+# names the case, rather than putting the raw pointer in the sp_int slot and
+# stopping the generated-C build. An object whose class compares nothing
+# simply misses -- pinned by test/typed_slot_conversion.rb.
+class Near
+  include Comparable
+  def <=>(other)
+    1 <=> other
+  end
+end
+p [1, 2, 3].count(Near.new)

--- a/test/typed_slot_conversion.rb
+++ b/test/typed_slot_conversion.rb
@@ -1,0 +1,213 @@
+# CRuby's protocol at the typed argument slots the emitters fill directly: a
+# user object converts through #to_str / #to_int where the slot asks, a value
+# of another class is the slot's TypeError, and a lookup slot -- a Hash key, an
+# Array element to find, a Range member -- takes any object and simply misses.
+class Sep
+  def to_str
+    "-"
+  end
+end
+
+class Idx
+  def to_int
+    1
+  end
+end
+
+def err
+  yield
+rescue StandardError => e
+  [e.class, e.message]
+end
+
+# String slots
+p "a-b-".chomp(Sep.new)
+s = String.new("a-b")
+p [s.chomp!(Sep.new), s]
+p "a".ljust(4, Sep.new)
+p "a".rjust(4, Sep.new)
+p "a".center(5, Sep.new)
+p "a-b".index(Sep.new, 0)
+p "a-b-".rindex(Sep.new)
+p "a-b-".rindex(Sep.new, 2)
+p "\xff".scrub(Sep.new) == "-"
+p String.new("\xff").scrub!(Sep.new) == "-"
+p "a-b-c".split(Sep.new, 2)
+p "a-b-c".split(Sep.new)
+p "a".upto(Sep.new).to_a.size
+class Fmt
+  def to_str
+    "a"
+  end
+end
+p "ab".unpack1(Fmt.new)
+p String.new("abc").bytesplice(0, 1, Sep.new)
+p Time.utc(2000).strftime(Sep.new)
+p String.new(Sep.new)
+p Regexp.escape(Sep.new)
+p format(Sep.new)
+p sprintf(Sep.new)
+ENV["SPINEL_SLOT"] = "v"
+class Key
+  def to_str
+    "SPINEL_SLOT"
+  end
+end
+p ENV[Key.new]
+p ENV.key?(Key.new)
+p ENV.store(Key.new, "w")
+p ENV.delete(Key.new)
+class Cmd
+  def to_str
+    "true"
+  end
+end
+p system(Cmd.new)
+p err { "abc".rindex(1) }
+p err { "abc".ljust(4, 1) }
+p err { "a-b".chomp(1) }
+p err { "abc".split(1) }
+p err { format(1) }
+p err { Time.utc(2000).strftime(1) }
+p err { Regexp.escape(1) }
+p err { String.new(1) }
+
+# Integer slots
+a = [1, 2, 3]
+p [a.slice!(Idx.new, Idx.new), a]
+p 8[Idx.new]
+p 1 << Idx.new
+p 8 >> Idx.new
+p Time.at(Idx.new).to_i
+p Time.utc(2000, Idx.new, Idx.new).month
+p Time.local(2000, Idx.new, Idx.new).day
+p Random.new(1).rand(Idx.new).class
+p Random.rand(Idx.new).class
+p [1, 2].each_slice(Idx.new).to_a
+p [[1, 2], 3].dig(Idx.new)
+m = /(a)(b)/.match("ab")
+p [m.begin(Idx.new), m.end(Idx.new), m.offset(Idx.new), m.byteoffset(Idx.new), m.values_at(Idx.new)]
+p /a/.match?("ba", Idx.new)
+p err { [1, 2].cycle("x") { } }
+p err { Random.rand("x") }
+p err { a.slice!("x", 1) }
+p err { 8["x"] }
+p err { [1, 2].each_slice("x") { }; :no }
+p err { Time.at([1]) }
+p err { File.utime("x", "x", "nope") }
+p err { 1.0.quo("x") }
+p err { Math.sqrt("x") }
+p err { Math.sqrt(nil) }
+p err { Math.sqrt(Sep.new) }
+
+# lookup slots: any object, a miss is a miss
+h = { 1 => 2 }
+p h.dig("a")
+p h.dig(1.0)
+p h.fetch("a", 9)
+p h.except("a")
+p h.slice("a", 1)
+p h.values_at("a", 1)
+p h.has_value?("x")
+p h.has_value?(2.0)
+p h.assoc("a")
+p err { h.fetch("a") }
+p err { h.fetch_values(1, :b) }
+sh = { "a" => 1 }
+p sh.assoc(2)
+p sh.dig(:a)
+p [1, 2].count("x")
+p [1, 2].all?("x")
+p [].all?("x")
+p [1, 2].any?("x")
+p [1, 2].none?("x")
+p [1, 2].one?("x")
+p [1, 2].delete("x")
+p [1, 2].delete("x") { :none }
+p ["a"].delete(1)
+p [1, 2].index("x")
+p [1, 2].rindex(:y)
+p (1..2).include?("x")
+p (1..2) === "x"
+p (1..2).member?(nil)
+p (1..2).eql?("x")
+p (1..2).count("x")
+p [1, 2.0].count(2)
+p [1, 2].count(1.0)
+
+# a Bignum never equals an element of an Integer array (a user object whose
+# class compares is refused at compile time: test/rbs-seed/typed_slot_compare_obj.rb)
+p [1, 2].count(2**100)
+
+# container slots: #to_ary / #to_hash, or CRuby's TypeError
+class Pair
+  def to_ary
+    [1, 2]
+  end
+end
+
+class Tbl
+  def to_hash
+    { "b" => 2 }
+  end
+end
+
+class Inert
+end
+p [3, 4].zip(Pair.new)
+p [3, 4].product(Pair.new)
+p({ "a" => 1 }.merge(Tbl.new))
+p err { [1].zip(5) }
+p err { [1].zip(nil) }
+p err { [1].zip(Inert.new) }
+p err { [1].product("x") }
+p err { { "a" => 1 }.merge(5) }
+p err { { "a" => 1 }.merge(Inert.new) }
+p({ "a" => 1 }[Sep.new])
+
+# the receiver still evaluates before the operand
+def trace(label, value)
+  puts label
+  value
+end
+p trace("recv", [1]).product(trace("arg", [2]))
+
+# nil where CRuby has a default, and the slots that are not the int slot
+path = "/tmp/spinel_typed_slot_conversion.txt"
+File.write(path, "x")
+p File.utime(nil, nil, path)
+File.delete(path)
+p Time.utc(2000, 5, nil)
+p Time.utc(2000, 5, 6, nil, nil, nil).min
+p err { Random.rand(nil) }
+p err { 1.0.quo(nil) }
+p err { 1.0.quo(:s) }
+p err { 7.0.fdiv(Sep.new) }
+p err { 7.fdiv("x") }
+p "a1b2c".split(/\d/) { |x| p x }
+p err { "a b".split(true) }
+
+# a key expression evaluates once whether it hits or misses
+calls = 0
+mk = -> { calls += 1; "k" }
+p [h.fetch(mk.call, 0), h.dig(mk.call), h.values_at(mk.call), calls]
+
+# the time-interval slot names the class the way rb_time_interval does
+# (sleep(nil) sleeps forever in CRuby and is not pinned here)
+p err { sleep(true) }
+p err { sleep(:s) }
+p err { File.utime(false, false, "/nonexistent") }
+
+# rb_reg_operand takes a Symbol by its name; the #to_str slot would refuse it
+p Regexp.escape(:"a.b")
+
+# a nil receiver from a typed-container miss raises NoMethodError without
+# asking the argument's #to_str
+class Needle
+  def to_str
+    puts "to_str asked"
+    "b"
+  end
+end
+misses = { "k" => "abcb" }
+p err { misses["zz"].rindex(Needle.new) }

--- a/test/typed_slot_conversion.rb.expected
+++ b/test/typed_slot_conversion.rb.expected
@@ -1,0 +1,121 @@
+"a-b"
+[nil, "a-b"]
+"a---"
+"---a"
+"--a--"
+1
+3
+1
+true
+true
+["a", "b-c"]
+["a", "b", "c"]
+0
+"a"
+"-bc"
+"-"
+"-"
+"\\-"
+"-"
+"-"
+"v"
+true
+"w"
+"w"
+true
+[TypeError, "no implicit conversion of Integer into String"]
+[TypeError, "no implicit conversion of Integer into String"]
+[TypeError, "no implicit conversion of Integer into String"]
+[TypeError, "wrong argument type Integer (expected Regexp)"]
+[TypeError, "no implicit conversion of Integer into String"]
+[TypeError, "no implicit conversion of Integer into String"]
+[TypeError, "no implicit conversion of Integer into String"]
+[TypeError, "no implicit conversion of Integer into String"]
+[[2], [1, 3]]
+0
+2
+4
+1
+1
+1
+Integer
+Integer
+[[1], [2]]
+3
+[0, 1, [0, 1], [0, 1], ["a"]]
+true
+[TypeError, "no implicit conversion of String into Integer"]
+[TypeError, "no implicit conversion of String into Integer"]
+[TypeError, "no implicit conversion of String into Integer"]
+[TypeError, "no implicit conversion of String into Integer"]
+[TypeError, "no implicit conversion of String into Integer"]
+[TypeError, "can't convert Array into an exact number"]
+[TypeError, "can't convert String into time"]
+[TypeError, "String can't be coerced into Float"]
+[TypeError, "can't convert String into Float"]
+[TypeError, "can't convert nil into Float"]
+[TypeError, "can't convert Sep into Float"]
+nil
+nil
+9
+{1 => 2}
+{1 => 2}
+[nil, 2]
+false
+true
+nil
+[KeyError, "key not found: \"a\""]
+[KeyError, "key not found: :b"]
+nil
+nil
+0
+false
+true
+false
+true
+false
+nil
+:none
+nil
+nil
+nil
+false
+false
+false
+false
+0
+1
+1
+0
+[[3, 1], [4, 2]]
+[[3, 1], [3, 2], [4, 1], [4, 2]]
+{"a" => 1, "b" => 2}
+[TypeError, "wrong argument type Integer (must respond to :each)"]
+[TypeError, "wrong argument type NilClass (must respond to :each)"]
+[TypeError, "wrong argument type Inert (must respond to :each)"]
+[TypeError, "no implicit conversion of String into Array"]
+[TypeError, "no implicit conversion of Integer into Hash"]
+[TypeError, "no implicit conversion of Inert into Hash"]
+nil
+recv
+arg
+[[1, 2]]
+1
+2000-05-01 00:00:00 UTC
+0
+[ArgumentError, "invalid argument - "]
+[TypeError, "nil can't be coerced into Float"]
+[TypeError, ":s can't be coerced into Float"]
+[TypeError, "Sep can't be coerced into Float"]
+[TypeError, "String can't be coerced into Integer"]
+"a"
+"b"
+"c"
+"a1b2c"
+[TypeError, "wrong argument type true (expected Regexp)"]
+[0, nil, [nil], 3]
+[TypeError, "can't convert TrueClass into time interval"]
+[TypeError, "can't convert Symbol into time interval"]
+[TypeError, "can't convert FalseClass into time"]
+"a\\.b"
+[NoMethodError, "undefined method 'rindex' for nil"]

--- a/tools/gen_conv_slot_probe.rb
+++ b/tools/gen_conv_slot_probe.rb
@@ -1,0 +1,362 @@
+#!/usr/bin/env ruby
+
+# Probe every builtin positional argument slot for the implicit conversion
+# protocol, then check which of those slots Spinel compiles:
+#
+#   ruby tools/gen_conv_slot_probe.rb [report.json]   (SPINEL=bin/spinel, JOBS=n)
+#
+# Technique, per (class, method), the same as tools/gen_nil_arg_probe.rb:
+#
+#   1. Find a WORKING baseline call in CRuby for each accepted count.
+#   2. For each slot whose baseline value is a String, Integer, Array or Hash,
+#      substitute a user object answering the slot's implicit conversion
+#      (#to_str, #to_int, #to_ary, #to_hash) and, separately, a wrong-class
+#      scalar (an Integer in a String slot, a String in an Integer slot).
+#      Record what CRuby answers: the result's inspect, or the error.
+#   3. Compile and run the same program with Spinel (`spinel -E`) and classify:
+#      "match", "cfail" (the generated C does not compile -- the slot takes
+#      the raw value), or "differ" (a run-time divergence).
+#
+# The report drives a sweep of the typed-slot emitters in src/codegen*.c: every
+# "cfail" is a slot still emitted with emit_expr where emit_str_expr /
+# emit_int_expr (or the Array / Hash protocols) belong.
+#
+# Probing runs inside a fresh temp directory. The fd-level forms are never
+# a baseline (File.open(1) would hand the probe its own stdout), and
+# Kernel#system is probed with `true` as its command only.
+
+require "timeout"
+require "json"
+require "tmpdir"
+require "stringio"
+require "strscan"
+require "pathname"
+require "set"
+require "etc"
+
+Warning[:deprecated] = false
+
+ROOT = File.expand_path("..", __dir__)
+SOURCE = File.join(ROOT, "src/codegen_call.c")
+OUT = File.expand_path(ARGV.fetch(0, "conv_slot_probe.json"))
+SPINEL = File.expand_path(ENV.fetch("SPINEL", File.join(ROOT, "bin/spinel")))
+JOBS = Integer(ENV.fetch("JOBS", Etc.nprocessors))
+
+# receiver source text (compiled by Spinel) and the matching CRuby thunk
+INSTANCE_RECEIVERS = {
+  "String" => ['"ab".dup', -> { "ab".dup }],
+  "Integer" => ["1", -> { 1 }],
+  "Float" => ["1.0", -> { 1.0 }],
+  "Symbol" => [":a", -> { :a }],
+  "Array" => ["[1, 2]", -> { [1, 2] }],
+  "Hash" => ["{1 => 2}", -> { {1 => 2} }],
+  "Range" => ["(1..2)", -> { (1..2) }],
+  "Time" => ["Time.at(0)", -> { Time.at(0) }],
+  "StringIO" => ['StringIO.new("ab".dup)', -> { StringIO.new("ab".dup) }],
+  "StringScanner" => ['StringScanner.new("ab")', -> { StringScanner.new("ab") }],
+  "Pathname" => ['Pathname.new("a")', -> { Pathname.new("a") }],
+  "Set" => ["Set.new([1, 2])", -> { Set.new([1, 2]) }],
+}
+
+CLASS_TARGETS = {
+  "File"    => %w[open new read write binread binwrite readlines foreach delete unlink
+                  rename exist? size basename dirname extname join split expand_path
+                  chmod utime truncate symlink link readlink realpath stat lstat
+                  ftype mtime atime ctime empty? zero? identical? absolute_path
+                  realdirpath birthtime readable? writable? executable? file?
+                  directory? readable_real? writable_real? executable_real?
+                  world_readable? world_writable? owned? grpowned? setuid? setgid?
+                  sticky? socket? blockdev? chardev? pipe? symlink? fnmatch fnmatch?
+                  mkfifo lchmod],
+  "FileTest" => %w[exist? size file? directory? readable? writable? executable?
+                   zero? empty? owned? grpowned? setuid? setgid? sticky? socket?
+                   blockdev? chardev? pipe? symlink? identical? world_readable?
+                   world_writable?],
+  "Dir"     => %w[new open mkdir rmdir delete unlink entries children glob foreach
+                  exist? empty? each_child],
+  "IO"      => %w[read write binread binwrite readlines foreach],
+  "Time"    => %w[at local mktime utc gm],
+  "Hash"    => %w[new],
+  "Array"   => %w[new],
+  "String"  => %w[new],
+  "Integer" => %w[sqrt],
+  "Math"    => %w[sqrt cbrt sin cos tan atan2 log log2 log10 exp hypot ldexp],
+  "Regexp"  => %w[new escape quote union],
+  "Random"  => %w[new rand srand],
+  "ENV"     => %w[fetch key? has_key? include? member? assoc rassoc values_at
+                  delete store [] []=],
+  "Kernel"  => %w[format sprintf putc print puts p system],
+  "Marshal" => %w[dump load],
+}
+
+SAMPLES = [1, "a", :a, [1], {1 => 2}, 0.5, (0..1), /a/]
+
+# The user classes substituted into a slot, by the baseline value's class; the
+# wrapped value is the baseline value itself so a passing probe answers the
+# baseline's result.
+CONVERSIONS = {
+  String => "to_str", Integer => "to_int", Array => "to_ary", Hash => "to_hash",
+}
+WRONG_SCALAR = { String => 1, Integer => "a" }
+
+def reset_fixture
+  File.chmod(0o644, "a") rescue nil
+  File.delete("a") rescue nil
+  File.binwrite("a", "hello")
+rescue SystemCallError
+end
+
+def attempt(recv_thunk, m, args, with_block: false)
+  reset_fixture
+  r = recv_thunk.call
+  res = Timeout.timeout(2) do
+    with_block ? r.__send__(m, *args) { |*| "a" } : r.__send__(m, *args)
+  end
+  return attempt(recv_thunk, m, args, with_block: true) if !with_block && res.is_a?(Enumerator)
+  [:ok, res, with_block]
+rescue Exception => e
+  e
+end
+
+def baseline_at(recv_thunk, m, n)
+  return [] if n == 0 && attempt(recv_thunk, m, []).is_a?(Array)
+  return nil if n == 0
+  SAMPLES.repeated_permutation(n) do |args|
+    r = attempt(recv_thunk, m, args)
+    next unless r.is_a?(Array)
+    # an Integer where a path belongs is the fd form: File.open(1) hands back
+    # the probe's OWN stdout, and closing it when the wrapper is collected
+    # takes the probe's output with it. Never a baseline; and close what a
+    # real path form opened, so the search does not leak a descriptor per
+    # permutation.
+    if r[1].is_a?(IO)
+      r[1].close unless r[1].closed? || r[1].fileno < 3
+      next if args.any?(Integer)
+    end
+    return args
+  end
+  nil
+end
+
+def accepted_counts(recv_thunk, m)
+  (0..3).select do |n|
+    r = attempt(recv_thunk, m, Array.new(n))
+    !(r.is_a?(ArgumentError) && r.message =~ /wrong number of arguments/)
+  end
+end
+
+# A probe's outcome as text both runtimes can be compared on.
+def outcome_text(r)
+  return "#{r.class}: #{r.message}"[0, 160] unless r.is_a?(Array)
+  v = r[1]
+  s = v.inspect
+  s = s.gsub(/0x[0-9a-f]+/, "0xADDR")
+  s[0, 160]
+end
+
+class Wrapped
+  def initialize(v, m)
+    @v = v
+    @m = m
+  end
+
+  def respond_to_missing?(name, priv = false)
+    name.to_s == @m || super
+  end
+
+  def method_missing(name, *args)
+    return @v if name.to_s == @m
+    super
+  end
+end
+
+# CRuby side: for each slot, the conversion and wrong-scalar outcomes.
+def probe_method(recv_thunk, m)
+  return nil unless recv_thunk.call.respond_to?(m)
+  counts = accepted_counts(recv_thunk, m)
+  return nil if counts.empty?
+  by_count = {}
+  counts.sort.reverse_each do |n|
+    next if n == 0
+    args = baseline_at(recv_thunk, m, n)
+    next if args.nil?
+    base = attempt(recv_thunk, m, args)
+    slots = args.each_index.map do |k|
+      conv = CONVERSIONS[args[k].class]
+      next nil unless conv
+      sub = args.dup
+      sub[k] = Wrapped.new(args[k], conv)
+      c = attempt(recv_thunk, m, sub)
+      wrong = WRONG_SCALAR[args[k].class]
+      sub2 = args.dup
+      sub2[k] = wrong
+      w = attempt(recv_thunk, m, sub2)
+      {"conv" => conv, "conv_out" => outcome_text(c),
+       "conv_ok" => c.is_a?(Array) && outcome_text(c) == outcome_text(base),
+       "wrong" => wrong.inspect, "wrong_out" => outcome_text(w)}
+    end
+    next if slots.compact.empty?
+    by_count[n] = {"baseline" => args.map(&:inspect), "block" => base[2],
+                   "base_out" => outcome_text(base), "slots" => slots}
+  end
+  by_count.empty? ? nil : by_count
+end
+
+# The Spinel-side program for one probe.
+def program(recv_src, m, info, k, kind)
+  args = info["baseline"].dup
+  slot = info["slots"][k]
+  pre = ""
+  if kind == "conv"
+    conv = slot["conv"]
+    pre = "class Conv\n  def initialize(v)\n    @v = v\n  end\n\n  def #{conv}\n    @v\n  end\nend\n"
+    args[k] = "Conv.new(#{args[k]})"
+  else
+    args[k] = slot["wrong"]
+  end
+  if m =~ /\A[a-z_]\w*[?!]?\z/
+    call = "#{recv_src}.#{m}(#{args.join(', ')})"
+  elsif m == "[]"
+    call = "#{recv_src}[#{args.join(', ')}]"
+  elsif m == "[]=" && args.size == 2
+    call = "#{recv_src}[#{args[0]}] = #{args[1]}"
+  elsif args.size == 1 && m =~ /\A[-+*\/%<>=!&|^~]+\z/
+    call = "#{recv_src} #{m} #{args[0]}"
+  else
+    return nil
+  end
+  call += ' { |*| "a" }' if info["block"]
+  <<~RUBY
+    require "stringio"
+    require "strscan"
+    require "pathname"
+    require "set"
+    #{pre}
+    File.binwrite("a", "hello")
+    begin
+      r = #{call}
+      puts "SP-RESULT \#{r.inspect.gsub(/0x[0-9a-f]+/, "0xADDR")}"
+    rescue Exception => e
+      puts "SP-RESULT \#{e.class}: \#{e.message}"
+    end
+  RUBY
+end
+
+# Each probe gets its own directory: File.open("a", "a", 1) leaves the shared
+# fixture mode 0o001 and every concurrent path-taking probe then sees EACCES.
+def run_spinel(src, root, idx)
+  dir = File.join(root, "p#{idx}")
+  Dir.mkdir(dir)
+  path = File.join(dir, "p#{idx}.rb")
+  File.write(path, src)
+  out = File.join(dir, "p#{idx}.out")
+  err = File.join(dir, "p#{idx}.err")
+  pid = Process.spawn(SPINEL, "-E", path, chdir: dir, in: File::NULL, out: out, err: err)
+  begin
+    Timeout.timeout(60) { Process.wait(pid) }
+  rescue Timeout::Error
+    Process.kill("KILL", pid) rescue nil
+    Process.wait(pid) rescue nil
+    return ["timeout", ""]
+  end
+  # the program's own output (puts / print probes) precedes the sentinel line
+  res = File.read(out).lines.find { |l| l.start_with?("SP-RESULT ") }
+  e = File.read(err)
+  if $?.exitstatus != 0 && res.nil?
+    line = e.lines.find { |l| l =~ /error:/ }
+    return [line ? "cfail" : "reject", (line || e.lines.first || "").strip[0, 200]]
+  end
+  [res ? res.delete_prefix("SP-RESULT ").strip[0, 160] : "", ""]
+end
+
+report = {}
+src = File.read(SOURCE)
+tbl = src[/sp_builtin_arity_tbl\[\] = \{(.*?)\n\};/m, 1] or
+  abort "sp_builtin_arity_tbl not found in #{SOURCE}"
+surface = Hash.new { |h, k| h[k] = [] }
+tbl.scan(/\{"(\w+)","([^"]+)",-?\d+\}/) { |cls, m| surface[cls] << m }
+# pread: probing StringIO#pread with mistyped arguments segfaults CRuby
+# 4.0.6 itself ([BUG] in pread); the fd-level forms stay off the surface.
+%w[StringIO StringScanner Pathname Set].each do |cls|
+  inst = INSTANCE_RECEIVERS[cls][1].call
+  surface[cls] = inst.public_methods(false).map(&:to_s).sort -
+                 %w[pretty_print pretty_print_cycle pread pwrite sysread syswrite
+                    readpartial read_nonblock write_nonblock sysseek ioctl fcntl
+                    set_encoding_by_bom reopen]
+end
+surface.each_value(&:uniq!)
+
+probes = []
+Dir.mktmpdir("conv_probe") do |dir|
+  Dir.chdir(dir) do
+    surface.each do |cls, meths|
+      recv = INSTANCE_RECEIVERS[cls] or next
+      meths.each do |m|
+        next if m =~ /\A(instance_|__|define_|method_missing|send|public_send|freeze|object_id|display|pretty)/
+        r = probe_method(recv[1], m) rescue nil
+        report["#{cls}##{m}"] = r if r
+      end
+    end
+    CLASS_TARGETS.each do |cls, meths|
+      const = Object.const_get(cls)
+      meths.each do |m|
+        r = probe_method(-> { const }, m) rescue nil
+        report["#{cls}.#{m}"] = r if r
+      end
+    end
+  end
+end
+warn "#{report.size} methods probed in CRuby"
+
+report.each do |key, counts|
+  cls, sep, m = key.partition(/[#.]/)
+  recv_src = sep == "#" ? INSTANCE_RECEIVERS[cls][0] : cls
+  counts.each do |n, info|
+    info["slots"].each_with_index do |slot, k|
+      next unless slot
+      # a conversion the method honours, and a wrong scalar whatever CRuby does
+      pc = program(recv_src, m, info, k, "conv")
+      pw = program(recv_src, m, info, k, "wrong")
+      unless pc
+        warn "cannot render #{key}: skipped"
+        next
+      end
+      probes << [key, n, k, "conv", pc, slot["conv_out"]] if slot["conv_ok"]
+      probes << [key, n, k, "wrong", pw, slot["wrong_out"]]
+    end
+  end
+end
+warn "#{probes.size} Spinel probes, #{JOBS} jobs"
+
+results = Array.new(probes.size)
+Dir.mktmpdir("conv_spinel") do |dir|
+  queue = Queue.new
+  probes.each_index { |i| queue << i }
+  JOBS.times.map do
+    Thread.new do
+      loop do
+        i = queue.pop(true) rescue nil
+        break if i.nil?
+        key, n, k, kind, prog, expect = probes[i]
+        out, detail = run_spinel(prog, dir, i)
+        status = case out
+                 when "cfail", "reject", "timeout" then out
+                 else out == expect ? "match" : "differ"
+                 end
+        results[i] = {"method" => key, "count" => n, "slot" => k, "kind" => kind,
+                      "status" => status, "expect" => expect, "got" => out,
+                      "detail" => detail}
+        $stderr.print "." if i % 50 == 0
+      end
+    end
+  end.each(&:join)
+end
+warn ""
+
+File.write(OUT, JSON.pretty_generate({"cruby" => report, "probes" => results}))
+tally = results.group_by { |r| [r["kind"], r["status"]] }.transform_values(&:size)
+warn tally.sort.map { |(kd, st), n| "#{kd}/#{st}=#{n}" }.join("  ")
+results.select { |r| r["status"] == "cfail" }.each do |r|
+  warn "  cfail #{r['kind']} #{r['method']}/#{r['count']} slot #{r['slot']}: #{r['detail'][0, 110]}"
+end
+warn "-> #{OUT}"


### PR DESCRIPTION
## Why

This PR makes the implicit conversion protocol work at the typed argument slots of the core methods: an object answering `#to_str`, `#to_int`, `#to_ary` or `#to_hash` handed to a builtin now converts the way CRuby converts it, and a value of the wrong class now raises CRuby's rescuable `TypeError` (or misses, where CRuby's answer is a miss) instead of failing the C build.

Today both of those programs are ones Spinel cannot compile at all. The argument slots of methods like `String#chomp`, `#ljust`, `#split`, `Time#strftime`, `Time.at`, `Array#slice!` or `format` are typed `const char *` or `sp_int` in the generated C, and the arms placed the argument's value in the slot raw — so a program that passes anything else dies in the C compiler with an error about a symbol the author never wrote:

```ruby
class Sep
  def to_str = "-"
end
p "a-b-".chomp(Sep.new)
# CRuby:  "a-b"
# Spinel: error: incompatible pointer types passing 'sp_Sep *' to parameter of type 'const char *'
```

That is one root cause with two user-visible faces. A program using the conversion protocol — the way duck typing crosses into the core classes, and what the last two conversion rounds were for — does not build, even though the helpers that implement the protocol have existed since those rounds; these arms simply never routed through them. And a program passing a genuinely wrong class, which under CRuby raises a `TypeError` it could rescue and handle, cannot even start.

Rather than fix the sites a differential corpus happened to hit, this round enumerates the population. `tools/gen_conv_slot_probe.rb` asks CRuby, for the positional slots of every method in the compiler's arity table (one receiver value per class, up to three arguments), what it does with an object answering `#to_str` / `#to_int` / `#to_ary` / `#to_hash` and with a scalar of the wrong class, then compiles the same call with Spinel. On the master this branch starts from it finds 210 failing probes over 108 argument slots in 71 methods whose generated C does not compile. On this branch, 18 remain — all one already-known inference question, detailed below.

## How

The probe's results fall into three slot families, and each now follows its own CRuby rule instead of a per-method fix:

- **Conversion slots** ask `#to_str` or `#to_int` and raise the implicit-conversion `TypeError` for any other class — the existing `emit_str_expr` / `emit_int_expr` helpers, now reached from every arm the probe flagged. The float slots follow `rb_to_float`, which converts only a `Numeric` and says `can't convert X into Float` for the rest (a plain object's `#to_f` is not asked — CRuby does not either). `String#split`'s separator is the pattern family and says `wrong argument type X (expected Regexp)`; `Float#quo` is arithmetic and says `String can't be coerced into Float`; `File.utime`'s times say `can't convert X into time` and `sleep`'s interval says `can't convert TrueClass into time interval`, naming the class the way `rb_time_interval` does. `Regexp.escape` takes a Symbol by its name, which `rb_reg_operand` accepts where `Regexp.union` genuinely refuses it.
- One ordering rule joins them: a conversion belongs below the nil-receiver dispatch guard. The rooted-temp hold that #4057 put in front of a call would hoist a `#to_str` above the guard's `NoMethodError`, running a conversion CRuby never asks for on a call that does not dispatch; the hold now stands down on a guarded arm and the conversion renders inside the guarded body.
- **Lookup slots** convert nothing. A Hash key, an element for `Array#count` / `#delete` / `#index`, a `Range#include?` operand: a value of a class the table cannot hold evaluates for its effects and misses, the way a boxed key of another tag already did (`emit_hash_key` gains the static arm; `hash_key_misses` and `elem_kind_misses` name the rule, the first by `eql?`, the second by `==`, which is why an Integer still finds a Float element). `fetch` and `fetch_values` name the key itself in their `KeyError`, boxed once.
- **Container slots** ask `#to_ary` or `#to_hash`: `Array#zip`, `#product` and `Hash#merge` take an object that answers them, typed as the container it returns, and raise CRuby's `TypeError` for one that does not.

What stays a compile-time refusal is named as such, where the raw pointer used to reach the C compiler: a user object whose class defines `==` (or `<=>`) looked up in a typed container — the slot has no room for it and CRuby would call the method — a `#to_hash` of another layout than the receiver's, a block that receives a missing key of another class than the hash's keys (`fetch { }`, `delete { }`, `fetch_values { }`), a literal that would widen a typed Array or Hash (`[1, 2].unshift("a")`, `{1 => 2}["a"] = 3` — an inference question), `system` with an environment Hash, and the dual-typed slots (`gets(limit)`, `File.open(fd)`, `readlines(limit)`) that belong to a later round.

## Validation

- `test/typed_slot_conversion.rb` (expectations generated by CRuby) covers the three families, the `KeyError` wording, and single evaluation of a key that misses. Under `SPINEL_GC_STRESS=1` it runs clean except for two lines whose `[e.class, e.message]` the pre-existing rescue-local hole below corrupts.
- The full suite: 3,283 pass, 0 fail, including two new compile-time refusal pins under `test/rbs-seed`.
- Against a differential corpus of ~2,100 minimized programs compared with CRuby: 63 programs go from a C build failure or wrong output to matching, 0 regress (37 from the ill-typed-C family the corpus had flagged, the other 26 nil/boolean/wrong-class cases at the same slots that the rules cover for free).
- `tools/gen_conv_slot_probe.rb` is included so the population can be re-measured. On this branch the 210 failing probes become 18, and all 18 are the same shape: a literal widening a typed Array or Hash (`[1, 2].unshift("a")`, `insert`, `prepend`, `{1 => 2}["a"] = 3`, `store`), which is an inference question rather than a slot one.

## What the probe shows that this round leaves alone

- The probe's `differ` column (a slot that neither converts nor refuses, answering something else) is not swept here; it is the next round's list. The ones worth knowing: `Hash#delete` on a typed-value hash answers the value's zero on a miss (`{1 => 2}.delete(3)` is `0`), `fetch { |k| }` hands its block nil rather than the missing key, a Symbol key on a String-keyed literal is treated as its name (the `Hash.new { }` model, which the new `hash_key_misses` inherits and names), and `Time.utc("x")` parses the String. All of these predate this branch.
- A rescued exception's class can be collected under `SPINEL_GC_STRESS=1` while `[e.class, e.message]` is built — a rescue-local rooting hole on master that the new test's stress run trips and that this branch does not touch.
- Under `--int-overflow=promote` a few of these slots (`Integer#<<`/`>>`/`[]`, `Time`'s calendar fields, `Array#slice!`) route through the promote-mode emitters, which this round does not touch — the raw pointer reaches the C compiler there exactly as it does on master. The suite compiles in default mode, so the swept arms are the ones it exercises.
- `sleep nil` stays the no-op that bare `sleep` already is; CRuby sleeps forever on both, which no gate can pin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 型付き引数で `to_str`、`to_int`、`to_ary`、`to_hash` などの暗黙変換に対応しました。
  * 数値・文字列・配列・ハッシュ操作で、変換結果に応じた処理とエラー報告を改善しました。
  * 正規表現による文字列分割や、型付きコンテナのキー・要素判定に対応しました。

* **バグ修正**
  * 不正な型の値を誤って処理せず、適切な `TypeError` などを報告するよう改善しました。
  * 型付きハッシュ検索で、互換性のないキーを正しく未検出として扱うよう修正しました。

* **テスト**
  * 型変換、エラー、コンテナ操作に関する包括的なテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->