### PR TITLE
Serve the builtin surface on a boxed receiver from one owner table

### DIFF
--- a/lib/sp_cold.c
+++ b/lib/sp_cold.c
@@ -1047,6 +1047,26 @@ sp_StrArray *sp_dir_entries_impl(const char *path, int children) {
   return a;
 }
 
+/* The rows of a transpose are Arrays; a row that is not is CRuby's TypeError,
+   named by the class of what was there. This unit sees the tags alone, so the
+   naming is by tag. */
+static int sp_transpose_row_p(sp_RbVal rv) {
+  return rv.tag == SP_TAG_OBJ &&
+         (rv.cls_id == SP_BUILTIN_INT_ARRAY || rv.cls_id == SP_BUILTIN_FLT_ARRAY ||
+          rv.cls_id == SP_BUILTIN_STR_ARRAY || rv.cls_id == SP_BUILTIN_SYM_ARRAY ||
+          rv.cls_id == SP_BUILTIN_POLY_ARRAY);
+}
+static const char *sp_transpose_row_class(sp_RbVal rv) {
+  switch (rv.tag) {
+    case SP_TAG_NIL: return "nil";
+    case SP_TAG_BOOL: return rv.v.i ? "true" : "false";
+    case SP_TAG_INT: return "Integer";
+    case SP_TAG_FLT: return "Float";
+    case SP_TAG_STR: return "String";
+    case SP_TAG_SYM: return "Symbol";
+    default: return "Object";
+  }
+}
 sp_PolyArray *sp_poly_array_transpose(sp_PolyArray *rows) {
   SP_GC_SAVE();
   SP_GC_ROOT(rows);
@@ -1057,7 +1077,9 @@ sp_PolyArray *sp_poly_array_transpose(sp_PolyArray *rows) {
   int16_t kind = 0; /* 0=unknown, SP_BUILTIN_INT_ARRAY, SP_BUILTIN_FLT_ARRAY, SP_BUILTIN_STR_ARRAY */
   for (sp_int r = 0; r < nrows; r++) {
     sp_RbVal rv = rows->data[r];
-    if (rv.tag != SP_TAG_OBJ) continue;
+    /* a row that is no Array is CRuby's TypeError, not a row of nothing */
+    if (!sp_transpose_row_p(rv))
+      sp_raise_cls("TypeError", sp_sprintf("no implicit conversion of %s into Array", sp_transpose_row_class(rv)));
     sp_int rlen = 0;
     if (rv.cls_id == SP_BUILTIN_INT_ARRAY)  { rlen = ((sp_IntArray *)rv.v.p)->len; if(!kind) kind = SP_BUILTIN_INT_ARRAY; }
     else if (rv.cls_id == SP_BUILTIN_FLT_ARRAY) { rlen = ((sp_FloatArray *)rv.v.p)->len; if(!kind) kind = SP_BUILTIN_FLT_ARRAY; }

--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -3520,31 +3520,59 @@ static sp_int sp_poly_int_recv(sp_RbVal v, const char *m) {
   sp_raise_nomethod(sp_nomethod_msg(m, v));
   return 0;  /* unreachable: sp_raise_nomethod does not return */
 }
-/* map!'s write-back through a boxed receiver: sp_poly_arr_recv normalizes a
-   TYPED array to a poly COPY, so in-place rewrites never reached the
-   original (#3234). Copy the mutated elements back into the original
-   representation; a POLY_ARRAY receiver shares storage and needs nothing. */
+/* A mutated element that the typed original has no representation for: a
+   String written into an Array of Integers through a boxed receiver. CRuby's
+   Array holds anything; the typed original cannot, and it cannot be re-laid
+   from here (the container slot that holds it is not in reach), so the
+   write-back refuses rather than coerce the value into something it was not
+   -- the earlier map! write-back answered 0 for such a String. */
+SP_NORETURN SP_COLD static void sp_raise_writeback_kind(sp_RbVal v, const char *into) {
+  sp_raise_cls("TypeError", sp_sprintf("can't store %s in an Array of %s through a boxed receiver",
+                                       sp_poly_class_name(v), into));
+}
+/* A mutator's write-back through a boxed receiver: sp_poly_arr_recv
+   normalizes a TYPED array to a poly COPY, so in-place rewrites never reached
+   the original (#3234). Replace the original's contents with the mutated
+   elements, in its own representation; a POLY_ARRAY receiver shares storage
+   and needs nothing. The length follows the work array -- reject!, uniq! and
+   slice! shrink it, fill(n) can grow it. Frozenness was refused at the
+   coercion, before the mutator ran. */
 static void sp_poly_arr_writeback(sp_RbVal orig, sp_PolyArray *work) {
   if (orig.tag != SP_TAG_OBJ || !work) return;
   switch (orig.cls_id) {
-    case SP_BUILTIN_INT_ARRAY:
+    case SP_BUILTIN_INT_ARRAY: {
+      sp_IntArray *a = (sp_IntArray *)orig.v.p;
+      for (sp_int i = 0; i < work->len; i++)
+        if (work->data[i].tag != SP_TAG_INT) sp_raise_writeback_kind(work->data[i], "Integer");
+      a->start = 0; a->len = 0;
+      for (sp_int i = 0; i < work->len; i++) sp_IntArray_push(a, work->data[i].v.i);
+      return;
+    }
     case SP_BUILTIN_SYM_ARRAY: {
       sp_IntArray *a = (sp_IntArray *)orig.v.p;
-      for (sp_int i = 0; i < a->len && i < work->len; i++)
-        a->data[a->start + i] = sp_poly_to_i(work->data[i]);
+      for (sp_int i = 0; i < work->len; i++)
+        if (work->data[i].tag != SP_TAG_SYM) sp_raise_writeback_kind(work->data[i], "Symbol");
+      a->start = 0; a->len = 0;
+      for (sp_int i = 0; i < work->len; i++) sp_IntArray_push(a, work->data[i].v.i);
       return;
     }
     case SP_BUILTIN_FLT_ARRAY: {
       sp_FloatArray *a = (sp_FloatArray *)orig.v.p;
-      for (sp_int i = 0; i < a->len && i < work->len; i++)
-        a->data[i] = sp_poly_to_f(work->data[i]);
+      for (sp_int i = 0; i < work->len; i++)
+        if (work->data[i].tag != SP_TAG_FLT && work->data[i].tag != SP_TAG_INT)
+          sp_raise_writeback_kind(work->data[i], "Float");
+      a->len = 0;
+      for (sp_int i = 0; i < work->len; i++) sp_FloatArray_push(a, sp_poly_to_f(work->data[i]));
       return;
     }
     case SP_BUILTIN_STR_ARRAY: {
       sp_StrArray *a = (sp_StrArray *)orig.v.p;
+      for (sp_int i = 0; i < work->len; i++)
+        if (work->data[i].tag != SP_TAG_STR && !sp_poly_is_strbuf(work->data[i]))
+          sp_raise_writeback_kind(work->data[i], "String");
       sp_gc_wb((void *)a);
-      for (sp_int i = 0; i < a->len && i < work->len; i++)
-        a->data[i] = sp_poly_to_s(work->data[i]);
+      a->len = 0;
+      for (sp_int i = 0; i < work->len; i++) sp_StrArray_push(a, sp_poly_to_s(work->data[i]));
       return;
     }
     default: return;   /* POLY_ARRAY: same storage; others: nothing to do */
@@ -3565,6 +3593,43 @@ static sp_PolyArray *sp_poly_arr_recv(sp_RbVal v, const char *m) {
   }
   sp_raise_nomethod(sp_nomethod_msg(m, v));
   return NULL;  /* unreachable: sp_raise_nomethod does not return */
+}
+
+/* Is the array a boxed value holds frozen? The flag rides in each array
+   struct, not in the GC header. */
+static sp_bool sp_poly_array_frozen(sp_RbVal v) {
+  switch (v.cls_id) {
+    case SP_BUILTIN_INT_ARRAY:
+    case SP_BUILTIN_SYM_ARRAY:  return ((sp_IntArray *)v.v.p)->frozen != 0;
+    case SP_BUILTIN_FLT_ARRAY:  return ((sp_FloatArray *)v.v.p)->frozen != 0;
+    case SP_BUILTIN_STR_ARRAY:  return ((sp_StrArray *)v.v.p)->frozen != 0;
+    case SP_BUILTIN_POLY_ARRAY: return ((sp_PolyArray *)v.v.p)->frozen != 0;
+  }
+  return FALSE;
+}
+/* The receiver of an Array-only method (sort!, fill, transpose, ...) reached
+   through a boxed value: an Array at run time, as a poly array, and anything
+   else -- a Hash, whose pairs sp_poly_arr_recv would have offered, a nil, a
+   String -- CRuby's NoMethodError naming the method. A mutator (`mut`) asks
+   about frozenness here, before any work: the typed emitter it re-enters
+   works on the poly copy, so only the write-back would notice, after a
+   block had already run over every element. */
+static sp_PolyArray *sp_poly_array_recv(sp_RbVal v, const char *m, int mut) {
+  if (v.tag == SP_TAG_OBJ && sp_poly_is_array_kind(v.cls_id)) {
+    if (mut && sp_poly_array_frozen(v)) sp_raise_frozen_array_at(v.v.p, v.cls_id);
+    return sp_poly_to_poly_array(v);
+  }
+  sp_raise_nomethod(sp_nomethod_msg(m, v));
+  return NULL;  /* unreachable: sp_raise_nomethod does not return */
+}
+/* The receiver of an Enumerable method reached through a boxed value: its
+   elements (a hash's pairs, a range's members) as a poly array, and for a
+   value that is no collection at all -- an Integer, a String, nil --
+   CRuby's NoMethodError, where the bare materialization answered an empty
+   list and the call went on as if over nothing. */
+static sp_PolyArray *sp_poly_enum_recv(sp_RbVal v, const char *m) {
+  if (v.tag != SP_TAG_OBJ) sp_raise_nomethod(sp_nomethod_msg(m, v));
+  return sp_enum_items_from(v);
 }
 
 /* inject/reduce with a symbol op over a poly iterable (a container-read row

--- a/src/analyze.h
+++ b/src/analyze.h
@@ -88,14 +88,12 @@ extern int g_ret_no_new_poly;
 /* Recompute a node's type without consulting the cache (used by the break
    wrapper with g_infer_ignore_brk set to recover the normal result type). */
 TyKind infer_uncached(Compiler *c, int id);
-/* Pin/read the node the inference should answer as the general boxed hash
-   (see an_set_hash_face_node). -1 clears the pin. */
-void an_set_handle_face(int node, TyKind t);
-int  an_handle_face_node(void);
-void an_set_hash_face_node(int node);
-int  an_hash_face_node(void);
-void an_set_poly_arr_face_node(int node);
-int  an_poly_arr_face_node(void);
+/* Pin/read the receiver node the inference should answer as `kind` while
+   codegen re-enters a typed emitter for a boxed receiver (the face table in
+   types.h). Node -1 clears the pin. */
+void an_set_face_node(int node, TyKind kind);
+int  an_face_node(void);
+TyKind an_face_kind(void);
 /* Name of a block's idx-th required parameter, or NULL. */
 const char *block_param_name(Compiler *c, int block, int idx);
 /* The name of a numbered block parameter (`_1`..`_9`) on this parameters node.

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -20,29 +20,18 @@ TyKind ivar_value_ty(ClassInfo *ci, int iv) {
   return ci->ivar_types[iv] == TY_STRBUF ? TY_STRING : ci->ivar_types[iv];
 }
 
-static int g_hash_face_node = -1;
-/* Codegen normalizes a boxed receiver to the general hash before re-dispatching
-   its Hash/Enumerable face, and needs the inference to answer the same way for
-   the duration -- poking the node's cached type does not survive, because
-   anything under the re-emission that asks re-establishes it. */
-void an_set_hash_face_node(int node) { g_hash_face_node = node; }
-int an_hash_face_node(void) { return g_hash_face_node; }
-/* The same pin for the poly ARRAY face: codegen materializes a boxed receiver
-   into a poly array and re-dispatches the call as the array form, and the
-   inference has to answer the same way for the duration. Poking the node's
-   cached type is not enough on its own -- under a safe-navigation guard the
-   re-emission asks again and re-establishes the receiver as poly, and the
-   array emitters then decline the call they were re-entered to serve. */
-static int g_poly_arr_face_node = -1;
-void an_set_poly_arr_face_node(int node) { g_poly_arr_face_node = node; }
-int an_poly_arr_face_node(void) { return g_poly_arr_face_node; }
-/* And for a boxed HANDLE (Addrinfo, Socket::Option): codegen unboxes the
-   receiver back to its own type and re-dispatches, so the pin carries the
-   TYPE too -- unlike the two above, which each name one fixed kind. */
-static int g_handle_face_node = -1;
-static TyKind g_handle_face_ty = TY_UNKNOWN;
-void an_set_handle_face(int node, TyKind t) { g_handle_face_node = node; g_handle_face_ty = t; }
-int an_handle_face_node(void) { return g_handle_face_node; }
+/* Codegen unboxes a poly receiver to one concrete kind before re-entering the
+   typed emitter (the face table in types.h), and needs the inference to
+   answer the same way for the duration -- poking the node's cached type does
+   not survive, because anything under the re-emission that asks re-establishes
+   it (under a safe-navigation guard the re-emission asks again, and the typed
+   emitters then decline the very call they were re-entered to serve). One
+   node at a time; -1 clears the pin. */
+static int g_face_node = -1;
+static TyKind g_face_kind = TY_UNKNOWN;
+void an_set_face_node(int node, TyKind kind) { g_face_node = node; g_face_kind = kind; }
+int an_face_node(void) { return g_face_node; }
+TyKind an_face_kind(void) { return g_face_kind; }
 #define SP_NMEMO_SZ 16384
 static unsigned g_narrow_gen = 1;
 static struct { unsigned gen; long key; signed char val; } g_nmemo[SP_NMEMO_SZ];
@@ -5680,34 +5669,40 @@ else {
     }
   }
 
-  /* Last resort for a boxed receiver: the read-only Hash/Enumerable face,
-     typed as if the receiver were the general boxed-key/value hash. Codegen
-     normalizes the receiver to exactly that before re-dispatching, so both
-     sides agree on the result slot; a receiver that is not a hash at runtime
-     raises NoMethodError there, as it did before (#3449). */
   /* A boxed HANDLE answering one of its own exclusive names: type the call as
      if the receiver were that handle. Codegen unboxes it back to exactly that
      before re-dispatching, and checks the runtime cls_id first, so a value of
      any other kind still raises NoMethodError (#4158 follow-up). */
-  if (recv >= 0 && rt == TY_POLY && g_handle_face_node < 0 &&
+  if (recv >= 0 && rt == TY_POLY && g_face_node < 0 &&
       ty_poly_handle_face(name) != TY_UNKNOWN &&
       !an_user_defines_or_reads(c, name)) {
-    an_set_handle_face(recv, ty_poly_handle_face(name));
+    an_set_face_node(recv, ty_poly_handle_face(name));
     TyKind kt = infer_call(c, id);
-    an_set_handle_face(-1, TY_UNKNOWN);
+    an_set_face_node(-1, TY_UNKNOWN);
     if (kt != TY_UNKNOWN) return kt;
   }
-  if (recv >= 0 && rt == TY_POLY && g_hash_face_node < 0 &&
-      ty_poly_hash_face_name(name) && !an_user_defines_or_reads(c, name)) {
-    /* Inside the pretence `each_entry` IS `each_pair`: Hash#each_entry yields
-       the same [key, value] pair, and only the pair name has an emitter. */
-    int ren = sp_streq(name, "each_entry");
-    if (ren) nt_node_set_str((NodeTable *)nt, id, "name", "each_pair");
-    g_hash_face_node = recv;
-    TyKind ht = infer_call(c, id);
-    g_hash_face_node = -1;
-    if (ren) nt_node_set_str((NodeTable *)nt, id, "name", "each_entry");
-    if (ht != TY_UNKNOWN) return ht;
+  /* Last resort for a boxed receiver: the face table. Answer as the typed
+     call would with the receiver pinned to each owner kind in turn -- codegen
+     unboxes to exactly that kind before re-entering the typed emitter, so
+     both sides agree on the result slot -- and unify the owners' answers: one
+     owner gives the typed call's own type, owners that disagree give poly and
+     the emission boxes each arm. A receiver of no owner's kind raises
+     NoMethodError there, as it did before (#3449). */
+  if (recv >= 0 && rt == TY_POLY && g_face_node < 0 && !an_user_defines_or_reads(c, name)) {
+    int blk = nt_ref(nt, id, "block") >= 0;
+    unsigned own = ty_poly_face_owners(name, argc, blk, nt_call_args_plain(nt, id), 1) & PF_OWNERS;
+    if (own) {
+      TyKind r = TY_UNKNOWN;
+      for (unsigned bit = 1; bit & PF_OWNERS; bit <<= 1) {
+        if (!(own & bit)) continue;
+        an_set_face_node(recv, ty_poly_face_kind(bit));
+        TyKind ht = infer_call(c, id);
+        an_set_face_node(-1, TY_UNKNOWN);
+        if (ht == TY_UNKNOWN) continue;
+        r = r == TY_UNKNOWN ? ht : ty_unify(r, ht);
+      }
+      if (r != TY_UNKNOWN) return r;
+    }
   }
 
   return TY_UNKNOWN;
@@ -6634,13 +6629,12 @@ TyKind infer_uncached(Compiler *c, int id) {
 
 TyKind infer_type(Compiler *c, int id) {
   if (id < 0 || id >= c->nt->count) return TY_UNKNOWN;
-  /* The boxed-hash face re-inference (infer_call's last resort) asks what one
-     call would be if this receiver were the general hash. Only that receiver
-     node, only for the duration of the recursion, and the cache is left
-     untouched so the receiver's own type is unaffected. */
-  if (id == g_hash_face_node) return TY_POLY_POLY_HASH;
-  if (id == g_poly_arr_face_node) return TY_POLY_ARRAY;
-  if (id == g_handle_face_node) return g_handle_face_ty;
+  /* The face re-inference (infer_call's last resort, and codegen's re-entry)
+     asks what one call would be with this receiver pinned to one concrete
+     kind (the face table in types.h). Only that receiver node, only for the
+     duration, and the cache is left untouched so the receiver's own type is
+     unaffected. */
+  if (id == g_face_node) return g_face_kind;
   TyKind t = infer_uncached(c, id);
   /* The builtin-only re-derivation (see an_builtin_only) asks what this call
      would be if no user class owned the name. That answer is not the node's

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -1292,12 +1292,6 @@ TyKind infer_call(Compiler *c, int id) {
       (sp_streq(name, "map!") || sp_streq(name, "collect!")) &&
       infer_type(c, recv) == TY_POLY)
     return TY_POLY_ARRAY;
-  /* `poly.fill(v, ...)`: Array's alone, and it answers self -- which the
-     codegen arm hands back as the coerced poly array (#4149). */
-  if (recv >= 0 && nt_ref(nt, id, "block") < 0 && argc >= 1 && argc <= 3 &&
-      sp_streq(name, "fill") && !an_user_defines_method(c, name) &&
-      infer_type(c, recv) == TY_POLY)
-    return TY_POLY_ARRAY;
   /* The filtering siblings answer whatever kind the receiver is -- Hash#select
      is a Hash, Array#select an Array -- and only the runtime value says which,
      so the result rides boxed (#3449). */

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -11846,11 +11846,12 @@ int emit_unresolved_call(Compiler *c, int id, Buf *b) {
       snprintf(g_argov_text[g_n_argov], sizeof g_argov_text[0], "_t%d", tkv);
       g_n_argov++;
       TyKind svk = c->ntype[recv]; c->ntype[recv] = kt;
-      int svkf = an_handle_face_node(); an_set_handle_face(recv, kt);
+      int svkf = an_face_node(); TyKind svkk = an_face_kind();
+      an_set_face_node(recv, kt);
       int svkn = g_handle_face_node; g_handle_face_node = id;
       emit_call(c, id, b);
       g_handle_face_node = svkn;
-      an_set_handle_face(svkf, svkf >= 0 ? kt : TY_UNKNOWN);
+      an_set_face_node(svkf, svkk);
       c->ntype[recv] = svk;
       g_n_argov--;
       return 1;
@@ -11884,9 +11885,8 @@ int emit_unresolved_call(Compiler *c, int id, Buf *b) {
          because anything under the re-emission that asks re-establishes it and
          the re-dispatch then finds no arm for a poly receiver (#4070 follow-up
          -- `v&.entries` raised NoMethodError with the conversion already made) */
-      int sv_face = an_hash_face_node(); an_set_hash_face_node(recv);
-      int hren = sp_streq(hnm, "each_entry");   /* same yield as each_pair */
-      if (hren) nt_node_set_str((NodeTable *)nt, id, "name", "each_pair");
+      int sv_face = an_face_node(); TyKind sv_fk = an_face_kind();
+      an_set_face_node(recv, TY_POLY_POLY_HASH);
       int sv_pp = g_pp_hash_node; g_pp_hash_node = id;
       if (hinl) {
         emit_call(c, id, &hib);
@@ -11896,8 +11896,7 @@ int emit_unresolved_call(Compiler *c, int id, Buf *b) {
       else emit_call(c, id, b);
       free(hib.p);
       g_pp_hash_node = sv_pp;
-      if (hren) nt_node_set_str((NodeTable *)nt, id, "name", "each_entry");
-      an_set_hash_face_node(sv_face);
+      an_set_face_node(sv_face, sv_fk);
       c->ntype[recv] = svh;
       g_n_argov--;
       return 1;
@@ -14062,9 +14061,10 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
              comes back poly while the value arm renders that face's C type. */
           if (ret2 == TY_POLY && natg == TY_POLY &&
               ty_poly_hash_face_name(nt_str(nt, id, "name"))) {
-            int svf = an_hash_face_node(); an_set_hash_face_node(recv);
+            int svf = an_face_node(); TyKind svfk = an_face_kind();
+            an_set_face_node(recv, TY_POLY_POLY_HASH);
             TyKind fac = infer_uncached(c, id);
-            an_set_hash_face_node(svf);
+            an_set_face_node(svf, svfk);
             /* only the array answers: a face that answers another hash boxes
                through a different entry point than emit_boxed_text picks */
             if (ty_is_array(fac)) natg = fac;

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -1355,7 +1355,8 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
        type alone does not survive a safe-navigation guard, whose re-emission
        asks again and re-establishes the receiver as poly -- the array emitters
        then decline the very call this arm re-entered to have them serve. */
-    int sv_face = an_poly_arr_face_node(); an_set_poly_arr_face_node(recv);
+    int sv_face = an_face_node(); TyKind sv_fk = an_face_kind();
+    an_set_face_node(recv, TY_POLY_ARRAY);
     /* The re-entry below is the SAME node, and neither the type nor the pin
        stops it reaching this arm again. Latch the node. */
     int sv_rd = g_poly_redispatch_id; g_poly_redispatch_id = id;
@@ -1367,7 +1368,7 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
     }
     else emit_call(c, id, b);
     g_poly_redispatch_id = sv_rd;
-    an_set_poly_arr_face_node(sv_face);
+    an_set_face_node(sv_face, sv_fk);
     c->ntype[recv] = sv;
     g_n_argov--;
     return 1;
@@ -11238,6 +11239,204 @@ static int splice_recv_index_slot(Compiler *c, int recv, int *outer, int *oidx) 
   return 1;
 }
 
+/* One owner's arm: unbox `box` (a temp holding the boxed receiver, or 0 to
+   unbox the receiver expression itself) to `kind`'s representation in the
+   statement prelude, override the receiver node with the temp, retype and
+   pin it, and re-enter the same call so the typed emitter takes it from
+   there. A receiver that is not of that kind at run time raises the
+   NoMethodError the call would have raised, from the coercion. Answers the
+   arm's value text in `val` and its type under the pin -- the node's settled
+   type is the union over the inference passes and the owners, and may be
+   poly where the arm answers a pointer. */
+static TyKind emit_face_arm(Compiler *c, int id, unsigned kind, unsigned flags, int box, Buf *val) {
+  const NodeTable *nt = c->nt;
+  /* The re-entered emitter may rename the node for its own re-entry (a
+     String bang takes its plain form) and restore it into fresh storage, so
+     the name is kept here, not borrowed from the node table. Only a table
+     row's name arrives, so the buffer cannot truncate. */
+  char name[128];
+  snprintf(name, sizeof name, "%s", nt_str(nt, id, "name"));
+  int recv = nt_ref(nt, id, "receiver");
+  int has_blk = nt_ref(nt, id, "block") >= 0;
+  int t = ++g_tmp;
+  char bx[32];
+  Buf rb; memset(&rb, 0, sizeof rb);
+  if (box) snprintf(bx, sizeof bx, "_t%d", box);
+  else {
+    /* the elements of a collection materialize from the box itself */
+    if (kind == PF_ENUM) emit_boxed(c, recv, &rb);
+    else emit_expr(c, recv, &rb);
+  }
+  const char *rs = box ? bx : rb.p ? rb.p : "sp_box_nil()";
+  emit_indent(g_pre, g_indent);
+  switch (kind) {
+    case PF_STRING:
+      buf_printf(g_pre, "const char *_t%d = sp_poly_recv_s(%s, \"%s\"); SP_GC_ROOT(_t%d);\n", t, rs, name, t);
+      break;
+    case PF_INT:
+      /* The block iterators check: `"x".times { }` is a NoMethodError in
+         CRuby, and coercing would silently run the loop zero times. The
+         blockless names keep the plain coercion they have always used. */
+      if (has_blk) buf_printf(g_pre, "sp_int _t%d = sp_poly_int_recv(%s, \"%s\");\n", t, rs, name);
+      else buf_printf(g_pre, "sp_int _t%d = sp_poly_to_i(%s);\n", t, rs);
+      break;
+    case PF_ENUM:
+      /* a hash gives its [key, value] pairs, and a receiver that is no
+         collection answers an empty list, which is what the helper does */
+      buf_printf(g_pre, "sp_PolyArray *_t%d = sp_enum_items_from(%s); SP_GC_ROOT(_t%d);\n", t, rs, t);
+      break;
+  }
+  free(rb.p);
+  g_argov_node[g_n_argov] = recv;
+  snprintf(g_argov_text[g_n_argov], sizeof g_argov_text[0], "_t%d", t);
+  g_n_argov++;
+  TyKind as = ty_poly_face_kind(kind);
+  TyKind sv = c->ntype[recv]; c->ntype[recv] = as;
+  int sv_face = an_face_node(); TyKind sv_fk = an_face_kind();
+  an_set_face_node(recv, as);
+  TyKind nat = infer_uncached(c, id);
+  Buf cb; memset(&cb, 0, sizeof cb);
+  emit_call(c, id, &cb);
+  an_set_face_node(sv_face, sv_fk);
+  c->ntype[recv] = sv;
+  g_n_argov--;
+  const char *call = cb.p ? cb.p : "0";
+  /* A typed emitter that declines the call's argument shape answers the
+     unresolved gate's raise token, a poly value that never returns: hand it
+     on as poly, untouched, rather than bind it into a typed temp. */
+  if (strncmp(call, "sp_raise_nomethod(", 18) == 0) {
+    TyKind slot = comp_ntype(c, id);
+    if (slot == TY_POLY || slot == TY_UNKNOWN || slot == TY_VOID) { buf_puts(val, call); slot = TY_POLY; }
+    else emit_unbox_text(c, slot, call, val);   /* the token is an sp_RbVal; the slot is not */
+    free(cb.p);
+    return slot;
+  }
+  buf_puts(val, call);
+  free(cb.p);
+  return nat;
+}
+
+/* The value of an arm in the call's result slot: as it is when the two
+   types agree, boxed into a poly slot otherwise. */
+static void emit_face_value(Compiler *c, TyKind slot, TyKind nat, const char *val, Buf *b) {
+  /* a poly answer under the pin is not a boxed value: the Integer iterators
+     answer their receiver's sp_int while the pinned inference says poly */
+  if (slot == nat || nat == TY_POLY || nat == TY_UNKNOWN || nat == TY_VOID) buf_puts(b, val);
+  else if (slot == TY_POLY) emit_boxed_text(c, nat, val, b);
+  else {
+    Buf bx; memset(&bx, 0, sizeof bx);
+    emit_boxed_text(c, nat, val, &bx);
+    emit_unbox_text(c, slot, bx.p, b);
+    free(bx.p);
+  }
+}
+
+/* An arm under the silent emittability probe the dynamic-send dispatch
+   uses: a typed emitter that declines the call longjmps out of emit, and
+   the arm is dropped rather than the build. Everything the arm may have
+   changed on the way out is put back -- the receiver's type override and
+   the inference pin emit_face_arm restores only on its normal return, the
+   argument overrides, the conversion hold, the prelude, and the recovery
+   point itself, which the driver armed for the whole unit. The arm's
+   prelude is captured to `pre` and its value to `val`; answers 0 when the
+   arm was dropped. */
+static int face_probe_arm(Compiler *c, int id, unsigned kind, unsigned flags, int box,
+                          Buf *pre, Buf *val, TyKind *nat) {
+  int recv = nt_ref(c->nt, id, "receiver");
+  Buf *sv_pre = g_pre;
+  int sv_probe = g_unsup_probe;
+  ConvHold *sv_hold = g_conv_hold;
+  int sv_argov = g_n_argov;
+  TyKind sv_ty = c->ntype[recv];
+  int sv_face = an_face_node(); TyKind sv_fk = an_face_kind();
+  jmp_buf sv_jb; memcpy(sv_jb, g_unsup_recover, sizeof(jmp_buf));
+  volatile int ok = 1;
+  g_pre = pre; g_unsup_probe = 1;
+  if (setjmp(g_unsup_recover) == 0) *nat = emit_face_arm(c, id, kind, flags, box, val);
+  else ok = 0;
+  memcpy(g_unsup_recover, sv_jb, sizeof(jmp_buf));
+  an_set_face_node(sv_face, sv_fk);
+  c->ntype[recv] = sv_ty;
+  g_n_argov = sv_argov;
+  g_conv_hold = sv_hold;
+  g_unsup_probe = sv_probe;
+  g_pre = sv_pre;
+  return ok;
+}
+
+/* One owner: exactly the re-entry. Answers 0 when the typed emitter
+   declined the call, and the call goes on to the arms after this one. */
+static int emit_face_reentry(Compiler *c, int id, unsigned kind, unsigned flags, Buf *b) {
+  const NodeTable *nt = c->nt;
+  int recv = nt_ref(nt, id, "receiver");
+  int box = 0;
+  Buf pre = {0, 0, 0}, val = {0, 0, 0};
+  TyKind nat = TY_UNKNOWN;
+  if (!face_probe_arm(c, id, kind, flags, box, &pre, &val, &nat)) {
+    free(pre.p); free(val.p);
+    return 0;
+  }
+  if (pre.p) buf_puts(g_pre, pre.p);
+  emit_face_value(c, comp_ntype(c, id), nat, val.p ? val.p : "0", b);
+  free(pre.p); free(val.p);
+  return 1;
+}
+
+/* A String value-form mutator on a boxed receiver: compute the non-bang
+   transform against the unboxed contents, then write the result back
+   through the box. */
+static void emit_face_str_bang(Compiler *c, int id, unsigned own, Buf *b) {
+  const NodeTable *nt = c->nt;
+  const char *name = nt_str(nt, id, "name");
+  int recv = nt_ref(nt, id, "receiver");
+  int nil_nc = !(own & PF_STR_SELF);
+  /* The node's name is rewritten to the plain form for the re-entry, so
+     both spellings live here, not in the node table. */
+  char bang[64], plain[64];   /* a table row's bang name: never empty, never near the cap */
+  snprintf(bang, sizeof bang, "%s", name);
+  snprintf(plain, sizeof plain, "%.*s", (int)strlen(name) - 1, name);
+  int tvb = ++g_tmp, tob = ++g_tmp, tnb = ++g_tmp;
+  Buf rbb; memset(&rbb, 0, sizeof rbb); emit_expr(c, recv, &rbb);
+  emit_indent(g_pre, g_indent);
+  buf_printf(g_pre, "sp_RbVal _t%d = %s; SP_GC_ROOT_RBVAL(_t%d);"
+                    " const char *_t%d = sp_poly_to_s(_t%d); SP_GC_ROOT(_t%d);\n",
+             tvb, rbb.p ? rbb.p : "sp_box_nil()", tvb, tob, tvb, tob);
+  free(rbb.p);
+  g_argov_node[g_n_argov] = recv;
+  snprintf(g_argov_text[g_n_argov], sizeof g_argov_text[0], "_t%d", tob);
+  g_n_argov++;
+  TyKind svb = c->ntype[recv]; c->ntype[recv] = TY_STRING;
+  nt_node_set_str((NodeTable *)nt, id, "name", plain);
+  Buf nbb; memset(&nbb, 0, sizeof nbb); emit_call(c, id, &nbb);
+  nt_node_set_str((NodeTable *)nt, id, "name", bang);
+  c->ntype[recv] = svb;
+  g_n_argov--;
+  buf_printf(b, "({ const char *_t%d = %s; ", tnb, nbb.p ? nbb.p : "\"\"");
+  free(nbb.p);
+  /* Decide "did it change?" BEFORE the mutation. The receiver's old text
+     is the LIVE payload of a shared handle, so once become() has written
+     the new contents into it the two compare equal and the bang method
+     answered nil after a substitution that plainly happened (#4042). */
+  int tchg = 0;
+  if (nil_nc) {
+    tchg = ++g_tmp;
+    buf_printf(b, "int _t%d = !sp_str_eq(_t%d, _t%d); ", tchg, tob, tnb);
+  }
+  /* A shared handle absorbs the new contents; a plain string box cannot,
+     so an lvalue receiver takes the value back the way the typed path
+     does for the same case. */
+  { const char *rvtb = nt_type(nt, recv);
+    if (rvtb && (sp_streq(rvtb, "LocalVariableReadNode") ||
+                 sp_streq(rvtb, "InstanceVariableReadNode"))) {
+      emit_expr(c, recv, b);
+      buf_printf(b, " = sp_poly_str_become(_t%d, _t%d); ", tvb, tnb);
+    }
+    else buf_printf(b, "sp_poly_str_become(_t%d, _t%d); ", tvb, tnb);
+  }
+  if (nil_nc) buf_printf(b, "_t%d ? _t%d : NULL; })", tchg, tnb);
+  else buf_printf(b, "_t%d; })", tnb);
+}
+
 int emit_poly_call(Compiler *c, int id, Buf *b) {
   const NodeTable *nt = c->nt;
   const char *name = nt_str(nt, id, "name");
@@ -11327,188 +11526,23 @@ int emit_poly_call(Compiler *c, int id, Buf *b) {
     buf_puts(b, "; })");
     return 1;
   }
-  /* String value-form mutators on a boxed receiver: compute the non-bang
-     transform against the unboxed contents, then write the result back through
-     the box. Only the bang names String alone owns -- reverse!/sort!/uniq! are
-     Array's too, and the receiver's runtime class is unknown here (#3445). */
+  /* The face table (types.h): unbox the receiver to the kind that owns the
+     name, retype the receiver node and re-enter the same call, so the typed
+     emitter IS the implementation and the inference, which answered under
+     the same pin, has already sized the result slot to it. The Hash face is
+     not taken here: it is the last resort, in emit_unresolved_call, so that
+     a poly-receiver emitter of its own claims the name first. A name several
+     kinds own is left to the arms after this one for now. */
   if (recv >= 0 && rt == TY_POLY && !user_defines_or_reads(c, name) &&
       g_n_argov < MAX_ARG_OVERRIDE) {
-    static const struct { const char *bang, *plain; int nil_nc; } PBANG[] = {
-      {"gsub!", "gsub", 1}, {"sub!", "sub", 1}, {"upcase!", "upcase", 1},
-      {"downcase!", "downcase", 1}, {"capitalize!", "capitalize", 1},
-      {"swapcase!", "swapcase", 1}, {"strip!", "strip", 1}, {"lstrip!", "lstrip", 1},
-      {"rstrip!", "rstrip", 1}, {"chomp!", "chomp", 1}, {"chop!", "chop", 1},
-      {"squeeze!", "squeeze", 1}, {"tr!", "tr", 1}, {"delete!", "delete", 1},
-      {"tr_s!", "tr_s", 1}, {"delete_prefix!", "delete_prefix", 1},
-      {"delete_suffix!", "delete_suffix", 1}, {"succ!", "succ", 0}, {"next!", "next", 0},
-      {NULL, NULL, 0}
-    };
-    int pbi = -1;
-    for (int j = 0; PBANG[j].bang; j++) if (sp_streq(name, PBANG[j].bang)) { pbi = j; break; }
-    if (pbi >= 0) {
-      int tvb = ++g_tmp, tob = ++g_tmp, tnb = ++g_tmp;
-      Buf rbb; memset(&rbb, 0, sizeof rbb); emit_expr(c, recv, &rbb);
-      emit_indent(g_pre, g_indent);
-      buf_printf(g_pre, "sp_RbVal _t%d = %s; SP_GC_ROOT_RBVAL(_t%d);"
-                        " const char *_t%d = sp_poly_to_s(_t%d); SP_GC_ROOT(_t%d);\n",
-                 tvb, rbb.p ? rbb.p : "sp_box_nil()", tvb, tob, tvb, tob);
-      free(rbb.p);
-      g_argov_node[g_n_argov] = recv;
-      snprintf(g_argov_text[g_n_argov], sizeof g_argov_text[0], "_t%d", tob);
-      g_n_argov++;
-      TyKind svb = c->ntype[recv]; c->ntype[recv] = TY_STRING;
-      nt_node_set_str((NodeTable *)nt, id, "name", PBANG[pbi].plain);
-      Buf nbb; memset(&nbb, 0, sizeof nbb); emit_call(c, id, &nbb);
-      nt_node_set_str((NodeTable *)nt, id, "name", PBANG[pbi].bang);
-      c->ntype[recv] = svb;
-      g_n_argov--;
-      buf_printf(b, "({ const char *_t%d = %s; ", tnb, nbb.p ? nbb.p : "\"\"");
-      free(nbb.p);
-      /* Decide "did it change?" BEFORE the mutation. The receiver's old text
-         is the LIVE payload of a shared handle, so once become() has written
-         the new contents into it the two compare equal and the bang method
-         answered nil after a substitution that plainly happened (#4042). */
-      int tchg = 0;
-      if (PBANG[pbi].nil_nc) {
-        tchg = ++g_tmp;
-        buf_printf(b, "int _t%d = !sp_str_eq(_t%d, _t%d); ", tchg, tob, tnb);
-      }
-      /* A shared handle absorbs the new contents; a plain string box cannot,
-         so an lvalue receiver takes the value back the way the typed path
-         does for the same case. */
-      { const char *rvtb = nt_type(nt, recv);
-        if (rvtb && (sp_streq(rvtb, "LocalVariableReadNode") ||
-                     sp_streq(rvtb, "InstanceVariableReadNode"))) {
-          emit_expr(c, recv, b);
-          buf_printf(b, " = sp_poly_str_become(_t%d, _t%d); ", tvb, tnb);
-        }
-        else buf_printf(b, "sp_poly_str_become(_t%d, _t%d); ", tvb, tnb);
-      }
-      if (PBANG[pbi].nil_nc) buf_printf(b, "_t%d ? _t%d : NULL; })", tchg, tnb);
-      else buf_printf(b, "_t%d; })", tnb);
-      return 1;
-    }
-  }
-  /* The names Integer alone owns, on a boxed receiver: unbox once and
-     re-dispatch through the typed emitter, the way the String surface below
-     does. Untyped, they raised NoMethodError naming Integer itself. */
-  if (recv >= 0 && rt == TY_POLY &&
-      !user_defines_or_reads(c, name) && g_n_argov < MAX_ARG_OVERRIDE) {
-    int pi_blk = nt_ref(nt, id, "block") >= 0;
-    static const struct { const char *name; int argc; } PINT[] = {
-      {"digits", 0}, {"digits", 1}, {"pred", 0}, {"bit_length", 0},
-      {"ceildiv", 1}, {"pow", 1}, {"pow", 2}, {"gcdlcm", 1},
-      {NULL, 0} };
-    /* The block iterators Integer owns take the same route. They were left
-       out because this arm only ever ran for the blockless names, so
-       `n.times { }` on a boxed receiver raised NoMethodError naming Integer. */
-    /* step is left out: a Float receiver owns it too, so unboxing to an
-       sp_int would truncate a legitimate `2.5.step(9, 3)`. */
-    static const struct { const char *name; int argc; } PINTB[] = {
-      {"times", 0}, {"upto", 1}, {"downto", 1},
-      {NULL, 0} };
-    int want_pi = 0;
-    for (int i = 0; PINT[i].name && !want_pi; i++)
-      if (!pi_blk && sp_streq(name, PINT[i].name) && argc == PINT[i].argc) want_pi = 1;
-    for (int i = 0; PINTB[i].name && !want_pi; i++)
-      if (pi_blk && sp_streq(name, PINTB[i].name) && argc == PINTB[i].argc) want_pi = 1;
-    if (want_pi) {
-      int tpi = ++g_tmp;
-      Buf rbi; memset(&rbi, 0, sizeof rbi); emit_expr(c, recv, &rbi);
-      emit_indent(g_pre, g_indent);
-      /* The block iterators check: `"x".times { }` is a NoMethodError in CRuby,
-         and coercing would silently run the loop zero times. The blockless
-         names keep the plain coercion they have always used. */
-      if (pi_blk)
-        buf_printf(g_pre, "sp_int _t%d = sp_poly_int_recv(%s, \"%s\");\n",
-                   tpi, rbi.p ? rbi.p : "sp_box_nil()", name);
-      else
-        buf_printf(g_pre, "sp_int _t%d = sp_poly_to_i(%s);\n", tpi, rbi.p ? rbi.p : "sp_box_nil()");
-      free(rbi.p);
-      g_argov_node[g_n_argov] = recv;
-      snprintf(g_argov_text[g_n_argov], sizeof g_argov_text[0], "_t%d", tpi);
-      g_n_argov++;
-      TyKind svpi = c->ntype[recv]; c->ntype[recv] = TY_INT;
-      emit_call(c, id, b);
-      c->ntype[recv] = svpi;
-      g_n_argov--;
-      return 1;
-    }
-  }
-  /* The Enumerable names a boxed receiver shares with Array: materialize its
-     elements into a poly array once and re-dispatch, so the poly-array
-     emitters serve them. Without this a widened array (a container read, a
-     destructured return) raised NoMethodError naming Array, the class that
-     defines them. Hashes and ranges materialize through the same helper, and
-     a receiver that is neither answers an empty list, which is what the
-     runtime helper already does for a non-collection. */
-  if (recv >= 0 && rt == TY_POLY && !user_defines_or_reads(c, name) &&
-      g_n_argov < MAX_ARG_OVERRIDE) {
-    static const struct { const char *name; int wants_block; } PENUM[] = {
-      {"minmax", 0}, {"tally", 0}, {"product", 0}, {"combination", 0},
-      {"permutation", 0}, {"group_by", 1}, {"partition", 1},
-      {"each_with_object", 1}, {"chunk_while", 1}, {"slice_when", 1},
-      {NULL, 0} };
-    int want_pe = 0;
     int has_blk = nt_ref(nt, id, "block") >= 0;
-    for (int i = 0; PENUM[i].name && !want_pe; i++)
-      if (sp_streq(name, PENUM[i].name) && (!PENUM[i].wants_block || has_blk)) want_pe = 1;
-    if (want_pe) {
-      int tpe = ++g_tmp;
-      Buf rbe; memset(&rbe, 0, sizeof rbe); emit_boxed(c, recv, &rbe);
-      emit_indent(g_pre, g_indent);
-      buf_printf(g_pre, "sp_PolyArray *_t%d = sp_enum_items_from(%s); SP_GC_ROOT(_t%d);\n",
-                 tpe, rbe.p ? rbe.p : "sp_box_nil()", tpe);
-      free(rbe.p);
-      g_argov_node[g_n_argov] = recv;
-      snprintf(g_argov_text[g_n_argov], sizeof g_argov_text[0], "_t%d", tpe);
-      g_n_argov++;
-      TyKind svpe = c->ntype[recv]; c->ntype[recv] = TY_POLY_ARRAY;
-      emit_call(c, id, b);
-      c->ntype[recv] = svpe;
-      g_n_argov--;
-      return 1;
-    }
-  }
-  /* The rest of the String surface on a boxed receiver: unbox once and
-
-     re-dispatch the same call with the receiver typed String, so the typed
-     emitter IS the implementation. Only names no other class answers may go
-     here -- the receiver's runtime class is unknown, so a name Array or
-     Enumerable also owns (index, count, sum, slice, insert) would compile the
-     String body for an array receiver. Those are served by their runtime kind
-     dispatch instead. `partition` qualifies only in its one-argument form:
-     Enumerable#partition takes no argument, and a block already excludes this
-     arm. Not a catch-all, so a name without a typed emitter still reports the
-     missing method. */
-  if (recv >= 0 && rt == TY_POLY && nt_ref(nt, id, "block") < 0 &&
-      !user_defines_or_reads(c, name) && g_n_argov < MAX_ARG_OVERRIDE) {
-    static const struct { const char *name; int argc; } PSR[] = {
-      {"squeeze", 0}, {"byteindex", 1}, {"byteindex", 2},
-      {"byterindex", 1}, {"byterindex", 2},
-      {"partition", 1}, {"rpartition", 1},
-      {"hex", 0}, {"oct", 0}, {"tr_s", 2}, {"crypt", 1},
-      {"casecmp", 1}, {"casecmp?", 1},
-      {NULL, 0} };
-    int want = 0;
-    for (int i = 0; PSR[i].name && !want; i++)
-      if (sp_streq(name, PSR[i].name) && argc == PSR[i].argc) want = 1;
-    if (want) {
-      int tps = ++g_tmp;
-      Buf rbs; memset(&rbs, 0, sizeof rbs); emit_expr(c, recv, &rbs);
-      emit_indent(g_pre, g_indent);
-      buf_printf(g_pre, "const char *_t%d = sp_poly_recv_s(%s, \"%s\"); SP_GC_ROOT(_t%d);\n",
-                 tps, rbs.p ? rbs.p : "sp_box_nil()", name, tps);
-      free(rbs.p);
-      g_argov_node[g_n_argov] = recv;
-      snprintf(g_argov_text[g_n_argov], sizeof g_argov_text[0], "_t%d", tps);
-      g_n_argov++;
-      TyKind svps = c->ntype[recv]; c->ntype[recv] = TY_STRING;
-      emit_call(c, id, b);
-      c->ntype[recv] = svps;
-      g_n_argov--;
-      return 1;
-    }
+    unsigned own = ty_poly_face_owners(name, argc, has_blk, nt_call_args_plain(nt, id), 0);
+    unsigned kinds = own & PF_OWNERS;
+    if (own & PF_STR_BANG) { emit_face_str_bang(c, id, own, b); return 1; }
+    if (kinds && !(kinds & (kinds - 1)) && emit_face_reentry(c, id, kinds, own, b)) return 1;
+    /* a declined re-entry may have renamed the node and restored it into
+       fresh storage (see emit_face_arm): the name is read again */
+    name = nt_str(nt, id, "name");
   }
   /* The one/two-String-argument transforms on a boxed receiver: a String
      arriving through a poly slot (a Fiber#resume value, a container read) had

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -1177,38 +1177,6 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
     buf_printf(b, " : (sp_StrArray *)(sp_raise_nomethod(sp_nomethod_msg(\"split\", _t%d)), (void *)0); })", tv);
     return 1;
   }
-  /* `poly.fill(v, ...)`: Array owns the name alone, but it MUTATES, so the
-     enumerator face (which hands out a copy) cannot serve it. Coerce to a poly
-     array the way map! does, re-enter the typed fill emitter against that, and
-     write the elements back into the receiver's own representation (#4149). */
-  if (recv >= 0 && rt == TY_POLY && sp_streq(name, "fill") && argc >= 1 &&
-      argc <= 3 && nt_ref(nt, id, "block") < 0 && g_n_argov < MAX_ARG_OVERRIDE) {
-    int torig = ++g_tmp, ta = ++g_tmp, tres = ++g_tmp;
-    Buf rb = expr_buf(c, recv);
-    emit_indent(g_pre, g_indent);
-    buf_printf(g_pre, "sp_RbVal _t%d = %s; SP_GC_ROOT_RBVAL(_t%d);\n",
-               torig, rb.p ? rb.p : "sp_box_nil()", torig);
-    free(rb.p);
-    emit_indent(g_pre, g_indent);
-    buf_printf(g_pre, "sp_PolyArray *_t%d = sp_poly_arr_recv(_t%d, \"fill\"); SP_GC_ROOT(_t%d);\n",
-               ta, torig, ta);
-    g_argov_node[g_n_argov] = recv;
-    snprintf(g_argov_text[g_n_argov], sizeof g_argov_text[0], "_t%d", ta);
-    g_n_argov++;
-    TyKind svf = c->ntype[recv]; c->ntype[recv] = TY_POLY_ARRAY;
-    Buf fb; memset(&fb, 0, sizeof fb);
-    emit_expr(c, id, &fb);
-    c->ntype[recv] = svf;
-    g_n_argov--;
-    emit_indent(g_pre, g_indent);
-    buf_printf(g_pre, "sp_PolyArray *_t%d = %s; SP_GC_ROOT(_t%d);\n",
-               tres, fb.p ? fb.p : "0", tres);
-    free(fb.p);
-    emit_indent(g_pre, g_indent);
-    buf_printf(g_pre, "sp_poly_arr_writeback(_t%d, _t%d);\n", torig, tres);
-    buf_printf(b, "_t%d", tres);
-    return 1;
-  }
   /* `poly.map! { |x| ... }` / `collect!` where poly is an array read out of a
      container: coerce to a poly array and rewrite each element in place with
      the block result, returning the (mutated) array (#3162). */
@@ -11280,10 +11248,17 @@ static TyKind emit_face_arm(Compiler *c, int id, unsigned kind, unsigned flags, 
       if (has_blk) buf_printf(g_pre, "sp_int _t%d = sp_poly_int_recv(%s, \"%s\");\n", t, rs, name);
       else buf_printf(g_pre, "sp_int _t%d = sp_poly_to_i(%s);\n", t, rs);
       break;
+    /* A mutator's coercion checks the original for frozenness first: the
+       typed emitter would otherwise work on the copy, running a block over
+       every element, and only the write-back would raise. */
+    case PF_ARRAY:
+      buf_printf(g_pre, "sp_PolyArray *_t%d = sp_poly_array_recv(%s, \"%s\", %d); SP_GC_ROOT(_t%d);\n",
+                 t, rs, name, (flags & PF_MUT) != 0, t);
+      break;
     case PF_ENUM:
-      /* a hash gives its [key, value] pairs, and a receiver that is no
-         collection answers an empty list, which is what the helper does */
-      buf_printf(g_pre, "sp_PolyArray *_t%d = sp_enum_items_from(%s); SP_GC_ROOT(_t%d);\n", t, rs, t);
+      /* a hash gives its [key, value] pairs; a receiver that is no collection
+         raises the NoMethodError the call raised before */
+      buf_printf(g_pre, "sp_PolyArray *_t%d = sp_poly_enum_recv(%s, \"%s\"); SP_GC_ROOT(_t%d);\n", t, rs, name, t);
       break;
   }
   free(rb.p);
@@ -11311,7 +11286,18 @@ static TyKind emit_face_arm(Compiler *c, int id, unsigned kind, unsigned flags, 
     free(cb.p);
     return slot;
   }
-  buf_puts(val, call);
+  /* A mutator worked on the poly copy a typed array was normalized to, and
+     the original has to take the result back once the value is taken. */
+  if ((flags & PF_MUT) && box && (kind == PF_ARRAY)) {
+    Buf wb; memset(&wb, 0, sizeof wb);
+    int tr = ++g_tmp;
+    int has_val = nat != TY_VOID && nat != TY_UNKNOWN;
+    buf_printf(&wb, "sp_poly_arr_writeback(_t%d, _t%d)", box, t);
+    if (!has_val) buf_printf(val, "({ (void)(%s); %s; })", call, wb.p);
+    else buf_printf(val, "({ %s _t%d = %s; %s; _t%d; })", c_type_name(nat), tr, call, wb.p, tr);
+    free(wb.p);
+  }
+  else buf_puts(val, call);
   free(cb.p);
   return nat;
 }
@@ -11364,17 +11350,25 @@ static int face_probe_arm(Compiler *c, int id, unsigned kind, unsigned flags, in
   return ok;
 }
 
-/* One owner: exactly the re-entry. Answers 0 when the typed emitter
-   declined the call, and the call goes on to the arms after this one. */
+/* One owner: exactly the re-entry, with the box kept only when a mutator
+   has to write back through it. Answers 0 when the typed emitter declined
+   the call, and the call goes on to the arms after this one. */
 static int emit_face_reentry(Compiler *c, int id, unsigned kind, unsigned flags, Buf *b) {
   const NodeTable *nt = c->nt;
   int recv = nt_ref(nt, id, "receiver");
   int box = 0;
   Buf pre = {0, 0, 0}, val = {0, 0, 0};
   TyKind nat = TY_UNKNOWN;
+  if ((flags & PF_MUT) && (kind == PF_ARRAY)) box = ++g_tmp;
   if (!face_probe_arm(c, id, kind, flags, box, &pre, &val, &nat)) {
     free(pre.p); free(val.p);
     return 0;
+  }
+  if (box) {
+    Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);
+    emit_indent(g_pre, g_indent);
+    buf_printf(g_pre, "sp_RbVal _t%d = %s; SP_GC_ROOT_RBVAL(_t%d);\n", box, rb.p ? rb.p : "sp_box_nil()", box);
+    free(rb.p);
   }
   if (pre.p) buf_puts(g_pre, pre.p);
   emit_face_value(c, comp_ntype(c, id), nat, val.p ? val.p : "0", b);

--- a/src/node_table.c
+++ b/src/node_table.c
@@ -601,3 +601,15 @@ const int *nt_arr_at(const NodeTable *nt, int id, int i, int *out_n) {
   *out_n = nd->a[i].n;
   return nd->a[i].ids;
 }
+
+int nt_call_args_plain(const NodeTable *nt, int id) {
+  int args = nt_ref(nt, id, "arguments");
+  if (args < 0) return 1;
+  int argc = 0;
+  const int *argv = nt_arr(nt, args, "arguments", &argc);
+  for (int i = 0; i < argc; i++) {
+    const char *ty = nt_type(nt, argv[i]);
+    if (ty && (sp_streq(ty, "SplatNode") || sp_streq(ty, "BlockArgumentNode"))) return 0;
+  }
+  return 1;
+}

--- a/src/node_table.h
+++ b/src/node_table.h
@@ -248,6 +248,11 @@ void nt_free(NodeTable *nt);
    Appends nodes and grows nt->count -- parallel per-node arrays must be
    resized to match afterward. */
 int nt_clone_subtree(NodeTable *nt, int root);
+/* Are a call's arguments all positional -- no splat, no block argument? (A
+   braceless trailing hash is one positional argument to the builtin surface.)
+   The face table's rows describe positional calls, and the two halves that
+   read it treat the other shapes alike. */
+int nt_call_args_plain(const NodeTable *nt, int id);
 
 /* ---- synthetic node construction ----
    Append a freshly-typed node and populate its fields, for desugaring AST

--- a/src/types.c
+++ b/src/types.c
@@ -35,6 +35,17 @@ static const PolyFace ty_poly_face_tbl[] = {
   {"group_by", PF_ENUM, 0, -1, 1}, {"partition", PF_ENUM, 0, -1, 1},
   {"each_with_object", PF_ENUM, 0, -1, 1}, {"chunk_while", PF_ENUM, 0, -1, 1},
   {"slice_when", PF_ENUM, 0, -1, 1},
+  /* The Array-only names, on an Array at run time; a mutator writes its
+     result back into a typed original. */
+  {"sort!", PF_ARRAY | PF_MUT, 0, 0, -1}, {"sort_by!", PF_ARRAY | PF_MUT, 0, 0, 1},
+  {"rotate!", PF_ARRAY | PF_MUT, 0, 1, 0}, {"uniq!", PF_ARRAY | PF_MUT, 0, 0, -1},
+  {"flatten!", PF_ARRAY | PF_MUT, 0, 1, 0}, {"fill", PF_ARRAY | PF_MUT, 1, 3, 0},
+  {"select!", PF_ARRAY | PF_MUT, 0, 0, 1}, {"filter!", PF_ARRAY | PF_MUT, 0, 0, 1},
+  {"reject!", PF_ARRAY | PF_MUT, 0, 0, 1}, {"keep_if", PF_ARRAY | PF_MUT, 0, 0, 1},
+  {"delete_if", PF_ARRAY | PF_MUT, 0, 0, 1},
+  {"to_ary", PF_ARRAY, 0, 0, 0}, {"transpose", PF_ARRAY, 0, 0, 0},
+  /* and the Enumerable names that had no arm at all */
+  {"grep", PF_ENUM, 1, 1, -1}, {"minmax_by", PF_ENUM, 0, 0, 1},
   /* The read-only Hash/Enumerable face. */
   {"dig", PF_HASH | PF_LAST, 0, -1, -1}, {"value?", PF_HASH | PF_LAST, 0, -1, -1}, {"has_value?", PF_HASH | PF_LAST, 0, -1, -1},
   {"invert", PF_HASH | PF_LAST, 0, -1, -1}, {"assoc", PF_HASH | PF_LAST, 0, -1, -1}, {"rassoc", PF_HASH | PF_LAST, 0, -1, -1}, {"key", PF_HASH | PF_LAST, 0, -1, -1},

--- a/src/types.c
+++ b/src/types.c
@@ -2,6 +2,80 @@
 #include <stddef.h>
 #include <string.h>
 
+/* ---- The boxed-receiver face table (see types.h) ---- */
+static const PolyFace ty_poly_face_tbl[] = {
+  /* String value-form mutators: the non-bang transform runs against the
+     unboxed contents and the result is written back through the box. */
+  {"gsub!", PF_STRING | PF_STR_BANG, 0, -1, -1}, {"sub!", PF_STRING | PF_STR_BANG, 0, -1, -1},
+  {"upcase!", PF_STRING | PF_STR_BANG, 0, -1, -1}, {"downcase!", PF_STRING | PF_STR_BANG, 0, -1, -1},
+  {"capitalize!", PF_STRING | PF_STR_BANG, 0, -1, -1}, {"swapcase!", PF_STRING | PF_STR_BANG, 0, -1, -1},
+  {"strip!", PF_STRING | PF_STR_BANG, 0, -1, -1}, {"lstrip!", PF_STRING | PF_STR_BANG, 0, -1, -1},
+  {"rstrip!", PF_STRING | PF_STR_BANG, 0, -1, -1}, {"chomp!", PF_STRING | PF_STR_BANG, 0, -1, -1},
+  {"chop!", PF_STRING | PF_STR_BANG, 0, -1, -1}, {"squeeze!", PF_STRING | PF_STR_BANG, 0, -1, -1},
+  {"tr!", PF_STRING | PF_STR_BANG, 0, -1, -1}, {"delete!", PF_STRING | PF_STR_BANG, 0, -1, -1},
+  {"tr_s!", PF_STRING | PF_STR_BANG, 0, -1, -1}, {"delete_prefix!", PF_STRING | PF_STR_BANG, 0, -1, -1},
+  {"delete_suffix!", PF_STRING | PF_STR_BANG, 0, -1, -1},
+  {"succ!", PF_STRING | PF_STR_BANG | PF_STR_SELF, 0, -1, -1},
+  {"next!", PF_STRING | PF_STR_BANG | PF_STR_SELF, 0, -1, -1},
+  /* The rest of the String surface. `partition` qualifies only in its
+     one-argument form: Enumerable#partition takes none. */
+  {"squeeze", PF_STRING, 0, 0, 0}, {"byteindex", PF_STRING, 1, 2, 0}, {"byterindex", PF_STRING, 1, 2, 0},
+  {"partition", PF_STRING, 1, 1, 0}, {"rpartition", PF_STRING, 1, 1, 0},
+  {"hex", PF_STRING, 0, 0, 0}, {"oct", PF_STRING, 0, 0, 0}, {"tr_s", PF_STRING, 2, 2, 0},
+  {"crypt", PF_STRING, 1, 1, 0}, {"casecmp", PF_STRING, 1, 1, 0}, {"casecmp?", PF_STRING, 1, 1, 0},
+  /* The names Integer alone owns. step is left out: a Float receiver owns it
+     too, so unboxing to an sp_int would truncate a legitimate `2.5.step(9, 3)`. */
+  {"digits", PF_INT, 0, 1, 0}, {"pred", PF_INT, 0, 0, 0}, {"bit_length", PF_INT, 0, 0, 0},
+  {"ceildiv", PF_INT, 1, 1, 0}, {"pow", PF_INT, 1, 2, 0}, {"gcdlcm", PF_INT, 1, 1, 0},
+  {"times", PF_INT, 0, 0, 1}, {"upto", PF_INT, 1, 1, 1}, {"downto", PF_INT, 1, 1, 1},
+  /* The Enumerable names a boxed receiver shares with Array: its elements
+     (a hash's [key, value] pairs) materialize into a poly array once. */
+  {"minmax", PF_ENUM, 0, -1, -1}, {"tally", PF_ENUM, 0, -1, -1}, {"product", PF_ENUM, 0, -1, -1},
+  {"combination", PF_ENUM, 0, -1, -1}, {"permutation", PF_ENUM, 0, -1, -1},
+  {"group_by", PF_ENUM, 0, -1, 1}, {"partition", PF_ENUM, 0, -1, 1},
+  {"each_with_object", PF_ENUM, 0, -1, 1}, {"chunk_while", PF_ENUM, 0, -1, 1},
+  {"slice_when", PF_ENUM, 0, -1, 1},
+  /* The read-only Hash/Enumerable face. */
+  {"dig", PF_HASH | PF_LAST, 0, -1, -1}, {"value?", PF_HASH | PF_LAST, 0, -1, -1}, {"has_value?", PF_HASH | PF_LAST, 0, -1, -1},
+  {"invert", PF_HASH | PF_LAST, 0, -1, -1}, {"assoc", PF_HASH | PF_LAST, 0, -1, -1}, {"rassoc", PF_HASH | PF_LAST, 0, -1, -1}, {"key", PF_HASH | PF_LAST, 0, -1, -1},
+  {"filter_map", PF_HASH | PF_LAST, 0, -1, -1}, {"each_with_object", PF_HASH | PF_LAST, 0, -1, -1},
+  {"group_by", PF_HASH | PF_LAST, 0, -1, -1}, {"partition", PF_HASH | PF_LAST, 0, -1, -1}, {"zip", PF_HASH | PF_LAST, 0, -1, -1},
+  {"reduce", PF_HASH | PF_LAST, 0, -1, -1}, {"inject", PF_HASH | PF_LAST, 0, -1, -1}, {"find_all", PF_HASH | PF_LAST, 0, -1, -1},
+  {"take", PF_HASH | PF_LAST, 0, -1, -1}, {"drop", PF_HASH | PF_LAST, 0, -1, -1}, {"select", PF_HASH | PF_LAST, 0, -1, -1},
+  {"filter", PF_HASH | PF_LAST, 0, -1, -1}, {"reject", PF_HASH | PF_LAST, 0, -1, -1}, {"compact", PF_HASH | PF_LAST, 0, -1, -1},
+  {"slice", PF_HASH | PF_LAST, 0, -1, -1}, {"except", PF_HASH | PF_LAST, 0, -1, -1}, {"values_at", PF_HASH | PF_LAST, 0, -1, -1},
+  {"fetch_values", PF_HASH | PF_LAST, 0, -1, -1}, {"entries", PF_HASH | PF_LAST, 0, -1, -1}, {"flatten", PF_HASH | PF_LAST, 0, -1, -1},
+  {"first", PF_HASH | PF_LAST, 0, -1, -1}, {"each_pair", PF_HASH | PF_LAST, 0, -1, -1}, {"each_key", PF_HASH | PF_LAST, 0, -1, -1},
+  {"each_value", PF_HASH | PF_LAST, 0, -1, -1}, {"transform_values", PF_HASH | PF_LAST, 0, -1, -1},
+  {"transform_keys", PF_HASH | PF_LAST, 0, -1, -1}, {"tally", PF_HASH | PF_LAST, 0, -1, -1},
+  {"chunk_while", PF_HASH | PF_LAST, 0, -1, -1}, {"flat_map", PF_HASH | PF_LAST, 0, -1, -1},
+  {"collect_concat", PF_HASH | PF_LAST, 0, -1, -1}, {"none?", PF_HASH | PF_LAST, 0, -1, -1}, {"one?", PF_HASH | PF_LAST, 0, -1, -1},
+  {0, 0, 0, 0, 0}
+};
+static int face_row_matches(const PolyFace *r, int argc, int has_blk, int plain) {
+  if (!plain) return r->argc_min == 0 && r->argc_max < 0 && r->blk != 0;
+  if (argc < r->argc_min || (r->argc_max >= 0 && argc > r->argc_max)) return 0;
+  return r->blk < 0 || r->blk == (has_blk != 0);
+}
+
+unsigned ty_poly_face_owners(const char *name, int argc, int has_blk, int plain, int with_last) {
+  unsigned own = 0;
+  if (!name) return 0;
+  for (const PolyFace *r = ty_poly_face_tbl; r->name; r++) {
+    if (!sp_streq(name, r->name)) continue;
+    if (!with_last && (r->flags & PF_LAST)) continue;
+    if (!face_row_matches(r, argc, has_blk, plain)) continue;
+    own |= r->flags;
+  }
+  return own;
+}
+int ty_poly_hash_face_name(const char *nm) {
+  if (!nm) return 0;
+  for (const PolyFace *r = ty_poly_face_tbl; r->name; r++)
+    if ((r->flags & PF_HASH) && (r->flags & PF_LAST) && sp_streq(nm, r->name)) return 1;
+  return 0;
+}
+
 const char *ty_name(TyKind t) {
   switch (t) {
     case TY_UNKNOWN: return "unknown";

--- a/src/types.h
+++ b/src/types.h
@@ -41,9 +41,10 @@ static inline int sp_streq(const char *a, const char *b) {
    A row marked PF_LAST answers only once no poly-receiver emitter of its own
    has claimed the name, because a claimed name's face answer is a type
    nothing renders (find and detect were such names -- their emitter walks
-   the elements and answers one of them). The Hash face is read-only: the
-   normalization copies every variant but the general one, so a write
-   would be lost. The table itself is in types.c. */
+   the elements and answers one of them). The read-only Hash face is all
+   PF_LAST; a Hash row that is not must carry PF_MUT and write back, because
+   the normalization copies every variant but the general one and a plain
+   write would be lost. The table itself is in types.c. */
 enum {
   PF_STRING = 1 << 0,  /* re-enter as TY_STRING (sp_poly_recv_s) */
   PF_ARRAY  = 1 << 1,  /* TY_POLY_ARRAY, an Array at run time only */
@@ -51,6 +52,7 @@ enum {
   PF_HASH   = 1 << 3,  /* TY_POLY_POLY_HASH */
   PF_INT    = 1 << 4,  /* TY_INT */
   PF_OWNERS = 0x1f,
+  PF_MUT      = 1 << 8,  /* mutates the receiver: the result is written back through the box */
   PF_STR_BANG = 1 << 9,  /* String value-form bang: re-enter the plain name, nil when unchanged */
   PF_STR_SELF = 1 << 10, /* ... but a bang that answers self (succ!/next!): never nil */
   PF_LAST     = 1 << 13  /* answers only once no poly-receiver emitter of its own has claimed the name */

--- a/src/types.h
+++ b/src/types.h
@@ -21,30 +21,58 @@ static inline int sp_streq(const char *a, const char *b) {
   }
 }
 
-/* Read-only Hash/Enumerable names a boxed receiver answers by pretending to be
-   the general boxed-key/value hash: inference types the call that way and
-   codegen normalizes the receiver to match, so the two agree by construction.
-   Every name here must have a PolyPolyHash emitter, and none may mutate -- the
-   normalization copies any other hash variant, so a write would be lost.
-   A name whose own poly-receiver emitter claims it FIRST does not belong here
-   even if a Hash answers it: the face's answer is then a type nothing renders.
-   find and detect were such names -- their emitter walks sp_poly_arr_recv,
-   which gives a Hash its [k, v] pairs, and answers one boxed ELEMENT of it. */
-static inline int ty_poly_hash_face_name(const char *nm) {
-  static const char *const NAMES[] = {
-    "dig", "value?", "has_value?", "invert", "assoc", "rassoc", "key",
-    "filter_map", "each_with_object", "group_by", "partition", "zip",
-    "reduce", "inject", "find_all", "take", "drop",
-    "select", "filter", "reject", "compact", "slice",
-    "except", "values_at", "fetch_values", "entries", "flatten", "first",
-    "each_pair", "each_key", "each_value", "transform_values",
-    "transform_keys", "tally", "chunk_while", "flat_map",
-    "collect_concat", "none?", "one?",
-    0 };
-  if (!nm) return 0;
-  for (int i = 0; NAMES[i]; i++) if (sp_streq(nm, NAMES[i])) return 1;
-  return 0;
-}
+/* ---- The boxed-receiver face table ----
+
+   A call on a receiver typed TY_POLY has no emitter of its own for most of
+   the builtin surface. What it has is a pretence: unbox the value to ONE
+   concrete kind, retype the receiver node as that kind, and re-enter the
+   typed emitter, which is then the implementation. This table says which
+   kinds own which names, and both halves of the compiler read it -- the
+   inference answers as the typed call would, under the same pin codegen
+   installs, so the result slot and the emission agree by construction
+   (#3449 introduced the shape for the Hash face; the String, Integer and
+   Enumerable lists in the poly emitter grew separately and are folded in).
+
+   A name several kinds own is dispatched on the receiver's run-time kind,
+   one re-entry per owner (see the poly emitter); a name none owns falls
+   through to whatever arm comes next, so this is not a catch-all and a name
+   without a typed emitter still reports the missing method.
+
+   A row marked PF_LAST answers only once no poly-receiver emitter of its own
+   has claimed the name, because a claimed name's face answer is a type
+   nothing renders (find and detect were such names -- their emitter walks
+   the elements and answers one of them). The Hash face is read-only: the
+   normalization copies every variant but the general one, so a write
+   would be lost. The table itself is in types.c. */
+enum {
+  PF_STRING = 1 << 0,  /* re-enter as TY_STRING (sp_poly_recv_s) */
+  PF_ARRAY  = 1 << 1,  /* TY_POLY_ARRAY, an Array at run time only */
+  PF_ENUM   = 1 << 2,  /* TY_POLY_ARRAY over any collection's elements (a hash's pairs) */
+  PF_HASH   = 1 << 3,  /* TY_POLY_POLY_HASH */
+  PF_INT    = 1 << 4,  /* TY_INT */
+  PF_OWNERS = 0x1f,
+  PF_STR_BANG = 1 << 9,  /* String value-form bang: re-enter the plain name, nil when unchanged */
+  PF_STR_SELF = 1 << 10, /* ... but a bang that answers self (succ!/next!): never nil */
+  PF_LAST     = 1 << 13  /* answers only once no poly-receiver emitter of its own has claimed the name */
+};
+typedef struct {
+  const char *name;
+  unsigned short flags;
+  signed char argc_min, argc_max;  /* argc_max -1: any count */
+  signed char blk;                 /* 1 block required, 0 none, -1 either */
+} PolyFace;
+/* The owners of `name` at a call of `argc` arguments with or without a block:
+   the OR of every matching row's flags (an owner bit per kind, plus the
+   write-back flags of the rows that carry them), the last-resort rows
+   included or not. A call whose arguments are not all positional (a splat,
+   a block argument -- see nt_call_args_plain) is no count a
+   bounded row can match: only a row open to any count and any block shape
+   answers it, which is how the name lists this table replaced answered.
+   0 when no row matches. */
+unsigned ty_poly_face_owners(const char *name, int argc, int has_blk, int plain, int with_last);
+/* Does the read-only Hash face answer `name` in some form? The face sites
+   ask by name alone, before the call's shape is known. */
+int ty_poly_hash_face_name(const char *nm);
 
 typedef enum {
   TY_UNKNOWN = 0,  /* not yet inferred, or an unsupported construct */
@@ -107,6 +135,18 @@ typedef enum {
   TY_CLASS,        /* a Class/Module value (sp_Class, carries cls_id) */
   TY_POLY          /* union / top: a value whose static type widened */
 } TyKind;
+
+/* The receiver type an owner bit re-enters the typed emitter with. */
+static inline TyKind ty_poly_face_kind(unsigned owner) {
+  switch (owner) {
+    case PF_STRING: return TY_STRING;
+    case PF_ARRAY:
+    case PF_ENUM:   return TY_POLY_ARRAY;
+    case PF_HASH:   return TY_POLY_POLY_HASH;
+    case PF_INT:    return TY_INT;
+  }
+  return TY_UNKNOWN;
+}
 
 const char *ty_name(TyKind t);         /* legacy string tag, for diagnostics */
 int ty_is_numeric(TyKind t);           /* INT or FLOAT */

--- a/test/boxed_array_methods.rb
+++ b/test/boxed_array_methods.rb
@@ -1,0 +1,56 @@
+# Array methods on a receiver whose class is only known at run time: an
+# element read out of a mixed container is boxed, and the call has to unbox
+# it to the Array it holds and answer as the typed call would. Covers the
+# in-place mutators writing their result back into a typed original (an
+# Array of Integers, of Strings, of Floats), the block forms, the
+# Enumerable names over a boxed Hash, and the NoMethodError a non-Array
+# receiver raises.
+rows = [[3, 1, 2], "x"]
+a = rows[0]
+p a.sort!
+p a.rotate!
+p a.uniq!
+p a.reverse
+p a.flatten!
+p a.fill(7, 1)
+p rows[0]
+
+words = [["pear", "fig", "apple"], 5]
+w = words[0]
+p w.sort!
+p w.select! { |s| s.length > 3 }
+p w.reject! { |s| s.start_with?("a") }
+p w.keep_if { |s| s.length > 1 }
+p w.delete_if { |s| s == "zzz" }
+p w.sort_by! { |s| -s.length }
+p w.filter! { |s| s.include?("e") }
+p words[0]
+
+floats = [[2.5, 1.5, 3.5], :sym]
+f = floats[0]
+p f.sort!
+p f.to_ary
+p f.fill(0.0)
+p floats[0]
+
+nested = [[[1, 2], [3, 4]], nil]
+n = nested[0]
+p n.transpose
+p n.grep(Array)
+p n.minmax_by { |x| x[1] }
+
+h = [{a: 1, b: 2}, 0][0]
+p h.grep(Array)
+p h.minmax_by { |k, v| -v }
+
+begin
+  h.sort!
+rescue NoMethodError => e
+  puts e.message
+end
+begin
+  s = ["str", 1][0]
+  s.transpose
+rescue NoMethodError => e
+  puts e.message
+end

--- a/test/boxed_array_methods.rb.expected
+++ b/test/boxed_array_methods.rb.expected
@@ -1,0 +1,26 @@
+[1, 2, 3]
+[2, 3, 1]
+nil
+[1, 3, 2]
+nil
+[2, 7, 7]
+[2, 7, 7]
+["apple", "fig", "pear"]
+["apple", "pear"]
+["pear"]
+["pear"]
+["pear"]
+["pear"]
+nil
+["pear"]
+[1.5, 2.5, 3.5]
+[1.5, 2.5, 3.5]
+[0.0, 0.0, 0.0]
+[0.0, 0.0, 0.0]
+[[1, 3], [2, 4]]
+[[1, 2], [3, 4]]
+[[1, 2], [3, 4]]
+[[:a, 1], [:b, 2]]
+[[:b, 2], [:a, 1]]
+undefined method 'sort!' for an instance of Hash
+undefined method 'transpose' for an instance of String


### PR DESCRIPTION
## Why

When Spinel cannot pin a receiver's class at compile time -- an element read out of a mixed container, a parameter that can also receive nil -- the value travels boxed, and a call on it is served by a pretence: unbox to one concrete kind, retype the receiver, and re-enter the typed emitter, which is then the implementation. That pretence is the compiler's whole answer for the builtin surface on such values, and it lived in six hand-curated name lists across three files, each with its own copy of the trampoline, the inference typing the same names by rules of its own -- and it keeps growing the same way: 2662ea2a added a copy for `fill` alone, 6c682db1 a third inference pin of the same shape, each right on its own and each one more place to keep in step. A name reaches a boxed receiver only if somebody has added it to the right list, so `sort!`, `uniq!`, `rotate!`, `flatten!`, `transpose`, `to_ary`, `select!`, `reject!`, `keep_if`, `delete_if`, `grep`, `minmax_by` and their siblings raise `NoMethodError` naming Array, the very class that defines them, while the typed emitters implement every one.

This PR replaces the lists with one owner table that both halves of the compiler read, so the result slot and the emission agree by construction, and adds the Array rows as the table's first consumer. The refactor is the first commit and changes no generated byte: the C for every program in the tree is identical to master's. The second commit adds fifteen rows -- fourteen names that raised, and `fill` -- a coercion that admits only an Array, and a write-back through the box that is exact where the old one coerced. The cost on the hot path is nothing -- optcarrot and all 61 benchmarks are byte-identical after both commits -- and the mechanism is what the follow-ups need: a name several kinds own (`concat`, `reverse!`, `slice!` are String's and Array's; `compact!`, `assoc` Array's and Hash's) is unrepresentable in a list keyed by name, and becomes a run-time kind switch over rows. Those come as their own PRs on top of this one.

## What

- `a = rows[0]; a.sort!` on a boxed Array raised `undefined method 'sort!' for an instance of Array`; so did `rotate!`, `uniq!`, `flatten!`, `transpose`, `to_ary`, `sort_by!`, `select!`, `filter!`, `reject!`, `keep_if`, `delete_if`, `grep` and `minmax_by`.
- The poly emitter's lists could only hold a name exactly one class answers -- the comment on one of them says so -- and the inference typed those names by separate hand rules, so a row added to one side without the other put a typed pointer in a poly slot or the reverse.
- The array write-back (`sp_poly_arr_writeback`, written for `map!`) copied `min(len)` elements and left the tail in place, so a mutator that shrinks its receiver could not have written back correctly even with a row; and a value the typed original could not hold (a String into an Array of Integers) it coerced to `0`.
- The Enumerable coercion answered an empty list for a receiver that is no collection, so `grep` on a boxed Integer would have answered `[]`; `transpose` answered `[]` for a row that is no Array where CRuby raises `TypeError`.

## How

- **One table** (`ty_poly_face_tbl` in `types.c`): a row per (name, owner kind, argument count, block shape) with the write-back and argument rules the name needs. The inference's last resort pins the receiver to each owner in turn and unifies the answers, the way the Hash face already did (#3449); the poly emitter looks the name up, unboxes to the owner's representation and re-enters -- under the silent emittability probe the dynamic-send dispatch already uses, so a typed emitter that declines drops the arm rather than the build. The four lists in the poly emitter and the Hash face's list become rows; the face's rows are marked last-resort and keep answering only once every poly-receiver emitter has declined the name. The three inference pins (the Hash face's, the poly array's, and the handle face's from 6c682db1, which already carried the type) become one that carries the kind. The first commit is this refactor alone: byte-identical C for every program in the tree.
- **Array rows**: `sp_poly_array_recv` takes an Array of any element kind, raises CRuby's `NoMethodError` for anything else (a Hash included, whose pairs the Enumerable coercion would have offered to `sort!`), and refuses a frozen original before a mutator runs -- a check at the write-back would have run a block over every element first. `sp_poly_arr_writeback` follows the work array's length and refuses an element the original has no representation for rather than coerce it. `grep` and `minmax_by` take the elements coercion, which now raises for a receiver that is no collection; `transpose` raises CRuby's `TypeError` for a row that is no Array. The `fill` arm from 2662ea2a -- the `map!` trampoline copied once more, for one name -- becomes a row, with the inference rule that went with it; its test keeps passing.
- A call with a splat or a block argument is no count a bounded row can match; the open rows -- the old lists' names -- answer it as the lists did.

## Validation

- A new test, `test/boxed_array_methods` (expectations generated by CRuby 4.0): every mutator writing back into typed originals of each layout, the result flowing into a slot the inference widened to poly, the frozen, `TypeError` and `NoMethodError` cases.
- Full suite: 3,309 pass, 0 fail, run from a cleared results cache, on each commit on its own (the first commit is byte-identical, so its suite is master's).
- Generated C against master (both compilers built at the same commit with the same flags): after the first commit, byte-identical for every program in the tree (every test, optcarrot, all 61 benchmarks: 3,335 programs at that commit). After the second, byte-identical for every program except eight: the new test; `poly_face_nilable_param`, whose `fill` now takes the row; and six where the Enumerable rows' coercion changes from `sp_enum_items_from` to `sp_poly_enum_recv`, the same call with a check in front (`boxed_receiver_enumerable_surface`, `combination_chain_in_destructured_block`, `container_read_blockless_enumerator`, `poly_hash_surface`, `safe_nav_block_calls`, `safe_nav_block_family`); all eight pass with their existing expectations. optcarrot and the 61 benchmarks are byte-identical; identical C is identical instructions, so the callgrind count cannot have moved. Compile time for optcarrot is unchanged (4.06–4.08 s vs 4.11–4.21 s on master, both compilers built with the same flags).
- `boxed_array_methods` and `poly_face_nilable_param` run clean under `SPINEL_GC_STRESS=1` and under ASAN+UBSAN (the re-entry roots the box across the typed emitter's call, so that was the thing to check). The inference fixpoint converges on every program in the suite, in the same number of rounds as on master (3,276 programs, at most 11).
- Against a differential corpus of ~2,100 minimized programs compared with CRuby (the same corpus behind #3999/#4003/#4029/#4050/#4057/#4144/#4153): 692 → 697 match, 5 gained and 0 lost -- `select!`/`reject!`/`keep_if` on an element of a nested Array, `sort_by!` and `minmax_by` on a boxed Array, `minmax_by` on a boxed Struct, and `transpose` on a non-Array row.

## Left alone, on purpose

- The names several kinds own -- `concat`, `prepend`, `reverse!`, `slice!` (String and Array), `compact!`, `assoc`, `rassoc`, `fetch_values`, `merge!` (Array and Hash) -- still raise on a boxed receiver. They need the run-time kind switch over rows, and the String write-back and the Hash write-back that go with them; each is a PR of its own on top of this table.
- `Array#shuffle`/`shuffle!` on a poly array: the poly array has no typed emitter for them yet, so a row would only move the `NoMethodError`.
- A boxed value that is a typed Array takes the mutation back by contents, not by identity: `x = a.sort!` answers the work array, and a later write to `x` does not reach `a`. The write-back keeps the two equal at the call; it cannot make them one object.
- A local read out of a container that also holds a String, then mutated by a name String owns, is narrowed to that String by the shared-mutable-string pass (#3227) before this table sees it. That is a decision of the narrowing pass, not of the dispatch.
- The exclusive-name handle face from 6c682db1 keeps its own lookup (`ty_poly_handle_face`); only its pin is shared. Its names become rows when the table grows owner bits for handle kinds.
- The remaining ~180 (class, method) pairs the poly path lacks (File, Float, Integer, MatchData, StringScanner, Thread, ...) are now rows rather than code, and come in their own rounds with their own coercions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for array and enumerable methods when the receiver’s type is determined at runtime.
  - Added safer handling for typed array updates, including validation of element types and correct length updates.
  - Added clear errors for unsupported receivers, frozen arrays, invalid rows, and incompatible values.

- **Bug Fixes**
  - Improved boxed-array operations, mutation behavior, nested-array methods, and method dispatch consistency.
  - Added coverage for sorting, filtering, filling, transposing, and other array operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->