### PR TITLE
Infer gsub/sub with a block on a poly receiver as String

### DIFF
--- a/src/analyze_infer_recv.c
+++ b/src/analyze_infer_recv.c
@@ -1597,6 +1597,16 @@ int infer_poly_call(Compiler *c, int id, TyKind rt, TyKind *out) {
         infer_type(c, argv[0]) == TY_STRING && infer_type(c, argv[1]) == TY_STRING)) &&
       !an_user_defines_or_reads(c, name))
     { *out = TY_STRING; return 1; }
+  /* poly.sub / poly.gsub with a block: like the typed String receiver's block
+     form, this always answers a String (the rebuilt receiver), whatever the
+     boxed value's runtime tag turns out to be. Without a rule here the call
+     fell through unresolved, and codegen's own poly gsub/sub arm only covers
+     the two-argument (blockless) shape above -- so this stayed unresolved on
+     both sides of the same gap. */
+  if (recv >= 0 && rt == TY_POLY && argc == 1 && nt_ref(nt, id, "block") >= 0 &&
+      (sp_streq(name, "sub") || sp_streq(name, "gsub")) &&
+      !an_user_defines_or_reads(c, name))
+    { *out = TY_STRING; return 1; }
   /* poly.compact / poly.flatten: an Array read out of a container answers a
      generic Array either way (#3423). */
   if (recv >= 0 && rt == TY_POLY && argc == 0 && nt_ref(nt, id, "block") < 0 &&

--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -1823,7 +1823,8 @@ int emit_gsub_block_expr(Compiler *c, int id, Buf *b) {
   if (!name || (!sp_streq(name, "gsub") && !sp_streq(name, "sub"))) return 0;
   int once = sp_streq(name, "sub");
   int recv = nt_ref(nt, id, "receiver");
-  if (recv < 0 || comp_ntype(c, recv) != TY_STRING) return 0;
+  TyKind recv_ty = recv >= 0 ? comp_ntype(c, recv) : TY_UNKNOWN;
+  if (recv < 0 || (recv_ty != TY_STRING && recv_ty != TY_POLY)) return 0;
   int args = nt_ref(nt, id, "arguments");
   int argc = 0; const int *argv = args >= 0 ? nt_arr(nt, args, "arguments", &argc) : NULL;
   if (argc != 1) return 0;
@@ -1841,7 +1842,13 @@ int emit_gsub_block_expr(Compiler *c, int id, Buf *b) {
   if (bn < 1) return 0;
   int ts = ++g_tmp, tpos = ++g_tmp, tslen = ++g_tmp, tout = ++g_tmp,
       tm = ++g_tmp, tms = ++g_tmp, tme = ++g_tmp;
-  Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);
+  /* poly values reaching here are strings, like the blockless poly gsub/sub
+     arm in codegen_call_recv.c -- unbox through sp_poly_to_s to get the same
+     `const char *` the typed String receiver emits directly. */
+  Buf rb; memset(&rb, 0, sizeof rb);
+  if (recv_ty == TY_POLY) buf_puts(&rb, "sp_poly_to_s(");
+  emit_expr(c, recv, &rb);
+  if (recv_ty == TY_POLY) buf_puts(&rb, ")");
   emit_indent(g_pre, g_indent); buf_printf(g_pre, "const char *_t%d = ", ts); buf_puts(g_pre, rb.p ? rb.p : ""); buf_puts(g_pre, ";\n"); free(rb.p);
   emit_indent(g_pre, g_indent); buf_printf(g_pre, "sp_int _t%d = 0;\n", tpos);
   emit_indent(g_pre, g_indent); buf_printf(g_pre, "sp_int _t%d = (sp_int)strlen(_t%d);\n", tslen, ts);

--- a/test/poly_gsub_block.rb
+++ b/test/poly_gsub_block.rb
@@ -1,0 +1,30 @@
+# A class defining a nil-returning `#to_s` anywhere in the program used to
+# make `gsub`/`sub` WITH A BLOCK on a widened (poly) receiver infer as
+# returning void: the poly-dispatch inference had a rule for the two-argument
+# blockless form but none for the block form, so the call fell through
+# unresolved -- either a bad C build, or (when the value reached a String
+# consumer instead) a runtime NoMethodError claiming a String had no #gsub.
+
+class Poison
+  def to_s
+    @never_set
+  end
+end
+
+def escape(text)
+  text.to_s.gsub(/[&<>]/) { |c| c == "<" ? "&lt;" : "&gt;" }
+end
+
+def first_vowel(text)
+  text.to_s.sub(/[aeiou]/) { |c| c.upcase }
+end
+
+puts escape("a<b")        # a&lt;b
+puts escape(123)          # 123
+puts first_vowel("hello") # hEllo
+puts first_vowel(42)      # 42
+
+# The blockless, two-argument form already worked before this fix; keep it
+# exercised here so a future change can't silently narrow the new rule.
+h = { stream: "abc/def", count: 5 }
+puts h[:stream].gsub(/[^a-z]/, "_") # abc_def

--- a/test/poly_gsub_block.rb.expected
+++ b/test/poly_gsub_block.rb.expected
@@ -1,0 +1,5 @@
+a&lt;b
+123
+hEllo
+42
+abc_def


### PR DESCRIPTION
## What

```ruby
class Banner
  def to_s
    @banner        # infers as nil; never called, never instantiated
  end
end

def escape(text)
  text.to_s.gsub(/[&<>]/) { |c| c == "<" ? "&lt;" : "&gt;" }
end

escape("a<b")   # two argument types widen `text` to untyped
escape(123)
```

`Banner` is never used anywhere in the program. Merely being defined is
enough to make `escape` infer as returning `void`:

```
$ spinel --emit-rbs repro.rb
def escape: (untyped) -> void # spinel: widened to untyped (slow path)
```

Depending on how the caller consumes the bogus `void`, this either fails
the C build (`passing 'void' to parameter of incompatible type 'sp_RbVal'`)
or compiles and raises at run time:

```
undefined method 'gsub' for an instance of String (NoMethodError)
```

`gsub`/`sub` on a widened receiver **without** a block already worked
(`text.to_s.gsub(/re/, "x")` infers `String`); only the block form was
affected.

## Why

`text` widens to a poly (boxed) receiver because `escape` is called with
two different argument types. `text.to_s` is itself a poly-receiver call,
and spinel answers it by unioning the builtin `String` answer with every
user class's own `#to_s` return (`an_poly_concrete` in `analyze_infer.c`) --
correct in general, since at compile time any of those classes could be the
runtime receiver. `Banner#to_s` reads `@banner`, an instance variable that
is never assigned anywhere in the class; such a read-only ivar is backstopped
to `TY_POLY` (`analyze.c`'s "unknown_backstop", by design -- a slot with no
C type of its own still needs to answer `.nil?`/`.inspect`). So `Banner#to_s`
itself reports `-> untyped`, and unioning that into `text.to_s` widens it to
poly too -- not a bug, just conservative typing once a user class owns the
method name.

The actual bug is one step later: `text.to_s.gsub(/re/) { ... }` now has a
**poly receiver with a block**, and nothing in spinel's poly-dispatch path
handles that shape. `analyze_infer_recv.c`'s poly-receiver rule for
`gsub`/`sub` only covers the two-argument, blockless form
(`poly.gsub(re, "x")`); the block form has no rule and falls through
unresolved, which is what surfaces as `void`. `codegen_fold.c`'s
`emit_gsub_block_expr` -- the emitter that actually generates the
match/replace loop for the block form -- has the same gap on the codegen
side: it requires the receiver to be statically `TY_STRING` and bails out
for anything else, including poly. The two gaps compound: even where
analysis alone would have accepted a poly receiver, codegen had nowhere to
route it.

## The fix

- `src/analyze_infer_recv.c`: add a rule beside the existing two-argument
  poly `gsub`/`sub` rule that types the block form the same way the typed
  `String` receiver's own block-form rule does -- the block form always
  returns the rebuilt string, so a poly receiver answers `TY_STRING` too.
- `src/codegen_fold.c`: let `emit_gsub_block_expr` accept a `TY_POLY`
  receiver alongside `TY_STRING`, unboxing it with `sp_poly_to_s` before
  feeding it into the existing match/replace loop. This mirrors the
  sibling poly `gsub`/`sub` codegen arm in `codegen_call_recv.c`, which
  already unboxes a poly receiver the same way for the blockless,
  two-argument form.

## What the test pins

- `gsub` with a block on a poly receiver (widened by two call-site argument
  types), in a program that also defines an unrelated, never-instantiated
  class with a nil-inferring `#to_s` -- the exact trigger from the report --
  infers and compiles as `String`, not `void`.
- `sub` with a block is affected identically to `gsub` and is exercised the
  same way.
- the pre-existing blockless, two-argument poly `gsub` form (`poly.gsub(re,
  "x")`) still works, so a future change to the new rule can't silently
  narrow or break the form that already worked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `sub` and `gsub` calls with blocks when used on values that may contain different types.
  * Ensured these operations correctly process and return string results at runtime.
  * Preserved support for existing two-argument, blockless `sub` and `gsub` calls.

* **Tests**
  * Added coverage for block-based substitutions across string and integer inputs, including expected output verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->