### PR TITLE
Fix build on MacOS

### DIFF
--- a/lib/sp_process_status.c
+++ b/lib/sp_process_status.c
@@ -19,6 +19,14 @@
 #include "sp_alloc.h"   /* sp_RbVal, sp_gc_alloc, sp_raise_cls */
 #include "sp_process_status.h"
 
+/* The W*() macros must be handed an int LVALUE, not a cast expression. macOS
+   still defines them through the legacy `union wait` bridge --
+   `#define _W_INT(w) (*(int *)&(w))` -- so the macro takes the ADDRESS of its
+   argument, and `WIFEXITED((int)s)` fails to compile there with "cannot take
+   the address of an rvalue". glibc casts instead of dereferencing, which is
+   why this built on Linux. Each accessor below copies its sp_int argument
+   into `int st` first and passes that. */
+
 /* CRuby answers nil for exitstatus on a signaled status and for termsig on
    one that exited, and spinel already has a spelling for a nullable Integer:
    SP_INT_NIL, which every renderer and `.nil?` understands. -1 is a real
@@ -50,24 +58,28 @@ sp_RbVal sp_box_process_status(sp_ProcessStatus *p) {
 /* ---- predicates ---- */
 
 int sp_process_status_exited_p(sp_int s) {
-  return WIFEXITED((int)s) ? 1 : 0;
+  int st = (int)s;
+  return WIFEXITED(st) ? 1 : 0;
 }
 
 int sp_process_status_signaled_p(sp_int s) {
-  return WIFSIGNALED((int)s) ? 1 : 0;
+  int st = (int)s;
+  return WIFSIGNALED(st) ? 1 : 0;
 }
 
 int sp_process_status_coredump_p(sp_int s) {
-  if (!WIFSIGNALED((int)s)) return 0;
-  return WCOREDUMP((int)s) ? 1 : 0;
+  int st = (int)s;
+  if (!WIFSIGNALED(st)) return 0;
+  return WCOREDUMP(st) ? 1 : 0;
 }
 
 /* Tri-state, because CRuby's is: true when the process exited with status 0,
    false when it exited with anything else, and NIL when it did not exit
    normally at all. -1 is that nil; the call site boxes it. */
 int sp_process_status_success_p(sp_int s) {
-  if (!WIFEXITED((int)s)) return -1;
-  return WEXITSTATUS((int)s) == 0 ? 1 : 0;
+  int st = (int)s;
+  if (!WIFEXITED(st)) return -1;
+  return WEXITSTATUS(st) == 0 ? 1 : 0;
 }
 
 /* ---- accessors ---- */
@@ -87,13 +99,15 @@ sp_int sp_process_status_pid(sp_int s) {
 }
 
 sp_int sp_process_status_exitstatus(sp_int s) {
-  if (!WIFEXITED((int)s)) return SP_STATUS_NIL;
-  return (sp_int)WEXITSTATUS((int)s);
+  int st = (int)s;
+  if (!WIFEXITED(st)) return SP_STATUS_NIL;
+  return (sp_int)WEXITSTATUS(st);
 }
 
 sp_int sp_process_status_termsig(sp_int s) {
-  if (!WIFSIGNALED((int)s)) return SP_STATUS_NIL;
-  return (sp_int)WTERMSIG((int)s);
+  int st = (int)s;
+  if (!WIFSIGNALED(st)) return SP_STATUS_NIL;
+  return (sp_int)WTERMSIG(st);
 }
 
 /* ---- boxed-struct pid access ---- */
@@ -147,11 +161,12 @@ static char sp_status_buf[96];
 const char *sp_process_status_to_s(sp_int s, int is_inspect) {
   const char *prefix = is_inspect ? "#<Process::Status: " : "";
   const char *suffix = is_inspect ? ">" : "";
-  if (WIFEXITED((int)s)) {
+  int st = (int)s;
+  if (WIFEXITED(st)) {
     snprintf(sp_status_buf, sizeof sp_status_buf,
-             "%sexit %d%s", prefix, WEXITSTATUS((int)s), suffix);
-  } else if (WIFSIGNALED((int)s)) {
-    int sig = WTERMSIG((int)s);
+             "%sexit %d%s", prefix, WEXITSTATUS(st), suffix);
+  } else if (WIFSIGNALED(st)) {
+    int sig = WTERMSIG(st);
     const char *name = sp_signal_name(sig);
     if (name) {
       snprintf(sp_status_buf, sizeof sp_status_buf,

--- a/test/process_spawn.rb
+++ b/test/process_spawn.rb
@@ -1,5 +1,9 @@
 # Process.spawn + Process.waitpid2 + Process::Status.
 #
+# true/false are spelled /usr/bin/... because that is where macOS keeps them;
+# /bin/true and /bin/false do not exist there, and spawning them raised an
+# uncaught Errno::ENOENT part way through this file. Both paths exist on Linux.
+#
 # CRuby semantics:
 #   Process.spawn(cmd, *args, opts) -> Integer pid
 #   Process.waitpid2(pid) -> [pid, Process::Status]
@@ -44,9 +48,9 @@ rescue Errno::ENOENT
 end
 puts ok
 
-# 3) /bin/false exits 1: exited? true, success? false.
+# 3) /usr/bin/false exits 1: exited? true, success? false.
 r, w = IO.pipe
-pid = Process.spawn("/bin/false", out: w)
+pid = Process.spawn("/usr/bin/false", out: w)
 w.close
 r.read
 _, status = Process.waitpid2(pid)
@@ -57,7 +61,7 @@ puts status.success? == false
 #    .exited? dispatch on the cls_id the poly path reads out of the boxed
 #    value. Goes through emit_poly_builtin_method in codegen_call.c.
 r, w = IO.pipe
-pid = Process.spawn("/bin/true", out: w)
+pid = Process.spawn("/usr/bin/true", out: w)
 w.close
 r.read
 result = Process.waitpid2(pid)
@@ -72,7 +76,7 @@ puts got_st.success?
 #    so the inference has to type them the same way -- otherwise the
 #    interpolation asks sp_poly_to_s for what the emitter produced as sp_int.
 r, w = IO.pipe
-pid = Process.spawn("/bin/false", out: w)
+pid = Process.spawn("/usr/bin/false", out: w)
 w.close
 r.read
 res = Process.waitpid2(pid)


### PR DESCRIPTION
`make` currently does not build on macOS. Every `W*()` use in `lib/sp_process_status.c` is rejected — 18 errors, and the object never links:

```
lib/sp_process_status.c:53:10: error: cannot take the address of an rvalue of type 'int'
   53 |   return WIFEXITED((int)s) ? 1 : 0;
      |          ^         ~~~~~~
/…/sys/wait.h:131:34: note: expanded from macro '_W_INT'
  131 | #define _W_INT(w)       (*(int *)&(w))  /* convert union wait to int */
```

## Why it only breaks here

macOS still routes the wait macros through the legacy `union wait` bridge, so `_W_INT` takes the **address** of its argument — and the argument at every call site is a cast expression, `WIFEXITED((int)s)`. You cannot take the address of a cast. glibc casts rather than dereferencing, so the same source is fine on Linux.

The fix copies the `sp_int` argument into an `int` lvalue in each accessor and passes that. Values, branches and answers are unchanged; only what the macro is handed differs. The reason is recorded once, next to the include that imposes it.

## A second macOS-only failure the build was hiding

With the build fixed, `process_spawn` then failed — for an unrelated reason. It spawns `/bin/false` and `/bin/true`, which live in `/usr/bin` on macOS. The raise landed *after* the deliberate `Errno::ENOENT` in case 2 had been rescued, so it surfaced as an uncaught exception part way through the file rather than as an obvious missing-file error.

Both spellings exist on Linux, so the test now uses `/usr/bin`. `/bin/echo` and `/bin/sleep` are present on both and are left alone.

These two are separable if you would rather take only the first — the build fix stands alone, and `make` is green after it. They are together here because the second is only reachable once the first lands, and both are the same platform gap in the same feature.

## On a regression test

The Contributing guide asks for one per fix. For the build half the compile *is* the test: it fails at the first `W*()` on any macOS host, so a `.rb` test could not express it. `process_spawn` is the coverage for the second half, and it now passes rather than raising.

## Checks

On macOS 25.6.0 (arm64):

- `make` — builds clean, no warnings
- `make test` — 3304 pass, 0 fail, 0 error
- `make bench` — 61 pass, 0 fail, 0 error
- `make optcarrot` — OK, checksum 59662

There is no `gen2.c == gen3.c` closure target on master, so nothing to run for that item.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process-status handling for compatibility with macOS.
  * Preserved existing process status behavior while ensuring status checks compile reliably across supported platforms.

* **Tests**
  * Updated subprocess test paths to use the correct executable locations on macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->