### PR TITLE
Serve the Hash mutators and the names Array and Hash share on a boxed receiver

### DIFF
--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -8979,6 +8979,116 @@ static void *sp_poly_as_handle(sp_RbVal v, int cls_id, const char *nm) {
   sp_raise_nomethod(sp_nomethod_msg(nm, v));
   return NULL;
 }
+/* The receiver of a Hash method reached through a boxed value, as the
+   general hash (sp_poly_as_pp_hash); a mutator (`mut`) refuses a frozen
+   original here, before the typed emitter works on the copy. */
+static sp_PolyPolyHash *sp_poly_hash_recv(sp_RbVal v, const char *m, int mut) {
+  if (mut && v.tag == SP_TAG_OBJ && sp_poly_is_hash_kind(v.cls_id) && sp_gc_is_frozen(v.v.p))
+    sp_raise_frozen_hash_at(v.v.p, v.cls_id);
+  return sp_poly_as_pp_hash(v, m);
+}
+/* A key or value the typed original has no representation for: the
+   sibling of sp_raise_writeback_kind for a hash. */
+SP_NORETURN SP_COLD static void sp_raise_hash_writeback_kind(sp_RbVal v, const char *what, const char *into) {
+  sp_raise_cls("TypeError", sp_sprintf("can't store %s as a %s in a Hash of %s through a boxed receiver",
+                                       v.tag == SP_TAG_BIGINT ? "a bignum" : sp_poly_class_name(v), what, into));
+}
+/* A String- or Integer-valued variant holds nil natively (a NULL, the int
+   nil sentinel), so a nil the original already held is its own to keep. A
+   shared-mutable handle is a String too -- the value a local stored here and
+   appended to afterwards -- and goes in by its contents, as it does through
+   sp_poly_arr_writeback. */
+static void sp_hash_wb_want(sp_RbVal v, int tag, int nil_ok, const char *what, const char *into) {
+  if (v.tag == tag || (nil_ok && v.tag == SP_TAG_NIL)) return;
+  if (tag == SP_TAG_STR && sp_poly_is_strbuf(v)) return;
+  sp_raise_hash_writeback_kind(v, what, into);
+}
+/* A mutator's write-back through a boxed hash: sp_poly_as_pp_hash gives a
+   typed variant as a general COPY, so a merge! or compact! that ran on the
+   copy never reached the original. Replace the original's entries with the
+   copy's, in its own representation; a general hash shares storage and needs
+   nothing. An entry the variant cannot hold -- a String key merged into a
+   Symbol-keyed hash, a String value into an Integer-valued one -- is refused
+   rather than coerced into a key or value it was not. Frozenness was refused
+   at the coercion, before the mutator ran, and is refused again here for an
+   original frozen since -- by its own argument, say. */
+static void sp_poly_hash_writeback(sp_RbVal orig, sp_PolyPolyHash *work) {
+  if (orig.tag != SP_TAG_OBJ || !work || !orig.v.p) return;
+  if (orig.cls_id == SP_BUILTIN_POLY_POLY_HASH) return;
+  if (!sp_poly_is_hash_kind(orig.cls_id)) return;
+  if (sp_gc_is_frozen(orig.v.p)) sp_raise_frozen_hash_at(orig.v.p, orig.cls_id);
+  SP_GC_ROOT_RBVAL(orig); SP_GC_ROOT(work);
+  for (sp_int i = 0; i < work->len; i++) {
+    sp_int j = work->order[i];
+    sp_RbVal k = work->keys[j], v = work->vals[j];
+    switch (orig.cls_id) {
+      case SP_BUILTIN_STR_INT_HASH: sp_hash_wb_want(k, SP_TAG_STR, 0, "key", "String keys"); sp_hash_wb_want(v, SP_TAG_INT, 1, "value", "Integer values"); break;
+      case SP_BUILTIN_STR_STR_HASH: sp_hash_wb_want(k, SP_TAG_STR, 0, "key", "String keys"); sp_hash_wb_want(v, SP_TAG_STR, 1, "value", "String values"); break;
+      case SP_BUILTIN_INT_STR_HASH: sp_hash_wb_want(k, SP_TAG_INT, 0, "key", "Integer keys"); sp_hash_wb_want(v, SP_TAG_STR, 1, "value", "String values"); break;
+      case SP_BUILTIN_INT_INT_HASH: sp_hash_wb_want(k, SP_TAG_INT, 0, "key", "Integer keys"); sp_hash_wb_want(v, SP_TAG_INT, 1, "value", "Integer values"); break;
+      case SP_BUILTIN_STR_POLY_HASH: sp_hash_wb_want(k, SP_TAG_STR, 0, "key", "String keys"); break;
+      case SP_BUILTIN_SYM_POLY_HASH: sp_hash_wb_want(k, SP_TAG_SYM, 0, "key", "Symbol keys"); break;
+      default: return;
+    }
+  }
+  switch (orig.cls_id) {
+    case SP_BUILTIN_STR_INT_HASH: {
+      sp_StrIntHash *h = (sp_StrIntHash *)orig.v.p;
+      sp_StrIntHash_clear(h);
+      for (sp_int i = 0; i < work->len; i++) {
+        sp_int j = work->order[i];
+        sp_StrIntHash_set(h, sp_poly_to_s(work->keys[j]), sp_poly_to_i_or_nil(work->vals[j]));
+      }
+      return;
+    }
+    case SP_BUILTIN_STR_STR_HASH: {
+      sp_StrStrHash *h = (sp_StrStrHash *)orig.v.p;
+      sp_StrStrHash_clear(h);
+      for (sp_int i = 0; i < work->len; i++) {
+        sp_int j = work->order[i];
+        sp_StrStrHash_set(h, sp_poly_to_s(work->keys[j]), sp_poly_to_s_or_nil(work->vals[j]));
+      }
+      return;
+    }
+    case SP_BUILTIN_INT_STR_HASH: {
+      sp_IntStrHash *h = (sp_IntStrHash *)orig.v.p;
+      sp_IntStrHash_clear(h);
+      for (sp_int i = 0; i < work->len; i++) {
+        sp_int j = work->order[i];
+        sp_IntStrHash_set(h, sp_poly_to_i(work->keys[j]), sp_poly_to_s_or_nil(work->vals[j]));
+      }
+      return;
+    }
+    case SP_BUILTIN_INT_INT_HASH: {
+      sp_IntIntHash *h = (sp_IntIntHash *)orig.v.p;
+      sp_IntIntHash_clear(h);
+      for (sp_int i = 0; i < work->len; i++) {
+        sp_int j = work->order[i];
+        sp_IntIntHash_set(h, sp_poly_to_i(work->keys[j]), sp_poly_to_i_or_nil(work->vals[j]));
+      }
+      return;
+    }
+    case SP_BUILTIN_STR_POLY_HASH: {
+      sp_StrPolyHash *h = (sp_StrPolyHash *)orig.v.p;
+      sp_StrPolyHash_clear(h);
+      for (sp_int i = 0; i < work->len; i++) {
+        sp_int j = work->order[i];
+        sp_StrPolyHash_set(h, sp_poly_to_s(work->keys[j]), work->vals[j]);
+      }
+      return;
+    }
+    case SP_BUILTIN_SYM_POLY_HASH: {
+      sp_SymPolyHash *h = (sp_SymPolyHash *)orig.v.p;
+      sp_SymPolyHash_clear(h);
+      for (sp_int i = 0; i < work->len; i++) {
+        sp_int j = work->order[i];
+        sp_SymPolyHash_set(h, (sp_sym)work->keys[j].v.i, work->vals[j]);
+      }
+      return;
+    }
+    default: return;
+  }
+}
 /* OpenStruct.new(hash) where hash is a runtime value (not a literal): seed the
    member table from the hash's entries, keys coerced to symbols. Copies, so
    mutating the OpenStruct does not alter the source hash (#3194). */

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -5693,6 +5693,9 @@ else {
         TyKind ht = infer_call(c, id);
         an_set_face_node(-1, TY_UNKNOWN);
         if (ht == TY_UNKNOWN) continue;
+        /* a Hash mutator answers its box, not the general copy its emitter
+           worked on (see emit_face_arm) */
+        if (bit == PF_HASH && (ty_poly_face_owner_flags(name, argc, blk, nt_call_args_plain(nt, id), bit) & PF_VAL_SELF)) ht = TY_POLY;
         r = r == TY_UNKNOWN ? ht : ty_unify(r, ht);
       }
       if (r != TY_UNKNOWN) return r;

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -4689,6 +4689,14 @@ void emit_hash_pairs_expr(Compiler *c, int recv, TyKind rt, const char *hn, Buf 
   buf_printf(b, " } _t%d; })", tr);
 }
 
+/* An empty hash literal: no variant to infer, nothing to fold into a merge. */
+static int hash_lit_empty(const NodeTable *nt, int n) {
+  const char *ty = nt_type(nt, n);
+  if (!ty || !(sp_streq(ty, "HashNode") || sp_streq(ty, "KeywordHashNode"))) return 0;
+  int en = 0; nt_arr(nt, n, "elements", &en);
+  return en == 0;
+}
+
 int emit_hash_call(Compiler *c, int id, Buf *b) {
   const NodeTable *nt = c->nt;
   const char *name = nt_str(nt, id, "name");
@@ -5548,22 +5556,33 @@ else {
       }
       if ((sp_streq(name, "merge!") || sp_streq(name, "update")) && argc >= 1 &&
           nt_ref(nt, id, "block") < 0 && rt == TY_POLY_POLY_HASH) {
-        for (int ai = 0; ai < argc; ai++)
-          if (!ty_is_hash(comp_ntype(c, argv[ai]))) return 0;
+        /* An argument that is a Hash at run time only is checked there, as
+           CRuby's implicit conversion would, so a boxed hash merges into
+           another; an empty literal has no variant to infer and nothing to
+           fold in. */
+        for (int ai = 0; ai < argc; ai++) {
+          TyKind at = comp_ntype(c, argv[ai]);
+          if (!ty_is_hash(at) && at != TY_POLY && !hash_lit_empty(nt, argv[ai])) return 0;
+        }
         int tr = ++g_tmp;
         buf_printf(b, "({ sp_PolyPolyHash *_t%d = ", tr); emit_expr(c, recv, b); buf_puts(b, ";");
         buf_printf(b, " if (sp_gc_is_frozen(_t%d)) sp_raise_frozen_hash_at(_t%d, %s);", tr, tr, hash_box_cls(rt));   /* (#3001) */
         for (int ai = 0; ai < argc; ai++) {
+          if (hash_lit_empty(nt, argv[ai])) continue;
           int to = ++g_tmp, ti = ++g_tmp, tp = ++g_tmp;
           buf_printf(b, " sp_RbVal _t%d = ", to); emit_boxed(c, argv[ai], b);
-          buf_printf(b, "; SP_GC_ROOT_RBVAL(_t%d);"
-                        " sp_int _t%d = sp_poly_arr_len_ex(_t%d);"
+          buf_printf(b, "; SP_GC_ROOT_RBVAL(_t%d);", to);
+          if (comp_ntype(c, argv[ai]) == TY_POLY)
+            buf_printf(b, " if (_t%d.tag != SP_TAG_OBJ || !sp_poly_is_hash_kind(_t%d.cls_id))"
+                          " sp_raise_cls(\"TypeError\", sp_sprintf(\"no implicit conversion of %%s into Hash\", sp_convert_src_name(_t%d)));",
+                       to, to, to);
+          buf_printf(b, " sp_int _t%d = sp_poly_arr_len_ex(_t%d);"
                         " for (sp_int _i9 = 0; _i9 < _t%d; _i9++) {"
                         " sp_RbVal _t%d = sp_poly_each_elem(_t%d, _i9);"
                         " sp_PolyPolyHash_set(_t%d,"
                         " sp_PolyArray_get((sp_PolyArray *)_t%d.v.p, 0),"
                         " sp_PolyArray_get((sp_PolyArray *)_t%d.v.p, 1)); }",
-                     to, ti, to, ti, tp, to, tr, tp, tp);
+                     ti, to, ti, tp, to, tr, tp, tp);
         }
         buf_printf(b, " _t%d; })", tr);
         return 1;
@@ -11270,6 +11289,10 @@ static TyKind emit_face_arm(Compiler *c, int id, unsigned kind, unsigned flags, 
          raises the NoMethodError the call raised before */
       buf_printf(g_pre, "sp_PolyArray *_t%d = sp_poly_enum_recv(%s, \"%s\"); SP_GC_ROOT(_t%d);\n", t, rs, name, t);
       break;
+    case PF_HASH:
+      buf_printf(g_pre, "sp_PolyPolyHash *_t%d = sp_poly_hash_recv(%s, \"%s\", %d); SP_GC_ROOT(_t%d);\n",
+                 t, rs, name, (flags & PF_MUT) != 0, t);
+      break;
   }
   free(rb.p);
   g_argov_node[g_n_argov] = recv;
@@ -11299,11 +11322,12 @@ static TyKind emit_face_arm(Compiler *c, int id, unsigned kind, unsigned flags, 
   /* A mutator worked on the unboxed representation -- the poly copy a typed
      array was normalized to, the text a string box stands for -- and the
      original has to take the result back once the value is taken. */
-  if ((flags & PF_MUT) && box && (kind == PF_ARRAY || kind == PF_STRING)) {
+  if ((flags & PF_MUT) && box && (kind == PF_ARRAY || kind == PF_STRING || kind == PF_HASH)) {
     Buf wb; memset(&wb, 0, sizeof wb);
     int tr = ++g_tmp;
     int has_val = nat != TY_VOID && nat != TY_UNKNOWN;
     if (kind == PF_ARRAY) buf_printf(&wb, "sp_poly_arr_writeback(_t%d, _t%d)", box, t);
+    else if (kind == PF_HASH) buf_printf(&wb, "sp_poly_hash_writeback(_t%d, _t%d)", box, t);
     else {
       /* The new contents -- the value itself when the mutator answers self,
          else the temp the typed emitter took the receiver's variable from and
@@ -11328,6 +11352,17 @@ static TyKind emit_face_arm(Compiler *c, int id, unsigned kind, unsigned flags, 
       }
     }
     if (!has_val) buf_printf(val, "({ (void)(%s); %s; })", call, wb.p);
+    else if (kind == PF_HASH && (flags & PF_VAL_SELF)) {
+      /* The value is the receiver -- the box -- not the general copy the
+         emitter worked on: a typed original has no general stand-in, and the
+         copy is detached once written back, so a write through the value
+         (h.merge!(a)[:k] = v, and the chain h.merge!(a, b) folds into) would
+         go nowhere. compact! answers nil when it removed nothing, and the
+         receiver else. */
+      if (nat == TY_POLY) buf_printf(val, "({ sp_RbVal _t%d = %s; %s; sp_poly_nil_p(_t%d) ? _t%d : _t%d; })", tr, call, wb.p, tr, tr, box);
+      else buf_printf(val, "({ (void)(%s); %s; _t%d; })", call, wb.p, box);
+      nat = TY_POLY;
+    }
     else buf_printf(val, "({ %s _t%d = %s; %s; _t%d; })", c_type_name(nat), tr, call, wb.p, tr);
     free(wb.p);
   }
@@ -11394,7 +11429,7 @@ static int emit_face_reentry(Compiler *c, int id, unsigned kind, unsigned flags,
   Buf pre = {0, 0, 0}, val = {0, 0, 0};
   TyKind nat = TY_UNKNOWN;
   if ((flags & PF_MUT) && kind == PF_STRING && !(flags & PF_VAL_SELF) && !face_str_var_recv(nt, recv)) return 0;
-  if ((flags & PF_MUT) && (kind == PF_ARRAY || kind == PF_STRING)) box = ++g_tmp;
+  if ((flags & PF_MUT) && (kind == PF_ARRAY || kind == PF_STRING || kind == PF_HASH)) box = ++g_tmp;
   if (!face_probe_arm(c, id, kind, flags, box, &pre, &val, &nat)) {
     free(pre.p); free(val.p);
     return 0;

--- a/src/types.c
+++ b/src/types.c
@@ -63,6 +63,18 @@ static const PolyFace ty_poly_face_tbl[] = {
   {"prepend", PF_STRING | PF_MUT | PF_ARGS_OWN | PF_VAL_SELF, 0, -1, 0}, {"prepend", PF_ARRAY | PF_MUT, 0, -1, 0},
   {"reverse!", PF_STRING | PF_MUT | PF_VAL_SELF, 0, 0, 0}, {"reverse!", PF_ARRAY | PF_MUT, 0, 0, 0},
   {"slice!", PF_STRING | PF_MUT, 1, 2, 0}, {"slice!", PF_ARRAY | PF_MUT, 1, 2, 0},
+  /* The Hash mutators, on a Hash at run time; a typed variant takes the
+     result back from the general copy it was normalized to, and the value is
+     the box, since the copy is detached once written back. */
+  {"merge!", PF_HASH | PF_MUT | PF_VAL_SELF, 1, -1, 0}, {"update", PF_HASH | PF_MUT | PF_VAL_SELF, 1, -1, 0},
+  /* The names Array and Hash share, blockless: the receiver's run-time kind
+     picks the arm. assoc, rassoc and fetch_values keep their last-resort Hash
+     rows below, so a splat or a block still reaches the read-only face;
+     compact! never had one. */
+  {"compact!", PF_ARRAY | PF_MUT, 0, 0, 0}, {"compact!", PF_HASH | PF_MUT | PF_VAL_SELF, 0, 0, 0},
+  {"assoc", PF_ARRAY, 1, 1, 0}, {"assoc", PF_HASH, 1, 1, 0},
+  {"rassoc", PF_ARRAY, 1, 1, 0}, {"rassoc", PF_HASH, 1, 1, 0},
+  {"fetch_values", PF_ARRAY, 1, -1, 0}, {"fetch_values", PF_HASH, 1, -1, 0},
   /* The read-only Hash/Enumerable face. */
   {"dig", PF_HASH | PF_LAST, 0, -1, -1}, {"value?", PF_HASH | PF_LAST, 0, -1, -1}, {"has_value?", PF_HASH | PF_LAST, 0, -1, -1},
   {"invert", PF_HASH | PF_LAST, 0, -1, -1}, {"assoc", PF_HASH | PF_LAST, 0, -1, -1}, {"rassoc", PF_HASH | PF_LAST, 0, -1, -1}, {"key", PF_HASH | PF_LAST, 0, -1, -1},

--- a/src/types.h
+++ b/src/types.h
@@ -42,9 +42,10 @@ static inline int sp_streq(const char *a, const char *b) {
    has claimed the name, because a claimed name's face answer is a type
    nothing renders (find and detect were such names -- their emitter walks
    the elements and answers one of them). The read-only Hash face is all
-   PF_LAST; a Hash row that is not must carry PF_MUT and write back, because
-   the normalization copies every variant but the general one and a plain
-   write would be lost. The table itself is in types.c. */
+   PF_LAST; a Hash row ahead of it either reads alone (assoc) or carries
+   PF_MUT and writes back, because the normalization copies every variant
+   but the general one and a plain write would be lost. The table itself is
+   in types.c. */
 enum {
   PF_STRING = 1 << 0,  /* re-enter as TY_STRING (sp_poly_recv_s) */
   PF_ARRAY  = 1 << 1,  /* TY_POLY_ARRAY, an Array at run time only */
@@ -56,7 +57,7 @@ enum {
   PF_STR_BANG = 1 << 9,  /* String value-form bang: re-enter the plain name, nil when unchanged */
   PF_STR_SELF = 1 << 10, /* ... but a bang that answers self (succ!/next!): never nil */
   PF_ARGS_OWN = 1 << 11, /* the arguments must be of the owner's own kind (concat) */
-  PF_VAL_SELF = 1 << 12, /* a String mutator whose value is the receiver's new contents */
+  PF_VAL_SELF = 1 << 12, /* a mutator whose value is the receiver: a String row's typed value is its new contents, a Hash row's value is the box itself */
   PF_SAME_OK  = 1 << 14, /* ... and contents that are the receiver's own mean no write, so no frozen check (scrub!) */
   PF_LAST     = 1 << 13  /* answers only once no poly-receiver emitter of its own has claimed the name */
 };

--- a/test/boxed_hash_methods.rb
+++ b/test/boxed_hash_methods.rb
@@ -1,0 +1,132 @@
+# Hash methods on a receiver whose class is only known at run time, and the
+# names Array and Hash share. Covers merge! and compact! writing back into
+# a typed hash of each layout (Symbol keys, String keys with Integer
+# values, String values, and the general hash); assoc, rassoc,
+# fetch_values and compact! on a parameter that is an Array at one call
+# site and a Hash at another; the value being the receiver, so a write
+# through it and a second merge! argument reach the original; an argument
+# that is a Hash at run time only; a nil a String-valued hash already held;
+# the result flowing into a slot the inference widened to poly; the frozen
+# original a mutator refuses before it runs; and the NoMethodError a
+# receiver of neither kind raises.
+cells = [{a: 1, b: nil}, 0]
+h = cells[0]
+p h.merge!({c: 3})
+p h.compact!
+p cells[0]
+
+counts = [{"x" => 1}, "s"]
+c = counts[0]
+p c.merge!({"y" => 2})
+p counts[0]
+
+names = [{"k" => "v"}, 1.5]
+n = names[0]
+p n.merge!({"k2" => "v2"})
+p names[0]
+
+mixed = [{1 => "one", "two" => 2}, :s]
+m = mixed[0]
+p m.merge!({3.0 => nil})
+p m.compact!
+p mixed[0]
+
+def pair_for(x, k)
+  x.assoc(k)
+end
+def pair_with(x, v)
+  x.rassoc(v)
+end
+def pick(x, k1, k2)
+  x.fetch_values(k1, k2)
+end
+def drop_nils(x)
+  x.compact!
+end
+
+p pair_for([[1, :a], [2, :b]], 2)
+p pair_for({1 => :a, 2 => :b}, 2)
+p pair_with([[1, :a], [2, :b]], :a)
+p pair_with({1 => :a, 2 => :b}, :a)
+p pick([10, 20, 30], 0, 2)
+p pick({"p" => 10, "q" => 20}, "q", "p")
+p drop_nils([1, nil, 2])
+p drop_nils({a: 1, b: nil})
+p drop_nils([1, 2])
+p drop_nils({a: 1})
+
+# the value is the receiver, as CRuby answers it: a write through it, and
+# the second argument of a merge! (which folds into a chain of one-argument
+# calls), reach the original; update is merge!'s other name
+d = [{a: 1}, 0]
+dh = d[0]
+p dh.merge!({b: 2}, {c: 3})
+p d[0]
+dh.merge!({d: 4})[:z] = 9
+p d[0]
+p dh.merge!({}).equal?(dh)
+p dh.update({y: 0})
+p dh.merge!({b: nil}).compact!
+p d[0]
+
+# an argument that is a Hash at run time only is checked there
+def fold(x, y)
+  x.merge!(y)
+end
+p fold({a: 1}, {b: 2})
+p fold({"s" => 1}, {"t" => 2})
+begin
+  fold({a: 1}, [1])
+rescue TypeError => e
+  puts e.message
+end
+
+# a String-valued hash keeps a nil it already held
+ns = {"a" => "x"}
+ns["b"] = "x"[5]
+p [ns, 0][0].merge!({"c" => "y"})
+p ns
+
+# a slot that held a typed value on an early pass and the box on the last
+v = {z: 0}
+v = [{y: 1, w: nil}, 5][0]
+p v.compact!
+
+begin
+  pick("str", 0, 1)
+rescue NoMethodError => e
+  puts e.message
+end
+begin
+  drop_nils(7)
+rescue NoMethodError => e
+  puts e.message
+end
+
+# a frozen original is refused before the mutator runs, and stays as it was
+f = [{a: 1, b: nil}.freeze, 0]
+begin
+  f[0].merge!({c: 3})
+rescue FrozenError => e
+  p e.class
+end
+begin
+  f[0].compact!
+rescue FrozenError => e
+  p e.class
+end
+p f[0]
+
+# a String the program appends to after storing it elsewhere is held as a
+# shared handle; merged in as a key or a value it goes into the original by
+# its contents, like any other String
+sh = "x".dup
+keep = [sh]
+sh << "y"
+m = [{"k" => "v"}, 0][0]
+m.merge!({"b" => sh, sh => "w"})
+p m
+n = [{1 => "v"}, 0][0]
+n.update({2 => sh})
+p n
+p keep

--- a/test/boxed_hash_methods.rb.expected
+++ b/test/boxed_hash_methods.rb.expected
@@ -1,0 +1,41 @@
+{a: 1, b: nil, c: 3}
+{a: 1, c: 3}
+{a: 1, c: 3}
+{"x" => 1, "y" => 2}
+{"x" => 1, "y" => 2}
+{"k" => "v", "k2" => "v2"}
+{"k" => "v", "k2" => "v2"}
+{1 => "one", "two" => 2, 3.0 => nil}
+{1 => "one", "two" => 2}
+{1 => "one", "two" => 2}
+[2, :b]
+[2, :b]
+[1, :a]
+[1, :a]
+[10, 30]
+[20, 10]
+[1, 2]
+{a: 1}
+nil
+nil
+{a: 1, b: 2, c: 3}
+{a: 1, b: 2, c: 3}
+{a: 1, b: 2, c: 3, d: 4, z: 9}
+true
+{a: 1, b: 2, c: 3, d: 4, z: 9, y: 0}
+{a: 1, c: 3, d: 4, z: 9, y: 0}
+{a: 1, c: 3, d: 4, z: 9, y: 0}
+{a: 1, b: 2}
+{"s" => 1, "t" => 2}
+no implicit conversion of Array into Hash
+{"a" => "x", "b" => nil, "c" => "y"}
+{"a" => "x", "b" => nil, "c" => "y"}
+{y: 1}
+undefined method 'fetch_values' for an instance of String
+undefined method 'compact!' for an instance of Integer
+FrozenError
+FrozenError
+{a: 1, b: nil}
+{"k" => "v", "b" => "xy", "xy" => "w"}
+{1 => "v", 2 => "xy"}
+["xy"]


### PR DESCRIPTION
## Why

The Hash face that serves a boxed receiver (#3449) is read-only by construction: it normalizes a typed variant to a general copy, so a write to the copy is lost. That is why `merge!` and `compact!` on a boxed Hash raise `NoMethodError` naming Hash, and why `assoc`, `rassoc` and `fetch_values` on a boxed Array are normalized as a Hash by that face and raise there. With the owner table (#4173) and the run-time kind switch (#4175) in place, these are rows: a Hash write-back that is the array write-back's sibling, and Array-or-Hash rows for the four shared names.

Six names that raised now answer as CRuby does, on the receiver's run-time kind, and the value of a mutator is the receiver itself, so a write through it reaches the original. The read-only face stays as it was, and the generated C for optcarrot and every benchmark is byte-identical to master's.

## What

- `merge!`, `update` and `compact!` on a boxed Hash raised: the Hash face was read-only, because it normalizes a typed variant to a general copy and a write to the copy was lost.
- `assoc`, `rassoc` and `fetch_values` on a boxed Array were normalized as a Hash by that face and raised there.
- The general hash's `merge!` declined an argument that is a Hash at run time only (a parameter that is a Hash of one layout at one call site and another at the next), so a boxed hash could not merge into another.

## How

- **The Hash re-entry**: a `PF_HASH` arm unboxes through `sp_poly_hash_recv`, which is `sp_poly_as_pp_hash` with the frozen check a mutator needs done first, on the original, before the typed emitter works on the copy.
- **The write-back**: `merge!`, `update` and `compact!` re-enter the general hash and then `sp_poly_hash_writeback` replaces the typed original's entries with the copy's, in the original's own layout, for each of the six typed variants. An entry the variant cannot hold, a String key merged into a Symbol-keyed hash or a Float value into an Integer-valued one, is refused with a `TypeError` rather than coerced into a key or value it was not (the array write-back's rule; CRuby would widen the hash, which a typed variant cannot do); a nil a String- or Integer-valued variant already held is its own to keep, and a String the program appends to after storing it elsewhere, which the runtime holds as a shared-mutable handle, goes in by its contents, as it does through the array write-back. The frozen check runs again at the write-back, for an original its own argument froze. A general hash shares storage with its box and needs nothing.
- **The value is the receiver**: the box, not the general copy, since a typed original has no general stand-in and the copy is detached once written back. That is what makes `h.merge!(a)[:k] = v` reach `h`, `h.merge!(a).equal?(h)` true, and `h.merge!(a, b)` correct at all: the compiler folds a multi-argument `merge!` into a chain of one-argument calls on the premise that `merge!` returns self, and a copy-valued arm would have written only the first argument back. `compact!` answers nil when it removed nothing, as CRuby does.
- **The general hash's `merge!`** takes an argument known only at run time, checking that it is a Hash there and raising CRuby's `no implicit conversion of X into Hash` otherwise, and skips an empty literal, which has no variant to infer and nothing to fold in.
- **The shared names**: `compact!`, `assoc`, `rassoc` and `fetch_values` become Array-or-Hash rows and dispatch on the receiver's run-time kind, the way the String-and-Array names do. `assoc`, `rassoc` and `fetch_values` keep their last-resort Hash rows, so a splat, which no bounded row's count admits, or a block, which a blockless row's shape refuses, still reaches the read-only face as before; `compact!` never had one, and none of those shapes reached it before either.

## Validation

- A new test, `test/boxed_hash_methods` (expectations generated by CRuby 4.0): `merge!` and `compact!` writing back into a typed hash of each layout and into the general hash; the shared names on a parameter that is an Array at one call site and a Hash at another; a write through the value and a two-argument `merge!` reaching the original, `equal?`, `update`, and `compact!` chained on `merge!`; an argument that is a Hash at run time only, and the `TypeError` an Array there raises; a nil a String-valued hash already held; a shared-mutable String merged in as a key and as a value; the result flowing into a slot the inference widened to poly; the frozen original a mutator refuses before it runs and leaves as it was; and the `NoMethodError` a receiver of neither kind raises.
- Full suite: 3,316 pass, 0 fail, from a cleared results cache.
- Generated C against master: byte-identical for every program except the new test and `test/poly_hash_surface.rb`, where `assoc`, `rassoc` and `fetch_values` on the boxed hash now go through the kind switch (an Array arm, the Hash arm the face emitted before, and the `NoMethodError` default) instead of straight into the face; the rest of that diff is temp renumbering. optcarrot and the 61 benchmarks are byte-identical, so the hot paths do not change.
- The new test, `test/boxed_array_methods`, `test/boxed_string_methods` and `test/issue_3227_container_read_mutation` run clean under `SPINEL_GC_STRESS=1` and ASAN+UBSAN with their expected output, as do 300-entry write-backs on every layout; the inference fixpoint converges in the same number of rounds as master on every program in the suite, and in 4 on the new test.
- The refusal, which the CRuby-generated test cannot hold: `s = [{a: 1}, 0]; s[0].merge!({"k" => 2})` raises `can't store String as a key in a Hash of Symbol keys through a boxed receiver` and leaves `s[0]` as `{a: 1}`; CRuby answers `{a: 1, "k" => 2}`.
- Against the differential corpus of ~2,100 minimized programs the campaign has been working from: 705 → 707 match, 2 gained and 0 lost; the two are the corpus's `compact!`-through-an-element and `assoc`/`rassoc`-through-an-element programs.
- Front-end compile time of optcarrot (`-c` to `/dev/null`) is unchanged: 4.08–4.14 s on master and 4.08–4.15 s on this branch over three runs of each.

## Left alone, on purpose

- `select!`, `reject!`, `keep_if` and `delete_if` on a boxed Hash, which 26adc3c4 notes belong in the kind switch (with `filter!`, `select!`'s alias): the general hash has no in-place filter emitter yet (the typed one stops at `TY_POLY_POLY_HASH`), so a Hash row today would only move the `NoMethodError`. They are the next change, the emitter and the rows together.
- `merge!` with a conflict block, and `fetch_values` with a block, on a boxed receiver: no bounded row takes a block, so they raise as before.
- `Hash#shift`, `default=`, `to_proc` and `deconstruct_keys`: `shift` has an Array arm of its own in the builtin-method dispatch that this table would have to subsume; `default=` writes a field the general copy does not carry back; `to_proc` and `deconstruct_keys` are owned by Symbol, Method, Proc, Struct, Data and Time as well, and a Hash-only row would preempt them.
- A frozen boxed receiver is refused before its arguments are evaluated, where CRuby evaluates them first; only an argument with side effects can tell.
- `h.equal?(x)` with a typed `h` and a box `x` of the same hash answers false on master as well; `x.equal?(h)` is true. That is `equal?` between a typed receiver and a box, not the face.
- A receiver the inference already knows to be a boxed Hash pays two tag-and-class tests before its Hash arm where it went straight into the face; that is the `poly_hash_surface` diff above, and it is the price of the Array arm existing at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for hash mutation methods such as `merge!` and `update` when the concrete hash type is determined at runtime.
  * Improved handling of shared collection methods including `compact!`, `assoc`, `rassoc`, and `fetch_values`.
  * Mutations now correctly update the original hash and preserve supported key and value types.

* **Bug Fixes**
  * Added clear errors for frozen hashes, unsupported values, and invalid receiver types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->