### PR TITLE
Be more accurate in thread.md

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -243,8 +243,9 @@ still works.
   ArgumentError names can differ from CRuby — deterministically so.
 - **Thread data races are observable** — Spinel runs threads with real
   parallelism and no GVL, so two threads mutating the same `Array`/`Hash`/object
-  without a `Mutex` is undefined at the Ruby level, exactly as in JRuby and
-  TruffleRuby. CRuby's GVL makes individual operations appear atomic; Spinel does
+  without a `Mutex` is undefined at the Ruby level, similar to `Array`/`Hash` in
+  JRuby and `Array` in TruffleRuby.
+  CRuby's GVL makes individual operations appear atomic; Spinel does
   not, and adds no implicit per-object locking — correctness across threads is the
   program's responsibility via `Mutex`/`Queue`/`ConditionVariable`. Relatedly,
   thread *interleaving* (and so the ordering of `Thread.pass`, `Thread.list`

--- a/docs/thread.md
+++ b/docs/thread.md
@@ -78,8 +78,9 @@ These are deliberate consequences of real parallelism, listed in
 
 - **Data races are observable.** Two threads mutating the same
   `Array`/`Hash`/object without a `Mutex` is undefined at the Ruby level,
-  exactly as in JRuby and TruffleRuby. CRuby's GVL makes individual operations
-  appear atomic; Spinel does not, and adds no implicit per-object locking.
+  similar to `Array`/`Hash` in JRuby and `Array` in TruffleRuby.
+  CRuby's GVL makes individual operations appear atomic;
+  Spinel does not, and adds no implicit per-object locking.
   Correctness across threads is the program's responsibility via
   `Mutex` / `Queue` / `ConditionVariable`.
 - **Interleaving is nondeterministic.** The ordering of `Thread.pass`,


### PR DESCRIPTION
Let me start by saying it's pretty cool and impressive Spinel supports shared-memory multithreading/parallelism :)

This is a short paragraph that says a lot, but what I want to express is:
* Hash is parallel and thread-safe on TruffleRuby ([slides](https://eregon.me/blog/assets/research/making-hash-parallel-thread-safe-and-fast-rubykaigi.pdf), [paper](https://eregon.me/blog/assets/research/thread-safe-collections.pdf))
* (Array is not yet thread-safe on TruffleRuby, though [the research has been done](https://eregon.me/blog/assets/research/thread-safe-collections.pdf))
* Objects are thread-safe on TruffleRuby ([paper](https://eregon.me/blog/assets/research/thread-safe-objects.pdf)) and on JRuby too. What that means concisely is no lost ivar, no lost write, no out-of-thin-air read (section 3).
* Can Spinel lose ivars if defining 2 new ivars concurrently, lose an ivar write with concurrent writes, or return a value the field was never assigned? Most likely yes if there is no synchronization when accessing ivars, though it depends on the exact representation of ivars in Spinel (is it shapes/maps?). Also depends if Spinel supports adding new ivars dynamically via `instance_variable_set` or code where it's not possible to know AOT in which class the ivar will land.
  Thread-safe objects is I think the most problematic one of the 3, nobody expects to lose ivars or ivar writes or get wrong values for reads. Data races OTOH are expected when using multiple threads accessing the same object, and much easier to deal with.
* "undefined/undefined behavior" is a lazy way to define things (we can blame C for overusing it). It would be more helpful to specify if it can crash the program, lead to some stale reads, raise a Ruby exception, or something in between.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Spinel’s data-race behavior is similar to specific array and hash behaviors in JRuby and TruffleRuby.
  * Confirmed that Spinel’s implicit per-object locking behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->