### PR TITLE
io: honor autoclose: false in close and finalizer; auto-detect mode i…

### DIFF
--- a/lib/sp_cold.c
+++ b/lib/sp_cold.c
@@ -2981,7 +2981,22 @@ sp_PolyArray *sp_io_pipe(void) {
 sp_File *sp_io_for_fd(sp_int fd, const char *mode, sp_bool autoclose) {SP_GC_ROOT_STR(mode);
   if (fd < 0 || fcntl((int)fd, F_GETFD) < 0)
     sp_raise_cls("Errno::EBADF", "Bad file descriptor");
-  sp_File *f = sp_io_fdopen_ex((int)fd, mode && *mode ? mode : "r", 0);
+  /* When the user did not pass a mode (mode is NULL or ""), CRuby picks a
+     mode that matches the fd's actual open flags via a "first fdopen
+     that does not fail" fallback. Mirror that: probe the fd's flags and
+     pass the closest fopen mode, so wrapping a write-only fd works
+     without forcing the caller to spell the mode. */
+  const char *m;
+  if (mode && *mode) {
+    m = mode;
+  } else {
+    int fl = fcntl((int)fd, F_GETFL);
+    if (fl < 0) m = "r";
+    else if ((fl & O_ACCMODE) == O_WRONLY) m = "w";
+    else if ((fl & O_ACCMODE) == O_RDWR)   m = "r+";
+    else                                   m = "r";
+  }
+  sp_File *f = sp_io_fdopen_ex((int)fd, m, 0);
   if (f && !autoclose) f->no_autoclose = 1;
   return f;
 }

--- a/lib/sp_io.c
+++ b/lib/sp_io.c
@@ -31,7 +31,14 @@ extern void *sp_gc_alloc(size_t sz, void (*fin)(void *), void (*scn)(void *));
 extern SP_NORETURN void sp_raise_cls(const char *cls, const char *msg);
 extern const char *sp_sprintf(const char *fmt, ...);
 
-static void sp_File_fin(void *p) { sp_File *f = (sp_File *)p; if (f->fp) { fclose(f->fp); f->fp = NULL; } }
+static void sp_File_fin(void *p) {
+  sp_File *f = (sp_File *)p;
+  /* f->no_autoclose is set by sp_io_for_fd when the user passed
+     autoclose: false. The runtime owns the underlying fd in that case
+     (closing it would surprise the caller, who is wrapping a fd they
+     opened via IO.sysopen or a similar call). Honour the flag. */
+  if (f->fp && !f->no_autoclose) { fclose(f->fp); f->fp = NULL; }
+}
 static void sp_File_scan(void *p) { sp_File *f = (sp_File *)p; if (f->path) sp_mark_string(f->path); if (f->mode) sp_mark_string(f->mode); }
 
 /* The two-argument form is the permission form with CRuby's default bits:
@@ -231,7 +238,11 @@ sp_int sp_File_close(sp_File *f) {
   /* never fclose the shared stdout/stderr handles (sp_io_stdout/sp_io_stderr):
      closing the process's standard streams would corrupt the singleton and any
      later write through it. Closing them is a no-op. */
-  if (f && f->fp && f->fp != stdout && f->fp != stderr && f->fp != stdin) { fclose(f->fp); f->fp = NULL; }
+  /* f->no_autoclose is set by sp_io_for_fd when the user passed
+     autoclose: false; the fd is not ours, so io.close must not fclose it. */
+  if (f && f->fp && f->fp != stdout && f->fp != stderr && f->fp != stdin && !f->no_autoclose) {
+    fclose(f->fp); f->fp = NULL;
+  }
   return 0;
 }
 

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -21054,11 +21054,20 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
         const char *lty = nt_type(nt, argv[argc - 1]);
         int kwh = (lty && sp_streq(lty, "KeywordHashNode")) ? argv[argc - 1] : -1;
         int ac = kwh >= 0 ? kwh_lookup(nt, kwh, "autoclose") : -1;
+        /* Detect a user-written string literal in argv[1] by the AST node
+           type (StringNode), not the inferred type. The inference result
+           widens to poly in larger contexts and the old comp_ntype guard
+           misfired; the AST type survives the widening. */
+        int user_string_mode = 0;
+        if (argc >= 2) {
+          const char *aty = nt_type(nt, argv[1]);
+          if (aty && sp_streq(aty, "StringNode")) user_string_mode = 1;
+        }
         buf_puts(b, "sp_io_for_fd(");
         emit_int_expr(c, argv[0], b);
         buf_puts(b, ", ");
-        if (argc >= 2 && comp_ntype(c, argv[1]) == TY_STRING) emit_expr(c, argv[1], b);
-        else buf_puts(b, "\"r\"");
+        if (user_string_mode) emit_expr(c, argv[1], b);
+        else buf_puts(b, "NULL");
         buf_puts(b, ", ");
         if (ac >= 0) { buf_puts(b, "("); emit_expr(c, ac, b); buf_puts(b, ")"); }
         else buf_puts(b, "1");


### PR DESCRIPTION
…n for_fd

Three related fixes for IO.for_fd / IO.new wrap semantics under AOT:

  1. sp_io_for_fd (lib/sp_cold.c): when the user does not pass a mode (or passes ""), pick a mode that matches the fd's actual open flags instead of defaulting to "r". CRuby's IO.for_fd is lenient here: a write-only fd wraps cleanly with no mode arg, but libc fdopen(fd, "r") on a write-only fd fails. Probe F_GETFL and pass "w" / "r+" / "r" to match.

  2. sp_File_close and sp_File_fin (lib/sp_io.c): honour the no_autoclose flag set by sp_io_for_fd. The flag was set but never read, so io.close and the GC finalizer would fclose a fd that the caller opened via IO.sysopen and asked us not to take ownership of. Honour it and the caller's fd survives the wrap.

  3. IO.for_fd codegen (src/codegen_call.c): detect the user-written string literal at the second positional by AST node type (StringNode) rather than the inferred type (TY_STRING). In larger inference contexts the inferred type widens to poly and the old check misfired, silently dropping the mode arg and defaulting to "r". When the user did not write a string literal at the call site, emit NULL so the runtime can auto-detect instead of being lied to with a hard-coded "r".

Together these bring the AOT behaviour in line with CRuby's IO.for_fd / IO.new semantics: a write-only fd wraps cleanly with no mode arg, autoclose: false keeps the underlying fd open across io.close and finalization, and an explicit mode survives the inference pass.

closes #4208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File wrappers now automatically select read, write, or read/write access based on the underlying file descriptor when no mode is specified.
  * Explicit file modes continue to work as provided.
  * Files opened with automatic closing disabled are no longer closed unexpectedly.
  * Improved handling of mode detection for file descriptor operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->