### PR TITLE
Hold a multiple assignment's values while the rest are built

### DIFF
--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -6291,6 +6291,145 @@ void emit_sg_activate(Compiler *c, int node, int recv, Buf *b, int indent) {
   buf_printf(b, ")->cls_id = %d;\n", ci);
 }
 
+/* The receiver and the index of a multiple-assignment target that has them
+   (`a[i]`, `o.x`); -1 for a target that is a slot. */
+static void masgn_target_parts(const NodeTable *nt, int t, int *recv, int *key) {
+  const char *ty = nt_type(nt, t);
+  *recv = *key = -1;
+  if (!ty) return;
+  if (sp_streq(ty, "IndexTargetNode")) {
+    *recv = nt_ref(nt, t, "receiver");
+    int args = nt_ref(nt, t, "arguments"), n = 0;
+    const int *av = args >= 0 ? nt_arr(nt, args, "arguments", &n) : NULL;
+    if (n >= 1) *key = av[0];
+  }
+  else if (sp_streq(ty, "CallTargetNode")) *recv = nt_ref(nt, t, "receiver");
+}
+/* Whether evaluating a part or a value can allocate, and so collect. A builtin
+   operator over scalars is a CallNode to subtree_may_allocate, but `a[i % n]`
+   builds nothing; what has no effect and answers a scalar is arithmetic. */
+static int masgn_part_allocates(Compiler *c, int id) {
+  if (!subtree_may_allocate(c->nt, id)) return 0;
+  if (subtree_has_side_effect(c, id)) return 1;
+  TyKind t = comp_ntype(c, id);
+  return !(t == TY_INT || t == TY_FLOAT || t == TY_BOOL);
+}
+/* Whether the subtree reads the variable a target of the given kind writes. */
+static int masgn_reads(const NodeTable *nt, int id, const char *rty, const char *name) {
+  if (id < 0) return 0;
+  const char *ty = nt_type(nt, id);
+  if (!ty) return 0;
+  if (sp_streq(ty, rty) && nt_str(nt, id, "name") && sp_streq(nt_str(nt, id, "name"), name)) return 1;
+  int nr = nt_num_refs(nt, id);
+  for (int i = 0; i < nr; i++)
+    if (masgn_reads(nt, nt_ref_at(nt, id, i), rty, name)) return 1;
+  int na = nt_num_arrs(nt, id);
+  for (int i = 0; i < na; i++) {
+    int n = 0;
+    const int *ids = nt_arr_at(nt, id, i, &n);
+    for (int j = 0; j < n; j++)
+      if (masgn_reads(nt, ids[j], rty, name)) return 1;
+  }
+  return 0;
+}
+/* Whether the target, or one nested in it, writes a variable the subtree
+   reads. */
+static int masgn_target_writes(const NodeTable *nt, int t, int id) {
+  static const char *const VARS[][2] = {
+    { "LocalVariableTargetNode", "LocalVariableReadNode" },
+    { "InstanceVariableTargetNode", "InstanceVariableReadNode" },
+    { "GlobalVariableTargetNode", "GlobalVariableReadNode" },
+    { "ClassVariableTargetNode", "ClassVariableReadNode" },
+    { "ConstantTargetNode", "ConstantReadNode" } };
+  const char *ty = nt_type(nt, t), *nm = nt_str(nt, t, "name");
+  if (!ty) return 0;
+  if (sp_streq(ty, "MultiTargetNode")) {
+    static const char *const SIDES[] = { "lefts", "rights" };
+    for (size_t s = 0; s < sizeof SIDES / sizeof SIDES[0]; s++) {
+      int n = 0;
+      const int *ts = nt_arr(nt, t, SIDES[s], &n);
+      for (int i = 0; i < n; i++) if (masgn_target_writes(nt, ts[i], id)) return 1;
+    }
+    return 0;
+  }
+  if (!nm) return 0;
+  for (size_t v = 0; v < sizeof VARS / sizeof VARS[0]; v++)
+    if (sp_streq(ty, VARS[v][0])) return masgn_reads(nt, id, VARS[v][1], nm);
+  return 0;
+}
+/* A part that answers the same whenever it runs: a read, a literal, or
+   arithmetic over them -- unless a target assigned before its store writes
+   what it reads (`i, a[i] = 1, 2`). */
+static int masgn_part_plain(Compiler *c, int id, const int *lefts, int before) {
+  if (masgn_part_allocates(c, id) || subtree_has_side_effect(c, id)) return 0;
+  for (int i = 0; i < before; i++) if (masgn_target_writes(c->nt, lefts[i], id)) return 0;
+  return 1;
+}
+/* A literal that is not built -- rodata, which no sweep touches; a Bignum
+   is built. */
+static int masgn_rodata(Compiler *c, int id) {
+  return node_is_pure_literal(c->nt, id) && !subtree_may_allocate(c->nt, id) && comp_ntype(c, id) != TY_BIGINT;
+}
+/* The root push for a temp, after the `;` of the statement that set it, when
+   `emit_gc_root_tmp` has one for the type. */
+static void masgn_root(Compiler *c, TyKind t, int tmp, Buf *b) {
+  Buf rb; memset(&rb, 0, sizeof rb);
+  emit_gc_root_tmp(c, t, tmp, &rb);
+  if (rb.p && rb.p[0]) buf_printf(b, " %s", rb.p);
+  free(rb.p);
+}
+/* Whether the slot value `vi` lands in boxes a by-value struct of type `vt`
+   on the heap: a local or an instance variable of that type holds it as it
+   is; any other slot may box it. */
+static int masgn_slot_boxes(Compiler *c, int id, const int *lefts, int ln, int vi, TyKind vt) {
+  if (vi >= ln) return 1;
+  const char *ty = nt_type(c->nt, lefts[vi]), *nm = nt_str(c->nt, lefts[vi], "name");
+  if (!ty || !nm) return 1;
+  if (sp_streq(ty, "LocalVariableTargetNode")) {
+    LocalVar *lv = scope_local(comp_scope_of(c, id), nm);
+    return !lv || lv->type != vt;
+  }
+  if (sp_streq(ty, "InstanceVariableTargetNode")) {
+    Scope *sc = comp_scope_of(c, id);
+    int cid = sc && sc->class_id >= 0 ? sc->class_id : g_class_body_id;
+    int ix = cid >= 0 ? comp_ivar_index(&c->classes[cid], nm) : -1;
+    return ix < 0 || c->classes[cid].ivar_types[ix] != vt;
+  }
+  return 1;
+}
+/* A part evaluated into a rooted temp in the statement's prelude, as its
+   store takes it: boxed for a poly slot, an Integer for an Array's index, a
+   hash's key as its kind keys. The part is emitted whole first, so what it
+   hoists lands before the declaration. */
+static int masgn_hoist_part(Compiler *c, int node, TyKind t, Buf *hb) {
+  Buf eb; memset(&eb, 0, sizeof eb);
+  if (t == TY_POLY) emit_boxed(c, node, &eb);
+  else if (t == TY_INT) emit_int_expr(c, node, &eb);
+  else emit_expr(c, node, &eb);
+  int tmp = ++g_tmp;
+  emit_indent(hb, g_indent);
+  emit_ctype(c, t, hb);
+  buf_printf(hb, " _t%d = %s;", tmp, eb.p ? eb.p : ""); free(eb.p);
+  masgn_root(c, t, tmp, hb);
+  buf_puts(hb, "\n");
+  return tmp;
+}
+/* The frozen guard a single ivar write makes, on a line of its own, when the
+   class has one; the guard's text ends in the separator an inline caller
+   continues from. Consumes `fb`. */
+static void masgn_guard_line(Buf *fb, Buf *b, int indent) {
+  size_t n = fb->p ? strlen(fb->p) : 0;
+  while (n && fb->p[n - 1] == ' ') n--;
+  if (n) { emit_indent(b, indent); buf_printf(b, "%.*s\n", (int)n, fb->p); }
+  free(fb->p);
+}
+/* `_t<tmp>` when the part was evaluated into that temp before the values, or
+   the part itself. */
+static void masgn_part(Compiler *c, int node, int tmp, Buf *b) {
+  if (tmp >= 0) buf_printf(b, "_t%d", tmp);
+  else emit_expr(c, node, b);
+}
+
 void emit_stmt_inner(Compiler *c, int id, Buf *b, int indent) {
   const NodeTable *nt = c->nt;
   const char *ty = nt_type(nt, id);
@@ -8682,6 +8821,64 @@ else {
         if (!lty || !sp_streq(lty, "LocalVariableTargetNode")) { unsupported(c, id, "multiple assignment"); return; }
       }
     }
+    /* Ruby evaluates each target's receiver and index before any value, left
+       to right -- `a[i], o.x = f, g` reads a, i and o, then f and g -- and
+       assigns last. A receiver or index that is a plain read or literal
+       answers the same whenever it runs and stays at its store; once any is a
+       call, a literal that allocates or a write, every target's receiver and
+       index goes into a temp, so the order is Ruby's, and a key that is a
+       fresh object is held while the values build. The temps go into the
+       statement's prelude, ahead of what a value hoists there -- a literal's
+       build -- and each part is emitted whole before its declaration is
+       written, and the index after the receiver's, so what a part hoists
+       lands before its own declaration and after the part before it. The
+       temps are rooted outright: a part that is a read is held by its
+       variable only until a later part or a value runs user code -- a call,
+       or the `to_s` an interpolation runs, which no predicate here sees -- a
+       literal part may be boxed on the heap by its slot, a Rational under a
+       poly key, and the hoist happens only where some part is a call or a
+       build. */
+    int *ttr = ln > 0 ? alloca(sizeof(int) * (size_t)ln) : NULL;
+    int *ttk = ln > 0 ? alloca(sizeof(int) * (size_t)ln) : NULL;
+    int hoist = 0;
+    for (int i = 0; i < ln; i++) {
+      int r, k;
+      masgn_target_parts(nt, lefts[i], &r, &k);
+      ttr[i] = ttk[i] = -1;
+      if (!masgn_part_plain(c, r, lefts, i) || !masgn_part_plain(c, k, lefts, i)) hoist = 1;
+    }
+    if (hoist) {
+      Buf *hb = g_pre;
+      for (int i = 0; i < ln; i++) {
+        int r, k;
+        masgn_target_parts(nt, lefts[i], &r, &k);
+        if (r < 0) continue;
+        int index = sp_streq(nt_type(nt, lefts[i]), "IndexTargetNode");
+        TyKind rt = comp_ntype(c, r);
+        int poly_r = index && (rt == TY_POLY || rt == TY_UNKNOWN);
+        if (index && (k < 0 || !(poly_r || ty_is_array(rt) || (ty_is_hash(rt) && ty_hash_cname(rt))))) continue;
+        if (!index && !ty_is_object(rt)) continue;
+        ttr[i] = masgn_hoist_part(c, r, poly_r ? TY_POLY : rt, hb);
+        if (index) ttk[i] = masgn_hoist_part(c, k, poly_r || ty_is_array(rt) ? TY_INT : ty_hash_key(rt), hb);
+      }
+    }
+    /* A store that can run user code -- the general hash's key hooks, a
+       receiver typed at run time -- or that allocates -- the rest array, a
+       value that is a by-value struct into a slot that boxes it -- comes
+       after every value is built and after the targets before it have taken
+       theirs, so it can collect what an earlier target dropped. */
+    int store_alloc = rest_var || rest_gvar;
+    for (int i = 0; i < ln && !store_alloc; i++) {
+      int r, k;
+      masgn_target_parts(nt, lefts[i], &r, &k);
+      if (k < 0) continue;
+      TyKind rt = comp_ntype(c, r);
+      store_alloc = rt == TY_POLY || rt == TY_UNKNOWN || rt == TY_POLY_POLY_HASH;
+    }
+    for (int i = 0; i < en && !store_alloc; i++) {
+      TyKind vt = comp_ntype(c, els[i]);
+      store_alloc = (ty_is_struct_valued(vt) || comp_ty_value_obj(c, vt)) && masgn_slot_boxes(c, id, lefts, ln, i, vt);
+    }
     /* evaluate all RHS values into temps first (so `a, b = b, a` swaps).
        Save each temp index separately: emit_expr may consume extra g_tmp
        slots via preludes (e.g. array literals), so base+i is unreliable. */
@@ -8763,8 +8960,15 @@ else {
         Buf vb; memset(&vb, 0, sizeof vb); emit_expr(c, els[i], &vb);
         buf_puts(b, vb.p ? vb.p : ""); free(vb.p);
       }
-      buf_puts(b, ";\n");
+      buf_puts(b, ";");
       if (tmpts) tmpts[i] = nilish ? TY_POLY : elt;
+      /* Nothing holds the temp until its target takes it, and whatever can
+         allocate after it can run user code that drops its other holder, so
+         it is rooted while a later value or a store can collect. */
+      int later_alloc = store_alloc;
+      for (int j = i + 1; j < en && !later_alloc; j++) later_alloc = masgn_part_allocates(c, els[j]);
+      if (!nilish && !masgn_rodata(c, els[i]) && later_alloc) masgn_root(c, elt, tmps[i], b);
+      buf_puts(b, "\n");
     }
     /* assign lefts */
     for (int i = 0; i < ln; i++) {
@@ -8845,6 +9049,11 @@ else {
           int iv_idx = comp_ivar_index(&c->classes[iv_cid], ivnm);
           if (iv_idx >= 0) ivt = c->classes[iv_cid].ivar_types[iv_idx];
         }
+        if (!(iv_sc && iv_sc->is_cmethod) && iv_cid >= 0) {
+          Buf fb; memset(&fb, 0, sizeof fb);
+          emit_frozen_obj_guard(c, iv_cid, g_self ? g_self : "self", &fb);
+          masgn_guard_line(&fb, b, indent);
+        }
         emit_indent(b, indent);
         if (iv_sc && iv_sc->is_cmethod && iv_cid >= 0)
           buf_printf(b, "civ_%s_%s = ", c->classes[iv_cid].name, ivnm + 1);
@@ -8878,8 +9087,15 @@ else {
         int defc2 = -1; comp_writer_in_chain(c, rc2, base2, &defc2);
         int iv2 = comp_ivar_index(&c->classes[defc2 < 0 ? rc2 : defc2], ivn2);
         TyKind ivt2 = iv2 >= 0 ? c->classes[defc2 < 0 ? rc2 : defc2].ivar_types[iv2] : TY_UNKNOWN;
-        emit_indent(b, indent);
-        buf_puts(b, "("); emit_expr(c, recv_id2, b); buf_printf(b, ")->iv_%s = ", iv_c(base2));
+        {
+          Buf rb; memset(&rb, 0, sizeof rb);
+          masgn_part(c, recv_id2, ttr[i], &rb);
+          Buf fb; memset(&fb, 0, sizeof fb);
+          emit_frozen_obj_guard(c, rc2, rb.p ? rb.p : "", &fb);
+          masgn_guard_line(&fb, b, indent);
+          emit_indent(b, indent);
+          buf_printf(b, "(%s)->iv_%s = ", rb.p ? rb.p : "", iv_c(base2)); free(rb.p);
+        }
         TyKind valt2 = comp_ntype(c, els[i]);
         if (ivt2 == TY_POLY && valt2 != TY_POLY) {
           char expr2[32]; snprintf(expr2, sizeof expr2, "_t%d", tmps[i]);
@@ -8930,13 +9146,16 @@ else {
         TyKind recv_t = comp_ntype(c, recv_id);
         emit_indent(b, indent);
         if (ty_is_array(recv_t)) {
+          /* a Range index stores a slice, which this arm has no call for */
+          if (comp_ntype(c, idx_argv[0]) == TY_RANGE) { unsupported(c, id, "multiple assignment array range index target"); continue; }
           const char *k = (recv_t == TY_POLY_ARRAY) ? "Poly" : array_kind(recv_t);
           if (!k) k = "Int";
           buf_printf(b, "sp_%sArray_set(", k);
-          emit_expr(c, recv_id, b); buf_puts(b, ", ");
+          masgn_part(c, recv_id, ttr[i], b); buf_puts(b, ", ");
           /* the index slot is an sp_int; a POLY index (a widened local, #4204)
              unboxes here, as the boxed-receiver branch below always has */
-          emit_int_expr(c, idx_argv[0], b); buf_puts(b, ", ");
+          if (ttk[i] >= 0) buf_printf(b, "_t%d", ttk[i]); else emit_int_expr(c, idx_argv[0], b);
+          buf_puts(b, ", ");
           if (recv_t == TY_POLY_ARRAY) {
             TyKind valt = tmpts ? tmpts[i] : comp_ntype(c, els[i]);
             char tmp_expr[32]; snprintf(tmp_expr, sizeof tmp_expr, "_t%d", tmps[i]);
@@ -8951,25 +9170,36 @@ else {
           /* A container the fixpoint could not type -- an attr read whose name
              several classes own, so the receiver's class is only known at run
              time -- sets through the boxed index path (#3781). */
-          int tmw = ++g_tmp;
-          buf_printf(b, "{ sp_RbVal _t%d = ", tmw);
-          emit_boxed(c, recv_id, b);
-          buf_puts(b, "; sp_poly_arr_set(_t");
-          buf_printf(b, "%d, ", tmw);
-          emit_int_expr(c, idx_argv[0], b); buf_puts(b, ", ");
+          if (ttr[i] >= 0) buf_printf(b, "sp_poly_arr_set(_t%d, _t%d, ", ttr[i], ttk[i]);
+          else {
+            int tmw = ++g_tmp;
+            buf_printf(b, "{ sp_RbVal _t%d = ", tmw);
+            emit_boxed(c, recv_id, b);
+            buf_puts(b, "; sp_poly_arr_set(_t");
+            buf_printf(b, "%d, ", tmw);
+            emit_int_expr(c, idx_argv[0], b); buf_puts(b, ", ");
+          }
           { TyKind valt = tmpts ? tmpts[i] : comp_ntype(c, els[i]);
             char tmp_expr[32]; snprintf(tmp_expr, sizeof tmp_expr, "_t%d", tmps[i]);
             Buf bxi; memset(&bxi, 0, sizeof bxi);
             emit_boxed_text(c, valt, tmp_expr, &bxi);
             buf_puts(b, bxi.p ? bxi.p : "sp_box_nil()"); free(bxi.p); }
-          buf_puts(b, "); }\n");
+          buf_puts(b, ttr[i] >= 0 ? ");\n" : "); }\n");
         }
         else if (ty_is_hash(recv_t)) {
           const char *hn = ty_hash_cname(recv_t);
           if (!hn) { unsupported(c, id, "multiple assignment hash index target unknown kind"); continue; }
+          /* The sets do not check for a frozen hash; a single store checks
+             before its set, and so does this store, after the values, where
+             CRuby's assignment raises. */
+          buf_puts(b, "if (sp_gc_is_frozen("); masgn_part(c, recv_id, ttr[i], b);
+          buf_puts(b, ")) sp_raise_frozen_hash_at("); masgn_part(c, recv_id, ttr[i], b);
+          buf_printf(b, ", %s);\n", hash_box_cls(recv_t));
+          emit_indent(b, indent);
           buf_printf(b, "sp_%sHash_set(", hn);
-          emit_expr(c, recv_id, b); buf_puts(b, ", ");
-          if (ty_hash_key(recv_t) == TY_INT) emit_int_expr(c, idx_argv[0], b);
+          masgn_part(c, recv_id, ttr[i], b); buf_puts(b, ", ");
+          if (ttk[i] >= 0) buf_printf(b, "_t%d", ttk[i]);
+          else if (ty_hash_key(recv_t) == TY_INT) emit_int_expr(c, idx_argv[0], b);
           else if (ty_hash_key(recv_t) == TY_POLY) emit_boxed(c, idx_argv[0], b);
           else emit_expr(c, idx_argv[0], b);
           buf_puts(b, ", ");

--- a/src/codegen_util.c
+++ b/src/codegen_util.c
@@ -71,16 +71,26 @@ int  g_pd_skip = -1;
    re-entered emission takes the ordinary path instead of rebuilding it. */
 int  g_cls_tag_skip = -1;
 /* True if evaluating the subtree at `id` may allocate (and so may trigger
-   a GC): any call, container literal, or string interpolation qualifies. */
+   a GC): any call, container literal, lambda, string, symbol or regexp
+   interpolation, or a read of the last match qualifies -- `$~` builds its
+   MatchData, $` and $' their String; $& and $+ are reads, counted with
+   them. */
 int subtree_may_allocate(const NodeTable *nt, int id) {
   if (id < 0) return 0;
   const char *ty = nt_type(nt, id);
   if (!ty) return 0;
   if (sp_streq(ty, "CallNode") || sp_streq(ty, "ArrayNode") ||
       sp_streq(ty, "HashNode") || sp_streq(ty, "KeywordHashNode") ||
-      sp_streq(ty, "InterpolatedStringNode") || sp_streq(ty, "SuperNode") ||
+      sp_streq(ty, "InterpolatedStringNode") || sp_streq(ty, "InterpolatedSymbolNode") ||
+      sp_streq(ty, "InterpolatedRegularExpressionNode") || sp_streq(ty, "BackReferenceReadNode") ||
+      sp_streq(ty, "LambdaNode") || sp_streq(ty, "SuperNode") ||
       sp_streq(ty, "ForwardingSuperNode") || sp_streq(ty, "YieldNode"))
     return 1;
+  /* Prism reads the match globals as plain globals as often as not. */
+  if (sp_streq(ty, "GlobalVariableReadNode")) {
+    const char *nm = nt_str(nt, id, "name");
+    return nm && (sp_streq(nm, "$~") || sp_streq(nm, "$`") || sp_streq(nm, "$'"));
+  }
   /* A NUL-containing (binary) string literal does not lower to an immortal
      rodata pointer: it allocates a heap string via sp_str_from_bytes (every
      evaluation when unfrozen, or once to fill a call-site cache when frozen).

--- a/test/multi_assign_operand_gc_root.rb
+++ b/test/multi_assign_operand_gc_root.rb
@@ -1,0 +1,321 @@
+# A multiple assignment builds each value into a temporary before any target
+# takes one, so a value that is a fresh object is held by nothing while the
+# values after it are built: a collection a later value's build ran swept it.
+# Its targets' receivers and indexes were evaluated at each store, after the
+# values, where Ruby evaluates them first, left to right, so a call in a
+# target ran after the values, a key evaluated in Ruby's order is a fresh
+# object held by nothing while the values build, and a frozen hash target was
+# written without complaint. Covers two and three values into locals, instance
+# and global variables; index targets with a built key on String-keyed hashes
+# with Integer, String and poly values, Integer- and Symbol-keyed hashes, the
+# general hash, an Array and a container typed at run time; attribute targets
+# whose receiver is a call, evaluated once; a splat and a nested target; a
+# value that drops the only other holder of an earlier one; the assignment as
+# a value; the order of the targets' receivers and keys against the values, a
+# value built in the statement's prelude among them, and a target assigned
+# before a later target's plain index, a nested target among them; the
+# assignment's own stores collecting, through a hash hook, what a target's
+# index cleared, an earlier target dropped, or a value held by a global alone;
+# the to_s an interpolation runs clearing the holder of a hoisted receiver, a
+# hoisted key and a value; a Bignum literal, which is built, an interpolated
+# Symbol, a lambda and the last match, which allocate, a store that boxes a
+# Process.times, and the receiver before an index built in the prelude; a
+# store that boxes a Range into a poly slot; a swap through plain indexes; and
+# a frozen hash, and a frozen object under an attribute or instance variable
+# target, refused after the values are built, as CRuby refuses them. Each
+# collecting builder collects the object heap outright and allocates past the
+# string heap's own trigger. The order sections, the swap and the Range store
+# have nothing to sweep; they hold the emitter to the shape.
+def gcv(i)
+  GC.start
+  ("pad" * 400_000).size
+  "v#{i}"
+end
+def gci(i)
+  GC.start
+  ("pad" * 400_000).size
+  i * 2
+end
+
+bad = 0
+200.times do |i|
+  a, b = "x#{i}", gcv(i)
+  bad += 1 unless a == "x#{i}" && b == "v#{i}"
+  a, b, c = "x#{i}", "y#{i}", gcv(i)
+  bad += 1 unless a == "x#{i}" && b == "y#{i}" && c == "v#{i}"
+  a, b = [i, i + 1], gcv(i)
+  bad += 1 unless a == [i, i + 1] && b == "v#{i}"
+  a, b = {"k" => i}, gci(i)
+  bad += 1 unless a == {"k" => i} && b == i * 2
+end
+p bad
+
+class Pair
+  attr_accessor :x, :y
+  def initialize; @x = "a"; @y = "b"; end
+  def fill(i)
+    @x, @y = "x#{i}", gcv(i)
+  end
+  def fill_gv(i)
+    $gx, $gy = "x#{i}", gcv(i)
+  end
+end
+$gx = nil
+$gy = nil
+pr = Pair.new
+bad = 0
+200.times do |i|
+  pr.fill(i)
+  bad += 1 unless pr.x == "x#{i}" && pr.y == "v#{i}"
+  pr.fill_gv(i)
+  bad += 1 unless $gx == "x#{i}" && $gy == "v#{i}"
+end
+p bad
+
+# index targets with a key that is a fresh object, on each hash kind
+ss = {"a" => "b"}
+200.times { |i| ss["k#{i}"], ss["m#{i}"] = "x#{i}", gcv(i) }
+p ss.size, ss.keys.uniq.size, ss["k50"], ss["m50"]
+si = {"a" => 1}
+200.times { |i| si["k#{i}"], si["m#{i}"] = i, gci(i) }
+p si.size, si.keys.uniq.size, si["k50"], si["m50"]
+is = {1 => "a"}
+200.times { |i| is[gci(i) + 1000], is[gci(i) + 2000] = "x#{i}", gcv(i) }
+p is.size, is[1100], is[2100]
+sp = {"a" => 1, "b" => "x"}
+200.times { |i| sp["k#{i}"], sp["m#{i}"] = "x#{i}", gci(i) }
+p sp.size, sp.keys.uniq.size, sp["k50"], sp["m50"]
+yp = {a: 1, b: "x"}
+200.times { |i| yp[i.even? ? :k0 : :k1], yp[:k2] = "x#{i}", gcv(i) }
+p yp.size, yp.keys.uniq.size, yp[:k0], yp[:k1], yp[:k2]
+gp = {"a" => 1, :b => 2}
+200.times { |i| gp["k#{i}"], gp[[i]] = "x#{i}", gcv(i) }
+p gp.size, gp.keys.uniq.size, gp["k50"], gp[[50]]
+arr = Array.new(10, "z")
+200.times { |i| arr[gci(i) % 10], arr[(gci(i) + 1) % 10] = "x#{i}", gcv(i) }
+p arr.size, arr.uniq.size, arr[0], arr[1]
+
+# a container typed at run time stores after the values are built
+def put(x, i)
+  x[i % 10], x[(i + 1) % 10] = "a#{i}", gcv(i)
+end
+def check(x)
+  bad = 0
+  x.each_with_index { |v, i| bad += 1 unless v == "a#{i}" || v == "a#{i + 190}" || v.start_with?("v") }
+  bad
+end
+def put2(x, i)
+  x[gci(i) % 10], x[(i + 1) % 10] = "a#{i}", gcv(i)
+end
+pa = Array.new(10, "z")
+pb = Array.new(10) { nil }
+200.times { |i| put(pa, i); put(pb, i) }
+p pa.size, check(pa), pa[0], pa[1], pb.size, check(pb), pb[0], pb[1]
+pc = Array.new(10, "z")
+pd = Array.new(10) { nil }
+100.times { |i| put2(pc, i); put2(pd, i) }
+p pc.size, pc.count { |v| v.start_with?("a") || v.start_with?("v") }, pd.size, pd.compact.size
+
+# a store that boxes a by-value struct into a poly slot allocates
+bs = {"a" => 1, "b" => "x"}
+bad = 0
+200.times do |i|
+  bs["r"], t = (i..i + 1), "t#{i}"
+  bad += 1 unless bs["r"] == (i..i + 1) && t == "t#{i}"
+end
+p bad
+
+# attribute targets whose receiver is a call
+$n = 0
+def mk; $n += 1; $pr; end
+$pr = Pair.new
+200.times { |i| mk.x, mk.y = "x#{i}", gcv(i) }
+p $n, $pr.x, $pr.y
+
+# a splat and a nested target
+def pair(i); ["x#{i}", "y#{i}"]; end
+bad = 0
+200.times do |i|
+  a, *r = "x#{i}", gcv(i), "z#{i}"
+  bad += 1 unless a == "x#{i}" && r == ["v#{i}", "z#{i}"]
+  a, *r, z = "x#{i}", gcv(i), "z#{i}"
+  bad += 1 unless a == "x#{i}" && r == ["v#{i}"] && z == "z#{i}"
+  (a, b), c = pair(i), gcv(i)
+  bad += 1 unless a == "x#{i}" && b == "y#{i}" && c == "v#{i}"
+end
+p bad
+
+# a value that drops the only other holder of an earlier one
+bad = 0
+200.times do |i|
+  $s = "keep#{i}"
+  a, b = $s, ($s = nil; gcv(i))
+  bad += 1 unless a == "keep#{i}" && b == "v#{i}"
+end
+p bad
+
+# the assignment as a value
+bad = 0
+200.times do |i|
+  r = (a, b = "x#{i}", gcv(i))
+  bad += 1 unless r == ["x#{i}", "v#{i}"] && a == "x#{i}"
+end
+p bad
+
+# the targets' receivers and keys are evaluated before the values, left to
+# right, and a receiver that is a call is evaluated once
+def k(n); puts "key #{n}"; n; end
+def v(n); puts "value #{n}"; n; end
+$h = {1 => 0}
+def r(n); puts "receiver #{n}"; $h; end
+r(1)[k(1)], r(2)[k(2)] = v(1), v(2)
+p $h
+ia = [0, 0]
+ia[k(0)], ia[k(1)] = v(3), v(4)
+p ia
+def o(n); puts "object #{n}"; $pr; end
+o(1).x, o(2).y = v(5).to_s, v(6).to_s
+p $pr.x, $pr.y
+$n = 0
+mk.x, mk.y = "p", "q"
+p $n
+# a value that is built in the statement's prelude, a literal, still comes
+# after the targets' parts, and a target assigned earlier does not reach a
+# later target's plain index
+pl = [nil, nil]
+pl[k(0)], x = [v(9), v(10)], v(11)
+p pl, x
+ib = [0, 0, 0]
+i = 2
+i, ib[i] = 0, 7
+p i, ib
+
+# the assignment's own stores can collect: a key held only by a global that
+# a later target's index clears, a receiver an earlier target's assignment
+# drops before a store that runs a hash hook, and a value held only by a
+# global the hook clears
+class KH
+  attr_reader :i
+  def initialize(i); @i = i; end
+  def hash; $s = nil; GC.start; ("pad" * 400_000).size; @i; end
+  def eql?(o); o.is_a?(KH) && o.i == @i; end
+end
+def clearer(i); $k = nil; GC.start; ("pad" * 400_000).size; i % 3; end
+$k = ""
+$s = ""
+h1 = {"a" => 1}
+h2 = {0 => 0}
+200.times { |i| $k = "key#{i}"; h1[$k], h2[clearer(i)] = 1, 2 }
+p h1.size, h1.keys.count { |s| s.start_with?("key") }, h2.size
+ks = Array.new(200) { |i| KH.new(i) }
+gh = {KH.new(-1) => 0}
+def mk3; [1, 2, 3]; end
+bad = 0
+200.times do |i|
+  a = mk3
+  a, gh[ks[i]], a[0] = [7, 8, 9], 1, 99
+  bad += 1 unless a == [7, 8, 9]
+end
+p gh.size, bad
+out = []
+200.times { |i| $s = "val#{i}"; gh[ks[i]], t = 1, $s; out << t }
+p gh.size, out.count { |s| s.start_with?("val") }
+
+# user code no predicate sees: the to_s an interpolation runs clears the
+# only other holder of a hoisted receiver, of a hoisted key, and of a value
+class Box
+  attr_accessor :v
+  def initialize(v); @v = v; end
+end
+class Killer
+  def to_s; $b = nil; $k = nil; $g = nil; GC.start; ("pad" * 400_000).size; "t"; end
+end
+$kk = Killer.new
+$pool = []
+th = {"z" => "zz"}
+200.times do |i|
+  $b = Box.new("b#{i}")
+  $b.v, th["x#{$kk}#{i}"] = "w#{i}", "hv#{i}"
+  $pool << Box.new("pool")
+end
+p th.size, $pool.count { |x| x.v == "pool" }
+t1 = {"z" => "zz"}
+t2 = {"z" => "zz"}
+200.times { |i| $k = "key#{i}"; t1[$k], t2["x#{$kk}#{i}"] = "v#{i}", "w#{i}" }
+p t1.size, t1.keys.count { |s| s.start_with?("key") }, t2.size
+out = []
+200.times { |i| $g = "g#{i}"; a, b = $g, "wrap#{$kk}"; out << a }
+p out.count { |s| s.is_a?(String) && s.start_with?("g") }
+
+# a value that is a Bignum literal is built, unlike the other literals; a
+# later value that is an interpolated Symbol allocates
+bad = 0
+200.times do |i|
+  a, b = 123456789012345678901234567890, gcv(i)
+  bad += 1 unless a == 123456789012345678901234567890 && b == "v#{i}"
+  a, b = "x#{i}", :"sym#{i}"
+  bad += 1 unless a == "x#{i}" && b == :"sym#{i}"
+end
+p bad
+
+# a later value that is a lambda allocates its Proc, and one that is the
+# last match builds its MatchData; a store that boxes a Process.times
+# allocates
+bad = 0
+pt = Array.new(4) { nil }
+200.times do |i|
+  a, b = "x#{i}", -> { i }
+  bad += 1 unless a == "x#{i}" && b.call == i
+  subject = "a#{i}b"
+  subject =~ /b/
+  a, m = "x#{i}", $~
+  bad += 1 unless a == "x#{i}" && m[0] == "b"
+  pt[0], s = Process.times, "t#{i}"
+  bad += 1 unless pt[0].class == Process::Tms && s == "t#{i}"
+end
+p bad
+
+# within one target the receiver runs before an index built in the prelude
+$gh = {[1] => 0}
+def gr(n); puts "receiver #{n}"; $gh; end
+gr(1)[[k(1)]], x = v(1), v(2)
+p $gh, x
+
+# a nested target assigned before a later target's index
+na = [0, 0, 0, 0]
+ni = 3
+(ni, nj), na[ni] = [1, 5], 2
+p ni, nj, na
+
+# a swap through plain indexes
+sw = %w[a b c d]
+sw[0], sw[3] = sw[3], sw[0]
+p sw
+sw[1], sw[2] = sw[2], sw[1]
+p sw
+
+# a frozen hash is refused after the values are built, and the value's
+# side effects have run
+fz = {"a" => 1}.freeze
+x = nil
+begin
+  fz[k(7).to_s], x = v(7), v(8)
+rescue FrozenError => e
+  p e.class
+end
+p fz, x
+# and a frozen object refused by an attribute target and by an instance
+# variable target
+fo = Pair.new.freeze
+begin
+  fo.x, x = "p", 9
+rescue FrozenError => e
+  p e.class
+end
+p fo.x, x
+begin
+  fo.fill(1)
+rescue FrozenError => e
+  p e.class
+end
+p fo.y

--- a/test/multi_assign_operand_gc_root.rb.expected
+++ b/test/multi_assign_operand_gc_root.rb.expected
@@ -1,0 +1,113 @@
+0
+0
+401
+401
+"x50"
+"v50"
+401
+401
+50
+100
+401
+"x50"
+"v50"
+402
+402
+"x50"
+100
+5
+5
+"x198"
+"x199"
+"v199"
+402
+402
+"x50"
+"v50"
+10
+10
+"x195"
+"v195"
+10
+0
+"v199"
+"a191"
+10
+0
+"v199"
+"a191"
+10
+10
+10
+10
+0
+400
+"x199"
+"v199"
+0
+0
+0
+receiver 1
+key 1
+receiver 2
+key 2
+value 1
+value 2
+{1 => 1, 2 => 2}
+key 0
+key 1
+value 3
+value 4
+[3, 4]
+object 1
+object 2
+value 5
+value 6
+"5"
+"6"
+2
+key 0
+value 9
+value 10
+value 11
+[[9, 10], nil]
+11
+0
+[0, 0, 7]
+201
+200
+3
+201
+0
+201
+200
+201
+200
+201
+200
+201
+200
+0
+0
+receiver 1
+key 1
+value 1
+value 2
+{[1] => 1}
+2
+1
+5
+[0, 0, 0, 2]
+["d", "b", "c", "a"]
+["d", "c", "b", "a"]
+key 7
+value 7
+value 8
+FrozenError
+{"a" => 1}
+nil
+FrozenError
+"a"
+nil
+FrozenError
+"b"


### PR DESCRIPTION
## Why

`a, b = "x#{i}", f(i)` builds each value into a temporary before any target takes one — that is what makes `a, b = b, a` a swap — and nothing holds the first temporary while the second is built. The collector does not scan the C stack: a value is a root only while it is on the shadow stack, and a temporary has no holder once its own expression is done. So a collection the second value's build runs sweeps the first when it is a fresh object. Under a value that collects, 200 rounds of `a, b = "x#{i}", gcv(i)` left, in about a third of runs, 188 distinct Strings in `a` where 200 went in and a hash filled from the pairs whose entries read freed memory — the others crashed, or came out whole, by where the sweep fell; `a, b, c = "x#{i}", "y#{i}", gcv(i)` answered wrong on every round; and `h["k#{i}"], h["m#{i}"] = "x#{i}", gcv(i)` stored the freed first value under its key, so `h["k50"]` read back its own key's text, or a later round's value, from the memory. The test that does all of these segfaults on master, in the collector's mark, with wrong answers before it; under ASAN the probe behind it is a use-after-free in the set's key compare.

The index targets add an order of their own. Ruby evaluates each target's receiver and index before any value, left to right, then the values, then assigns: `r(1)[k(1)], r(2)[k(2)] = v(1), v(2)` runs r, k, r, k, v, v. The emitter ran the values first and built each receiver and index inside its store, so the calls ran in the wrong order. Evaluated before the values, as Ruby has it, a key that is a fresh object is held by nothing while the values build, so the new order needs the roots a single store's key has (#4203). And a hash index target never refused a frozen hash: `fz["b"], x = 2, 3` wrote into it, where a single store checks before its set and CRuby raises; an attribute target and an instance variable target wrote into a frozen object the same way, where the single writes raise.

## What

- A value of a multiple assignment that is a fresh object was swept while the values after it were built: 200 rounds of `a, b = "x#{i}", gcv(i)`, with `gcv` collecting the object heap and allocating past the string heap's own trigger, left, in about a third of runs, 188 distinct Strings in `a` and a hash filled from the pairs whose entries read freed memory, and in the others crashed or came out whole in about equal measure; the three-value form answered wrong on every round; `arr[gci(i) % 10], arr[(gci(i) + 1) % 10] = "x#{i}", gcv(i)` over an Array of 10 left 6 distinct where CRuby leaves 10; `h["k#{i}"], h["m#{i}"] = "x#{i}", gcv(i)` stored the freed first value, so `h["k50"]` read back its own key's text or a later round's value. The same across instance variable, global variable, attribute, splat and nested targets, and with the assignment as a value. Each is whole now; the test that exercises them all segfaults on master partway through, with wrong answers before it.
- The targets' receivers and indexes are evaluated before the values, left to right, as Ruby evaluates them: `r(1)[k(1)], r(2)[k(2)] = v(1), v(2)` printed the values first, and `o(1).x, o(2).y = v(5), v(6)` likewise.
- `fz["b"], x = 2, 3` on a frozen hash wrote into it and answered as if nothing were wrong; it raises `FrozenError` after the values are built, with `x` untouched, as CRuby does. `o.x, x = "p", 9` on a frozen object, and `@x, @y = ...` in a method on a frozen `self`, wrote too, where `o.x = "p"` and `@x = "p"` raise; they raise as the single writes do.

## How

- **The value temps** (the tuple path of `MultiWriteNode` in `codegen_stmt.c`): a temp is rooted, through `emit_gc_root_tmp`, while something after it can collect — a later value that allocates, a store that runs user code (the general hash's key hooks, a receiver typed at run time), or a store that allocates (the rest array, a by-value struct such as a Range boxed into a slot that is not a local or an instance variable of its own type). Nothing holds the temp but its slot, and whatever can allocate can run user code that drops its other holder: a call, or the `to_s` an interpolation runs, which no side-effect predicate sees, so a temp that is a plain read of a global is rooted too — `a, b = $g, "wrap#{$kk}"` with a `to_s` that clears `$g`. A literal that is rodata is never rooted; a Bignum literal is built, so it is. `a, b = b, a`, `a, b = 1, 2` and every other assignment whose values are reads, literals or arithmetic, with no such store after them, emit as they did.
- **The targets' parts**: once any target's receiver or index is a call, a literal that allocates, a write, or a read of a variable a target before it assigns (`i, a[i] = 1, 2`), every target's receiver and index — the plain ones too, so the order among them holds — is evaluated into a temp before the values, in Ruby's order, and the stores read the temps. The temps go into the statement's prelude, ahead of what a value hoists there (a literal's build), each part emitted whole before its declaration is written and the index after the receiver's line, so what a part hoists lands before its own declaration and after the receiver — `r(1)[[k(1)]], x = v(1), v(2)` runs r, k, v, v. The receiver's temp and the index's are rooted outright: a part that is a read is held by its variable only until a later part or a value runs user code — `h1[$k], h2["x#{$kk}#{i}"] = 1, 2` with a `to_s` that clears `$k` — and the hoist happens only where some part is a call or a build, so the roots land where a single store's would (#4203). When every receiver and index is a plain read, a literal, or arithmetic over them, they all stay at their stores, so `a[i], a[j] = a[j], a[i]` over Integers and `a[i % n]` are emitted as they were. `subtree_may_allocate` counts a builtin operator over scalars as a call; `masgn_part_allocates` reads one back as arithmetic, since `i % n` builds nothing. And `subtree_may_allocate` gains the interpolated Symbol, `:"k#{i}"`, which builds a String to intern, the interpolated Regexp, the lambda literal, `-> { }`, which allocates its Proc (`lambda { }` is a call and counted already), and the last-match reads, of which `$~`, `` $` `` and `$'` build a MatchData or a String. A `[]` read is a call to it, so the same swap over Strings gains one root, on the first value while the second is read.
- **The frozen checks**: the hash arm emits the check a single store makes, `sp_gc_is_frozen` before the set, at the store; the attribute and instance variable arms emit `emit_frozen_obj_guard`, the single write's guard, which is nothing on a class whose instances are never frozen.
- The other paths of the emitter — a call, a splat or a typed array on the right, destructured at run time — are untouched. `subtree_may_allocate` is shared with the single store's and the argument roots' sites; one program, `issue_3146`, changes through them, as above.

The generated C changes for 10 of the 3,369 programs of master's suite, the benchmarks and optcarrot: 7 tests gain a root or the frozen check, one (`poly_multi_write_index_target`) has its attr-read receivers hoisted and rooted, with a root on its first value, one (`issue_3146`) has a single store's interpolated-Symbol key, `big[:"k#{i}"] = i * 3`, take #4203's hoisted form now that the key counts as allocating — the Symbol is interned, so nothing there is rooted — and optcarrot gains one root, in `APU#initialize`, on the first of `@pulse_0, @pulse_1 = Pulse.new(self), Pulse.new(self)` while the second is built — construction time, once. Every benchmark is byte-identical.

## Validation

- A new test, `test/multi_assign_operand_gc_root` (expectations generated by CRuby 4.0), a segfault on master partway through: two and three values into locals, instance and global variables, with a value that collects; index targets with a built key on String-keyed hashes with Integer, String and poly values, Integer- and Symbol-keyed hashes, the general hash, an Array and a container typed at run time, with a call as its index too; attribute targets whose receiver is a call, evaluated once; a splat and a nested target; a value that drops the only other holder of an earlier one; the assignment as a value; the order of the targets' receivers and keys against the values, a value built in the statement's prelude among them, and a target assigned before a later target's plain index, a nested target among them; the assignment's own stores collecting, through a hash hook, a key a later target's index cleared, a receiver an earlier target dropped, and a value held by a global alone; the `to_s` an interpolation runs clearing the holder of a hoisted receiver, a hoisted key and a value; a Bignum literal, which is built, an interpolated Symbol, a lambda and the last match, which allocate, a store that boxes a Range into a poly slot and one that boxes a `Process.times`, and the receiver before an index built in the prelude; a swap through plain indexes; and a frozen hash, and a frozen object under an attribute and an instance variable target, refused after the values are built.
- Full suite: 3,346 pass, 0 fail, from a cleared results cache, at `-O2` and at the gate's `-O1`.
- The new test runs clean under `SPINEL_GC_STRESS=1` and ASAN+UBSAN with CRuby's output; so do the probes behind each number above.
- Generated C against master: 10 of 3,369 programs differ, as listed under How; the benchmarks are byte-identical, optcarrot differs by the one root.
- Against the differential corpus of ~2,100 minimized programs the campaign has been working from: 712 → 712 match, 0 gained and 0 lost.
- The gate's other legs: 61 benchmarks pass, optcarrot's checksum is 59662, and its frame rate is master's within the run-to-run spread — 1,847 fps against 1,845, each the median of five with a spread under 2%.

## Left alone, on purpose

- A receiver or index that is a plain read is still read at its store, after the values, so a value that reassigns it — `x[0], x[1] = (x = other; 1), 2` — stores into the new container where Ruby stores into the old, and `h[$1], x = (s =~ /(y+)/), 2` stores under the value's own capture; the hoist is for what a plain read cannot be, a call or a build, as #4203's is.
- The values are built in order, but a value that hoists a build into the statement's prelude — an Array literal, an interpolated Regexp — runs before an earlier value that does not — `a, b = v(1), [v(2), v(3)]` runs v(2) and v(3) first — on master and here alike; the targets' parts now come before both.
- A Range index into an Array target, `a[1..2], x = 9, 1`, is refused at compile time, as `unsupported`, where the C compiler refused it; a Range that arrives through a poly slot, `a[q[0]], x = 9, 1`, is coerced as an index and raises a `TypeError` at run time, where it did not compile; the single store answers CRuby's slice. A two-argument index, `a[k(1), k(2)], x = 9, 1`, drops its second argument without a word, as before. Both want the slice store, not a root.
- The run-time-destructure paths — `a, b = f()`, `a, *b = arr` — evaluate an attribute target's receiver at its store as before; their values sit in the rooted array, so there is nothing to sweep, and the order is observable only when the receiver is a call.
- A container typed at run time that is a Hash drops a multiple-assignment store — `sp_poly_arr_set` on a Hash box stores nothing, where the single store's path finds the hash — on master and here alike; the test's run-time-typed section uses two Array kinds.
- A Symbol-keyed hash target whose key is a poly value (`h[syms[i]], x = ...`) fails to compile, on master and here alike: the masgn arm passes the key as it is, where a single store coerces it through `emit_hash_key`.
- Index targets after a splat (`a, *r, h[k] = ...`) are skipped without a word, as before; that arm has no index case.
- A namespaced constant assigned before a later target's index, `M::X, a[M::X] = 2, 9`, is not among the targets the plain gate consults — a plain `X, a[X] = 2, 9` is — so the index reads the new value, on master and here alike.
- The general hash's key hooks running over a value that is a temporary is #4201's; here such a store counts as one that can collect, so the value temps before it are rooted.
- A root pushed for a temp stays on the shadow stack to the end of the enclosing C scope, as the rest array's does, so a recursive method with such an assignment holds more roots per frame: one more for `a, b = "s#{n}", "t#{n}"`, where the shadow stack's 65,536 slots hold about 21,800 frames instead of about 32,800; four more for `$h[k(n)], b = "v#{n}", "w#{n}"` on a general hash, whose two parts and two values are all rooted, about 13,100 frames. The stack overflows silently, into a dropped root. Bracing the assignment would give that back, at a brace around every one that roots.
- A value that is a rooted temp of its own prelude — an Array literal — is rooted again by its temp; a bare `_tN` in a prelude is not always rooted, so the second root stays.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multiple-assignment behavior to preserve Ruby’s left-to-right evaluation order.
  * Prevented values, receivers, and indexes from being collected during assignments.
  * Added safeguards for frozen objects and hashes, and rejected invalid range-based array indexes.
  * Improved handling of additional allocating expressions, including interpolations, lambdas, regular expressions, and match references.
* **Tests**
  * Added comprehensive coverage for garbage collection, evaluation order, nested assignments, swaps, indexed targets, and frozen-object errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->