### PR TITLE
Spin: add --verbose flag; create both .o and _mt.o

### DIFF
--- a/tools/spin.rb
+++ b/tools/spin.rb
@@ -1693,11 +1693,15 @@ end
 
 # --- main --------------------------------------------------------------------
 
-# --verbose can sit in any position; strip every occurrence from
-# ARGV before picking the command. An empty ARGV after that is the
-# no-arg form (usage).
-args = ARGV.reject { |a| a == "--verbose" }
-$spin_verbose = true if args.length != ARGV.length
+# --verbose belongs to spin and only to spin: strip it from the part of
+# ARGV before the `--` separator, leaving any --verbose after `--` in
+# `rest` so it reaches the program (e.g. `spin run app -- --verbose`
+# forwards --verbose to the app, not to spin).
+dd = ARGV.index("--")
+spin_part = dd ? ARGV[0, dd] : ARGV
+app_part = dd ? ARGV[(dd + 1)..] : []
+$spin_verbose = spin_part.count("--verbose") > 0 || ENV["SPIN_VERBOSE"].to_s != ""
+args = spin_part.reject { |a| a == "--verbose" } + (dd ? ["--"] : []) + app_part
 cmd = args.empty? ? "" : args[0]
 rest = args[1..] || []
 

--- a/tools/spin.rb
+++ b/tools/spin.rb
@@ -1092,6 +1092,10 @@ def compile(prj, entry, out, extra)
   # behaviour (#4136 in spirit) and the hint check still works.
   text = ""
   if $spin_verbose
+    # Echo the command (run_command's behaviour for every other exec) so
+    # the operator sees it on stderr, then spawn with stderr piped for
+    # live stream + retained text below.
+    $stderr.puts compile_cmd(prj, entry, out, extra)
     rd, wr = IO.pipe
     pid = Process.spawn("/bin/sh", "-c", compile_cmd(prj, entry, out, extra), :err => wr)
     wr.close

--- a/tools/spin.rb
+++ b/tools/spin.rb
@@ -5,6 +5,29 @@
 require_relative "spin/toml"
 
 $spin_hasher = ""   # memoized content-hasher command (native_hasher)
+$spin_verbose = ENV["SPIN_VERBOSE"].to_s != ""   # --verbose / SPIN_VERBOSE=1
+                                                  # makes run_command print the
+                                                  # command before exec'ing it
+
+# Wrap one external command. Returns true on exit 0, false on non-zero
+# exit, raises on exec failure (Errno::ENOENT, etc.). Every external
+# exec in this file goes through here so a single flag -- or env var --
+# turns on command echoing, and so a future refactor (capture output,
+# parallelize, dry-run) has one site to touch.
+#
+# Implementation: Process.spawn("/bin/sh", "-c", cmd) with a waitpid2.
+# CRuby's `system(cmd)` does the same under the hood; the AOT runtime
+# runs the codegen-emitted form directly, so the call is portable across
+# both runtimes. The shell wrapper is needed because `cmd` is a string
+# with multiple argv tokens (paths, flags) and we do not want to write
+# a shell-quote parser; `/bin/sh -c` already handles it. Stderr is
+# inherited from spin so cc/spinel errors stream live to the operator.
+def run_command(cmd)
+  $stderr.puts cmd if $spin_verbose
+  pid = Process.spawn("/bin/sh", "-c", cmd)
+  _, status = Process.waitpid2(pid)
+  status.success?
+end
 
 SPIN_USAGE = <<USAGE
 usage: spin <command> [args]
@@ -399,11 +422,13 @@ def native_objs_for(name, dir, version)
       cmd = native_cc + " -O2 -c '#{c}' -I '#{dir}'"
       cmd += " -I '#{hdr}'" if hdr != ""
       cmd += " -o '#{o}'"
-      spin_die("native compile failed: " + rel + " (" + name + ")") unless system(cmd)
-      # stderr, not stdout: `spin flags` prints a flag string on stdout and a
-      # cold cache compiles here first, so progress on stdout would be spliced
-      # into the flags the caller passes to the compiler (#4105).
-      $stderr.puts "cc #{name}/#{rel}"
+      spin_die("native compile failed: " + rel + " (" + name + ")") unless run_command(cmd)
+      # stderr, not stdout: `spin flags` prints a flag string on stdout and
+      # a cold cache compiles here first, so progress on stdout would be
+      # spliced into the flags the caller passes to the compiler (#4105).
+      # In --verbose the run_command echo already shows the full command,
+      # so the short status line is redundant there.
+      $stderr.puts "cc #{name}/#{rel}" unless $spin_verbose
     end
     objs.push(o)
   end
@@ -1043,10 +1068,21 @@ def compile(prj, entry, out, extra)
   tmp = ENV["TMPDIR"].to_s
   tmp = "/tmp" if tmp == ""
   err = File.join(tmp, "spin-compile-#{Process.pid}.err")
-  ok = system(compile_cmd(prj, entry, out, extra) + " 2>#{err}")
-  text = File.exist?(err) ? File.read(err) : ""
-  $stderr.print text unless text.empty?
-  File.unlink(err) if File.exist?(err)
+  # In verbose mode let the compiler's stderr stream live to the
+  # operator: run_command's echo + the cc/spinel warnings and errors
+  # arrive interleaved, which is what someone running --verbose
+  # wants. In non-verbose mode keep the existing capture-then-replay,
+  # so a build's "what went wrong" hint lands after the exit line,
+  # not before (#4136).
+  text = ""
+  if $spin_verbose
+    ok = run_command(compile_cmd(prj, entry, out, extra))
+  else
+    ok = system(compile_cmd(prj, entry, out, extra) + " 2>#{err}")
+    text = File.exist?(err) ? File.read(err) : ""
+    $stderr.print text unless text.empty?
+    File.unlink(err) if File.exist?(err)
+  end
   unless ok
     if text.include?("cannot load such file")
       $stderr.puts "spin: build failed (hint: an unresolved require may need a dependency: spin add <name> --path <dir>)"
@@ -1623,13 +1659,13 @@ end
 
 # --- main --------------------------------------------------------------------
 
-cmd = ARGV.empty? ? "" : ARGV[0]
-rest = []
-i = 1
-while i < ARGV.length
-  rest.push(ARGV[i])
-  i += 1
-end
+# --verbose can sit in any position; strip every occurrence from
+# ARGV before picking the command. An empty ARGV after that is the
+# no-arg form (usage).
+args = ARGV.reject { |a| a == "--verbose" }
+$spin_verbose = true if args.length != ARGV.length
+cmd = args.empty? ? "" : args[0]
+rest = args[1..] || []
 
 case cmd
 when "new"
@@ -1778,7 +1814,7 @@ when "build", "run", "test", "clean"
     files = rest.reject { |a| a.start_with?("--") }
     cmd_test(prj, files, regen)
   when "clean"
-    system("rm -rf #{File.join(prj.root, 'build')}")
+    run_command("rm -rf #{File.join(prj.root, 'build')}")
     puts "cleaned"
   end
 when "--version"

--- a/tools/spin.rb
+++ b/tools/spin.rb
@@ -1084,15 +1084,29 @@ def compile(prj, entry, out, extra)
   tmp = ENV["TMPDIR"].to_s
   tmp = "/tmp" if tmp == ""
   err = File.join(tmp, "spin-compile-#{Process.pid}.err")
-  # In verbose mode let the compiler's stderr stream live to the
-  # operator: run_command's echo + the cc/spinel warnings and errors
-  # arrive interleaved, which is what someone running --verbose
-  # wants. In non-verbose mode keep the existing capture-then-replay,
-  # so a build's "what went wrong" hint lands after the exit line,
-  # not before (#4136).
+  # The compiler's stderr ends up in `text` either way -- in non-verbose
+  # mode by redirecting to a file and reading it after; in verbose mode by
+  # spawning with a pipe, streaming each chunk to the operator live, and
+  # accumulating it. `text` is then used below for the "cannot load such
+  # file" hint. The verbose branch keeps the existing live-streaming
+  # behaviour (#4136 in spirit) and the hint check still works.
   text = ""
   if $spin_verbose
-    ok = run_command(compile_cmd(prj, entry, out, extra))
+    rd, wr = IO.pipe
+    pid = Process.spawn("/bin/sh", "-c", compile_cmd(prj, entry, out, extra), :err => wr)
+    wr.close
+    stream = Thread.new do
+      buf = ""
+      while (chunk = rd.gets)
+        $stderr.write chunk
+        buf += chunk
+      end
+      buf
+    end
+    _, status = Process.waitpid2(pid)
+    rd.close
+    text = stream.value
+    ok = status.success?
   else
     ok = system(compile_cmd(prj, entry, out, extra) + " 2>#{err}")
     text = File.exist?(err) ? File.read(err) : ""

--- a/tools/spin.rb
+++ b/tools/spin.rb
@@ -15,17 +15,39 @@ $spin_verbose = ENV["SPIN_VERBOSE"].to_s != ""   # --verbose / SPIN_VERBOSE=1
 # turns on command echoing, and so a future refactor (capture output,
 # parallelize, dry-run) has one site to touch.
 #
-# Implementation: Process.spawn("/bin/sh", "-c", cmd) with a waitpid2.
-# CRuby's `system(cmd)` does the same under the hood; the AOT runtime
-# runs the codegen-emitted form directly, so the call is portable across
-# both runtimes. The shell wrapper is needed because `cmd` is a string
-# with multiple argv tokens (paths, flags) and we do not want to write
-# a shell-quote parser; `/bin/sh -c` already handles it. Stderr is
-# inherited from spin so cc/spinel errors stream live to the operator.
-def run_command(cmd)
+# Implementation: Process.spawn("/bin/sh", "-c", cmd) plus a
+# Process.waitpid2 for the exit status. The shell wrapper handles the
+# multi-token cmd string (paths, flags) without us writing a quote
+# parser, and is portable: CRuby's `system(cmd)` runs the same command
+# via /bin/sh, and spinel's AOT runtime routes the codegen-emitted
+# spawn through its own fork/exec with the same shell semantics.
+#
+# When called with `text:` the child's stderr is also accumulated into
+# the given String (line by line, on a background thread that writes
+# each line to $stderr so it still streams live to the operator). This
+# is what compile()'s "cannot load such file" diagnostic needs: the
+# live stream from run_command, plus the captured text for the hint
+# check afterwards. Other call sites pass nothing and get the plain
+# status.
+def run_command(cmd, text: nil)
   $stderr.puts cmd if $spin_verbose
-  pid = Process.spawn("/bin/sh", "-c", cmd)
+  if text.nil?
+    pid = Process.spawn("/bin/sh", "-c", cmd)
+    _, status = Process.waitpid2(pid)
+    return status.success?
+  end
+  rd, wr = IO.pipe
+  pid = Process.spawn("/bin/sh", "-c", cmd, :err => wr)
+  wr.close
+  cap = Thread.new do
+    while (line = rd.gets)
+      $stderr.write line
+      text << line
+    end
+  end
   _, status = Process.waitpid2(pid)
+  rd.close
+  cap.join
   status.success?
 end
 
@@ -1092,25 +1114,10 @@ def compile(prj, entry, out, extra)
   # behaviour (#4136 in spirit) and the hint check still works.
   text = ""
   if $spin_verbose
-    # Echo the command (run_command's behaviour for every other exec) so
-    # the operator sees it on stderr, then spawn with stderr piped for
-    # live stream + retained text below.
-    $stderr.puts compile_cmd(prj, entry, out, extra)
-    rd, wr = IO.pipe
-    pid = Process.spawn("/bin/sh", "-c", compile_cmd(prj, entry, out, extra), :err => wr)
-    wr.close
-    stream = Thread.new do
-      buf = ""
-      while (chunk = rd.gets)
-        $stderr.write chunk
-        buf += chunk
-      end
-      buf
-    end
-    _, status = Process.waitpid2(pid)
-    rd.close
-    text = stream.value
-    ok = status.success?
+    # run_command echoes the cmd, streams stderr live, and (with text:)
+    # captures the same stderr for the "cannot load such file" hint
+    # check below.
+    ok = run_command(compile_cmd(prj, entry, out, extra), text: text)
   else
     ok = system(compile_cmd(prj, entry, out, extra) + " 2>#{err}")
     text = File.exist?(err) ? File.read(err) : ""

--- a/tools/spin.rb
+++ b/tools/spin.rb
@@ -402,7 +402,16 @@ def native_cache_dir(key)
   d
 end
 
-# Compile one package's carried C into the cache; returns the object list.
+# Compile one package's carried C into the cache; returns the object list
+# of PLAIN (.o) entries only. For each .c, a companion "<stem>_mt.o" is
+# also built with the same -DSP_THREADS -ftls-model=initial-exec the
+# spinel compiler uses for the main binary when the program uses threads
+# (lib/sp_process.c and lib/sp_alloc.c read runtime globals through these;
+# without the matching thread-local storage class the link fails). Both
+# variants land in the same cache directory; spinel's linker (src/main.c)
+# computes <stem>_mt.o from each --link and prefers it when the program
+# uses threads, falling back to the plain one otherwise. So one build
+# serves either kind of project, and the --link list is unchanged.
 def native_objs_for(name, dir, version)
   excl = native_excludes(dir)
   cs = collect_c(dir, excl)
@@ -417,20 +426,27 @@ def native_objs_for(name, dir, version)
   objs = []
   cs.split("\n").each do |c|
     rel = c[dir.length + 1..-1].to_s
-    o = File.join(odir, rel.gsub("/", "_")[0..-3] + ".o")
-    if !File.exist?(o) || File.mtime(o).to_i < hnew || ENV["SPIN_NO_NATIVE_CACHE"].to_s != ""
-      cmd = native_cc + " -O2 -c '#{c}' -I '#{dir}'"
-      cmd += " -I '#{hdr}'" if hdr != ""
-      cmd += " -o '#{o}'"
-      spin_die("native compile failed: " + rel + " (" + name + ")") unless run_command(cmd)
-      # stderr, not stdout: `spin flags` prints a flag string on stdout and
-      # a cold cache compiles here first, so progress on stdout would be
-      # spliced into the flags the caller passes to the compiler (#4105).
-      # In --verbose the run_command echo already shows the full command,
-      # so the short status line is redundant there.
-      $stderr.puts "cc #{name}/#{rel}" unless $spin_verbose
+    base = rel.gsub("/", "_")[0..-3]
+    [["", ""], ["_mt", " -DSP_THREADS -ftls-model=initial-exec"]].each do |suffix, flags|
+      o = File.join(odir, base + suffix + ".o")
+      if !File.exist?(o) || File.mtime(o).to_i < hnew || ENV["SPIN_NO_NATIVE_CACHE"].to_s != ""
+        cmd = native_cc + " -O2" + flags + " -c '#{c}' -I '#{dir}'"
+        cmd += " -I '#{hdr}'" if hdr != ""
+        cmd += " -o '#{o}'"
+        spin_die("native compile failed: " + rel + " (" + name + ")") unless run_command(cmd)
+        # stderr, not stdout: `spin flags` prints a flag string on stdout and
+        # a cold cache compiles here first, so progress on stdout would be
+        # spliced into the flags the caller passes to the compiler (#4105).
+        # In --verbose the run_command echo already shows the full command,
+        # so the short status line is redundant there.
+        $stderr.puts "cc #{name}/#{rel}#{suffix}" unless $spin_verbose
+      end
+      # Only the plain .o goes on the --link list; spinel computes the
+      # _mt variant from it. Including _mt.o here would have the linker
+      # add it twice (once via dedup of the _mt->_mt path, once via
+      # the plain->_mt rewrite) and break with multiple-definition errors.
+      objs.push(o) if suffix == ""
     end
-    objs.push(o)
   end
   objs
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added verbose output for build and cleanup commands, enabled with the `--verbose` option or `SPIN_VERBOSE`.
  * Compiler commands and output now stream live in verbose mode.
  * Native builds now generate additional thread-enabled object variants.

* **Bug Fixes**
  * Improved visibility into external commands during builds and cleanup.
  * Preserved clear compiler error reporting in verbose and standard modes.
  * Improved handling of the verbose option around the `--` argument separator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->