### PR TITLE
Give the openssl package EC keys, ECDH and HKDF

### DIFF
--- a/packages/openssl/openssl.rb
+++ b/packages/openssl/openssl.rb
@@ -1,14 +1,18 @@
-# Spinel bundled `openssl` -- the SSL half only.
+# Spinel bundled `openssl`.
 #
 # The spelling is CRuby's, deliberately: the goal is that a program written
 # against CRuby compiles here, so inventing a shorter name would be worth
 # nothing. What is missing is missing the way a subset is missing things --
-# OpenSSL::Digest, Cipher, PKey and most of X509 are not here, and a program
-# that uses them fails at COMPILE time with an unresolved call rather than at
-# run time somewhere deep.
+# OpenSSL::Cipher and most of X509 are not here, and a program that uses them
+# fails at COMPILE time with an unresolved call rather than at run time
+# somewhere deep. Digest, HMAC, KDF and PKey::EC are here; EC is a subset of
+# CRuby's in a second sense, spelled out in openssl/pkey.rb -- it keeps
+# CRuby's method names but trades BN, EC::Group and EC::Point for the raw
+# bytes every protocol that names an EC key means by them.
 #
-# Spinel implements no TLS. sp_openssl.c is glue over the system libssl, and
-# the trust anchors are the operating system's; nothing is bundled.
+# Spinel implements neither TLS nor any of the arithmetic below it.
+# sp_openssl.c is glue over the system libssl and libcrypto, and the trust
+# anchors are the operating system's; nothing is bundled.
 #
 # SSLSocket is not an IO, exactly as in CRuby: it is an ordinary object that
 # answers #to_io, which is why IO.select had to learn that protocol. The
@@ -16,6 +20,8 @@
 # is handed to a garbage-collected world.
 require "openssl/buffering"
 require "openssl/digest"
+require "openssl/kdf"
+require "openssl/pkey"
 
 module OpenSSL
   module Native
@@ -33,6 +39,12 @@ module OpenSSL
     native_func :read_nb,      [:int, :int],          :string, "sp_ssl_read_nb"
     native_func :want,         [],                    :int,    "sp_ssl_want"
     native_func :write_nb,     [:int, :string, :int], :int,    "sp_ssl_write_nb"
+
+    # EC, over the same object. Bytes in, bytes out, and an empty answer
+    # means the reason is in last_error -- see openssl/pkey.rb.
+    native_func :ec_generate,     [:string],                   :cbinstr, "sp_ec_generate"
+    native_func :ec_public_bytes, [:string, :string],          :cbinstr, "sp_ec_public_bytes"
+    native_func :ec_dh,           [:string, :string, :string], :cbinstr, "sp_ec_dh"
     ffi_lib "ssl"
     ffi_lib "crypto"
   end

--- a/packages/openssl/openssl/kdf.rb
+++ b/packages/openssl/openssl/kdf.rb
@@ -1,0 +1,46 @@
+# OpenSSL::KDF.hkdf -- HKDF (RFC 5869), CRuby's spelling and CRuby's keywords.
+#
+# No C: HKDF is HMAC over raw bytes, extract then expand, and the raw HMAC
+# spelling landed beside this file. Writing it in Ruby keeps it out of the
+# OPENSSL_AVAILABLE gate -- a program that reaches HKDF through this package
+# gets it whether or not the build found libcrypto's headers, the same way
+# OpenSSL::Digest works.
+module OpenSSL
+  module KDF
+    class KDFError < OpenSSLError
+    end
+
+    # Extract-then-expand, in one call as CRuby has it. `salt` is optional in
+    # the RFC and defaults to a string of zeros the length of the hash; CRuby
+    # requires the keyword, so an explicit "" gets the RFC's default here.
+    #
+    # The length ceiling is the RFC's: expand emits 255 hash-lengths at most,
+    # because the counter it appends is one octet.
+    def self.hkdf(ikm, salt:, info:, length:, hash:)
+      algo = hash.to_s.upcase
+      hlen = case algo
+             when "SHA256" then 32
+             when "SHA1"   then 20
+             else raise Digest::DigestError, "unsupported digest algorithm: #{hash}"
+             end
+      raise KDFError, "length must be positive" if length <= 0
+      raise KDFError, "length exceeds #{255 * hlen} for #{algo}" if length > 255 * hlen
+
+      prk = HMAC.digest(algo, salt.empty? ? "\0" * hlen : salt, ikm)
+
+      blocks = []
+      block = ""
+      have = 0
+      counter = 1
+      while have < length
+        block = HMAC.digest(algo, prk, block + info + counter.chr)
+        blocks << block
+        have += block.bytesize
+        counter += 1
+      end
+      # ASCII-8BIT, as CRuby answers: this is keying material, and a caller
+      # comparing it against bytes off a wire needs the tag to agree.
+      blocks.join.byteslice(0, length).b
+    end
+  end
+end

--- a/packages/openssl/openssl/pkey.rb
+++ b/packages/openssl/openssl/pkey.rb
@@ -1,0 +1,76 @@
+# OpenSSL::PKey::EC -- elliptic-curve keys, in the shape #4221 settled on:
+# CRuby's names where CRuby has a spelling, raw bytes where CRuby would hand
+# back a BN or an EC::Point.
+#
+# So `EC.generate("prime256v1")` and `key.dh_compute_key(peer)` are the names
+# a CRuby program already writes, but a key's halves are Strings --
+# `private_key_bytes` is the scalar, `public_key_bytes` is the X9.62
+# uncompressed point, 0x04 || X || Y -- and dh_compute_key takes the peer's
+# bytes rather than a Point built out of a BN. `OpenSSL::BN`, `EC::Group` and
+# `EC::Point` are not here, and a program that builds one fails at COMPILE
+# time the way the rest of this package's gaps do.
+#
+# That is a real subset, and it is a deliberate one: those three classes exist
+# in CRuby to express things this runtime has no other use for, and every
+# protocol that names raw EC keys -- RFC 8291 Web Push, JWK's x/y halves,
+# WebAuthn, ES256 -- names them as the byte strings above. A program that
+# reaches for EC::Point is already doing protocol work that has to know the
+# encoding anyway.
+#
+# A key is its bytes, so nothing on the C side outlives a call: there is no
+# handle to release and no slot to run out of, unlike the connection table
+# SSLSocket holds. An abandoned key costs nothing.
+module OpenSSL
+  module PKey
+    class PKeyError < OpenSSLError
+    end
+
+    class ECError < PKeyError
+    end
+
+    class EC
+      # The curve is carried, not inferred: the byte lengths of both halves
+      # follow from it, and a key whose curve is implicit has to be guessed at
+      # from a length the moment two curves are in play.
+      attr_reader :curve
+      attr_reader :private_key_bytes
+      attr_reader :public_key_bytes
+
+      # CRuby's spelling, and CRuby's argument: the curve's name, "prime256v1"
+      # for P-256. Whatever OBJ_txt2nid resolves works; anything else raises.
+      def self.generate(curve)
+        priv = Native.ec_generate(curve)
+        raise ECError, Native.last_error if priv.empty?
+        new(curve, priv)
+      end
+
+      # No CRuby spelling: CRuby reads a key from DER or PEM, and this package
+      # parses neither. The bytes are what a protocol stores -- a VAPID
+      # application server key is exactly this scalar, base64url'd.
+      def self.from_private_bytes(curve, bytes)
+        new(curve, bytes)
+      end
+
+      def initialize(curve, private_key_bytes)
+        @curve = curve
+        @private_key_bytes = private_key_bytes
+        @public_key_bytes = Native.ec_public_bytes(curve, private_key_bytes)
+        raise ECError, Native.last_error if @public_key_bytes.empty?
+      end
+
+      # CRuby's name; CRuby takes an EC::Point and this takes the same point's
+      # uncompressed bytes. The answer is identical either way: the X
+      # coordinate of the product, field-width, which is what CRuby returns
+      # when no KDF is asked for.
+      #
+      # A peer key that is not a point on this curve raises rather than
+      # answering: an ECDH against an off-curve point leaks the private scalar
+      # to whoever chose it.
+      def dh_compute_key(peer_public_bytes)
+        secret = Native.ec_dh(@curve, @private_key_bytes, peer_public_bytes)
+        raise ECError, Native.last_error if secret.empty?
+        secret
+      end
+    end
+  end
+end

--- a/packages/openssl/sp_openssl.c
+++ b/packages/openssl/sp_openssl.c
@@ -22,6 +22,9 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/x509v3.h>
+#include <openssl/ec.h>
+#include <openssl/bn.h>
+#include <openssl/objects.h>
 #include <string.h>
 #include <fcntl.h>
 
@@ -312,4 +315,186 @@ sp_int sp_ssl_close(sp_int h) {
   SSL_CTX_free(c->ctx);
   c->ssl = NULL; c->ctx = NULL; c->fd = -1; c->in_use = 0;
   return 0;
+}
+
+/* ---------- EC over the named prime curves ----------
+
+   The shape is the one #4221 settled on: one-shot functions over raw bytes.
+   No BN, EC::Group or EC::Point is built on the Ruby side, and -- unlike the
+   connection table above -- nothing here outlives a call. An EC key is fully
+   described by its two byte strings (the private scalar and the uncompressed
+   point), so Ruby holds those and hands them back, rather than holding a
+   handle into a table with a slot somebody has to remember to release. A key
+   abandoned mid-protocol costs nothing.
+
+   Everything below is the EC_GROUP / EC_POINT / BIGNUM API rather than
+   EC_KEY or ECDH_compute_key: those two are deprecated in OpenSSL 3.0, and
+   their replacements (EVP_PKEY_get_bn_param and friends) did not exist at
+   this file's 1.1.0 floor. The low-level three are current in 3.x and present
+   in every version this file compiles against.
+
+   Points cross the boundary in X9.62 uncompressed form, 0x04 || X || Y, which
+   is what every protocol that names raw EC keys means by "the public key" --
+   RFC 8291 Web Push, JWK's x and y halves, and WebAuthn all use it. It also
+   makes the ECDH answer a slice: the shared secret is the X coordinate, which
+   is bytes 1..flen of the encoded product point. */
+
+/* P-521, the widest curve anyone names: 66 bytes of field, 133 of point. */
+#define SP_EC_MAX_FIELD 66
+#define SP_EC_MAX_POINT (1 + 2 * SP_EC_MAX_FIELD)
+
+/* Each entry point gets its own buffer, the same rule sp_crypto.c states for
+   its digests: a caller holding the bytes of one result must not have the
+   next call clobber them. `key.public_key_bytes` and `key.dh_compute_key(x)`
+   are exactly that pair. */
+static SP_TLS char sp_ec_gen_buf[SP_EC_MAX_FIELD];
+static SP_TLS char sp_ec_pub_buf[SP_EC_MAX_POINT];
+static SP_TLS char sp_ec_dh_buf[SP_EC_MAX_FIELD];
+
+/* An empty answer plus a reason in sp_ssl_last_error; the Ruby side turns it
+   into OpenSSL::PKey::ECError. Nothing here answers a short-but-nonempty
+   string, so "empty" is unambiguously the failure. */
+static const char *sp_ec_fail(const char *what) {
+  sp_ssl_note(what);
+  sp_ffi_bin_len = 0;
+  return "";
+}
+
+static EC_GROUP *sp_ec_group(const char *curve, int *flen) {
+  int nid = OBJ_txt2nid(curve);
+  EC_GROUP *g;
+  if (nid == NID_undef) return NULL;
+  if (!(g = EC_GROUP_new_by_curve_name(nid))) return NULL;
+  *flen = (EC_GROUP_get_degree(g) + 7) / 8;
+  if (*flen <= 0 || *flen > SP_EC_MAX_FIELD) { EC_GROUP_free(g); return NULL; }
+  return g;
+}
+
+/* A private key is a scalar in [1, n-1], written field-width big-endian.
+   Out-of-range is rejected here rather than multiplied into a point that is
+   not the caller's key: d == 0 gives the point at infinity, and d >= n is a
+   silent alias for d - n. */
+static BIGNUM *sp_ec_scalar(const EC_GROUP *g, const char *priv, int flen) {
+  BIGNUM *d, *order;
+  if ((int)sp_str_byte_len(priv) != flen) return NULL;
+  if (!(d = BN_bin2bn((const unsigned char *)priv, flen, NULL))) return NULL;
+  if (!(order = BN_new())) { BN_free(d); return NULL; }
+  if (!EC_GROUP_get_order(g, order, NULL) ||
+      BN_is_zero(d) || BN_cmp(d, order) >= 0) {
+    BN_free(order); BN_clear_free(d); return NULL;
+  }
+  BN_free(order);
+  return d;
+}
+
+/* Read a peer's uncompressed point, refusing anything that is not a usable
+   public key on this curve. EC_POINT_oct2point already rejects a point off
+   the curve, and the explicit check after it is belt and braces: an ECDH
+   against an attacker-chosen off-curve point leaks the private scalar a few
+   bits at a time (the invalid-curve attack), and the whole defence is this
+   one test. Small-subgroup confinement needs no separate check on the prime
+   curves OBJ_txt2nid resolves, whose cofactor is 1 -- every on-curve point
+   other than infinity generates the full group. */
+static EC_POINT *sp_ec_peer(const EC_GROUP *g, const char *pub, int flen) {
+  EC_POINT *p;
+  size_t want = (size_t)(1 + 2 * flen);
+  if (sp_str_byte_len(pub) != want || (unsigned char)pub[0] != 0x04) return NULL;
+  if (!(p = EC_POINT_new(g))) return NULL;
+  if (!EC_POINT_oct2point(g, p, (const unsigned char *)pub, want, NULL) ||
+      !EC_POINT_is_on_curve(g, p, NULL) ||
+      EC_POINT_is_at_infinity(g, p)) {
+    EC_POINT_free(p);
+    return NULL;
+  }
+  return p;
+}
+
+/* A fresh private scalar, uniform in [1, n-1]. BN_rand_range draws from the
+   same CSPRNG the rest of libcrypto uses; the retry is for the zero it can
+   return, which is not a key. */
+const char *sp_ec_generate(const char *curve) {
+  int flen = 0;
+  EC_GROUP *g = sp_ec_group(curve, &flen);
+  BIGNUM *order = NULL, *d = NULL;
+  int ok = 0;
+
+  sp_ssl_errbuf[0] = 0;
+  if (!g) return sp_ec_fail("unknown or unsupported curve");
+  if ((order = BN_new()) && (d = BN_new()) && EC_GROUP_get_order(g, order, NULL)) {
+    for (int tries = 0; tries < 16 && !ok; tries++)
+      if (BN_rand_range(d, order) && !BN_is_zero(d)) ok = 1;
+  }
+  if (ok) ok = BN_bn2binpad(d, (unsigned char *)sp_ec_gen_buf, flen) == flen;
+
+  BN_free(order);
+  BN_clear_free(d);
+  EC_GROUP_free(g);
+  if (!ok) return sp_ec_fail("EC key generation failed");
+  sp_ffi_bin_len = flen;
+  return sp_ec_gen_buf;
+}
+
+/* dG for a private scalar d: the public half of a key the caller already
+   holds, which is why generate() answers only the scalar. */
+const char *sp_ec_public_bytes(const char *curve, const char *priv) {
+  int flen = 0;
+  EC_GROUP *g = sp_ec_group(curve, &flen);
+  BIGNUM *d = NULL;
+  EC_POINT *pub = NULL;
+  size_t n = 0;
+
+  sp_ssl_errbuf[0] = 0;
+  if (!g) return sp_ec_fail("unknown or unsupported curve");
+  if (!(d = sp_ec_scalar(g, priv, flen))) {
+    EC_GROUP_free(g);
+    return sp_ec_fail("private key is not a scalar on this curve");
+  }
+  if ((pub = EC_POINT_new(g)) && EC_POINT_mul(g, pub, d, NULL, NULL, NULL))
+    n = EC_POINT_point2oct(g, pub, POINT_CONVERSION_UNCOMPRESSED,
+                           (unsigned char *)sp_ec_pub_buf,
+                           (size_t)(1 + 2 * flen), NULL);
+
+  EC_POINT_free(pub);
+  BN_clear_free(d);
+  EC_GROUP_free(g);
+  if (n != (size_t)(1 + 2 * flen)) return sp_ec_fail("EC_POINT_mul");
+  sp_ffi_bin_len = (int)n;
+  return sp_ec_pub_buf;
+}
+
+/* ECDH: the X coordinate of d * peer, field-width. That is the raw shared
+   secret every protocol here means -- ECDH_compute_key's default KDF is the
+   identity, so this is the same answer CRuby's dh_compute_key returns. */
+const char *sp_ec_dh(const char *curve, const char *priv, const char *peer) {
+  int flen = 0;
+  EC_GROUP *g = sp_ec_group(curve, &flen);
+  BIGNUM *d = NULL;
+  EC_POINT *pt = NULL, *shared = NULL;
+  unsigned char oct[SP_EC_MAX_POINT];
+  size_t n = 0;
+
+  sp_ssl_errbuf[0] = 0;
+  if (!g) return sp_ec_fail("unknown or unsupported curve");
+  if (!(d = sp_ec_scalar(g, priv, flen))) {
+    EC_GROUP_free(g);
+    return sp_ec_fail("private key is not a scalar on this curve");
+  }
+  if (!(pt = sp_ec_peer(g, peer, flen))) {
+    BN_clear_free(d); EC_GROUP_free(g);
+    return sp_ec_fail("peer public key is not a point on this curve");
+  }
+  if ((shared = EC_POINT_new(g)) && EC_POINT_mul(g, shared, NULL, pt, d, NULL) &&
+      !EC_POINT_is_at_infinity(g, shared))
+    n = EC_POINT_point2oct(g, shared, POINT_CONVERSION_UNCOMPRESSED,
+                           oct, sizeof oct, NULL);
+
+  EC_POINT_free(shared);
+  EC_POINT_free(pt);
+  BN_clear_free(d);
+  EC_GROUP_free(g);
+  if (n != (size_t)(1 + 2 * flen)) return sp_ec_fail("ECDH failed");
+  memcpy(sp_ec_dh_buf, oct + 1, (size_t)flen);
+  OPENSSL_cleanse(oct, sizeof oct);
+  sp_ffi_bin_len = flen;
+  return sp_ec_dh_buf;
 }

--- a/packages/openssl/test/openssl_pkey_ec.rb
+++ b/packages/openssl/test/openssl_pkey_ec.rb
@@ -1,0 +1,108 @@
+require "openssl"
+
+def hx(s) = [s].pack("H*")
+
+# RFC 8291 section 5 and appendix A: a complete Web Push example with fixed
+# keys, so every value below is published rather than computed here. The
+# base64url beside each is the RFC's own spelling of the same bytes.
+#
+# as_private: yfWPiYE-n46HLnH0KqZOF1fJJU3MYrct3AELtAQ-oRw
+AS_PRIV = hx("c9f58f89813e9f8e872e71f42aa64e1757c9254dcc62b72ddc010bb4043ea11c")
+# as_public: BP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8
+AS_PUB = hx("04fe33f4ab0dea71914db55823f73b54948f41306d920732dbb9a59a53286482200e597a7b7bc260ba1c227998580992e93973002f3012a28ae8f06bbb78e5ec0f")
+# ua_private: q1dXpw3UpT5VOmu_cf_v6ih07Aems3njxI-JWgLcM94
+UA_PRIV = hx("ab5757a70dd4a53e553a6bbf71ffefea2874ec07a6b379e3c48f895a02dc33de")
+# ua_public: BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4
+UA_PUB = hx("042571b2becdfde360551aaf1ed0f4cd366c11cebe555f89bcb7b186a53339173168ece2ebe018597bd30479b86e3c8f8eced577ca59187e9246990db682008b0e")
+# ecdh_secret: kyrL1jIIOHEzg3sM2ZWRHDRB62YACZhhSlknJ672kSs
+SECRET = hx("932acbd63208387133837b0cd995911c3441eb66000998614a592727aef6912b")
+# auth_secret: BTBZMqHH6r4Tts7J_aSIgg  /  salt: DGv6ra1nlYgDCS1FRnbzlw
+AUTH = hx("05305932a1c7eabe13b6cec9fda48882")
+SALT = hx("0c6bfaadad67958803092d454676f397")
+# IKM: S4lYMb_L0FxCeq0WhDx813KgSYqU26kOyzWUdsXYyrg
+IKM = hx("4b895831bfcbd05c427aad16843c7cd772a0498a94dba90ecb359476c5d8cab8")
+# CEK: oIhVW04MRdy2XN9CiKLxTg  /  NONCE: 4h_95klXJ5E_qnoN
+CEK = hx("a088555b4e0c45dcb65cdf4288a2f14e")
+NONCE = hx("e21ffde6495727913faa7a0d")
+
+as_key = OpenSSL::PKey::EC.from_private_bytes("prime256v1", AS_PRIV)
+ua_key = OpenSSL::PKey::EC.from_private_bytes("prime256v1", UA_PRIV)
+
+# The public half derives from the private one; both are the RFC's.
+p as_key.public_key_bytes == AS_PUB
+p ua_key.public_key_bytes == UA_PUB
+p as_key.private_key_bytes == AS_PRIV
+
+# ECDH agrees in both directions, and on the RFC's published secret.
+p as_key.dh_compute_key(UA_PUB) == SECRET
+p ua_key.dh_compute_key(AS_PUB) == SECRET
+
+# The rest of the RFC 8291 key schedule, which is HKDF three times.
+key_info = "WebPush: info\0" + UA_PUB + AS_PUB
+ikm = OpenSSL::KDF.hkdf(SECRET, salt: AUTH, info: key_info, length: 32, hash: "SHA256")
+p ikm == IKM
+p OpenSSL::KDF.hkdf(ikm, salt: SALT, info: "Content-Encoding: aes128gcm\0", length: 16, hash: "SHA256") == CEK
+p OpenSSL::KDF.hkdf(ikm, salt: SALT, info: "Content-Encoding: nonce\0", length: 12, hash: "SHA256") == NONCE
+
+# RFC 5869 test case 1, so HKDF is pinned by its own vector and not only by a
+# caller's.
+p OpenSSL::KDF.hkdf(hx("0b" * 22), salt: hx("000102030405060708090a0b0c"),
+                    info: hx("f0f1f2f3f4f5f6f7f8f9"), length: 42,
+                    hash: "SHA256").unpack1("H*")
+
+# A generated key is a usable key: the two sides of a fresh exchange agree.
+a = OpenSSL::PKey::EC.generate("prime256v1")
+b = OpenSSL::PKey::EC.generate("prime256v1")
+p a.private_key_bytes.bytesize
+p a.public_key_bytes.bytesize
+p a.public_key_bytes.getbyte(0)
+p a.private_key_bytes != b.private_key_bytes
+p a.dh_compute_key(b.public_key_bytes) == b.dh_compute_key(a.public_key_bytes)
+
+# The lengths follow the curve, not a constant: P-384 is 48 and 97.
+c = OpenSSL::PKey::EC.generate("secp384r1")
+p [c.private_key_bytes.bytesize, c.public_key_bytes.bytesize]
+p c.dh_compute_key(OpenSSL::PKey::EC.generate("secp384r1").public_key_bytes).bytesize
+
+# Refusals. An off-curve peer point is the one that matters: an ECDH against
+# it leaks the private scalar to whoever chose it, so it must not answer.
+bad = AS_PUB.byteslice(0, 64) + "\xff".b
+begin
+  ua_key.dh_compute_key(bad)
+rescue OpenSSL::PKey::ECError => e
+  puts "ECError: #{e.message}"
+end
+
+begin
+  OpenSSL::PKey::EC.generate("brainpoolP256r1x")
+rescue OpenSSL::PKey::ECError => e
+  puts "ECError: #{e.message}"
+end
+
+# A scalar of the wrong width is not a key on this curve.
+begin
+  OpenSSL::PKey::EC.from_private_bytes("prime256v1", "\x01".b * 31)
+rescue OpenSSL::PKey::ECError => e
+  puts "ECError: #{e.message}"
+end
+
+# Zero is a scalar of the right width and still not a key.
+begin
+  OpenSSL::PKey::EC.from_private_bytes("prime256v1", "\0" * 32)
+rescue OpenSSL::PKey::ECError => e
+  puts "ECError: #{e.message}"
+end
+
+begin
+  OpenSSL::KDF.hkdf("ikm", salt: "", info: "", length: 32, hash: "MD5")
+rescue OpenSSL::OpenSSLError => e
+  puts "#{e.class}: #{e.message}"
+end
+
+begin
+  OpenSSL::KDF.hkdf("ikm", salt: "", info: "", length: 8161, hash: "SHA256")
+rescue OpenSSL::OpenSSLError => e
+  puts "#{e.class}: #{e.message}"
+end
+
+p OpenSSL::PKey::ECError.ancestors.take(4).map(&:to_s)

--- a/packages/openssl/test/openssl_pkey_ec.rb.expected
+++ b/packages/openssl/test/openssl_pkey_ec.rb.expected
@@ -1,0 +1,23 @@
+true
+true
+true
+true
+true
+true
+true
+true
+"3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
+32
+65
+4
+true
+true
+[48, 97]
+48
+ECError: peer public key is not a point on this curve: error:0800006B:elliptic curve routines::point is not on curve
+ECError: unknown or unsupported curve: error:04000067:object identifier routines::unknown object name
+ECError: private key is not a scalar on this curve
+ECError: private key is not a scalar on this curve
+OpenSSL::Digest::DigestError: unsupported digest algorithm: MD5
+OpenSSL::KDF::KDFError: length exceeds 8160 for SHA256
+["OpenSSL::PKey::ECError", "OpenSSL::PKey::PKeyError", "OpenSSL::OpenSSLError", "StandardError"]


### PR DESCRIPTION
The shape you settled in #4221: one-shot over raw bytes, CRuby's names where CRuby has a spelling.

```ruby
key  = OpenSSL::PKey::EC.generate("prime256v1")
key.private_key_bytes            # 32 raw
key.public_key_bytes             # 65 raw, X9.62 uncompressed
key.dh_compute_key(peer_bytes)   # CRuby's name, bytes not a Point
OpenSSL::PKey::EC.from_private_bytes("prime256v1", bytes)

OpenSSL::KDF.hkdf(ikm, salt:, info:, length:, hash:)   # CRuby's name and keywords
```

No `BN`, no `EC::Group`, no `EC::Point`; a program that names one still fails at compile time the way the package's other gaps do. `openssl/pkey.rb`'s header says that out loud, and why.

The C glue is in `packages/openssl/sp_openssl.c`, behind `OPENSSL_AVAILABLE` with the rest. Nothing reaches `lib/`, and a program that does not require openssl links exactly what it did before.

## Two decisions worth calling out

**No handle table.** A key is fully described by its bytes, so nothing on the C side outlives a call — no slot to release, no table to exhaust. That is the deliberate contrast with the connection table above it in the same file, and a key abandoned mid-protocol costs nothing.

**`EC_GROUP` / `EC_POINT` / `BIGNUM`, not `EC_KEY` / `ECDH_compute_key`.** Those two are deprecated in OpenSSL 3.0, and their replacements (`EVP_PKEY_get_bn_param` and friends) did not exist at this file's 1.1.0 floor. The low-level three are current in 3.x and present in every version the file compiles against. Points cross the boundary as `0x04 || X || Y` — what every protocol naming raw EC keys means by "the public key" — which also makes ECDH a slice: the shared secret is the X coordinate.

## Three refusals that are load-bearing

- **A peer point off the curve is rejected before any multiply.** An ECDH against an attacker-chosen off-curve point leaks the private scalar a few bits at a time, and that check is the whole defence. Small-subgroup confinement needs no separate check on these prime curves, whose cofactor is 1.
- **A scalar outside [1, n-1] is rejected** rather than multiplied into a point that is not the caller's key: zero gives the point at infinity, and `d >= n` is a silent alias for `d - n`.
- **A scalar of the wrong width** is not a key on this curve.

## HKDF has no C

It is HMAC over raw bytes twice, and #4220 gave HMAC its raw spelling. Being Ruby also keeps it outside the `OPENSSL_AVAILABLE` gate, the same way `OpenSSL::Digest` is.

## Tests

RFC 8291 §5 and Appendix A — a complete Web Push example with fixed keys, so every value is published rather than computed by the code under test. The public halves derive to the RFC's, ECDH agrees in both directions on the RFC's `ecdh_secret`, and the RFC's IKM, CEK and nonce come out of three HKDF calls. RFC 5869 test case 1 pins HKDF by its own vector. A generated pair agrees with itself, and the byte lengths follow the curve rather than a constant — P-384 answers 48 and 97.

`make test`: **3365 pass, 0 fail, 0 error**, with the openssl package tests running. The new test also passes under `SPINEL_GC_STRESS=1`.

The byte comparisons in that test need #4224, now merged — before it they were all false, because a `:cbinstr` return was tagged as text and an EC public key always has a byte >= 0x80. Writing this surface is what turned that up.

## Not here

**ES256.** Same namespace, but it brings the DER to raw `r || s` conversion with it, which you asked to live in the C glue, and it reviews better on its own.

**AES-GCM.** The other half you named. I have one question about `Cipher`'s state across the FFI to put on #4221 before writing it — `SSLSocket` gets away with an int handle into a fixed table because `close` is in its protocol, and `Cipher` has no `close` in CRuby's.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for elliptic-curve key generation, public-key handling, and Diffie-Hellman shared secrets.
  * Added HKDF key derivation with SHA-1 and SHA-256 support, including validation for invalid parameters.
  * Added access to EC key and curve byte representations.

* **Bug Fixes**
  * Added validation for invalid curves, key sizes, scalar values, and peer keys.

* **Tests**
  * Added coverage for RFC-based EC, ECDH, and HKDF scenarios and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->