### PR TITLE
Give HMAC its raw spelling, the one another primitive reads

### DIFF
--- a/lib/sp_crypto.c
+++ b/lib/sp_crypto.c
@@ -372,6 +372,19 @@ const char *sp_crypto_hmac_sha256_hex(const char *key, const char *msg) {SP_GC_R
     return sp_crypto_hmac_hex_buf;
 }
 
+/* The same MAC as its own bytes rather than as hex. Its own buffer, per
+ * the file header's rule: a caller that hexes one MAC and takes the raw
+ * bytes of another must not have the second clobber the first. */
+static SP_TLS char sp_crypto_hmac_sha256_bin_buf[32];
+
+const char *sp_crypto_hmac_sha256_bin(const char *key, const char *msg) {SP_GC_ROOT_STR(key);SP_GC_ROOT_STR(msg);
+    sp_crypto_hmac_sha256((const uint8_t *)key, sp_str_byte_len(key),
+                          (const uint8_t *)msg, sp_str_byte_len(msg),
+                          (uint8_t *)sp_crypto_hmac_sha256_bin_buf);
+    sp_ffi_bin_len = 32;
+    return sp_crypto_hmac_sha256_bin_buf;
+}
+
 /* HMAC-SHA1 (RFC 2104). SHA-1 is here for the same reason
  * sp_crypto_websocket_accept is: an existing protocol names it, and
  * reproducing that protocol is not a new security design. Rails signs
@@ -464,6 +477,17 @@ const char *sp_crypto_hmac_sha1_hex(const char *key, const char *msg) {SP_GC_ROO
     }
     sp_crypto_hmac_sha1_hex_buf[40] = '\0';
     return sp_crypto_hmac_sha1_hex_buf;
+}
+
+/* HMAC-SHA1 as its own bytes; see the SHA-256 sibling. */
+static SP_TLS char sp_crypto_hmac_sha1_bin_buf[20];
+
+const char *sp_crypto_hmac_sha1_bin(const char *key, const char *msg) {SP_GC_ROOT_STR(key);SP_GC_ROOT_STR(msg);
+    sp_crypto_hmac_sha1((const uint8_t *)key, sp_str_byte_len(key),
+                        (const uint8_t *)msg, sp_str_byte_len(msg),
+                        (uint8_t *)sp_crypto_hmac_sha1_bin_buf);
+    sp_ffi_bin_len = 20;
+    return sp_crypto_hmac_sha1_bin_buf;
 }
 
 /* ---------- Base64URL (RFC 4648 §5) ---------- */

--- a/lib/sp_crypto.h
+++ b/lib/sp_crypto.h
@@ -85,6 +85,18 @@ const char *sp_crypto_hmac_sha256_hex(const char *key, const char *msg);
 /* HMAC-SHA256(key, msg) -> 43-char unpadded base64url. */
 const char *sp_crypto_hmac_sha256_b64url(const char *key, const char *msg);
 
+/* HMAC-SHA256(key, msg) / HMAC-SHA1(key, msg) -> the raw digest bytes
+ * (32 and 20). Same buffer contract as sp_crypto_sha256_bin above: the
+ * result is not NUL-terminated, and its length rides sp_ffi_bin_len.
+ *
+ * The hex spellings beside these are the right primitive when a human or
+ * a protocol header reads the answer. These are for when it feeds another
+ * primitive: HKDF (RFC 5869) is HMAC over raw bytes twice, and hex-then-
+ * decode would be a lossless detour with a chance to get the decode
+ * wrong. */
+const char *sp_crypto_hmac_sha256_bin(const char *key, const char *msg);
+const char *sp_crypto_hmac_sha1_bin(const char *key, const char *msg);
+
 /* HMAC-SHA1(key, msg) -> 40-char lowercase hex. Here for the same
  * reason sp_crypto_websocket_accept is -- an existing protocol names
  * SHA-1 and reproducing it is not a new security design. Rails signs

--- a/packages/openssl/openssl/digest.rb
+++ b/packages/openssl/openssl/digest.rb
@@ -23,6 +23,8 @@ module OpenSSL
     native_func :sha1_bin,        [:string],          :cbinstr, "sp_crypto_sha1_bin"
     native_func :hmac_sha256_hex, [:string, :string], :cstring, "sp_crypto_hmac_sha256_hex"
     native_func :hmac_sha1_hex,   [:string, :string], :cstring, "sp_crypto_hmac_sha1_hex"
+    native_func :hmac_sha256_bin, [:string, :string], :cbinstr, "sp_crypto_hmac_sha256_bin"
+    native_func :hmac_sha1_bin,   [:string, :string], :cbinstr, "sp_crypto_hmac_sha1_bin"
   end
 
   module Digest
@@ -51,6 +53,26 @@ module OpenSSL
       case algo.to_s.upcase
       when "SHA256" then Crypto.hmac_sha256_hex(key, data)
       when "SHA1"   then Crypto.hmac_sha1_hex(key, data)
+      else raise Digest::DigestError, "unsupported digest algorithm: #{algo}"
+      end
+    end
+
+    # The same MAC as its own bytes. `Digest::SHA256` has had both spellings
+    # since this file was written; HMAC had only the hex one, which is the
+    # half a human or a header reads.
+    #
+    # The raw half is what another primitive reads. HKDF (RFC 5869) is HMAC
+    # over raw bytes twice, and a caller with only hex has to decode between
+    # the two rounds -- a lossless detour with a chance to get the decode
+    # wrong. The same is true of anything comparing a MAC to bytes off a
+    # wire: a webhook signature, a JWT's HS256 half, an AWS SigV4 chain.
+    #
+    # Same algorithm set and the same refusal as `hexdigest`: whatever one
+    # answers, the other answers.
+    def self.digest(algo, key, data)
+      case algo.to_s.upcase
+      when "SHA256" then Crypto.hmac_sha256_bin(key, data)
+      when "SHA1"   then Crypto.hmac_sha1_bin(key, data)
       else raise Digest::DigestError, "unsupported digest algorithm: #{algo}"
       end
     end

--- a/packages/openssl/test/openssl_digest.rb
+++ b/packages/openssl/test/openssl_digest.rb
@@ -28,3 +28,20 @@ begin
 rescue OpenSSL::OpenSSLError => e
   puts "#{e.class}: #{e.message}"
 end
+
+# HMAC's raw half. The bytes are the same bytes the hex spelling names, which
+# is the property that matters: hex(digest(...)) == hexdigest(...).
+p OpenSSL::HMAC.digest("SHA256", "key", "msg").bytesize
+p OpenSSL::HMAC.digest("SHA1", "key", "msg").bytesize
+p OpenSSL::HMAC.digest("SHA256", "key", "msg").unpack1("H*") ==
+  OpenSSL::HMAC.hexdigest("SHA256", "key", "msg")
+p OpenSSL::HMAC.digest("SHA1", "key", "msg").unpack1("H*") ==
+  OpenSSL::HMAC.hexdigest("SHA1", "key", "msg")
+# A MAC with an embedded NUL is the case a NUL-terminated return would lose.
+p OpenSSL::HMAC.digest("SHA256", "\x0b" * 20, "Hi There").unpack1("H*")
+
+begin
+  OpenSSL::HMAC.digest("MD5", "k", "m")
+rescue OpenSSL::OpenSSLError => e
+  puts "#{e.class}: #{e.message}"
+end

--- a/packages/openssl/test/openssl_digest.rb.expected
+++ b/packages/openssl/test/openssl_digest.rb.expected
@@ -10,3 +10,9 @@
 ["OpenSSL::Digest::DigestError", "OpenSSL::OpenSSLError", "StandardError"]
 ["OpenSSL::SSL::SSLError", "OpenSSL::OpenSSLError", "StandardError"]
 OpenSSL::Digest::DigestError: unsupported digest algorithm: MD5
+32
+20
+true
+true
+"b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+OpenSSL::Digest::DigestError: unsupported digest algorithm: MD5

--- a/test/sp_crypto_basic.rb
+++ b/test/sp_crypto_basic.rb
@@ -12,10 +12,16 @@
 #   - Random b64url returns the right length for the requested byte
 #     count, and (because it's random) doesn't compare-equal across
 #     calls.
+#   - The binary HMAC spellings against RFC 4231 test case 1 (a
+#     20-byte 0x0b key), hexed here so the vector stays readable, plus
+#     the property that matters: raw and hex are the same MAC, and the
+#     raw one is its full width whatever bytes it happens to contain.
 module Crypto
   ffi_func :sp_crypto_hmac_sha256_hex,      [:str, :str],       :str
   ffi_func :sp_crypto_hmac_sha256_b64url,   [:str, :str],       :str
   ffi_func :sp_crypto_hmac_sha1_hex,        [:str, :str],       :str
+  ffi_func :sp_crypto_hmac_sha256_bin,      [:str, :str],       :binstr
+  ffi_func :sp_crypto_hmac_sha1_bin,        [:str, :str],       :binstr
   ffi_func :sp_crypto_b64url_encode,        [:str],             :str
   ffi_func :sp_crypto_b64url_decode,        [:str],             :str
   ffi_func :sp_crypto_pbkdf2_sha256_b64url, [:str, :str, :int], :str
@@ -55,3 +61,18 @@ r1 = Crypto.sp_crypto_random_b64url(16) + ""
 r2 = Crypto.sp_crypto_random_b64url(16) + ""
 puts r1.length
 puts(r1 == r2 ? "same" : "diff")
+
+# RFC 4231 test case 1: key = 20 bytes of 0x0b, msg = "Hi There". The raw
+# spellings must agree with the hex ones byte for byte -- the point of having
+# both is the representation, never a different MAC.
+bkey = "\x0b" * 20
+puts Crypto.sp_crypto_hmac_sha256_bin(bkey, "Hi There").unpack1("H*")
+puts Crypto.sp_crypto_hmac_sha256_bin(bkey, "Hi There").unpack1("H*") ==
+     Crypto.sp_crypto_hmac_sha256_hex(bkey, "Hi There")
+puts Crypto.sp_crypto_hmac_sha1_bin(key, msg).unpack1("H*") ==
+     Crypto.sp_crypto_hmac_sha1_hex(key, msg)
+# The length rides sp_ffi_bin_len rather than a terminator, so a digest is
+# always its full width -- a MAC is uniform random bytes and roughly one in
+# eight contains a NUL, which a NUL-terminated return would silently truncate.
+puts Crypto.sp_crypto_hmac_sha256_bin(bkey, "Hi There").bytesize
+puts Crypto.sp_crypto_hmac_sha1_bin(bkey, "Hi There").bytesize

--- a/test/sp_crypto_basic.rb.expected
+++ b/test/sp_crypto_basic.rb.expected
@@ -8,3 +8,8 @@ Eg-2z_z4syxD5yJSVsT4N6hlSMkszDVICAWYfLcL4XtNvzovPa0zdyZLt7joMw1O_HRRQYYX2r72g3NT
 86
 22
 diff
+b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7
+true
+true
+32
+20


### PR DESCRIPTION
`Digest::SHA256` has had both `hexdigest` and `digest` since the file was written. `HMAC` had only the hex one, which is the half a human or a protocol header reads.

The raw half is what another primitive reads. HKDF (RFC 5869) is HMAC over raw bytes twice, so a caller with only hex has to decode between the two rounds — a lossless detour with a chance to get the decode wrong. Same for anything comparing a MAC against bytes off a wire: a webhook signature, a JWT's HS256 half, an AWS SigV4 chain.

## What's here

`sp_crypto_hmac_sha256_bin` / `_sha1_bin` are the twins of the `sha256_bin` / `sha1_bin` beside them, and follow the same contract: the result is not NUL-terminated, its length rides `sp_ffi_bin_len`, and each gets its own `SP_TLS` buffer so a caller that hexes one MAC and takes the bytes of another doesn't have the second clobber the first.

`OpenSSL::HMAC.digest` answers exactly what `hexdigest` answers, for the same two algorithms, and refuses the rest the same way (`DigestError`, so `rescue OpenSSL::OpenSSLError` still catches it).

The length mattering rather than a terminator is the whole point of the binary return: a MAC is uniform random bytes, so roughly one in eight contains a NUL that a NUL-terminated return would truncate at.

## Tests

RFC 4231 test case 1 for the vector, plus the property that keeps the two spellings honest — `hex(digest) == hexdigest` for both algorithms — at both the `sp_crypto` level (`test/sp_crypto_basic.rb`) and the Ruby surface (`packages/openssl/test/openssl_digest.rb`).

`make test`: **3357 pass, 0 fail, 0 error.**

## One thing worth knowing about the suite on macOS

The `OPENSSL_AVAILABLE` probe uses a bare `$(CC)`, which doesn't search `/opt/homebrew/include`, so on a Homebrew Mac `packages/openssl/test/*` is silently filtered out of `make test` — a green run there has not exercised that package. I ran it with `CPATH=/opt/homebrew/include LIBRARY_PATH=/opt/homebrew/lib` so the openssl-side expected file is a real run rather than a hand-written guess. Happy to send a probe tweak separately if you'd want one; it's orthogonal to this change.

## Why now

This is the smallest slice of a larger question I've opened as an issue alongside it — the `PKey` / `Cipher` half of the package, where the design call is yours. This piece stands on its own regardless of how that goes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added binary HMAC digest support for SHA-256 and SHA-1.
  - Added `OpenSSL::HMAC.digest` for retrieving raw digest bytes.
  - Unsupported algorithms now report a consistent digest error.

- **Tests**
  - Added coverage confirming digest sizes, byte-for-byte accuracy, embedded NUL handling, and unsupported algorithm errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->