### PR TITLE
spin: realpath the spinel binary that <$0-dir>/spinel found

### DIFF
--- a/tools/spin.rb
+++ b/tools/spin.rb
@@ -78,7 +78,13 @@ def spinel_bin
   # macOS) instead of falling through to the installed binary (#3407).
   me = File.expand_path($0)
   cand = File.join(File.expand_path("..", me), "spinel")
-  return cand if File.file?(cand) && File.executable?(cand)
+  if File.file?(cand) && File.executable?(cand)
+    # Realpath: a symlinked install (e.g. /home/user/bin/spin ->
+    # /home/user/spinel/bin/spin) has $0 resolve to the symlink path; without
+    # realpath, spinel_hdr_dir's <bin>/../lib probe walks from the symlink's
+    # parent and misses the install tree's lib/.
+    return File.symlink?(cand) ? File.realpath(cand) : cand
+  end
   "spinel"  # PATH fallback
 end
 


### PR DESCRIPTION
When spin is invoked through a symlink, $0 is the symlink path, and the "<dir-of-$0>/spinel" probe in spinel_bin also yields a symlink to the real binary. spinel_hdr_dir then walks from that symlink path looking for lib/spinel_rt.h, finds none of its fallbacks, and returns empty. The cc command for a package that includes spinel/runtime.h has no -I for the header and the build dies on a missing-header error.

The same one-line realpath the spinel_hdr_dir PATH branch already does for which("spinel") fixes it for the <$0-dir> branch: when cand is a symlink, return its realpath so the lib probe walks from the real install tree.