### PR TITLE
Find a keg-only openssl, so its package tests actually run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,15 @@ ifeq ($(OPENSSL_AVAILABLE),yes)
 # prefix, so a default host's environment is untouched.
 export CPATH := $(OPENSSL_PREFIX)/include$(if $(CPATH),:$(CPATH))
 export LIBRARY_PATH := $(OPENSSL_PREFIX)/lib$(if $(LIBRARY_PATH),:$(LIBRARY_PATH))
+# LIBRARY_PATH is the LINKER's search path; it says nothing to the loader.
+# On macOS that is enough -- a Homebrew dylib's install name is absolute
+# (`otool -D` on libssl.dylib prints the keg path), so a linked binary
+# already knows where to find it at run time. An ELF host is the other way
+# round: the -L leaves no RUNPATH behind, so a package test would link and
+# then die at exec with `libssl.so.3: cannot open shared object file`. Same
+# reason as the two above for being an export rather than a flag -- the run
+# is a child process of the test recipe.
+export LD_LIBRARY_PATH := $(OPENSSL_PREFIX)/lib$(if $(LD_LIBRARY_PATH),:$(LD_LIBRARY_PATH))
 endif
 endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,45 @@ SPINEL = bin/spinel
 # the header: a system with headers but no libssl, or one too old for
 # TLS_client_method, would otherwise pass the header check and fail at the
 # package's own link.
-OPENSSL_AVAILABLE := $(shell printf '\043include <openssl/ssl.h>\nint main(void){return TLS_client_method()!=0;}\n' > /tmp/sp_ossl_probe.c 2>/dev/null && $(CC) /tmp/sp_ossl_probe.c -lssl -lcrypto -o /tmp/sp_ossl_probe >/dev/null 2>&1 && echo yes)
+#
+# KEG-ONLY INSTALLS. On a Homebrew host the headers and libraries are real
+# but off the default search path, so a bare $(CC) fails this probe and the
+# whole package -- sp_openssl.o, `require "openssl"`, and every
+# packages/openssl/test/*.rb -- drops out of the build without saying so.
+# A green `make test` there has not exercised the package at all, which is
+# how an .expected file for it can be written from a run that never
+# happened.
+#
+# So: probe bare first, and only if that fails ask for a prefix and probe
+# AGAIN with -I/-L. A prefix is trusted only when it passes the same
+# compile-and-link probe, so a stale or partial install cannot flip this to
+# yes and then fail at the package's own link. On a host where the bare
+# probe already passes, nothing below runs and the build is unchanged.
+SP_OSSL_PROBE = $(shell printf '\043include <openssl/ssl.h>\nint main(void){return TLS_client_method()!=0;}\n' > /tmp/sp_ossl_probe.c 2>/dev/null && $(CC) $(1) /tmp/sp_ossl_probe.c -lssl -lcrypto -o /tmp/sp_ossl_probe >/dev/null 2>&1 && echo yes)
+OPENSSL_AVAILABLE := $(call SP_OSSL_PROBE,)
+ifneq ($(OPENSSL_AVAILABLE),yes)
+# `brew --prefix` first: it knows a non-default HOMEBREW_PREFIX, which the
+# hardcoded pair below does not. The pair is the fallback for a host with
+# the install but without brew on PATH (a CI image that untars it, say).
+OPENSSL_PREFIX := $(firstword $(wildcard \
+    $(shell brew --prefix openssl@3 2>/dev/null) \
+    $(shell brew --prefix openssl 2>/dev/null) \
+    /opt/homebrew/opt/openssl@3 /usr/local/opt/openssl@3))
+ifneq ($(OPENSSL_PREFIX),)
+OPENSSL_CPPFLAGS := -I$(OPENSSL_PREFIX)/include
+OPENSSL_LDFLAGS  := -L$(OPENSSL_PREFIX)/lib
+OPENSSL_AVAILABLE := $(call SP_OSSL_PROBE,$(OPENSSL_CPPFLAGS) $(OPENSSL_LDFLAGS))
+ifeq ($(OPENSSL_AVAILABLE),yes)
+# The compiler shells out to cc for a program's final link, and the -lssl
+# that openssl.rb's ffi_lib puts on that line needs the -L too. Exported
+# rather than threaded through each recipe because the link happens inside
+# `bin/spinel`, one process further down. Set ONLY on a host that needed a
+# prefix, so a default host's environment is untouched.
+export CPATH := $(OPENSSL_PREFIX)/include$(if $(CPATH),:$(CPATH))
+export LIBRARY_PATH := $(OPENSSL_PREFIX)/lib$(if $(LIBRARY_PATH),:$(LIBRARY_PATH))
+endif
+endif
+endif
 BUNDLED_NATIVE_OBJS = packages/json/sp_json.o packages/stringio/sp_stringio.o packages/strscan/sp_strscan.o packages/base64/sp_base64.o
 ifeq ($(OPENSSL_AVAILABLE),yes)
 BUNDLED_NATIVE_OBJS += packages/openssl/sp_openssl.o
@@ -296,10 +334,10 @@ packages/json/sp_json_mt.o: packages/json/sp_json.c packages/json/sp_json.h \
 # which is parsed only when a program requires it.
 packages/openssl/sp_openssl.o: packages/openssl/sp_openssl.c \
                                lib/spinel/runtime.h lib/sp_alloc.h lib/sp_gc.h lib/sp_types.h
-	$(CC) -c $(COPT) -Wno-all $(SEC_FLAGS) -Ilib -Ipackages/openssl packages/openssl/sp_openssl.c -o $@
+	$(CC) -c $(COPT) -Wno-all $(SEC_FLAGS) $(OPENSSL_CPPFLAGS) -Ilib -Ipackages/openssl packages/openssl/sp_openssl.c -o $@
 packages/openssl/sp_openssl_mt.o: packages/openssl/sp_openssl.c \
                                   lib/spinel/runtime.h lib/sp_alloc.h lib/sp_gc.h lib/sp_types.h
-	$(CC) -c $(COPT) -Wno-all $(SEC_FLAGS) $(PKG_MT_FLAGS) -Ilib -Ipackages/openssl packages/openssl/sp_openssl.c -o $@
+	$(CC) -c $(COPT) -Wno-all $(SEC_FLAGS) $(PKG_MT_FLAGS) $(OPENSSL_CPPFLAGS) -Ilib -Ipackages/openssl packages/openssl/sp_openssl.c -o $@
 
 # stringio is a native-bound spin package (Path B typed object): the struct,
 # every method, and the header live in the package; the compiler knows it only


### PR DESCRIPTION
Follow-up to your note on #4220.

The `OPENSSL_AVAILABLE` probe compiles and links with a bare `$(CC)`. On a Homebrew host the headers and libraries are real but off the default search path, so the probe fails and the whole package — `sp_openssl.o`, `require "openssl"`, and every `packages/openssl/test/*.rb` — drops out of the build without saying so.

That silence is the reason this is worth fixing rather than documenting: `make test` reports a green run that never touched the package. I only noticed because I was about to write an `.expected` file from a run that had not happened.

## Shape

Probe bare first; only if that fails, ask for a prefix and probe **again** with `-I`/`-L`. A prefix is trusted only when it passes the same compile-and-link probe, so a stale or partial install cannot flip the flag to `yes` and then fail at the package's own link — the property the original probe was built around, kept.

`brew --prefix` is asked first because it knows a non-default `HOMEBREW_PREFIX`; the two standard locations are the fallback for a host with the install but no `brew` on PATH. **On a host where the bare probe already passes, none of it runs and the build is byte-identical.**

## Verified with CPATH and LIBRARY_PATH explicitly unset

macOS 26.0, Apple clang 21, `openssl@3` from Homebrew:

|  | `OPENSSL_AVAILABLE` | openssl entries in `PKG_TESTS` |
|---|---|---|
| before | *(empty)* | none |
| after | `yes` | all four |

`make test`: **3360 pass, 0 fail, 0 error** — the four that were being skipped now run and pass, including the `openssl_digest` file from #4220.

## What this does NOT fix

I checked this rather than assumed it. A standalone `spinel prog.rb` that requires openssl still fails:

```
ld: library 'ssl' not found
```

The `-lssl` that `openssl.rb`'s `ffi_lib` contributes lands on a command line one process further down, inside `bin/spinel`, and a Makefile can export `CPATH`/`LIBRARY_PATH` for its own recipes but not for a user's later shell. Teaching the compiler the prefix would close that; where it belongs is your call, so I scoped this to making the build and the gate see the package rather than guess at the compiler side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenSSL detection during builds.
  * Added support for Homebrew’s keg-only OpenSSL installations.
  * Ensured OpenSSL headers and libraries are correctly located, linked, and available during test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->