### PR TITLE
Dispatch a name String and Array share on the receiver's run-time kind

### DIFF
--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -3505,7 +3505,7 @@ static sp_PolyArray *sp_poly_set_operand(sp_RbVal v) {
   if (v.tag == SP_TAG_OBJ && sp_poly_is_array_kind(v.cls_id))
     return sp_poly_to_poly_array(v);
   sp_raise_cls("TypeError", sp_sprintf("no implicit conversion of %s into Array",
-                                       sp_poly_class_name(v)));
+                                       sp_convert_src_name(v)));
   return NULL;  /* unreachable: sp_raise_cls is noreturn */
 }
 /* Coerce a poly value that a container-read Array method (find/reject/sort/
@@ -5691,6 +5691,26 @@ static sp_RbVal sp_poly_str_become(sp_RbVal v, const char *s) {
   if (sp_poly_is_strbuf(v)) { sp_String_set_bin((sp_String *)v.v.p, s); return v; }
   sp_str_check_mutable(v.v.s);
   return sp_box_str(s);
+}
+/* The same through a receiver that is no variable -- an element read, a Hash
+   value: a shared handle absorbs the new contents and every alias observes
+   the change; a plain string box has nowhere to send them, and the call
+   raises the NoMethodError it raised before the row existed, rather than a
+   mutation that silently goes nowhere. */
+static sp_RbVal sp_poly_str_become_handle(sp_RbVal v, const char *s, const char *name) {
+  if (sp_poly_is_strbuf(v)) { sp_String_set_bin((sp_String *)v.v.p, s); return v; }
+  sp_raise_nomethod(sp_nomethod_msg(name, v));
+  return v;
+}
+/* Are the contents a mutator answered the receiver's own? Then it changed
+   nothing, and a mutator that writes only when it changed something (scrub!)
+   writes nothing -- and raises no FrozenError for a write that never happens,
+   as CRuby does not. Only such a row asks: sub! with no match answers its
+   receiver's own contents too, and CRuby raises for it. */
+static int sp_poly_str_is_own(sp_RbVal v, const char *s) {
+  if (v.tag == SP_TAG_STR) return v.v.s == s;
+  if (sp_poly_is_strbuf(v)) return ((sp_String *)v.v.p)->data == s;
+  return 0;
 }
 static sp_RbVal sp_poly_insert(sp_RbVal v, sp_int i, sp_RbVal x) {
   /* String#insert on a boxed receiver: splice at a character index, where a

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -4083,7 +4083,7 @@ static int emit_poly_builtin_method(Compiler *c, int id, Buf *b) {
       {"capitalize!","capitalize",0,1},{"swapcase!","swapcase",0,1},
       {"strip!","strip",0,1},{"lstrip!","lstrip",0,1},{"rstrip!","rstrip",0,1},
       {"chomp!","chomp",0,1},{"chop!","chop",0,1},{"squeeze!","squeeze",0,1},
-      {"reverse!","reverse",0,0},{"succ!","succ",0,0},{"next!","succ",0,0},
+      {"succ!","succ",0,0},{"next!","succ",0,0},
       {"delete_prefix!","delete_prefix",1,1},{"delete_suffix!","delete_suffix",1,1},
       {"delete!","delete",1,1},
       {"gsub!","gsub",2,1},{"sub!","sub",2,1},{"tr!","tr",2,1},{"tr_s!","tr_s",2,1},

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -1902,8 +1902,9 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
         if (from) { buf_printf(b, "%s(", from); emit_expr(c, argv[ai], b); buf_puts(b, ")"); }
         else if (at == TY_POLY || at == TY_UNKNOWN) {
           /* a boxed argument (a rest param widened to poly): unbox to the
-             working array through the runtime kind dispatch (#3317) */
-          buf_puts(b, "sp_poly_to_poly_array("); emit_boxed(c, argv[ai], b); buf_puts(b, ")");
+             working array through the runtime kind dispatch (#3317); one
+             that is no Array is CRuby's TypeError, not an empty list */
+          buf_puts(b, "sp_poly_set_operand("); emit_boxed(c, argv[ai], b); buf_puts(b, ")");
         }
         else emit_expr(c, argv[ai], b);   /* already a poly array */
         buf_printf(b, "; SP_GC_ROOT(_t%d);", base + ai);
@@ -11207,6 +11208,15 @@ static int splice_recv_index_slot(Compiler *c, int recv, int *outer, int *oidx) 
   return 1;
 }
 
+/* Is the receiver a variable? A String mutator's new contents go back into
+   one; a receiver that is no variable -- an element read, a Hash value -- can
+   take them only through a shared handle, and only from a mutator whose value
+   is those contents (PF_VAL_SELF): the typed emitter leaves them in the
+   receiver's temp for a variable alone. */
+static int face_str_var_recv(const NodeTable *nt, int recv) {
+  const char *rvt = nt_type(nt, recv);
+  return rvt && (sp_streq(rvt, "LocalVariableReadNode") || sp_streq(rvt, "InstanceVariableReadNode"));
+}
 /* One owner's arm: unbox `box` (a temp holding the boxed receiver, or 0 to
    unbox the receiver expression itself) to `kind`'s representation in the
    statement prelude, override the receiver node with the temp, retype and
@@ -11286,13 +11296,37 @@ static TyKind emit_face_arm(Compiler *c, int id, unsigned kind, unsigned flags, 
     free(cb.p);
     return slot;
   }
-  /* A mutator worked on the poly copy a typed array was normalized to, and
-     the original has to take the result back once the value is taken. */
-  if ((flags & PF_MUT) && box && (kind == PF_ARRAY)) {
+  /* A mutator worked on the unboxed representation -- the poly copy a typed
+     array was normalized to, the text a string box stands for -- and the
+     original has to take the result back once the value is taken. */
+  if ((flags & PF_MUT) && box && (kind == PF_ARRAY || kind == PF_STRING)) {
     Buf wb; memset(&wb, 0, sizeof wb);
     int tr = ++g_tmp;
     int has_val = nat != TY_VOID && nat != TY_UNKNOWN;
-    buf_printf(&wb, "sp_poly_arr_writeback(_t%d, _t%d)", box, t);
+    if (kind == PF_ARRAY) buf_printf(&wb, "sp_poly_arr_writeback(_t%d, _t%d)", box, t);
+    else {
+      /* The new contents -- the value itself when the mutator answers self,
+         else the temp the typed emitter took the receiver's variable from and
+         wrote to -- go back into the receiver's variable: a shared handle
+         absorbs them, so a container the value came from observes the change;
+         a plain string box is replaced, the way the typed path replaces its
+         own. A receiver that is no variable (face_str_var_recv) has a handle
+         to absorb them or nowhere to send them, and then raises what the call
+         raised before the row existed, rather than a mutation that silently
+         goes nowhere. Contents that are the receiver's own mean no write at
+         all when the row says so (scrub!). */
+      int var = face_str_var_recv(nt, recv);
+      int nv = ((flags & PF_VAL_SELF) && has_val) ? tr : t;
+      if (var) {
+        emit_expr(c, recv, &wb); buf_puts(&wb, " = ");
+        if (flags & PF_SAME_OK) buf_printf(&wb, "sp_poly_str_is_own(_t%d, _t%d) ? _t%d : ", box, nv, box);
+        buf_printf(&wb, "sp_poly_str_become(_t%d, _t%d)", box, nv);
+      }
+      else {
+        if (flags & PF_SAME_OK) buf_printf(&wb, "if (!sp_poly_str_is_own(_t%d, _t%d)) ", box, nv);
+        buf_printf(&wb, "sp_poly_str_become_handle(_t%d, _t%d, \"%s\")", box, nv, name);
+      }
+    }
     if (!has_val) buf_printf(val, "({ (void)(%s); %s; })", call, wb.p);
     else buf_printf(val, "({ %s _t%d = %s; %s; _t%d; })", c_type_name(nat), tr, call, wb.p, tr);
     free(wb.p);
@@ -11359,7 +11393,8 @@ static int emit_face_reentry(Compiler *c, int id, unsigned kind, unsigned flags,
   int box = 0;
   Buf pre = {0, 0, 0}, val = {0, 0, 0};
   TyKind nat = TY_UNKNOWN;
-  if ((flags & PF_MUT) && (kind == PF_ARRAY)) box = ++g_tmp;
+  if ((flags & PF_MUT) && kind == PF_STRING && !(flags & PF_VAL_SELF) && !face_str_var_recv(nt, recv)) return 0;
+  if ((flags & PF_MUT) && (kind == PF_ARRAY || kind == PF_STRING)) box = ++g_tmp;
   if (!face_probe_arm(c, id, kind, flags, box, &pre, &val, &nat)) {
     free(pre.p); free(val.p);
     return 0;
@@ -11373,6 +11408,112 @@ static int emit_face_reentry(Compiler *c, int id, unsigned kind, unsigned flags,
   if (pre.p) buf_puts(g_pre, pre.p);
   emit_face_value(c, comp_ntype(c, id), nat, val.p ? val.p : "0", b);
   free(pre.p); free(val.p);
+  return 1;
+}
+
+/* The run-time test that the boxed value in temp `t` is of an owner's kind. */
+static void emit_face_kind_test(unsigned kind, int t, Buf *b) {
+  switch (kind) {
+    case PF_STRING: buf_printf(b, "(_t%d.tag == SP_TAG_STR || sp_poly_is_strbuf(_t%d))", t, t); break;
+    case PF_INT:    buf_printf(b, "(_t%d.tag == SP_TAG_INT)", t); break;
+    case PF_ARRAY:  buf_printf(b, "(_t%d.tag == SP_TAG_OBJ && sp_poly_is_array_kind(_t%d.cls_id))", t, t); break;
+    case PF_HASH:   buf_printf(b, "(_t%d.tag == SP_TAG_OBJ && sp_poly_is_hash_kind(_t%d.cls_id))", t, t); break;
+    case PF_ENUM:   buf_printf(b, "(_t%d.tag == SP_TAG_OBJ && (sp_poly_is_array_kind(_t%d.cls_id) || sp_poly_is_hash_kind(_t%d.cls_id)))", t, t, t); break;
+    default:        buf_puts(b, "(0)"); break;
+  }
+}
+
+/* Has the inference typed the argument as some other kind than the owner's
+   own? A poly or unknown one may still be of the owner's kind at run time;
+   any other kind cannot be, whether or not it has a class name of its own (a
+   Boolean is true or false only at run time), so the noun CRuby's TypeError
+   names is spelled from the value when the arm runs. */
+static int face_arg_misfit(Compiler *c, unsigned kind, int arg) {
+  TyKind at = comp_ntype(c, arg);
+  if (at == TY_POLY || at == TY_UNKNOWN) return 0;
+  if (kind == PF_STRING && (at == TY_STRING || at == TY_STRBUF || at == TY_INT)) return 0;  /* a codepoint concatenates too */
+  if (kind == PF_ARRAY && (ty_is_array(at) || at == TY_POLY_ARRAY)) return 0;
+  return 1;
+}
+
+/* Several owners: bind the box once and dispatch on its run-time kind, one
+   re-entry per owner, each with its own coercion and prelude inside its own
+   branch. An arm whose typed emitter declines the call is dropped, under the
+   silent probe the dynamic-send dispatch uses; an arm ruled out by an
+   argument's type raises CRuby's TypeError; a receiver of no owner's kind
+   raises the NoMethodError the call raised before. Answers 0 when no arm
+   survives, and the call falls through to the arms after this one. */
+static int emit_face_switch(Compiler *c, int id, unsigned own, Buf *b) {
+  const NodeTable *nt = c->nt;
+  char name[128];   /* kept, not borrowed: an arm's re-entry may rename the node (see emit_face_arm) */
+  snprintf(name, sizeof name, "%s", nt_str(nt, id, "name"));
+  int recv = nt_ref(nt, id, "receiver");
+  int argc;
+  const int *argv = call_args(nt, id, &argc);
+  int has_blk = nt_ref(nt, id, "block") >= 0;
+  TyKind slot = comp_ntype(c, id);
+  if (slot == TY_UNKNOWN || slot == TY_VOID) slot = TY_POLY;
+  int plain = nt_call_args_plain(nt, id);
+  Buf arms; memset(&arms, 0, sizeof arms);
+  int narm = 0;
+  int box = ++g_tmp, tr = ++g_tmp;
+  for (unsigned kind = 1; kind & PF_OWNERS; kind <<= 1) {
+    if (!(own & kind)) continue;
+    unsigned fl = ty_poly_face_owner_flags(name, argc, has_blk, plain, kind);
+    if ((fl & PF_MUT) && kind == PF_STRING && !(fl & PF_VAL_SELF) && !face_str_var_recv(nt, recv)) continue;
+    int misfit = -1;
+    if ((fl & PF_ARGS_OWN) && plain)
+      for (int i = 0; i < argc && misfit < 0; i++) if (face_arg_misfit(c, kind, argv[i])) misfit = i;
+    Buf pre = {0, 0, 0}, val = {0, 0, 0};
+    TyKind nat = TY_UNKNOWN;
+    int ok = 1;
+    if (misfit >= 0) {
+      /* the arguments are evaluated for their effects and in order, as the
+         typed arm would, and under the arm's own prelude, so an argument
+         that needs one runs it in this branch alone; the one that cannot
+         convert is kept to name itself (nil, true and false spell themselves,
+         an object its class) */
+      Buf *sv_pre = g_pre; g_pre = &pre;
+      int tm = ++g_tmp;
+      buf_printf(&val, "sp_RbVal _t%d = sp_box_nil(); SP_GC_ROOT_RBVAL(_t%d); (void)(", tm, tm);
+      for (int i = 0; i < argc; i++) {
+        if (i) buf_puts(&val, ", ");
+        if (i == misfit) buf_printf(&val, "(_t%d = ", tm);
+        emit_boxed(c, argv[i], &val);
+        if (i == misfit) buf_puts(&val, ")");
+      }
+      buf_printf(&val, "); sp_raise_cls(\"TypeError\", sp_sprintf(\"no implicit conversion of %%s into %s\", sp_convert_src_name(_t%d)))",
+                 kind == PF_STRING ? "String" : "Array", tm);
+      g_pre = sv_pre;
+    }
+    else ok = face_probe_arm(c, id, kind, fl, box, &pre, &val, &nat);
+    if (!ok) { free(pre.p); free(val.p); continue; }
+    if (narm) buf_puts(&arms, "}\nelse ");
+    buf_puts(&arms, "if ");
+    emit_face_kind_test(kind, box, &arms);
+    buf_puts(&arms, " { ");
+    if (pre.p) buf_puts(&arms, pre.p);
+    if (misfit >= 0) buf_printf(&arms, "%s;", val.p);
+    else {
+      buf_printf(&arms, "_t%d = ", tr);
+      emit_face_value(c, slot, nat, val.p ? val.p : "0", &arms);
+      buf_puts(&arms, ";");
+    }
+    buf_puts(&arms, " ");
+    narm++;
+    free(pre.p); free(val.p);
+  }
+  if (!narm) { free(arms.p); return 0; }
+  /* The box's declaration goes to the prelude only now: the arms name it,
+     but whether any survived to need it is known only after they are built. */
+  Buf rb; memset(&rb, 0, sizeof rb); emit_boxed(c, recv, &rb);
+  emit_indent(g_pre, g_indent);
+  buf_printf(g_pre, "sp_RbVal _t%d = %s; SP_GC_ROOT_RBVAL(_t%d);\n", box, rb.p ? rb.p : "sp_box_nil()", box);
+  free(rb.p);
+  buf_printf(b, "({ %s _t%d = %s; ", c_type_name(slot), tr, default_value(slot));
+  buf_puts(b, arms.p);
+  buf_printf(b, "}\nelse sp_raise_nomethod(sp_nomethod_msg(\"%s\", _t%d)); _t%d; })", name, box, tr);
+  free(arms.p);
   return 1;
 }
 
@@ -11523,10 +11664,9 @@ int emit_poly_call(Compiler *c, int id, Buf *b) {
   /* The face table (types.h): unbox the receiver to the kind that owns the
      name, retype the receiver node and re-enter the same call, so the typed
      emitter IS the implementation and the inference, which answered under
-     the same pin, has already sized the result slot to it. The Hash face is
-     not taken here: it is the last resort, in emit_unresolved_call, so that
-     a poly-receiver emitter of its own claims the name first. A name several
-     kinds own is left to the arms after this one for now. */
+     the same pin, has already sized the result slot to it. The last-resort
+     rows are not taken here: the Hash face answers in emit_unresolved_call,
+     once every poly-receiver emitter of its own has declined the name. */
   if (recv >= 0 && rt == TY_POLY && !user_defines_or_reads(c, name) &&
       g_n_argov < MAX_ARG_OVERRIDE) {
     int has_blk = nt_ref(nt, id, "block") >= 0;
@@ -11534,6 +11674,7 @@ int emit_poly_call(Compiler *c, int id, Buf *b) {
     unsigned kinds = own & PF_OWNERS;
     if (own & PF_STR_BANG) { emit_face_str_bang(c, id, own, b); return 1; }
     if (kinds && !(kinds & (kinds - 1)) && emit_face_reentry(c, id, kinds, own, b)) return 1;
+    if (kinds && (kinds & (kinds - 1)) && emit_face_switch(c, id, kinds, b)) return 1;
     /* a declined re-entry may have renamed the node and restored it into
        fresh storage (see emit_face_arm): the name is read again */
     name = nt_str(nt, id, "name");

--- a/src/types.c
+++ b/src/types.c
@@ -52,6 +52,17 @@ static const PolyFace ty_poly_face_tbl[] = {
   {"to_ary", PF_ARRAY, 0, 0, 0}, {"transpose", PF_ARRAY, 0, 0, 0},
   /* and the Enumerable names that had no arm at all */
   {"grep", PF_ENUM, 1, 1, -1}, {"minmax_by", PF_ENUM, 0, 0, 1},
+  /* The String mutators String alone owns. */
+  {"setbyte", PF_STRING | PF_MUT, 2, 2, 0}, {"scrub!", PF_STRING | PF_MUT | PF_VAL_SELF | PF_SAME_OK, 0, 1, -1},
+  {"bytesplice", PF_STRING | PF_MUT | PF_VAL_SELF, 2, 5, 0}, {"append_as_bytes", PF_STRING | PF_MUT | PF_VAL_SELF, 0, -1, 0},
+  /* The names String and Array share: the receiver's run-time kind picks
+     the arm. concat's arguments are of the receiver's own kind in CRuby
+     (a String concatenates Strings, an Array Arrays), so an argument the
+     inference has typed as the other kind rules that arm out. */
+  {"concat", PF_STRING | PF_MUT | PF_ARGS_OWN | PF_VAL_SELF, 0, -1, 0}, {"concat", PF_ARRAY | PF_MUT | PF_ARGS_OWN, 0, -1, 0},
+  {"prepend", PF_STRING | PF_MUT | PF_ARGS_OWN | PF_VAL_SELF, 0, -1, 0}, {"prepend", PF_ARRAY | PF_MUT, 0, -1, 0},
+  {"reverse!", PF_STRING | PF_MUT | PF_VAL_SELF, 0, 0, 0}, {"reverse!", PF_ARRAY | PF_MUT, 0, 0, 0},
+  {"slice!", PF_STRING | PF_MUT, 1, 2, 0}, {"slice!", PF_ARRAY | PF_MUT, 1, 2, 0},
   /* The read-only Hash/Enumerable face. */
   {"dig", PF_HASH | PF_LAST, 0, -1, -1}, {"value?", PF_HASH | PF_LAST, 0, -1, -1}, {"has_value?", PF_HASH | PF_LAST, 0, -1, -1},
   {"invert", PF_HASH | PF_LAST, 0, -1, -1}, {"assoc", PF_HASH | PF_LAST, 0, -1, -1}, {"rassoc", PF_HASH | PF_LAST, 0, -1, -1}, {"key", PF_HASH | PF_LAST, 0, -1, -1},
@@ -85,6 +96,16 @@ unsigned ty_poly_face_owners(const char *name, int argc, int has_blk, int plain,
     own |= r->flags;
   }
   return own;
+}
+unsigned ty_poly_face_owner_flags(const char *name, int argc, int has_blk, int plain, unsigned owner) {
+  unsigned fl = 0;
+  if (!name) return 0;
+  for (const PolyFace *r = ty_poly_face_tbl; r->name; r++) {
+    if (!(r->flags & owner) || !sp_streq(name, r->name)) continue;
+    if (!face_row_matches(r, argc, has_blk, plain)) continue;
+    fl |= r->flags;
+  }
+  return fl;
 }
 int ty_poly_hash_face_name(const char *nm) {
   if (!nm) return 0;

--- a/src/types.h
+++ b/src/types.h
@@ -55,6 +55,9 @@ enum {
   PF_MUT      = 1 << 8,  /* mutates the receiver: the result is written back through the box */
   PF_STR_BANG = 1 << 9,  /* String value-form bang: re-enter the plain name, nil when unchanged */
   PF_STR_SELF = 1 << 10, /* ... but a bang that answers self (succ!/next!): never nil */
+  PF_ARGS_OWN = 1 << 11, /* the arguments must be of the owner's own kind (concat) */
+  PF_VAL_SELF = 1 << 12, /* a String mutator whose value is the receiver's new contents */
+  PF_SAME_OK  = 1 << 14, /* ... and contents that are the receiver's own mean no write, so no frozen check (scrub!) */
   PF_LAST     = 1 << 13  /* answers only once no poly-receiver emitter of its own has claimed the name */
 };
 typedef struct {
@@ -72,6 +75,9 @@ typedef struct {
    answers it, which is how the name lists this table replaced answered.
    0 when no row matches. */
 unsigned ty_poly_face_owners(const char *name, int argc, int has_blk, int plain, int with_last);
+/* The flags of the rows that give `owner` the name at this call shape: the
+   owner's own write-back and argument rules, apart from the other owners'. */
+unsigned ty_poly_face_owner_flags(const char *name, int argc, int has_blk, int plain, unsigned owner);
 /* Does the read-only Hash face answer `name` in some form? The face sites
    ask by name alone, before the call's shape is known. */
 int ty_poly_hash_face_name(const char *nm);

--- a/test/boxed_string_methods.rb
+++ b/test/boxed_string_methods.rb
@@ -1,0 +1,106 @@
+# String mutators on a receiver whose class is only known at run time, and
+# the names String and Array share. Covers the String-only mutators writing
+# back through the box (setbyte, scrub!, bytesplice, append_as_bytes); the
+# shared names (concat, prepend, reverse!, slice!) on a parameter that is a
+# String at one call site and an Array at another, picking the arm by the
+# receiver's run-time kind; the result flowing into a slot the inference
+# widened to poly; the TypeError an argument of the other kind raises; and
+# the NoMethodError a receiver of neither kind raises.
+s = "seed"
+s = ["hello".dup, 42][0]
+p s.setbyte(0, 72)
+p s.scrub!
+p s.bytesplice(1, 1, "a")
+p s.append_as_bytes(" world")
+p s
+
+def tack(x, y)
+  x.concat(y)
+end
+def lead(x, y)
+  x.prepend(y)
+end
+def flip(x)
+  x.reverse!
+end
+def cut(x, i, n)
+  x.slice!(i, n)
+end
+def head(x)
+  x.slice!(0)
+end
+
+p tack("ab".dup, "c")
+p tack([1, 2], [3])
+p lead("ab".dup, ">")
+p lead([1, 2], 0)
+p flip("abc".dup)
+p flip([1, 2, 3])
+p cut("abcdef".dup, 1, 3)
+p cut([1, 2, 3, 4], 1, 2)
+p head("xyz".dup)
+p head([7, 8, 9])
+
+# the value keeps the receiver's kind: a String's answer is a String
+t = tack("q".dup, "r")
+p t.upcase
+u = flip([4, 5])
+p u.sum
+
+# a slot that held a typed value on an early pass and the box on the last
+v = [9, 8]
+v = [[7, 6], 5][0]
+p v.reverse!
+
+begin
+  x = [[1], 2][0]
+  x.concat("z")
+rescue TypeError => e
+  puts e.message
+end
+begin
+  lead("ab".dup, [1])
+rescue TypeError => e
+  puts e.message
+end
+begin
+  flip(5)
+rescue NoMethodError => e
+  puts e.message
+end
+
+# the receiver's variable takes the new contents back whatever the mutator
+# answers -- the removed part, the scrubbed text -- and so does an
+# instance variable
+w = ["abcdef".dup, 1][0]
+p w.slice!(1, 3)
+p w
+z = ["a\xffb".dup, 1][0]
+p z.scrub!
+p z
+@q = ["ab".dup, 0][0]
+@q.concat("c")
+@q.prepend(">")
+p @q.reverse!
+p @q
+
+# an argument of a kind that is never the receiver's own is named as CRuby
+# names it, whether the kind is known when the program is compiled (a
+# Boolean is true or false only when it runs) or only when it runs
+begin
+  x.concat(1 > 0)
+rescue TypeError => e
+  puts e.message
+end
+begin
+  w.concat(nil)
+rescue TypeError => e
+  puts e.message
+end
+[true, nil, 1.5].each do |v|
+  begin
+    tack(x, v)
+  rescue TypeError => e
+    puts e.message
+  end
+end

--- a/test/boxed_string_methods.rb.expected
+++ b/test/boxed_string_methods.rb.expected
@@ -1,0 +1,32 @@
+72
+"Hello"
+"Hallo"
+"Hallo world"
+"Hallo world"
+"abc"
+[1, 2, 3]
+">ab"
+[0, 1, 2]
+"cba"
+[3, 2, 1]
+"bcd"
+[2, 3]
+"x"
+7
+"QR"
+9
+[6, 7]
+no implicit conversion of String into Array
+no implicit conversion of Array into String
+undefined method 'reverse!' for an instance of Integer
+"bcd"
+"aef"
+"a�b"
+"a�b"
+"cba>"
+"cba>"
+no implicit conversion of true into Array
+no implicit conversion of nil into String
+no implicit conversion of true into Array
+no implicit conversion of nil into Array
+no implicit conversion of Float into Array


### PR DESCRIPTION
## Why

The owner table that serves the builtin surface on a boxed receiver (#4173) can hold a name several kinds own -- the one thing the lists it replaced could not -- but nothing yet reads such a row. So `concat`, `prepend`, `reverse!` and `slice!` on a boxed value, which String and Array both answer, still raise `NoMethodError` for a String and for an Array alike, naming the class that defines them; and `setbyte`, `scrub!`, `bytesplice` and `append_as_bytes` on a boxed String raise because the String arm has no write-back at all.

This PR makes a multi-owner name dispatch on the receiver's run-time kind -- the box bound once, one re-entry per owner inside its own branch, the `NoMethodError` the call raised before as the default -- and gives the String mutators a write-back into the receiver's variable, so a container the value came from observes the change. Eight names that raised now answer as CRuby does on a receiver that is a variable, with one exception named under "left alone" (a boxed Array whose element type cannot hold the argument raises a store `TypeError` rather than widening); a boxed receiver of the wrong kind still raises what it raised before, and an arm ruled out by an argument's static type raises CRuby's `TypeError`. The generated C for optcarrot and every benchmark is byte-identical to master's; the tests whose C changes are the ones that reach these names, and all pass with their existing expectations.

## What

- `concat`, `prepend`, `reverse!` and `slice!` on a boxed value raised for a String and for an Array alike: a list keyed by name cannot hold a name two classes own, since the receiver's class is unknown when the list is read.
- `setbyte`, `scrub!`, `bytesplice` and `append_as_bytes` on a boxed String raised: the String arm had no write-back.
- `Array#concat` with a boxed argument that is no Array appended nothing where CRuby raises `TypeError`.

## How

- **Several owners**: the box is bound once and its kind tested at run time, one re-entry per owner inside its own branch with its own prelude, and the `NoMethodError` the call raised before as the default -- nothing that raised starts silently succeeding. Because the re-entry probe already restores everything it touched (#4173), a declined owner just drops its arm and the others stand. An arm ruled out by an argument's static type (`concat`'s, and `String#prepend`'s, arguments are of the receiver's own kind) raises CRuby's `TypeError`, naming the value as CRuby names it -- `nil`, `true` and `false` spell themselves, which matters because a Boolean is `true` or `false` only at run time -- and so does a boxed argument of `Array#concat` that is no Array (`sp_poly_set_operand`, which now spells those three the same way). Owners that answer different types leave the call poly and each arm boxes its value.
- **String write-back**: the new contents go back into the receiver's variable, a local or an instance variable: a shared handle absorbs them, so a container the value came from observes the change; a plain string box is replaced, the way the typed path replaces its own. A receiver that is no variable -- an element read, a Hash value -- takes them only from a mutator whose value is those contents (`concat`, `prepend`, `reverse!`, `bytesplice`, `append_as_bytes`, `scrub!`; the typed emitter leaves `slice!`'s and `setbyte`'s in the receiver's temp for a variable alone) and only through a shared handle (`sp_poly_str_become_handle`); a plain box there has nowhere to send them, and the call raises the `NoMethodError` it raised before, rather than a mutation that silently goes nowhere. The #3227 tests that reached `prepend`, `concat` and `reverse!` on a shared handle through the builtin-method arms now take this arm, with the same output. `scrub!` answers self in CRuby, so its value is the new contents, and contents that are the receiver's own mean it scrubbed nothing: no write, so no frozen check (`"abc".freeze.scrub!` answers `"abc"` in CRuby too). That is a row flag (`PF_SAME_OK`) for `scrub!` alone, because `sub!` with no match answers its own contents too and CRuby raises for it; the value-form bang rows are untouched, and every bang name on a frozen, unchanged boxed string raises exactly as CRuby does.

## Validation

- A new test, `test/boxed_string_methods` (expectations generated by CRuby 4.0): the shared names on a parameter that is a String at one call site and an Array at another, the mutators writing back through a local, an instance variable and a shared handle, the `TypeError` cases with the argument named at compile time and at run time, and the `NoMethodError` case.
- Full suite: 3,311 test cases pass, 0 fail, from a cleared results cache.
- Generated C against master, over the 3,276 suite programs, optcarrot and the 61 benchmarks: byte-identical for every program except the new test and seven existing ones -- `bang_result_through_shared_handle`, `concat_boxed_source`, `issue_3227_container_read_mutation`, `issue_3227_corners`, `issue_3227_matrix`, `issue_3227_poly_mutators`, `issue_3317_reader_concat_splat` -- which are the programs that reach `concat`, `prepend` or `reverse!` on a shared handle, or `Array#concat` with a boxed argument, and all pass with their existing expectations. optcarrot and the 61 benchmarks are byte-identical; optcarrot's compile time is unchanged (4.0-4.2 s either way on this machine).
- `boxed_string_methods`, `boxed_array_methods` and `issue_3227_container_read_mutation` run clean under `SPINEL_GC_STRESS=1` and ASAN+UBSAN, with the expected output. The inference fixpoint converges on every suite program (at most 11 rounds), in the same number of rounds as under master for every one of them.
- Against the differential corpus (~2,100 minimized programs; the same corpus behind #3999/#4003/#4029/#4050/#4057/#4144/#4153/#4173): 697 → 705 match, 8 gained (the seven shared or String-only names on a boxed receiver, and `scrub!` on a String read out of an Array) and 0 lost.

## Left alone, on purpose

- A boxed Array whose element type cannot hold what `concat` or `prepend` brings: `def c(x, y) = x.concat(y); c("a".dup, "b"); p c([1], ["z"])` raises `can't store String in an Array of Integer through a boxed receiver (TypeError)` where CRuby answers `[1, "z"]` and master raised `NoMethodError`. The typed origin cannot hold the element and the inference cannot see the call widen it -- the same diagnosis #4173 gives `map!`: proof against a wrong answer, not yet CRuby's answer.
- A plain (non-handle) String box mutated through a method parameter does not reach the caller's variable: `def tack(x, y) = x.concat(y); a = "ab".dup; tack(a, "c"); tack([1], [2]); p a` prints `"ab"` where CRuby prints `"abc"` (with the second call site gone, `x` is typed and the typed path's return handle keeps the aliasing). The boxed path has no handle to write through. Pre-existing for `upcase!`, wider now.
- A String mutator on a receiver that is no variable and no shared handle -- `h[:k].concat("x")` on a Hash of plain strings, a global -- raises the `NoMethodError` it raised on master, where CRuby mutates in place: a plain box has nowhere to send the new contents, and a silent no-op would be worse than the raise. `slice!` and `setbyte` on any receiver that is no variable (`arr[0].slice!(1)`) raise the same way, since their value is not the new contents.
- A local read out of a container that also holds a String, then mutated by a name String owns, is narrowed to that String by the shared-mutable-string pass (#3227) before the table sees it; `rows = [[1, 2], "x"]; a = rows[0]; a.reverse!` therefore still compiles the String body and answers `""` where CRuby answers `[2, 1]`, as on master.
- The builtin-method arms for `prepend`/`concat`/`bytesplice` on a shared handle in `codegen_call.c` stay: a call with a splat argument still reaches them, since a row that does not ask for a block declines a non-plain argument list (that shape fails to compile on master too, unchanged here). The `reverse!` row of that dispatch's bang table cannot be reached any more and is dropped.
- `String#slice!(i, 0)` answers `nil` where CRuby answers `""`, through the box as on the typed path: the typed emitter's, not the table's.
- The names Array and Hash share (`compact!`, `assoc`, `rassoc`, `fetch_values`) and the Hash mutators (`merge!`) need the Hash write-back, and come next.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved runtime dispatch for boxed String and Array mutation methods.
  * Added support for shared mutation through variables and instance variables.
  * Improved handling of polymorphic receivers and return values.

* **Bug Fixes**
  * Corrected operand type errors for `nil`, `true`, and `false`.
  * Improved `NoMethodError` and `TypeError` behavior for unsupported operations.
  * Fixed mutation handling for change-only String methods and shared aliases.

* **Tests**
  * Added comprehensive coverage for boxed String mutations, dispatch, return values, and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->