### PR TITLE
Reach every typed receiver with the builtin arity guard

### DIFF
--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -1011,7 +1011,21 @@ static int an_bare_call_class_owned(Compiler *c, int id) {
          comp_reader_in_chain(c, cid, name, NULL);
 }
 
+static TyKind infer_call_inner(Compiler *c, int id);
+
+/* A builtin call whose count the arity guard refuses raises before it
+   answers, so any type is sound for it; nil lets the shapes that need one
+   -- a send candidate, which is dropped when it types unknown, an argument
+   -- compile down to the raise instead of a miss. The guard runs after a
+   few arms of emit_call, so none of those may claim a call it refuses, or
+   the value typed here is not the one emitted. */
 TyKind infer_call(Compiler *c, int id) {
+  TyKind t = infer_call_inner(c, id);
+  if (t == TY_UNKNOWN && builtin_arity_violation(c, id)) return TY_NIL;
+  return t;
+}
+
+static TyKind infer_call_inner(Compiler *c, int id) {
 
   /* a yielder push (`y << v` inside an Enumerator.new generator) lowers to a
      Fiber.yield, whose value is boxed -- never the array append it looks like */

--- a/src/analyze_internal.h
+++ b/src/analyze_internal.h
@@ -69,6 +69,7 @@ int is_builtin_class_name(const char *n);
 int is_builtin_module_name(const char *n);
 int is_builtin_exception_name(const char *n);
 int builtin_method_known(const char *cls, const char *m);
+int builtin_arity_violation(Compiler *c, int id);
 int is_handler_proc_block(Compiler *c, int id);
 int builtin_class_id(const char *name);
 int builtin_object_method_known(const char *m);

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -9850,26 +9850,33 @@ static int emit_range_step_bad_stride(Compiler *c, int id, int recv, int arg,
   buf_printf(b, "%s; })", dv ? dv : "0");
   return 1;
 }
+/* A row of the two spec tables below; the instance table's comment says
+   how to read one. */
+typedef struct { const char *cls; const char *m; int min; int max;
+                 const char *lo_exp; const char *hi_exp;
+                 int blk_min; int blk_max;
+                 const char *blk_lo_exp; const char *blk_hi_exp; } SpAritySpec;
+
 /* A call whose argument count CRuby's own method cannot take: evaluate the
    receiver and arguments for effect, then raise CRuby's ArgumentError --
    instead of falling into an emitter specialized to another count, where a
    missing operand read argv[] blind (a compile-time SIGSEGV) and an extra one
    was silently dropped. Conservative by construction: fires only when the
    dumped CRuby arity table proves the count wrong, never on a call whose
-   runtime count a splat / kwargs / forwarding keeps open, and never when a
-   reopened builtin owns the name. */
+   runtime count a splat / kwargs / forwarding keeps open, and never when
+   the program owns the name -- a def in the enclosing chain, at top level
+   or in a reopened builtin, a singleton def or accessor on the constant, a
+   module's own method behind `extend self`. */
 /* Positional-arity spec for the builtin instance surface, probed from
    ruby 4.0.6 by tools/gen_builtin_arity_spec.rb (see there for the
    technique; rerun it with --write to regenerate both tables). max -1 =
    no upper bound; a NULL exp = that side is never violated. The first
    quartet describes the bare call, the blk_ quartet the block-carrying
    call (several counts change under a block: Array#fill 1..3 vs 0..2,
-   Integer#step); a quartet the probe could not prove is -1,-1,NULL,NULL
-   and never fires. */
-static const struct { const char *cls; const char *m; int min; int max;
-                      const char *lo_exp; const char *hi_exp;
-                      int blk_min; int blk_max;
-                      const char *blk_lo_exp; const char *blk_hi_exp; }
+   Integer#step); a quartet the probe could not prove, or a name whose
+   counts are its target's (Proc#call, Enumerator#each), is
+   -1,-1,NULL,NULL and never fires. */
+static const SpAritySpec
 sp_builtin_arity_spec_tbl[] = {
   {"String","%",1,1,"1","1",1,1,"1","1"},
   {"String","*",1,1,"1","1",1,1,"1","1"},
@@ -9930,6 +9937,7 @@ sp_builtin_arity_spec_tbl[] = {
   {"String","encoding",0,0,NULL,"0",0,0,NULL,"0"},
   {"String","eql?",1,1,"1","1",1,1,"1","1"},
   {"String","force_encoding",1,1,"1","1",1,1,"1","1"},
+  {"String","freeze",0,0,NULL,"0",0,0,NULL,"0"},
   {"String","getbyte",1,1,"1","1",1,1,"1","1"},
   {"String","grapheme_clusters",0,0,NULL,"0",0,0,NULL,"0"},
   {"String","gsub",1,2,"1..2","1..2",1,2,"1..2","1..2"},
@@ -10234,6 +10242,7 @@ sp_builtin_arity_spec_tbl[] = {
   {"Array","flat_map",0,0,NULL,"0",0,0,NULL,"0"},
   {"Array","flatten",0,1,NULL,"0..1",0,1,NULL,"0..1"},
   {"Array","flatten!",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Array","freeze",0,0,NULL,"0",0,0,NULL,"0"},
   {"Array","grep",1,1,"1","1",1,1,"1","1"},
   {"Array","grep_v",1,1,"1","1",1,1,"1","1"},
   {"Array","group_by",0,0,NULL,"0",0,0,NULL,"0"},
@@ -10361,6 +10370,7 @@ sp_builtin_arity_spec_tbl[] = {
   {"Hash","first",0,1,NULL,"0..1",0,1,NULL,"0..1"},
   {"Hash","flat_map",0,0,NULL,"0",0,0,NULL,"0"},
   {"Hash","flatten",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Hash","freeze",0,0,NULL,"0",0,0,NULL,"0"},
   {"Hash","grep",1,1,"1","1",1,1,"1","1"},
   {"Hash","grep_v",1,1,"1","1",1,1,"1","1"},
   {"Hash","group_by",0,0,NULL,"0",0,0,NULL,"0"},
@@ -10708,6 +10718,7 @@ sp_builtin_arity_spec_tbl[] = {
   {"Object","eql?",1,1,"1","1",1,1,"1","1"},
   {"Object","equal?",1,1,"1","1",1,1,"1","1"},
   {"Object","extend",1,-1,"1+",NULL,1,-1,"1+",NULL},
+  {"Object","freeze",0,0,NULL,"0",0,0,NULL,"0"},
   {"Object","frozen?",0,0,NULL,"0",0,0,NULL,"0"},
   {"Object","hash",0,0,NULL,"0",0,0,NULL,"0"},
   {"Object","inspect",0,0,NULL,"0",0,0,NULL,"0"},
@@ -10921,6 +10932,7 @@ sp_builtin_arity_spec_tbl[] = {
   {"Pathname","find",0,0,NULL,"0",0,0,NULL,"0"},
   {"Pathname","fnmatch",1,-1,"1+",NULL,1,-1,"1+",NULL},
   {"Pathname","fnmatch?",1,-1,"1+",NULL,1,-1,"1+",NULL},
+  {"Pathname","freeze",0,0,NULL,"0",0,0,NULL,"0"},
   {"Pathname","ftype",0,0,NULL,"0",0,0,NULL,"0"},
   {"Pathname","glob",1,2,"1..2","1..2",1,2,"1..2","1..2"},
   {"Pathname","grpowned?",0,0,NULL,"0",0,0,NULL,"0"},
@@ -11085,18 +11097,608 @@ sp_builtin_arity_spec_tbl[] = {
   {"Mutex","synchronize",0,0,NULL,"0",0,0,NULL,"0"},
   {"Mutex","try_lock",0,0,NULL,"0",0,0,NULL,"0"},
   {"Mutex","unlock",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Regexp","==",1,1,"1","1",1,1,"1","1"},
+  {"Regexp","===",1,1,"1","1",1,1,"1","1"},
+  {"Regexp","=~",1,1,"1","1",1,1,"1","1"},
+  {"Regexp","casefold?",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Regexp","encoding",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Regexp","eql?",1,1,"1","1",1,1,"1","1"},
+  {"Regexp","fixed_encoding?",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Regexp","hash",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Regexp","inspect",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Regexp","match",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Regexp","match?",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Regexp","named_captures",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Regexp","names",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Regexp","options",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Regexp","source",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Regexp","timeout",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Regexp","to_s",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Regexp","~",0,0,NULL,"0",0,0,NULL,"0"},
+  {"MatchData","==",1,1,"1","1",1,1,"1","1"},
+  {"MatchData","[]",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"MatchData","begin",1,1,"1","1",1,1,"1","1"},
+  {"MatchData","bytebegin",1,1,"1","1",1,1,"1","1"},
+  {"MatchData","byteend",1,1,"1","1",1,1,"1","1"},
+  {"MatchData","byteoffset",1,1,"1","1",1,1,"1","1"},
+  {"MatchData","captures",0,0,NULL,"0",0,0,NULL,"0"},
+  {"MatchData","deconstruct",0,0,NULL,"0",0,0,NULL,"0"},
+  {"MatchData","deconstruct_keys",1,1,"1","1",1,1,"1","1"},
+  {"MatchData","end",1,1,"1","1",1,1,"1","1"},
+  {"MatchData","eql?",1,1,"1","1",1,1,"1","1"},
+  {"MatchData","hash",0,0,NULL,"0",0,0,NULL,"0"},
+  {"MatchData","inspect",0,0,NULL,"0",0,0,NULL,"0"},
+  {"MatchData","length",0,0,NULL,"0",0,0,NULL,"0"},
+  {"MatchData","match",1,1,"1","1",1,1,"1","1"},
+  {"MatchData","match_length",1,1,"1","1",1,1,"1","1"},
+  {"MatchData","named_captures",0,0,NULL,"0",0,0,NULL,"0"},
+  {"MatchData","names",0,0,NULL,"0",0,0,NULL,"0"},
+  {"MatchData","offset",1,1,"1","1",1,1,"1","1"},
+  {"MatchData","post_match",0,0,NULL,"0",0,0,NULL,"0"},
+  {"MatchData","pre_match",0,0,NULL,"0",0,0,NULL,"0"},
+  {"MatchData","regexp",0,0,NULL,"0",0,0,NULL,"0"},
+  {"MatchData","size",0,0,NULL,"0",0,0,NULL,"0"},
+  {"MatchData","string",0,0,NULL,"0",0,0,NULL,"0"},
+  {"MatchData","to_a",0,0,NULL,"0",0,0,NULL,"0"},
+  {"MatchData","to_s",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Proc","<<",1,1,"1","1",1,1,"1","1"},
+  {"Proc","==",1,1,"1","1",1,1,"1","1"},
+  {"Proc",">>",1,1,"1","1",1,1,"1","1"},
+  {"Proc","arity",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Proc","binding",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Proc","clone",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Proc","curry",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Proc","dup",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Proc","eql?",1,1,"1","1",1,1,"1","1"},
+  {"Proc","hash",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Proc","inspect",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Proc","lambda?",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Proc","parameters",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Proc","ruby2_keywords",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Proc","source_location",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Proc","to_proc",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Proc","to_s",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Proc","call",-1,-1,NULL,NULL,-1,-1,NULL,NULL},
+  {"Proc","[]",-1,-1,NULL,NULL,-1,-1,NULL,NULL},
+  {"Proc","===",-1,-1,NULL,NULL,-1,-1,NULL,NULL},
+  {"Proc","yield",-1,-1,NULL,NULL,-1,-1,NULL,NULL},
+  {"Method","<<",1,1,"1","1",1,1,"1","1"},
+  {"Method","==",1,1,"1","1",1,1,"1","1"},
+  {"Method",">>",1,1,"1","1",1,1,"1","1"},
+  {"Method","arity",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Method","box",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Method","clone",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Method","curry",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Method","dup",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Method","eql?",1,1,"1","1",1,1,"1","1"},
+  {"Method","hash",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Method","inspect",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Method","name",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Method","original_name",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Method","owner",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Method","parameters",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Method","receiver",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Method","source_location",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Method","super_method",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Method","to_proc",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Method","to_s",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Method","unbind",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Method","call",-1,-1,NULL,NULL,-1,-1,NULL,NULL},
+  {"Method","[]",-1,-1,NULL,NULL,-1,-1,NULL,NULL},
+  {"Method","===",-1,-1,NULL,NULL,-1,-1,NULL,NULL},
+  {"Fiber","alive?",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Fiber","backtrace",0,2,NULL,"0..2",0,2,NULL,"0..2"},
+  {"Fiber","backtrace_locations",0,2,NULL,"0..2",0,2,NULL,"0..2"},
+  {"Fiber","blocking?",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Fiber","inspect",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Fiber","kill",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Fiber","raise",0,3,NULL,"0..3",0,3,NULL,"0..3"},
+  {"Fiber","storage",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Fiber","storage=",1,1,"1","1",1,1,"1","1"},
+  {"Fiber","to_s",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","[]",1,1,"1","1",1,1,"1","1"},
+  {"Thread","[]=",2,2,"2","2",2,2,"2","2"},
+  {"Thread","abort_on_exception",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","abort_on_exception=",1,1,"1","1",1,1,"1","1"},
+  {"Thread","add_trace_func",1,1,"1","1",1,1,"1","1"},
+  {"Thread","alive?",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","fetch",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Thread","group",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","inspect",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","join",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Thread","key?",1,1,"1","1",1,1,"1","1"},
+  {"Thread","keys",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","kill",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","name",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","name=",1,1,"1","1",1,1,"1","1"},
+  {"Thread","native_thread_id",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","priority",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","priority=",1,1,"1","1",1,1,"1","1"},
+  {"Thread","report_on_exception",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","report_on_exception=",1,1,"1","1",1,1,"1","1"},
+  {"Thread","run",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","set_trace_func",1,1,"1","1",1,1,"1","1"},
+  {"Thread","status",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","stop?",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","terminate",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","thread_variable?",1,1,"1","1",1,1,"1","1"},
+  {"Thread","thread_variable_get",1,1,"1","1",1,1,"1","1"},
+  {"Thread","thread_variable_set",2,2,"2","2",2,2,"2","2"},
+  {"Thread","thread_variables",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","to_s",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","value",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","wakeup",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Queue","clear",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Queue","close",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Queue","closed?",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Queue","deq",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Queue","empty?",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Queue","length",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Queue","marshal_dump",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Queue","num_waiting",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Queue","pop",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Queue","shift",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Queue","size",0,0,NULL,"0",0,0,NULL,"0"},
+  {"ConditionVariable","broadcast",0,0,NULL,"0",0,0,NULL,"0"},
+  {"ConditionVariable","marshal_dump",0,0,NULL,"0",0,0,NULL,"0"},
+  {"ConditionVariable","signal",0,0,NULL,"0",0,0,NULL,"0"},
+  {"ConditionVariable","wait",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"File","<<",1,1,"1","1",1,1,"1","1"},
+  {"File","advise",1,3,"1..3","1..3",1,3,"1..3","1..3"},
+  {"File","all?",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"File","any?",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"File","atime",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","autoclose=",1,1,"1","1",1,1,"1","1"},
+  {"File","autoclose?",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","binmode",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","binmode?",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","birthtime",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","chmod",1,1,"1","1",1,1,"1","1"},
+  {"File","chown",2,2,"2","2",2,2,"2","2"},
+  {"File","chunk",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","chunk_while",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","close",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","close_on_exec=",1,1,"1","1",1,1,"1","1"},
+  {"File","close_on_exec?",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","close_read",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","close_write",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","closed?",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","collect",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","collect_concat",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","compact",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","count",0,1,NULL,"1",0,1,NULL,"1"},
+  {"File","ctime",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","cycle",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"File","detect",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"File","drop",1,1,"1","1",1,1,"1","1"},
+  {"File","drop_while",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","each",-1,-1,NULL,NULL,0,2,NULL,"0..2"},
+  {"File","each_byte",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","each_char",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","each_codepoint",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","each_cons",1,1,"1","1",1,1,"1","1"},
+  {"File","each_entry",-1,-1,NULL,NULL,0,2,NULL,"0..2"},
+  {"File","each_line",-1,-1,NULL,NULL,0,2,NULL,"0..2"},
+  {"File","each_slice",1,1,"1","1",1,1,"1","1"},
+  {"File","each_with_index",-1,-1,NULL,NULL,0,2,NULL,"0..2"},
+  {"File","each_with_object",1,1,"1","1",1,1,"1","1"},
+  {"File","entries",0,2,NULL,"0..2",0,2,NULL,"0..2"},
+  {"File","eof",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","eof?",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","external_encoding",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","fdatasync",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","fileno",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","filter",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","filter_map",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","find",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"File","find_all",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","find_index",0,1,NULL,"1",0,1,NULL,"1"},
+  {"File","first",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"File","flat_map",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","flock",1,1,"1","1",1,1,"1","1"},
+  {"File","flush",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","fsync",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","getbyte",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","getc",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","grep",1,1,"1","1",1,1,"1","1"},
+  {"File","grep_v",1,1,"1","1",1,1,"1","1"},
+  {"File","group_by",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","include?",1,1,"1","1",1,1,"1","1"},
+  {"File","inject",1,2,"1..2","1..2",0,2,NULL,"0..2"},
+  {"File","internal_encoding",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","isatty",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","lazy",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","lineno",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","lineno=",1,1,"1","1",1,1,"1","1"},
+  {"File","lstat",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","map",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","max",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"File","max_by",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"File","member?",1,1,"1","1",1,1,"1","1"},
+  {"File","min",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"File","min_by",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"File","minmax",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","minmax_by",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","mtime",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","none?",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"File","one?",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"File","partition",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","path",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","pathconf",1,1,"1","1",1,1,"1","1"},
+  {"File","pid",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","pos",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","pos=",1,1,"1","1",1,1,"1","1"},
+  {"File","putc",1,1,"1","1",1,1,"1","1"},
+  {"File","read",0,2,NULL,"0..2",0,2,NULL,"0..2"},
+  {"File","readbyte",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","readchar",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","readlines",0,2,NULL,"0..2",0,2,NULL,"0..2"},
+  {"File","reduce",1,2,"1..2","1..2",0,2,NULL,"0..2"},
+  {"File","reject",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","reopen",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"File","reverse_each",-1,-1,NULL,NULL,0,2,NULL,"0..2"},
+  {"File","rewind",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","seek",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"File","select",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","set_encoding",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"File","size",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","slice_after",1,1,"1","1",-1,-1,NULL,NULL},
+  {"File","slice_before",1,1,"1","1",0,0,NULL,"0"},
+  {"File","slice_when",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","sort",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","sort_by",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","stat",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","sum",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"File","sync",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","sync=",1,1,"1","1",1,1,"1","1"},
+  {"File","take",1,1,"1","1",1,1,"1","1"},
+  {"File","take_while",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","tally",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"File","tell",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","timeout",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","timeout=",1,1,"1","1",1,1,"1","1"},
+  {"File","to_a",0,2,NULL,"0..2",0,2,NULL,"0..2"},
+  {"File","to_h",0,2,NULL,"0..2",0,2,NULL,"0..2"},
+  {"File","to_i",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","to_io",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","to_path",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","truncate",1,1,"1","1",1,1,"1","1"},
+  {"File","tty?",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","ungetbyte",1,1,"1","1",1,1,"1","1"},
+  {"File","ungetc",1,1,"1","1",1,1,"1","1"},
+  {"File","uniq",0,0,NULL,"0",0,0,NULL,"0"},
+  {"File","wait_priority",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"File","wait_readable",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"File","wait_writable",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Dir","all?",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Dir","any?",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Dir","chdir",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","children",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","chunk",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","chunk_while",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","close",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","collect",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","collect_concat",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","compact",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","count",0,1,NULL,"1",0,1,NULL,"1"},
+  {"Dir","cycle",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Dir","detect",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Dir","drop",1,1,"1","1",1,1,"1","1"},
+  {"Dir","drop_while",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","each",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","each_child",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","each_cons",1,1,"1","1",1,1,"1","1"},
+  {"Dir","each_entry",-1,-1,NULL,NULL,0,0,NULL,"0"},
+  {"Dir","each_slice",1,1,"1","1",1,1,"1","1"},
+  {"Dir","each_with_index",-1,-1,NULL,NULL,0,0,NULL,"0"},
+  {"Dir","each_with_object",1,1,"1","1",1,1,"1","1"},
+  {"Dir","entries",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","fileno",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","filter",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","filter_map",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","find",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Dir","find_all",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","find_index",0,1,NULL,"1",0,1,NULL,"1"},
+  {"Dir","first",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Dir","flat_map",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","grep",1,1,"1","1",1,1,"1","1"},
+  {"Dir","grep_v",1,1,"1","1",1,1,"1","1"},
+  {"Dir","group_by",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","include?",1,1,"1","1",1,1,"1","1"},
+  {"Dir","inject",1,2,"1..2","1..2",0,2,NULL,"0..2"},
+  {"Dir","inspect",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","lazy",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","map",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","max",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Dir","max_by",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Dir","member?",1,1,"1","1",1,1,"1","1"},
+  {"Dir","min",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Dir","min_by",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Dir","minmax",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","minmax_by",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","none?",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Dir","one?",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Dir","partition",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","path",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","pos",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","pos=",1,1,"1","1",1,1,"1","1"},
+  {"Dir","read",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","reduce",1,2,"1..2","1..2",0,2,NULL,"0..2"},
+  {"Dir","reject",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","reverse_each",-1,-1,NULL,NULL,0,0,NULL,"0"},
+  {"Dir","rewind",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","seek",1,1,"1","1",1,1,"1","1"},
+  {"Dir","select",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","slice_after",1,1,"1","1",-1,-1,NULL,NULL},
+  {"Dir","slice_before",1,1,"1","1",0,0,NULL,"0"},
+  {"Dir","slice_when",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","sort",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","sort_by",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","sum",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Dir","take",1,1,"1","1",1,1,"1","1"},
+  {"Dir","take_while",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","tally",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Dir","tell",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","to_a",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","to_h",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","to_path",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Dir","uniq",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Exception","backtrace",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Exception","backtrace_locations",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Exception","cause",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Exception","detailed_message",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Exception","exception",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Exception","full_message",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Exception","message",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Exception","set_backtrace",1,1,"1","1",1,1,"1","1"},
+  {"Enumerator","+",1,1,"1","1",1,1,"1","1"},
+  {"Enumerator","all?",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Enumerator","any?",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Enumerator","chunk",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","chunk_while",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","collect",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","collect_concat",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","compact",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","count",0,1,NULL,"1",0,1,NULL,"1"},
+  {"Enumerator","cycle",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Enumerator","detect",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Enumerator","drop",1,1,"1","1",1,1,"1","1"},
+  {"Enumerator","drop_while",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","each_cons",1,1,"1","1",1,1,"1","1"},
+  {"Enumerator","each_slice",1,1,"1","1",1,1,"1","1"},
+  {"Enumerator","each_with_index",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","each_with_object",1,1,"1","1",1,1,"1","1"},
+  {"Enumerator","feed",1,1,"1","1",1,1,"1","1"},
+  {"Enumerator","filter",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","filter_map",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","find",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Enumerator","find_all",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","find_index",0,1,NULL,"1",0,1,NULL,"1"},
+  {"Enumerator","first",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Enumerator","flat_map",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","grep",1,1,"1","1",1,1,"1","1"},
+  {"Enumerator","grep_v",1,1,"1","1",1,1,"1","1"},
+  {"Enumerator","group_by",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","include?",1,1,"1","1",1,1,"1","1"},
+  {"Enumerator","inject",1,2,"1..2","1..2",0,2,NULL,"0..2"},
+  {"Enumerator","inspect",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","lazy",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","map",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","max",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Enumerator","max_by",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Enumerator","member?",1,1,"1","1",1,1,"1","1"},
+  {"Enumerator","min",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Enumerator","min_by",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Enumerator","minmax",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","minmax_by",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","next",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","next_values",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","none?",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Enumerator","one?",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Enumerator","partition",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","peek",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","peek_values",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","reduce",1,2,"1..2","1..2",0,2,NULL,"0..2"},
+  {"Enumerator","reject",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","rewind",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","select",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","size",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","slice_after",1,1,"1","1",-1,-1,NULL,NULL},
+  {"Enumerator","slice_before",1,1,"1","1",0,0,NULL,"0"},
+  {"Enumerator","slice_when",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","sort",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","sort_by",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","sum",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Enumerator","take",1,1,"1","1",1,1,"1","1"},
+  {"Enumerator","take_while",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","tally",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Enumerator","uniq",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Enumerator","with_index",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Enumerator","with_object",1,1,"1","1",1,1,"1","1"},
+  {"Enumerator","each",-1,-1,NULL,NULL,-1,-1,NULL,NULL},
+  {"Enumerator","to_a",-1,-1,NULL,NULL,-1,-1,NULL,NULL},
+  {"Enumerator","entries",-1,-1,NULL,NULL,-1,-1,NULL,NULL},
+  {"Enumerator","to_h",-1,-1,NULL,NULL,-1,-1,NULL,NULL},
+  {"Enumerator","each_entry",-1,-1,NULL,NULL,-1,-1,NULL,NULL},
+  {"Enumerator","reverse_each",-1,-1,NULL,NULL,-1,-1,NULL,NULL},
+  {"Random","==",1,1,"1","1",1,1,"1","1"},
+  {"Random","bytes",1,1,"1","1",1,1,"1","1"},
+  {"Random","rand",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Random","random_number",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Random","seed",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","[]",1,1,"1","1",1,1,"1","1"},
+  {"Struct","[]=",2,2,"2","2",2,2,"2","2"},
+  {"Struct","all?",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Struct","any?",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Struct","chunk",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","chunk_while",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","collect",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","collect_concat",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","compact",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","count",0,1,NULL,"1",0,1,NULL,"1"},
+  {"Struct","cycle",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Struct","deconstruct",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","deconstruct_keys",1,1,"1","1",1,1,"1","1"},
+  {"Struct","detect",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Struct","dig",1,-1,"1+",NULL,1,-1,"1+",NULL},
+  {"Struct","drop",1,1,"1","1",1,1,"1","1"},
+  {"Struct","drop_while",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","each",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","each_cons",1,1,"1","1",1,1,"1","1"},
+  {"Struct","each_entry",-1,-1,NULL,NULL,0,0,NULL,"0"},
+  {"Struct","each_pair",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","each_slice",1,1,"1","1",1,1,"1","1"},
+  {"Struct","each_with_index",-1,-1,NULL,NULL,0,0,NULL,"0"},
+  {"Struct","each_with_object",1,1,"1","1",1,1,"1","1"},
+  {"Struct","entries",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","filter",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","filter_map",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","find",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Struct","find_all",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","find_index",0,1,NULL,"1",0,1,NULL,"1"},
+  {"Struct","first",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Struct","flat_map",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","grep",1,1,"1","1",1,1,"1","1"},
+  {"Struct","grep_v",1,1,"1","1",1,1,"1","1"},
+  {"Struct","group_by",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","include?",1,1,"1","1",1,1,"1","1"},
+  {"Struct","inject",1,2,"1..2","1..2",0,2,NULL,"0..2"},
+  {"Struct","lazy",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","length",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","map",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","max",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Struct","max_by",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Struct","member?",1,1,"1","1",1,1,"1","1"},
+  {"Struct","members",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","min",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Struct","min_by",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Struct","minmax",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","minmax_by",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","none?",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Struct","one?",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Struct","partition",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","reduce",1,2,"1..2","1..2",0,2,NULL,"0..2"},
+  {"Struct","reject",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","reverse_each",-1,-1,NULL,NULL,0,0,NULL,"0"},
+  {"Struct","select",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","size",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","slice_after",1,1,"1","1",-1,-1,NULL,NULL},
+  {"Struct","slice_before",1,1,"1","1",0,0,NULL,"0"},
+  {"Struct","slice_when",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","sort",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","sort_by",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","sum",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Struct","take",1,1,"1","1",1,1,"1","1"},
+  {"Struct","take_while",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","tally",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Struct","to_a",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","to_h",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","uniq",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Struct","values",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Data","deconstruct",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Data","deconstruct_keys",1,1,"1","1",1,1,"1","1"},
+  {"Data","members",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Data","to_h",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Data","with",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Class","<",1,1,"1","1",1,1,"1","1"},
+  {"Class","<=",1,1,"1","1",1,1,"1","1"},
+  {"Class",">",1,1,"1","1",1,1,"1","1"},
+  {"Class",">=",1,1,"1","1",1,1,"1","1"},
+  {"Class","alias_method",2,2,"2","2",2,2,"2","2"},
+  {"Class","allocate",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Class","ancestors",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Class","attached_object",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Class","autoload?",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Class","class_variable_defined?",1,1,"1","1",1,1,"1","1"},
+  {"Class","class_variable_get",1,1,"1","1",1,1,"1","1"},
+  {"Class","class_variable_set",2,2,"2","2",2,2,"2","2"},
+  {"Class","class_variables",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Class","const_defined?",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Class","const_get",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Class","const_missing",1,1,"1","1",1,1,"1","1"},
+  {"Class","const_set",2,2,"2","2",2,2,"2","2"},
+  {"Class","const_source_location",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Class","constants",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Class","define_method",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Class","include",1,-1,"1+",NULL,1,-1,"1+",NULL},
+  {"Class","include?",1,1,"1","1",1,1,"1","1"},
+  {"Class","included_modules",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Class","instance_method",1,1,"1","1",1,1,"1","1"},
+  {"Class","instance_methods",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Class","method_defined?",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Class","name",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Class","prepend",1,-1,"1+",NULL,1,-1,"1+",NULL},
+  {"Class","private_instance_methods",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Class","private_method_defined?",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Class","protected_instance_methods",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Class","protected_method_defined?",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Class","public_instance_method",1,1,"1","1",1,1,"1","1"},
+  {"Class","public_instance_methods",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Class","public_method_defined?",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Class","refinements",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Class","remove_class_variable",1,1,"1","1",1,1,"1","1"},
+  {"Class","set_temporary_name",1,1,"1","1",1,1,"1","1"},
+  {"Class","singleton_class?",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Class","subclasses",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Class","superclass",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Class","undefined_instance_methods",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Class","new",-1,-1,NULL,NULL,-1,-1,NULL,NULL},
+  {"Module","<",1,1,"1","1",1,1,"1","1"},
+  {"Module","<=",1,1,"1","1",1,1,"1","1"},
+  {"Module","<=>",1,1,"1","1",1,1,"1","1"},
+  {"Module","==",1,1,"1","1",1,1,"1","1"},
+  {"Module","===",1,1,"1","1",1,1,"1","1"},
+  {"Module",">",1,1,"1","1",1,1,"1","1"},
+  {"Module",">=",1,1,"1","1",1,1,"1","1"},
+  {"Module","alias_method",2,2,"2","2",2,2,"2","2"},
+  {"Module","ancestors",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Module","autoload?",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Module","class_variable_defined?",1,1,"1","1",1,1,"1","1"},
+  {"Module","class_variable_get",1,1,"1","1",1,1,"1","1"},
+  {"Module","class_variable_set",2,2,"2","2",2,2,"2","2"},
+  {"Module","class_variables",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Module","const_defined?",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Module","const_get",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Module","const_missing",1,1,"1","1",1,1,"1","1"},
+  {"Module","const_set",2,2,"2","2",2,2,"2","2"},
+  {"Module","const_source_location",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Module","constants",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Module","define_method",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Module","freeze",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Module","include",1,-1,"1+",NULL,1,-1,"1+",NULL},
+  {"Module","include?",1,1,"1","1",1,1,"1","1"},
+  {"Module","included_modules",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Module","inspect",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Module","instance_method",1,1,"1","1",1,1,"1","1"},
+  {"Module","instance_methods",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Module","method_defined?",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Module","name",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Module","prepend",1,-1,"1+",NULL,1,-1,"1+",NULL},
+  {"Module","private_instance_methods",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Module","private_method_defined?",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Module","protected_instance_methods",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Module","protected_method_defined?",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Module","public_instance_method",1,1,"1","1",1,1,"1","1"},
+  {"Module","public_instance_methods",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Module","public_method_defined?",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Module","refinements",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Module","remove_class_variable",1,1,"1","1",1,1,"1","1"},
+  {"Module","set_temporary_name",1,1,"1","1",1,1,"1","1"},
+  {"Module","singleton_class?",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Module","to_s",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Module","undefined_instance_methods",0,0,NULL,"0",0,0,NULL,"0"},
   {NULL, NULL, 0, 0, NULL, NULL, 0, 0, NULL, NULL}
 };
 
 /* Class/module-method positional arity, probed from ruby 4.0.6 the same
-   way as the instance table above (tools/gen_builtin_arity_spec.rb).
-   These are the constructors and module functions whose emitters index
-   argv[] unconditionally (File.open with no arguments was a compile-time
-   SIGSEGV). */
-static const struct { const char *cls; const char *m; int min; int max;
-                      const char *lo_exp; const char *hi_exp;
-                      int blk_min; int blk_max;
-                      const char *blk_lo_exp; const char *blk_hi_exp; }
+   way as the instance table above (tools/gen_builtin_arity_spec.rb): the
+   constructors and module functions whose emitters index argv[]
+   unconditionally (File.open with no arguments was a compile-time
+   SIGSEGV), the surface of the constants a program names bare -- GC,
+   Fiber, Thread, a class Struct.new or Data.define answered, keyed
+   StructClass and DataClass -- and the Kernel functions a bare call
+   reaches. */
+static const SpAritySpec
 sp_builtin_cmeth_arity_spec_tbl[] = {
   {"File","open",1,3,"1..3","1..3",1,3,"1..3","1..3"},
   {"File","new",1,3,"1..3","1..3",1,3,"1..3","1..3"},
@@ -11132,6 +11734,25 @@ sp_builtin_cmeth_arity_spec_tbl[] = {
   {"File","zero?",1,1,"1","1",1,1,"1","1"},
   {"File","identical?",2,2,"2","2",2,2,"2","2"},
   {"File","absolute_path",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"File","file?",1,1,"1","1",1,1,"1","1"},
+  {"File","directory?",1,1,"1","1",1,1,"1","1"},
+  {"File","readable?",1,1,"1","1",1,1,"1","1"},
+  {"File","writable?",1,1,"1","1",1,1,"1","1"},
+  {"File","executable?",1,1,"1","1",1,1,"1","1"},
+  {"File","symlink?",1,1,"1","1",1,1,"1","1"},
+  {"File","size?",1,1,"1","1",1,1,"1","1"},
+  {"File","fnmatch",2,3,"2..3","2..3",2,3,"2..3","2..3"},
+  {"File","fnmatch?",2,3,"2..3","2..3",2,3,"2..3","2..3"},
+  {"File","owned?",1,1,"1","1",1,1,"1","1"},
+  {"File","world_readable?",1,1,"1","1",1,1,"1","1"},
+  {"File","world_writable?",1,1,"1","1",1,1,"1","1"},
+  {"File","path",1,1,"1","1",1,1,"1","1"},
+  {"File","absolute_path?",1,1,"1","1",1,1,"1","1"},
+  {"File","birthtime",1,1,"1","1",1,1,"1","1"},
+  {"File","chown",2,-1,"2+",NULL,2,-1,"2+",NULL},
+  {"File","lchmod",1,-1,"1+",NULL,1,-1,"1+",NULL},
+  {"File","lchown",2,-1,"2+",NULL,2,-1,"2+",NULL},
+  {"File","mkfifo",1,2,"1..2","1..2",1,2,"1..2","1..2"},
   {"IO","for_fd",1,2,"1..2","1..2",1,2,"1..2","1..2"},
   {"IO","sysopen",1,3,"1..3","1..3",1,3,"1..3","1..3"},
   {"IO","new",1,2,"1..2","1..2",1,2,"1..2","1..2"},
@@ -11199,8 +11820,6 @@ sp_builtin_cmeth_arity_spec_tbl[] = {
   {"Process","setpriority",3,3,"3","3",3,3,"3","3"},
   {"Process","getsid",0,1,NULL,"0..1",0,1,NULL,"0..1"},
   {"Process","kill",2,-1,"2+",NULL,2,-1,"2+",NULL},
-  {"Process","spawn",1,-1,"1+",NULL,1,-1,"1+",NULL},
-  {"Process","waitpid2",1,1,"1","1",1,1,"1","1"},
   {"Process","clock_gettime",1,2,"1..2","1..2",1,2,"1..2","1..2"},
   {"Process","clock_getres",1,2,"1..2","1..2",1,2,"1..2","1..2"},
   {"Process","pid",0,0,NULL,"0",0,0,NULL,"0"},
@@ -11210,6 +11829,9 @@ sp_builtin_cmeth_arity_spec_tbl[] = {
   {"Process","euid",0,0,NULL,"0",0,0,NULL,"0"},
   {"Process","egid",0,0,NULL,"0",0,0,NULL,"0"},
   {"Process","setproctitle",1,1,"1","1",1,1,"1","1"},
+  {"Process","times",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Process","spawn",1,-1,"1+",NULL,1,-1,"1+",NULL},
+  {"Process","waitpid2",0,2,NULL,"0..2",0,2,NULL,"0..2"},
   {"Regexp","new",1,2,"1..2","1..2",1,2,"1..2","1..2"},
   {"Regexp","escape",1,1,"1","1",1,1,"1","1"},
   {"Regexp","quote",1,1,"1","1",1,1,"1","1"},
@@ -11230,6 +11852,35 @@ sp_builtin_cmeth_arity_spec_tbl[] = {
   {"Kernel","Hash",1,1,"1","1",1,1,"1","1"},
   {"Kernel","Rational",1,2,"1..2","1..2",1,2,"1..2","1..2"},
   {"Kernel","Complex",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Kernel","throw",1,2,"1..2","1..2",1,2,"1..2","1..2"},
+  {"Kernel","catch",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Kernel","raise",0,3,NULL,"0..3",0,3,NULL,"0..3"},
+  {"Kernel","rand",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Kernel","srand",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Kernel","caller",0,2,NULL,"0..2",0,2,NULL,"0..2"},
+  {"Kernel","lambda",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Kernel","proc",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Kernel","binding",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Kernel","block_given?",0,0,NULL,"0",0,0,NULL,"0"},
+  {"GC","start",0,0,NULL,"0",0,0,NULL,"0"},
+  {"GC","stat",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"GC","compact",0,0,NULL,"0",0,0,NULL,"0"},
+  {"GC","count",0,0,NULL,"0",0,0,NULL,"0"},
+  {"GC","disable",0,0,NULL,"0",0,0,NULL,"0"},
+  {"GC","enable",0,0,NULL,"0",0,0,NULL,"0"},
+  {"GC","stress",0,0,NULL,"0",0,0,NULL,"0"},
+  {"GC","latest_gc_info",0,1,NULL,"0..1",0,1,NULL,"0..1"},
+  {"Fiber","current",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","current",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","main",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","list",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","pass",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","abort_on_exception",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","report_on_exception",0,0,NULL,"0",0,0,NULL,"0"},
+  {"Thread","handle_interrupt",1,1,"1","1",1,1,"1","1"},
+  {"StructClass","members",0,0,NULL,"0",0,0,NULL,"0"},
+  {"StructClass","keyword_init?",0,0,NULL,"0",0,0,NULL,"0"},
+  {"DataClass","members",0,0,NULL,"0",0,0,NULL,"0"},
   {"Marshal","dump",1,3,"1..3","1..3",1,3,"1..3","1..3"},
   {"Marshal","load",1,2,"1..2","1..2",1,2,"1..2","1..2"},
   {"Signal","signame",1,1,"1","1",1,1,"1","1"},
@@ -11291,11 +11942,153 @@ sp_builtin_cmeth_arity_spec_tbl[] = {
   {"Pathname","pwd",0,0,NULL,"0",0,0,NULL,"0"},
   {NULL, NULL, 0, 0, NULL, NULL, 0, 0, NULL, NULL}
 };
-int emit_builtin_arity_guard(Compiler *c, int id, Buf *b) {
+/* The row of one spec table for (cls, name), read for the bare or the
+   block-carrying call. Answers whether the table has the row; exp receives
+   CRuby's wording when argc falls outside the accepted counts. */
+static int arity_spec_row(const SpAritySpec *tbl, const char *cls, const char *name,
+                          int with_block, int argc, char *exp, size_t n) {
+  for (int i = 0; tbl[i].cls; i++) {
+    if (!sp_streq(tbl[i].cls, cls) || !sp_streq(tbl[i].m, name)) continue;
+    int mn = with_block ? tbl[i].blk_min : tbl[i].min;
+    int mx = with_block ? tbl[i].blk_max : tbl[i].max;
+    const char *lo = with_block ? tbl[i].blk_lo_exp : tbl[i].lo_exp;
+    const char *hi = with_block ? tbl[i].blk_hi_exp : tbl[i].hi_exp;
+    if (mn >= 0 && argc < mn && lo) snprintf(exp, n, "%s", lo);
+    else if (mx >= 0 && argc > mx && hi) snprintf(exp, n, "%s", hi);
+    return 1;
+  }
+  return 0;
+}
+
+/* Whether a reopened builtin -- Object, Kernel, Class, Module, the
+   receiver's own or the other class its kind stands for -- defines the
+   name: a def there keeps its dispatch, whatever the count. */
+static int reopened_owns(Compiler *c, const char *cls, const char *name) {
+  int bc = comp_class_index(c, cls);
+  return bc >= 0 && comp_method_in_chain(c, bc, name, NULL) >= 0;
+}
+
+/* The singleton defs a program writes on a constant -- `def S1.m`, or a
+   def or define_method under `class << S1` or `class << self` in its body,
+   through statement lists, branches, loops and blocks -- read off the tree
+   once per table, with the `extend self` a body may carry (only the module
+   arm reads that). A class Struct.new or Data.define answered is not yet a
+   class when they are collected, so they reach no chain, and a def under a
+   conditional in a singleton body reaches none either; the constant arm
+   asks here. */
+typedef struct { char *cn; char *name; } SingletonDef;
+static SingletonDef *g_sdefs;
+static int g_nsdefs, g_csdefs;
+static const NodeTable *g_sdefs_nt;
+static int g_sdefs_count;
+static unsigned g_sdefs_version;
+static void sdefs_add(const char *cn, const char *name) {
+  if (g_nsdefs >= g_csdefs) {
+    int cap = g_csdefs ? g_csdefs * 2 : 16;
+    SingletonDef *grown = realloc(g_sdefs, sizeof *grown * (size_t)cap);
+    if (!grown) return;
+    g_sdefs = grown; g_csdefs = cap;
+  }
+  g_sdefs[g_nsdefs].cn = strdup(cn); g_sdefs[g_nsdefs].name = strdup(name); g_nsdefs++;
+}
+static void sdefs_scan(const NodeTable *nt, int id, const char *cn, int in_singleton) {
+  const char *ty = id >= 0 ? nt_type(nt, id) : NULL;
+  if (!ty) return;
+  if (sp_streq(ty, "DefNode")) {
+    /* a def with a receiver of its own is that receiver's (the pass below
+       reads those off every DefNode) */
+    const char *dn = nt_str(nt, id, "name");
+    if (in_singleton && cn && dn && nt_ref(nt, id, "receiver") < 0) sdefs_add(cn, dn);
+  }
+  else if (sp_streq(ty, "SingletonClassNode")) {
+    /* `class << Const` is entered from the pass over every node; `class <<
+       self` from its class's body -- and a singleton's own singleton is not
+       the class's */
+    int ex = nt_ref(nt, id, "expression");
+    const char *ety = ex >= 0 ? nt_type(nt, ex) : NULL;
+    const char *scn = ety && sp_streq(ety, "ConstantReadNode") && !cn ? nt_str(nt, ex, "name")
+                    : ety && sp_streq(ety, "SelfNode") && cn && !in_singleton ? cn : NULL;
+    if (scn) sdefs_scan(nt, nt_ref(nt, id, "body"), scn, 1);
+  }
+  else if (sp_streq(ty, "CallNode")) {
+    const char *nm = nt_str(nt, id, "name");
+    int an = nt_ref(nt, id, "arguments"); int n = 0;
+    const int *av = an >= 0 ? nt_arr(nt, an, "arguments", &n) : NULL;
+    const char *a0 = av && n == 1 ? nt_type(nt, av[0]) : NULL;
+    if (nm && a0 && nt_ref(nt, id, "receiver") < 0) {
+      if (!in_singleton && cn && sp_streq(nm, "extend") && sp_streq(a0, "SelfNode"))
+        sdefs_add(cn, "extend self");
+      /* define_method(:m) { } in a singleton body is the class's own too */
+      const char *dm = sp_streq(a0, "SymbolNode") ? nt_str(nt, av[0], "value") : NULL;
+      if (in_singleton && cn && dm && sp_streq(nm, "define_method")) sdefs_add(cn, dm);
+    }
+    sdefs_scan(nt, nt_ref(nt, id, "block"), cn, in_singleton);   /* `[1].each do def m` */
+  }
+  else if (sp_streq(ty, "StatementsNode")) {
+    int n = 0; const int *st = nt_arr(nt, id, "body", &n);
+    for (int i = 0; i < n; i++) sdefs_scan(nt, st[i], cn, in_singleton);
+  }
+  else if (sp_streq(ty, "BlockNode")) sdefs_scan(nt, nt_ref(nt, id, "body"), cn, in_singleton);
+  else if (sp_streq(ty, "IfNode") || sp_streq(ty, "UnlessNode") || sp_streq(ty, "ElseNode") ||
+           sp_streq(ty, "WhenNode") || sp_streq(ty, "InNode") || sp_streq(ty, "RescueNode") ||
+           sp_streq(ty, "EnsureNode") || sp_streq(ty, "BeginNode") || sp_streq(ty, "CaseNode") ||
+           sp_streq(ty, "CaseMatchNode") || sp_streq(ty, "WhileNode") ||
+           sp_streq(ty, "UntilNode") || sp_streq(ty, "ForNode")) {
+    static const char *const KEYS[] = { "statements", "subsequent", "else_clause",
+                                        "rescue_clause", "ensure_clause" };
+    for (size_t k = 0; k < sizeof KEYS / sizeof KEYS[0]; k++)
+      sdefs_scan(nt, nt_ref(nt, id, KEYS[k]), cn, in_singleton);
+    int n = 0; const int *cs = nt_arr(nt, id, "conditions", &n);
+    for (int i = 0; i < n; i++) sdefs_scan(nt, cs[i], cn, in_singleton);
+  }
+  /* a class, module or def of its own is another scope */
+}
+static int singleton_def_of(Compiler *c, const char *cn, const char *name) {
+  const NodeTable *nt = c->nt;
+  /* the version as well as the count: a rename pass rewrites a name in
+     place without growing the table */
+  if (g_sdefs_nt != nt || g_sdefs_count != nt->count || g_sdefs_version != nt->version) {
+    for (int i = 0; i < g_nsdefs; i++) { free(g_sdefs[i].cn); free(g_sdefs[i].name); }
+    g_nsdefs = 0; g_sdefs_nt = nt; g_sdefs_count = nt->count; g_sdefs_version = nt->version;
+    for (int id = 0; id < nt->count; id++) {
+      const char *ty = nt_type(nt, id);
+      if (!ty) continue;
+      if (sp_streq(ty, "DefNode")) {
+        int dr = nt_ref(nt, id, "receiver");
+        const char *rty = dr >= 0 ? nt_type(nt, dr) : NULL;
+        const char *rn = rty && sp_streq(rty, "ConstantReadNode") ? nt_str(nt, dr, "name") : NULL;
+        const char *dn = nt_str(nt, id, "name");
+        if (rn && dn) sdefs_add(rn, dn);
+      }
+      else if (sp_streq(ty, "ClassNode") || sp_streq(ty, "ModuleNode")) {
+        int cp = nt_ref(nt, id, "constant_path");
+        const char *cty = cp >= 0 ? nt_type(nt, cp) : NULL;
+        const char *kn = cty && sp_streq(cty, "ConstantReadNode") ? nt_str(nt, cp, "name") : NULL;
+        if (kn) sdefs_scan(nt, nt_ref(nt, id, "body"), kn, 0);
+      }
+      else if (sp_streq(ty, "SingletonClassNode")) sdefs_scan(nt, id, NULL, 0);
+    }
+  }
+  for (int i = 0; i < g_nsdefs; i++)
+    if (sp_streq(g_sdefs[i].cn, cn) && sp_streq(g_sdefs[i].name, name)) return 1;
+  return 0;
+}
+
+/* A top-level def or alias: Object's private instance method, which CRuby
+   refuses on any receiver as a NoMethodError, never as a count. */
+static int toplevel_def(Compiler *c, const char *name) {
+  int mi = comp_method_index(c, name);
+  return mi >= 0 && !c->scopes[mi].is_cmethod;
+}
+
+/* The guard's decision: a builtin call whose positional count CRuby rejects.
+   exp receives CRuby's wording of the accepted range, eval_recv whether the
+   receiver is an expression to evaluate before the raise. */
+static int arity_violation(Compiler *c, int id, char *exp, size_t n, int *eval_recv) {
   const NodeTable *nt = c->nt;
   const char *name = nt_str(nt, id, "name");
   int recv = nt_ref(nt, id, "receiver");
-  if (!name || recv < 0) return 0;
+  if (!name) return 0;
   /* nil&.m short-circuits before any arity check */
   const char *safe_op = nt_str(nt, id, "call_operator");
   if (safe_op && sp_streq(safe_op, "&.")) return 0;
@@ -11321,34 +12114,66 @@ int emit_builtin_arity_guard(Compiler *c, int id, Buf *b) {
                sp_streq(at, "BlockArgumentNode")))
       return 0;
   }
-  char exp[32]; exp[0] = 0;
-  int eval_recv = 1;
-  const char *rty2 = nt_type(nt, recv);
-  if (rty2 && sp_streq(rty2, "ConstantReadNode")) {
+  exp[0] = 0;
+  *eval_recv = 1;
+  const SpAritySpec *itbl = sp_builtin_arity_spec_tbl;
+  const SpAritySpec *ctbl = sp_builtin_cmeth_arity_spec_tbl;
+  const char *rty2 = recv >= 0 ? nt_type(nt, recv) : NULL;
+  if (recv < 0) {
+    /* A bare call resolves to the enclosing class's chain, then to a
+       top-level def or a reopened Kernel or Object, and only then to the
+       Kernel function, whose rows sit with the class methods; a def keeps
+       its dispatch (the plain ones went to emit_method_call above this
+       guard already). */
+    Scope *esc = comp_scope_of(c, id);
+    int ecls = esc ? esc->class_id : -1;
+    if (ecls >= 0 && ecls < c->nclasses &&
+        (esc->is_cmethod ? comp_cmethod_in_chain(c, ecls, name, NULL) >= 0
+                         : comp_method_in_chain(c, ecls, name, NULL) >= 0 ||
+                           comp_reader_in_chain(c, ecls, name, NULL)))
+      return 0;
+    if (comp_method_index(c, name) >= 0 ||
+        reopened_owns(c, "Kernel", name) || reopened_owns(c, "Object", name)) return 0;
+    if (!arity_spec_row(ctbl, "Kernel", name, with_block, argc, exp, n) || !exp[0]) return 0;
+    *eval_recv = 0;
+  }
+  else if (rty2 && sp_streq(rty2, "ConstantReadNode")) {
     const char *cn = nt_str(nt, recv, "name");
     if (!cn) return 0;
     /* the analyzer renames Hash.new-with-default; the spec row is "new" */
     if (sp_streq(name, "__hash_new_default")) name = "new";
-    /* a user class by this name owns its own methods */
+    /* a user class owns the class methods it defines, and a module that
+       extends itself its instance methods too; the rest of its surface is
+       Class's or Module's own (name, superclass, ancestors) with Object's
+       beneath, or the readers a class Struct.new or Data.define answered
+       carries */
+    const char *surface = NULL;   /* the instance rows a class object answers with */
     int uc = comp_class_index(c, cn);
-    if (uc >= 0 && !c->classes[uc].is_native_class) return 0;
-    for (int i = 0; sp_builtin_cmeth_arity_spec_tbl[i].cls; i++) {
-      if (!sp_streq(sp_builtin_cmeth_arity_spec_tbl[i].cls, cn) ||
-          !sp_streq(sp_builtin_cmeth_arity_spec_tbl[i].m, name)) continue;
-      int mn = with_block ? sp_builtin_cmeth_arity_spec_tbl[i].blk_min
-                          : sp_builtin_cmeth_arity_spec_tbl[i].min;
-      int mx = with_block ? sp_builtin_cmeth_arity_spec_tbl[i].blk_max
-                          : sp_builtin_cmeth_arity_spec_tbl[i].max;
-      const char *lo = with_block ? sp_builtin_cmeth_arity_spec_tbl[i].blk_lo_exp
-                                  : sp_builtin_cmeth_arity_spec_tbl[i].lo_exp;
-      const char *hi = with_block ? sp_builtin_cmeth_arity_spec_tbl[i].blk_hi_exp
-                                  : sp_builtin_cmeth_arity_spec_tbl[i].hi_exp;
-      if (mn >= 0 && argc < mn && lo) snprintf(exp, sizeof exp, "%s", lo);
-      else if (mx >= 0 && argc > mx && hi) snprintf(exp, sizeof exp, "%s", hi);
-      break;
+    if (uc >= 0 && !c->classes[uc].is_native_class) {
+      int mod = comp_class_is_module(c, &c->classes[uc]);
+      /* a `class << self` reader is the class object's own and sits in no
+         chain; a writer's name has no row to meet */
+      if (comp_cmethod_in_chain(c, uc, name, NULL) >= 0 ||
+          comp_is_sg_reader(&c->classes[uc], name) || singleton_def_of(c, cn, name) ||
+          (mod && singleton_def_of(c, cn, "extend self") &&
+           (comp_method_in_chain(c, uc, name, NULL) >= 0 ||
+            comp_reader_in_chain(c, uc, name, NULL))))
+        return 0;
+      if (c->classes[uc].is_struct) cn = "StructClass";
+      else if (c->classes[uc].is_data) cn = "DataClass";
+      else surface = mod ? "Module" : "Class";
     }
+    if (surface) {
+      if (reopened_owns(c, surface, name) ||
+          (sp_streq(surface, "Class") && reopened_owns(c, "Module", name)) ||
+          reopened_owns(c, "Object", name) || reopened_owns(c, "Kernel", name)) return 0;
+      if (!arity_spec_row(itbl, surface, name, with_block, argc, exp, n) &&
+          (!arity_spec_row(itbl, "Object", name, with_block, argc, exp, n) || toplevel_def(c, name)))
+        return 0;
+    }
+    else if (!arity_spec_row(ctbl, cn, name, with_block, argc, exp, n)) return 0;
     if (!exp[0]) return 0;
-    eval_recv = 0;  /* a constant read has no effect to evaluate */
+    *eval_recv = 0;  /* a constant read has no effect to evaluate */
   }
   else {
     TyKind rt = comp_ntype(c, recv);
@@ -11361,40 +12186,65 @@ int emit_builtin_arity_guard(Compiler *c, int id, Buf *b) {
                     : rt == TY_BOOL ? "TrueClass"  /* FalseClass: same surface */
                     : rt == TY_RATIONAL ? "Rational" : rt == TY_COMPLEX ? "Complex"
                     : rt == TY_MUTEX ? "Mutex"
+                    : rt == TY_REGEX ? "Regexp" : rt == TY_MATCHDATA ? "MatchData"
+                    : rt == TY_PROC ? "Proc" : rt == TY_METHOD ? "Method"
+                    : rt == TY_FIBER ? "Fiber" : rt == TY_THREAD ? "Thread"
+                    : rt == TY_QUEUE ? "Queue"  /* SizedQueue too: the rows they share */
+                    : rt == TY_CONDVAR ? "ConditionVariable"
+                    : rt == TY_IO ? "File" : rt == TY_DIR ? "Dir"
+                    : rt == TY_EXCEPTION ? "Exception"
+                    : rt == TY_ENUMERATOR ? "Enumerator" : rt == TY_RANDOM ? "Random"
                     : ty_is_array(rt) ? "Array" : ty_is_hash(rt) ? "Hash" : NULL;
     /* a native (package-backed) receiver checks its own class's rows -- the
        loose C dispatch dropped excess arguments (StringIO#eof?(1) answered
-       false); a user object falls back to Object's universal rows. Both only
-       for a method the user's own chain does not define. */
+       false); a Struct or Data instance its kind's; a user object falls back
+       to Object's universal rows. All only for a method the user's own chain
+       does not define. */
     if (!bcn && ty_is_object(rt)) {
       int ocid = ty_object_class(rt);
       if (ocid >= 0 && ocid < c->nclasses &&
           comp_method_in_chain(c, ocid, name, NULL) < 0 &&
           !comp_reader_in_chain(c, ocid, name, NULL) &&
           !comp_writer_in_chain(c, ocid, name, NULL))
-        bcn = c->classes[ocid].is_native_class ? c->classes[ocid].name : "Object";
+        bcn = c->classes[ocid].is_native_class ? c->classes[ocid].name
+            : c->classes[ocid].is_struct ? "Struct"
+            : c->classes[ocid].is_data ? "Data" : "Object";
     }
     if (!bcn) return 0;
-    for (int i = 0; sp_builtin_arity_spec_tbl[i].cls; i++) {
-      if (!sp_streq(sp_builtin_arity_spec_tbl[i].cls, bcn) ||
-          !sp_streq(sp_builtin_arity_spec_tbl[i].m, name)) continue;
-      int mn = with_block ? sp_builtin_arity_spec_tbl[i].blk_min
-                          : sp_builtin_arity_spec_tbl[i].min;
-      int mx = with_block ? sp_builtin_arity_spec_tbl[i].blk_max
-                          : sp_builtin_arity_spec_tbl[i].max;
-      const char *lo = with_block ? sp_builtin_arity_spec_tbl[i].blk_lo_exp
-                                  : sp_builtin_arity_spec_tbl[i].lo_exp;
-      const char *hi = with_block ? sp_builtin_arity_spec_tbl[i].blk_hi_exp
-                                  : sp_builtin_arity_spec_tbl[i].hi_exp;
-      if (mn >= 0 && argc < mn && lo) snprintf(exp, sizeof exp, "%s", lo);
-      else if (mx >= 0 && argc > mx && hi) snprintf(exp, sizeof exp, "%s", hi);
-      break;
+    /* a name the class inherits from Object unchanged has Object's row: the
+       table keeps a class's own row only where the class defines the name,
+       and a forwarding name keeps one that never fires */
+    const char *owner = bcn;
+    if (!arity_spec_row(itbl, bcn, name, with_block, argc, exp, n)) {
+      if (!arity_spec_row(itbl, "Object", name, with_block, argc, exp, n)) return 0;
+      owner = "Object";
     }
     if (!exp[0]) return 0;
-    /* a reopened builtin that defines the name keeps its own dispatch */
-    int bc = comp_class_index(c, bcn);
-    if (bc >= 0 && comp_method_in_chain(c, bc, name, NULL) >= 0) return 0;
+    /* a reopened builtin that defines the name keeps its own dispatch --
+       the receiver's class, the other class its kind stands for, or the
+       Object the row came from; a top-level def is Object's too, private,
+       which CRuby refuses as a NoMethodError, not a count */
+    const char *twin = rt == TY_BOOL ? "FalseClass" : rt == TY_IO ? "IO"
+                     : rt == TY_QUEUE ? "SizedQueue" : NULL;
+    if (reopened_owns(c, bcn, name) || reopened_owns(c, owner, name) ||
+        (twin && reopened_owns(c, twin, name)) ||
+        (sp_streq(owner, "Object") && toplevel_def(c, name))) return 0;
   }
+  return 1;
+}
+
+int builtin_arity_violation(Compiler *c, int id) {
+  char exp[32]; int eval_recv;
+  return arity_violation(c, id, exp, sizeof exp, &eval_recv);
+}
+
+int emit_builtin_arity_guard(Compiler *c, int id, Buf *b) {
+  const NodeTable *nt = c->nt;
+  char exp[32]; int eval_recv;
+  if (!arity_violation(c, id, exp, sizeof exp, &eval_recv)) return 0;
+  int recv = nt_ref(nt, id, "receiver");
+  int anode = nt_ref(nt, id, "arguments");
+  int argc = 0; const int *argv = anode >= 0 ? nt_arr(nt, anode, "arguments", &argc) : NULL;
   TyKind rty = comp_ntype(c, id);
   const char *dv = default_value(rty);
   buf_puts(b, "({ ");

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -115,6 +115,7 @@ extern int g_yield_block_fallback_nren;
 extern int  g_nren;
 extern int  g_block_id;
 int builtin_method_known(const char *cls, const char *m);
+int builtin_arity_violation(Compiler *c, int id);
 int builtin_object_method_known(const char *m);
 int name_is_enumerable_module_method(const char *m);
 int scope_reads_callee(Compiler *c, int si);

--- a/test/builtin_arity_reach.rb
+++ b/test/builtin_arity_reach.rb
@@ -1,0 +1,241 @@
+# The arity guard on the receivers it did not reach: a builtin called with a
+# count CRuby rejects raises CRuby's ArgumentError, message and all, on every
+# handle kind the compiler types -- Regexp, MatchData, Proc, Method, Fiber,
+# Thread, Queue and SizedQueue, ConditionVariable, IO, Dir, Exception,
+# Enumerator, Random, a Struct or Data instance -- on a class or module
+# constant (its own Class or Module surface, a Struct or Data class's
+# readers, GC, Fiber, Thread), on a bare Kernel function, and on the
+# universal names a builtin inherits from Object. Beside each, the in-range
+# shape still answers, and a class's own row outranks Object's; a def of the
+# name -- at top level, in a reopened Object, a module function, a class
+# object's `class << self` accessor -- keeps its own dispatch, where an
+# instance reader on a class does not reach the class object; a name handed
+# to public_send reaches the raise; the receiver and the arguments are
+# evaluated before the raise.
+def bad
+  yield
+  puts "no error"
+rescue ArgumentError => e
+  puts "#{e.class}: #{e.message}"
+end
+
+re = /a(b)?/
+bad { re.source(1) }
+bad { re.match }
+bad { re.match("ab", 0, 1) }
+bad { re.names(nil) }
+p re.source, re.match("xab", 1)[1], re.match?("a")
+
+m = "xab".match(re)
+bad { m.begin(0, 1) }
+bad { m.length(1) }
+bad { m.captures(1) }
+bad { m.pre_match(1) }
+bad { m[0, 1, 2] }
+p m.begin(0), m[1], m.pre_match, m.captures
+
+pr = proc { |x| x.to_s * 2 }
+bad { pr.arity(1) }
+bad { pr.lambda?(1) }
+bad { pr.curry(1, 2) }
+p pr.arity, pr.call(4), pr.lambda?
+
+mt = 12.method(:to_s)
+bad { mt.name(1) }
+bad { mt.arity(nil) }
+bad { mt.owner(1) }
+p mt.name, mt.call, mt.arity
+
+f = Fiber.new { 7 }
+bad { f.alive?(nil) }
+bad { Fiber.current(nil) }
+p f.alive?, f.resume, f.alive?
+
+t = Thread.new { 2 }
+bad { t.join(1, 2) }
+bad { t.value(1) }
+bad { t.alive?(nil) }
+bad { Thread.list(1) }
+bad { Thread.current(1) }
+bad { Thread.pass(1) }
+p t.value, t.join.equal?(t), t.alive?
+
+q = Queue.new
+bad { q.size(1) }
+bad { q.empty?(1) }
+bad { q.pop(true, 1) }
+bad { q.close(1) }
+q.push(1)
+q << 2
+p q.size, q.pop, q.empty?
+sq = SizedQueue.new(2)
+sq.push(3)
+bad { sq.size(1) }
+p sq.size, sq.pop
+
+cv = ConditionVariable.new
+bad { cv.signal(1) }
+bad { cv.broadcast(1) }
+bad { cv.wait }
+p cv.signal.equal?(cv)
+
+bad { $stdout.fileno(1) }
+bad { $stdout.tty?(1) }
+bad { $stdin.closed?(nil) }
+p $stdout.fileno, $stdout.closed?
+File.open("/dev/null") do |fh|
+  bad { fh.eof?(1) }
+  bad { fh.closed?(1) }
+  p fh.eof?, fh.read(0)
+end
+
+d = Dir.new(".")
+bad { d.path(1) }
+bad { d.close(1) }
+p d.path
+d.close
+
+ex = RuntimeError.new("x")
+bad { ex.message(1) }
+bad { ex.full_message(1) }
+bad { ex.backtrace(nil) }
+p ex.message
+begin
+  raise "boom"
+rescue => err
+  bad { err.message(1) }
+  bad { err.cause(1) }
+  p err.message, err.cause
+end
+
+en = [1, 2].each
+bad { en.next(1) }
+bad { en.peek(nil) }
+bad { en.size(1) }
+bad { en.rewind(1) }
+p en.next, en.peek, en.size
+
+rn = Random.new(1)
+bad { rn.seed(1) }
+bad { rn.rand(1, 2) }
+p rn.seed, rn.rand(1)
+
+S = Struct.new(:a, :b)
+s = S.new(1, 2)
+bad { s.members(1) }
+bad { s.to_a(1) }
+bad { s.values(nil) }
+bad { s.size(1) }
+bad { S.members(nil) }
+bad { S.keyword_init?(1) }
+p s.members, s.to_a, S.members, s.a, s.size
+
+D = Data.define(:x)
+dd = D.new(x: 1)
+bad { dd.members(1) }
+bad { D.members(1) }
+p dd.members, dd.x
+
+class Foo
+  def self.own(*a)
+    a.size
+  end
+end
+module Mod
+end
+bad { Foo.name(1) }
+bad { Foo.superclass(1) }
+bad { Foo.ancestors(nil) }
+bad { Mod.name(1) }
+p Foo.own(1, 2), Foo.name, Foo.superclass, Mod.name
+
+bad { GC.start(1) }
+bad { GC.count(1) }
+GC.start
+puts "gc ok"
+
+# a refused call in argument or assignment position: the raise stands in
+# for a value the analyzer has no type for
+bad { p Fiber.current(nil).alive? }
+bad { x = re.source(1); p x }
+bad { p Thread.list(1).size }
+
+bad { Integer() }
+bad { Integer("1", 10, 3) }
+bad { Float() }
+bad { catch(:t) { throw :t, 1, 2 } }
+bad { catch(1, 2) { } }
+bad { catch(1, 2) }
+bad { Rational(1, 2, 3) }
+bad { block_given?(1) }
+bad { caller(1, 2, 3) }
+p Integer("7"), format("%02d", 3), catch(:t) { throw :t, 5 }, rand(1)
+
+# a def of a Kernel function's name keeps its own dispatch, count and all
+def srand(*a)
+  "mine #{a.size}"
+end
+p srand(1, 2)
+
+# the names every builtin inherits from Object
+bad { 1.respond_to? }
+bad { "s".is_a? }
+bad { [1].instance_of?(Array, 1) }
+bad { :s.nil?(1) }
+bad { 1.5.frozen?(1) }
+bad { (1..2).hash(1) }
+bad { re.respond_to?(:match, true, 1) }
+bad { q.instance_of?(Queue, 1) }
+p 1.respond_to?(:to_s), "s".is_a?(String)
+p [1].instance_of?(Array), re.respond_to?(:match)
+
+# the receiver and the arguments are evaluated first, in order
+def rx
+  puts "recv"
+  /a/
+end
+def ag
+  puts "arg"
+  1
+end
+bad { rx.source(ag) }
+
+# a name handed to public_send, and Object's row beneath a class's own
+nm = :frozen?
+bad { 1.public_send(nm, nil) }
+bad { 1.public_send(:frozen?, nil) }
+p 1.public_send(:frozen?), 1.public_send(nm)
+bad { 12.to_s(2, 3) }
+bad { re.freeze(1) }
+p 12.to_s(2), re.freeze.frozen?
+bad { p rand(1, 2) }
+
+# a class object's own accessors and a module's own functions keep their
+# dispatch; an instance reader on a class does not reach the class object
+class Request
+  class << self
+    attr_accessor :method
+  end
+end
+Request.method = "POST"
+p Request.method
+class Bar
+  attr_reader :name
+end
+bad { Bar.name(1) }
+p Bar.name
+module MF
+  def freeze(a)
+    "mf #{a}"
+  end
+  module_function :freeze
+end
+p MF.freeze(1)
+
+# a reopened Object owns the name on an Integer and a String
+class Object
+  def itself(a)
+    "obj #{a}"
+  end
+end
+p 5.itself(1), "s".itself(2)

--- a/test/builtin_arity_reach.rb.expected
+++ b/test/builtin_arity_reach.rb.expected
@@ -1,0 +1,160 @@
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 0, expected 1..2)
+ArgumentError: wrong number of arguments (given 3, expected 1..2)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+"a(b)?"
+"b"
+true
+ArgumentError: wrong number of arguments (given 2, expected 1)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 3, expected 1..2)
+1
+"b"
+"x"
+["b"]
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 2, expected 0..1)
+1
+"44"
+false
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+:to_s
+"12"
+-1
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+true
+7
+false
+ArgumentError: wrong number of arguments (given 2, expected 0..1)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+2
+true
+false
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 2, expected 0..1)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+2
+1
+false
+ArgumentError: wrong number of arguments (given 1, expected 0)
+1
+3
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 0, expected 1..2)
+true
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+1
+false
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+true
+""
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+"."
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+"x"
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+"boom"
+nil
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+1
+2
+2
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 2, expected 0..1)
+1
+0
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+[:a, :b]
+[1, 2]
+[:a, :b]
+1
+2
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+[:x]
+1
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+2
+"Foo"
+Object
+"Mod"
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+gc ok
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 0, expected 1..2)
+ArgumentError: wrong number of arguments (given 3, expected 1..2)
+ArgumentError: wrong number of arguments (given 0, expected 1)
+ArgumentError: wrong number of arguments (given 3, expected 1..2)
+ArgumentError: wrong number of arguments (given 2, expected 0..1)
+ArgumentError: wrong number of arguments (given 2, expected 0..1)
+ArgumentError: wrong number of arguments (given 3, expected 1..2)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 3, expected 0..2)
+7
+"03"
+5
+0
+"mine 2"
+ArgumentError: wrong number of arguments (given 0, expected 1..2)
+ArgumentError: wrong number of arguments (given 0, expected 1)
+ArgumentError: wrong number of arguments (given 2, expected 1)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 3, expected 1..2)
+ArgumentError: wrong number of arguments (given 2, expected 1)
+true
+true
+true
+true
+recv
+arg
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+true
+true
+ArgumentError: wrong number of arguments (given 2, expected 0..1)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+"1100"
+true
+ArgumentError: wrong number of arguments (given 2, expected 0..1)
+"POST"
+ArgumentError: wrong number of arguments (given 1, expected 0)
+"Bar"
+"mf 1"
+"obj 1"
+"obj 2"

--- a/tools/gen_builtin_arity_spec.rb
+++ b/tools/gen_builtin_arity_spec.rb
@@ -26,10 +26,10 @@
 #      method whose accepted set is not one contiguous range (Time.utc takes
 #      1..8 OR exactly 10) is left out -- unguarded -- rather than guessed.
 #
-# The instance surface probed is exactly sp_builtin_arity_tbl (the Method#arity
-# dump already in codegen_call.c); the class-method surface is the curated
-# list below. Anything the probe cannot prove is omitted, so the guard the
-# tables drive fires only where CRuby itself would raise.
+# The instance surface probed is every public method of each receiver below;
+# the class-method surface is the curated list. Anything the probe cannot
+# prove is omitted, so the guard the tables drive fires only where CRuby
+# itself would raise.
 #
 # Every method is probed twice: bare, and carrying an inert block ("2.step { }"
 # accepts 0 args where the bare call wants a limit; Array#fill drops to 0..2).
@@ -67,7 +67,41 @@ INSTANCE_RECEIVERS = {
   "StringScanner" => -> { StringScanner.new("ab") },
   "Pathname" => -> { Pathname.new("a") }, "Set" => -> { Set.new([1, 2]) },
   "Mutex" => -> { Mutex.new },
+  # the handle kinds the guard maps by TyKind (emit_builtin_arity_guard): a
+  # row must hold for every value of the kind, so Queue's rows are those
+  # Queue and SizedQueue agree on (one TyKind stands for both), the IO rows
+  # are probed on a File (the surface an IO handle can answer), and Struct
+  # and Data instances lose their own members' accessors below
+  "Regexp" => -> { /a/ }, "MatchData" => -> { "ab".match(/a/) },
+  "Proc" => -> { proc { } }, "Method" => -> { 1.method(:to_s) },
+  "Fiber" => -> { Fiber.new { } }, "Thread" => -> { Thread.new { }.join },
+  "Queue" => -> { Queue.new([1, 2]) },
+  "SizedQueue" => -> { q = SizedQueue.new(4); q << 1; q },
+  "ConditionVariable" => -> { ConditionVariable.new },
+  # a handle per probe would run the process out of descriptors: close the last
+  "File" => -> { ($probe_io&.close rescue nil)
+                 $probe_io = File.open("f", "w+"); $probe_io.write("ab"); $probe_io.rewind; $probe_io },
+  "Dir" => -> { ($probe_dir&.close rescue nil); $probe_dir = Dir.new(".") },
+  "Exception" => -> { RuntimeError.new("x") },
+  "Enumerator" => -> { [1, 2].each }, "Random" => -> { Random.new(1) },
+  "Struct" => -> { Struct.new(:a).new(1) },
+  "Data" => -> { Data.define(:a).new(a: 1) },
+  "Class" => -> { Class.new }, "Module" => -> { Module.new },
 }
+
+# Names whose accepted counts belong to what the receiver forwards to, not
+# to its class: Method#call is its target's, Enumerator#each and to_a hand
+# their arguments to the call underneath, Class#new is initialize's. Each
+# keeps a row that never fires (the sentinel quartets), so the guard sees the
+# class owns the name and does not read Object's row for it -- Proc#=== is
+# an Object name too. A probe Struct's or Data's member accessors are the
+# receiver's, not the class's, and get no row at all.
+FORWARDING = {
+  "Proc" => %w[call [] === yield], "Method" => %w[call [] ===],
+  "Enumerator" => %w[each to_a entries to_h each_entry reverse_each],
+  "Class" => %w[new],
+}
+PROBE_ARTEFACTS = { "Struct" => %w[a a=], "Data" => %w[a] }
 
 # The surface probed per class: every public instance method (the arity dump
 # alone missed Float#div, Integer#step, ...), minus anything that could act
@@ -76,7 +110,7 @@ INSTANCE_METHOD_SKIP = %w[
   exit exit! fork system exec spawn sleep gets readline trap syscall
   display print puts pp p warn require require_relative load autoload
   instance_eval instance_exec class_eval module_eval eval
-  freeze taint untaint
+  taint untaint
   pread pwrite sysread syswrite readpartial read_nonblock write_nonblock
   sysseek ioctl fcntl
   set_encoding_by_bom
@@ -86,13 +120,20 @@ INSTANCE_METHOD_SKIP = %w[
 
 # Class/module methods: the constructors and module functions whose emitters
 # index argv[] unconditionally (File.open with no arguments crashed the
-# compiler). Never probe anything that could act on the probing process
-# itself (fork / exec / select / sleep).
+# compiler), the surface of the constants a program names bare, and the
+# Kernel functions a bare call reaches. Every call is made with nil
+# arguments, which Process.spawn, waitpid2 and the socket constructors
+# reject before acting; still, never probe anything that could act on the
+# probing process itself with any argument (fork / exec / select / sleep).
+# GC.disable is undone by the GC.enable probed right after it.
 CLASS_TARGETS = {
   "File"    => %w[open new read write binread binwrite readlines foreach delete unlink
                   rename exist? size basename dirname extname join split expand_path
                   chmod utime umask truncate symlink link readlink realpath stat lstat
-                  ftype mtime atime ctime empty? zero? identical? absolute_path],
+                  ftype mtime atime ctime empty? zero? identical? absolute_path
+                  file? directory? readable? writable? executable? symlink? size?
+                  fnmatch fnmatch? owned? world_readable? world_writable? path
+                  absolute_path? birthtime chown lchmod lchown mkfifo],
   # IO.select probes slowly (a nil-args call waits for the 2 s timeout) but
   # the row it yields is real: a missing-argument call is CRuby's
   # ArgumentError, and the probe never passes an actual IO to wait on.
@@ -108,17 +149,27 @@ CLASS_TARGETS = {
   "Math"    => %w[sqrt cbrt sin cos tan asin acos atan atan2 sinh cosh tanh asinh acosh
                   atanh log log2 log10 exp hypot ldexp frexp erf erfc gamma lgamma],
   "Process" => %w[getpriority setpriority getsid kill clock_gettime clock_getres pid ppid
-                  uid gid euid egid setproctitle],
+                  uid gid euid egid setproctitle times spawn waitpid2],
   "Regexp"  => %w[new escape quote union],
   "Random"  => %w[new rand srand],
   "ENV"     => %w[fetch key? has_key? include? member? assoc rassoc values_at],
-  "Kernel"  => %w[format sprintf Integer Float String Array Hash Rational Complex],
+  "Kernel"  => %w[format sprintf Integer Float String Array Hash Rational Complex
+                  throw catch raise rand srand caller lambda proc binding block_given?],
+  # the class-side surface of the constants a program names bare: GC, Fiber
+  # and Thread are not classes the compiler declares; a class Struct.new or
+  # Data.define answered is keyed StructClass / DataClass
+  "GC"      => %w[start stat compact count disable enable stress latest_gc_info],
+  "Fiber"   => %w[current yield],
+  "Thread"  => %w[current main list pass new start abort_on_exception
+                  report_on_exception pending_interrupt? handle_interrupt],
+  "StructClass" => %w[members keyword_init?],
+  "DataClass"   => %w[members],
   "Marshal" => %w[dump load],
   # arity-only probing is safe here: every call is made with nil arguments,
   # which these constructors and entry points reject before acting
   "Signal"  => %w[signame list trap],
   "Socket"  => %w[new getaddrinfo getnameinfo pair socketpair gethostname sockaddr_in
-                  unpack_sockaddr_in],
+                  unpack_sockaddr_in pack_sockaddr_in sockaddr_un pack_sockaddr_un],
   "TCPSocket"  => %w[new open],
   "TCPServer"  => %w[new open],
   "UNIXSocket" => %w[new open],
@@ -137,7 +188,11 @@ CLASS_TARGETS = {
   "Pathname"      => %w[new glob getwd pwd],
 }
 
-def probe(thunk, m, n, block: false)
+# A top-level def is a private method of every object, the probe receivers
+# included, and a builtin's internals may dispatch to it -- an Enumerator's
+# size asks its target for `call` -- so these helpers keep names no
+# builtin sends.
+def probe_counts(thunk, m, n, block: false)
   r2 = thunk.call
   Timeout.timeout(2) do
     block ? r2.__send__(m, *Array.new(n)) { |*| "a" } : r2.__send__(m, *Array.new(n))
@@ -153,13 +208,13 @@ end
 # args where the bare call wants 1..; Array#fill drops to 0..2). The block
 # used is inert but really runs, which is why the probe surface excludes
 # anything that could act on the probing process.
-def spec_for(recv, m, block: false)
+def spec_of(recv, m, block: false)
   sym = m.to_sym
   return nil unless recv.call.respond_to?(sym)
-  low = (0..3).map { |n| probe(recv, sym, n, block: block) }
+  low = (0..3).map { |n| probe_counts(recv, sym, n, block: block) }
   min = low.index(:ok)
   return nil if min.nil?  # needs > 3 required args: not on this surface
-  hi = probe(recv, sym, 99, block: block)
+  hi = probe_counts(recv, sym, 99, block: block)
   max, hi_exp =
     case hi
     when :ok then [-1, nil]
@@ -178,7 +233,7 @@ def spec_for(recv, m, block: false)
   # every count below min must still be rejected with the same wording
   (0..12).each do |n|
     predicted_ok = n >= min && (max < 0 || n <= max)
-    actual = n <= 3 ? low[n] : probe(recv, sym, n, block: block)
+    actual = n <= 3 ? low[n] : probe_counts(recv, sym, n, block: block)
     next if (actual == :ok) == predicted_ok
     return nil unless min > 0 && lo_exp
     (0...min).each { |k| return nil if low[k] == :ok }
@@ -190,21 +245,17 @@ end
 # The bare spec plus the with-block spec in one 10-column row; a side the
 # probe could not prove is the -1/NULL sentinel quartet (never fires).
 NO_SPEC = [-1, -1, nil, nil]
-def full_spec_for(recv, m)
-  bare = spec_for(recv, m)
-  blk = spec_for(recv, m, block: true)
+def full_spec_of(recv, m)
+  bare = spec_of(recv, m)
+  blk = spec_of(recv, m, block: true)
   return nil if bare.nil? && blk.nil?
   [*(bare || NO_SPEC), *(blk || NO_SPEC)]
 end
 
-def render(name, header, entries)
+def render_table(name, header, entries)
   out = +""
   header.each_line { |l| out << l }
-  out << "static const struct { const char *cls; const char *m; int min; int max;\n"
-  out << "                      const char *lo_exp; const char *hi_exp;\n"
-  out << "                      int blk_min; int blk_max;\n"
-  out << "                      const char *blk_lo_exp; const char *blk_hi_exp; }\n"
-  out << "#{name}[] = {\n"
+  out << "static const SpAritySpec\n#{name}[] = {\n"
   entries.each do |c, m, mn, mx, lo, hi, bmn, bmx, blo, bhi|
     q = ->(s) { s ? "\"#{s}\"" : "NULL" }
     out << %Q[  {"#{c}","#{m}",#{mn},#{mx},#{q.(lo)},#{q.(hi)},#{bmn},#{bmx},#{q.(blo)},#{q.(bhi)}},\n]
@@ -226,7 +277,8 @@ Dir.chdir(PROBE_DIR)
 inst = []
 INSTANCE_RECEIVERS.each do |cls, thunk|
   recv = thunk.call
-  meths = recv.public_methods.map(&:to_s).sort - INSTANCE_METHOD_SKIP
+  meths = recv.public_methods.map(&:to_s).sort - INSTANCE_METHOD_SKIP -
+          FORWARDING.fetch(cls, []) - PROBE_ARTEFACTS.fetch(cls, [])
   # Object's universal surface is carried by the "Object" rows; the per-class
   # rows keep only what the class itself (or its non-Object ancestry) defines,
   # so the table stays deduplicated and the guard falls back explicitly.
@@ -235,10 +287,15 @@ INSTANCE_RECEIVERS.each do |cls, thunk|
     meths -= universal.map(&:to_s) - recv.class.instance_methods(false).map(&:to_s)
   end
   meths.each do |m|
-    s = full_spec_for(thunk, m)
+    s = full_spec_of(thunk, m)
     inst << [cls, m, *s] if s
   end
+  FORWARDING.fetch(cls, []).each { |m| inst << [cls, m, *NO_SPEC, *NO_SPEC] }
 end
+# one TyKind stands for Queue and SizedQueue both: keep the rows they agree on
+sized = inst.select { |r| r[0] == "SizedQueue" }.map { |r| r[1..] }
+inst.reject! { |r| r[0] == "SizedQueue" || (r[0] == "Queue" && !sized.include?(r[1..])) }
+
 inst_hdr = <<~C
   /* Positional-arity spec for the builtin instance surface, probed from
      #{ver} by tools/gen_builtin_arity_spec.rb (see there for the
@@ -246,28 +303,35 @@ inst_hdr = <<~C
      no upper bound; a NULL exp = that side is never violated. The first
      quartet describes the bare call, the blk_ quartet the block-carrying
      call (several counts change under a block: Array#fill 1..3 vs 0..2,
-     Integer#step); a quartet the probe could not prove is -1,-1,NULL,NULL
-     and never fires. */
+     Integer#step); a quartet the probe could not prove, or a name whose
+     counts are its target's (Proc#call, Enumerator#each), is
+     -1,-1,NULL,NULL and never fires. */
 C
-inst_out = render("sp_builtin_arity_spec_tbl", inst_hdr, inst)
+inst_out = render_table("sp_builtin_arity_spec_tbl", inst_hdr, inst)
 
+CLASS_CONSTANTS = {
+  "StructClass" => Struct.new(:a), "DataClass" => Data.define(:a),
+}
 cm = []
 CLASS_TARGETS.each do |cls, meths|
-  const = Object.const_get(cls)
+  const = CLASS_CONSTANTS.fetch(cls) { Object.const_get(cls) }
   thunk = -> { const }
   meths.each do |m|
-    s = full_spec_for(thunk, m)
+    s = full_spec_of(thunk, m)
     cm << [cls, m, *s] if s
   end
 end
 cm_hdr = <<~C
   /* Class/module-method positional arity, probed from #{ver} the same
-     way as the instance table above (tools/gen_builtin_arity_spec.rb).
-     These are the constructors and module functions whose emitters index
-     argv[] unconditionally (File.open with no arguments was a compile-time
-     SIGSEGV). */
+     way as the instance table above (tools/gen_builtin_arity_spec.rb): the
+     constructors and module functions whose emitters index argv[]
+     unconditionally (File.open with no arguments was a compile-time
+     SIGSEGV), the surface of the constants a program names bare -- GC,
+     Fiber, Thread, a class Struct.new or Data.define answered, keyed
+     StructClass and DataClass -- and the Kernel functions a bare call
+     reaches. */
 C
-cm_out = render("sp_builtin_cmeth_arity_spec_tbl", cm_hdr, cm)
+cm_out = render_table("sp_builtin_cmeth_arity_spec_tbl", cm_hdr, cm)
 
 Dir.chdir("/")   # leave the probe dir so it can be removed
 FileUtils.remove_entry(PROBE_DIR) rescue nil


### PR DESCRIPTION
## Why

A builtin called with a count CRuby rejects is a rescuable `ArgumentError` there, message and all. The guard that raises it here (33ae1e98's, widened in 505009f1) runs only on the receiver kinds its map names — String, Integer, Float, Symbol, Range, Time, nil, the booleans, Rational, Complex, Mutex, the arrays and hashes — and on a native package object or a user object. Everything else the compiler types goes past it, and lands one of four ways: `/a/.source(1)`, `m.begin(0, 1)`, `q.size(1)`, `pr.arity(1)`, `Foo.superclass(1)` and `GC.start(1)` refuse to compile as unsupported calls; `Thread.list(1)`, `File.file?` and `1.respond_to?` lower to a NoMethodError; `e.message(1)`, `$stdout.fileno(1)`, `f.alive?(nil)` and `throw :t, 1, 2` drop the argument and answer; `Foo.name(1)` and `Mod.name(1)` answer nil, a value the in-range call never gives. All four report a supported method as something it is not, the first stops the build, and the last is quietly wrong.

The rows come from CRuby itself — the generator probes each method's accepted counts and takes CRuby's own wording for the range — so reaching a receiver kind is a matter of probing its class and mapping the kind to the rows. This does that for Regexp, MatchData, Proc, Method, Fiber, Thread, Queue, ConditionVariable, IO, Dir, Exception, Enumerator, Random, Struct and Data instances, for a class constant — a user class's own Class surface, a Struct or Data class's readers, `GC`, `Fiber`, `Thread` — for a bare Kernel function, and for the universal names every builtin inherits from Object, which only a user object consulted before.

## What

- A wrong count on a Regexp, MatchData, Proc, Method, Queue, ConditionVariable, Dir or Enumerator receiver, on a Struct or Data instance, on a class or module constant or on a bare Kernel function refused to compile — `spinel: unsupported call: node 4 (CallNode \`source\`) recv=RegularExpressionNode/ty17 argc=1 arg0ty3` for `/a/.source(1)`, and the like for `/a/.match`, `q.size(1)`, `pr.arity(1)`, `mt.name(1)`, `cv.signal(1)`, `en.next(1)`, `S.members(nil)`, `Foo.superclass(1)`, `GC.start(1)`, `Process.times(nil)`, `Integer()`; `unsupported MatchData method` for `m.begin(0, 1)` and `m.length(1)`. Each is CRuby's `ArgumentError: wrong number of arguments (given 1, expected 0)` now, with the range CRuby names — `(given 0, expected 1..2)` for `Integer()`, `(given 3, expected 1..2)` for `throw :t, 1, 2`.
- A wrong count on a Thread or Fiber, on a class constant's own surface, or on a name every object answers lowered to a NoMethodError at run time: `Thread.list(1)` was `undefined method 'list' for class Thread`, `Fiber.current(nil)` the same for Fiber, `File.file?` with no path the same for File, `s.members(1)` on a Struct instance `undefined method 'members' for an instance of S`, `1.respond_to?` with no name `undefined method 'respond_to?' for an instance of Integer`, and `1.public_send(nm, nil)` with `nm = :itself` — the candidate a dynamic send synthesizes for a name it is handed — `undefined method 'itself'`.
- A wrong count on an Exception, an IO, a Fiber or a Kernel function dropped the argument and answered: `e.message(1)` printed the message, `$stdin.eof?(1)` answered true, `f.alive?(nil)` true for an unstarted fiber, `throw :t, 1, 2` threw 1, `x = rand(1, 2)` assigned 0; `Foo.name(1)` and `Mod.name(1)` answered nil where the in-range call answers the name.
- `1.5.respond_to?(:clamp)` and `:abc.respond_to?(:=~)` answered false where CRuby answers true: the inference probe behind `respond_to?` synthesizes a zero-argument call, and a count the method refuses typed unknown, which read as "no such method". A refused count names a method that exists, so the probe's call types nil and the answer is true.
- The in-range shape beside each still answers; the guard stands down for a def of the name — at top level, in a reopened Object or Kernel, in the enclosing class's chain, on a Struct class in either singleton spelling, on a module whose instance method `extend self` or `module_function` makes its own, and for a class object's own `class << self` accessors — whatever the count; and the receiver and the arguments are evaluated first, in order, as the guard always did.

## How

- **The rows** (`tools/gen_builtin_arity_spec.rb`): the probe receivers grow by the handle kinds the guard maps — a Regexp, a MatchData, a Proc, a Method, an unstarted Fiber, a finished Thread, a Queue, a SizedQueue, a ConditionVariable, an open File and Dir, a RuntimeError, an Array's Enumerator, a Random, a Struct and a Data instance, a Class and a Module — and the class-method targets by GC, Fiber, Thread, the Kernel functions (`throw`, `catch`, `raise`, `rand`, `srand`, `caller`, `lambda`, `proc`, `binding`, `block_given?`), File's predicates and metadata calls, `Process.times`, `spawn` and `waitpid2`, and the three Socket packers; the readers a class `Struct.new` or `Data.define` answers are keyed `StructClass` and `DataClass`. A row must hold for every value of its kind: Queue's rows are the ones Queue and SizedQueue agree on, since one TyKind stands for both; the IO rows are probed on a File, the surface any IO handle can answer. The names whose counts belong to what the receiver forwards to — `Proc#call`, `Method#call`, `Enumerator#each` and its `to_a`, `entries`, `to_h`, `each_entry`, `reverse_each`, `Class#new` — keep a row that never fires, the sentinel quartet the tables already had for a shape the probe cannot characterize, so the guard sees the class owns the name and does not read Object's row for it (`Proc#===` is an Object name too); a probe Struct's own accessors get no row. `freeze` joins the surface, since a fresh receiver per probe makes it harmless. 1,214 instance rows become 1,809 (fourteen of them the sentinels) and 191 class-method rows 240; every row that was there is in the regenerated tables unchanged but `waitpid2`'s, and the generator reproduces today's instance table from this Ruby before the change.
- **The map** (`emit_builtin_arity_guard`, `src/codegen_call.c`): each new kind names its rows; a Struct or Data instance its kind's; a name a builtin inherits from Object unchanged — `respond_to?`, `is_a?`, `freeze`, `instance_of?` — checks Object's row, but only when the class has no row of its own, so `12.to_s(2)` keeps Integer's. A bare call resolves the way the bare-call arm above the guard does — the enclosing class's chain, then a top-level def or a reopened Kernel or Object, then Kernel's rows. A user class constant keeps the class methods it defines and its `class << self` accessors (a singleton def on a class `Struct.new` answered, `def S1.members` or a def or `define_method` under a statement list, a branch, a loop or a block inside `class << S1`, is collected before that class exists and never reaches its chain, and a def under a conditional inside `class << self` reaches none either; the singleton defs written on a constant, and a module body's `extend self`, are read off the tree once and asked by name) and checks Class's or Module's surface (`name`, `superclass`, `ancestors`) with Object's beneath for the rest, or its Struct or Data readers; a native class or a bare constant (`GC`, `Fiber`, `Thread`) checks the class-method rows as before. A row Object supplied is checked against a reopened Object the way a class's own row is checked against a reopened class — `class Object; def itself(a)` keeps `5.itself(1)` — and, in either arm, against a top-level def, which is Object's private method and CRuby's NoMethodError, not a count; a kind that stands for two classes (the booleans, File and IO, the queues) asks the other class too. A module that extends itself owns its instance methods too, so a def of the name on such a module stands the guard down as well; `module_function` registers the name class-side and is found there. The two tables share a row type now, `SpAritySpec`, and one lookup, `arity_spec_row`.
- **The decision and the emission** are separate functions, so the analyzer can ask the first: `infer_call` types a refused call nil when the inference has no type for its shape. A dynamic `public_send` synthesizes a call per candidate name and drops one that types unknown, which is how `1.public_send(nm, nil)` became a NoMethodError; typed nil it is kept, and lowers to the raise. Any type is sound for a call that raises before it answers.

## Validation

- A new test, `test/builtin_arity_reach` (expectations generated by CRuby 4.0.6; 90 rescued ArgumentErrors, 3 ms of run time): a wrong count on each of the thirteen handle kinds, on a Struct and a Data instance and their classes, on a user class and a module constant, on `GC`, `Fiber` and `Thread`, on eight Kernel functions, `catch` bare and with a block, on the universal names over eight receiver kinds, and on a name handed to `public_send` in a variable; the in-range shape beside each, and a class's own row outranking Object's (`12.to_s(2)`); a top-level def shadowing a Kernel function, a reopened Object owning `itself` on an Integer and a String, a class object's `class << self` accessor, a module function, and an instance reader on a class that does not reach the class object; the receiver and the argument evaluated, in order, before the raise. On master it stops at its first assertion as an unsupported call.
- Full suite: 3,368 pass, 0 fail, from a cleared results cache, at `-O2`; the same 3,368 pass at the gate's `-O1`.
- Generated C against master, over the suite, the benchmarks and optcarrot (3,386 programs): 3 differ — `test/block_call_arity` (a guarded call types nil now, so `p` prints its nil path after the raise), `test/format_raise_dollarbang_symproc` and `test/issue_3053` (a symbol-proc dispatch on a Symbol read from a variable gains the arm for `+` with no argument, CRuby's ArgumentError where it said `undefined method '+'`). The 61 benchmarks and optcarrot are byte-identical, so no hot path changes; optcarrot's checksum is 59662 and its binary is master's.
- Against the differential corpus of ~2,100 minimized programs the campaign has been working from: 715 → 757 match, 42 gained and 0 lost. Forty are the wrong-count programs — a Regexp, MatchData, Proc, Method, Fiber, Thread, Queue, ConditionVariable, Exception or Enumerator receiver, a Struct class, a user class or module constant, `GC`, `Process`, `Thread`, `Fiber`, `Integer()`, `throw`, `respond_to?`, `public_send` with a name in a variable — and two are the `respond_to?` answers above.
- The generator reproduces master's instance table byte-for-byte on this Ruby before the change, and every row that was there is in the regenerated tables unchanged but `waitpid2`'s (see below).
- Front-end compile time of optcarrot (`-c --no-line-map` to `/dev/null`, three runs each, both compilers built the same way): the same to within run-to-run noise (1.00–1.01 s on both in one session, 1.04–1.06 s on both in another). The row lookup is a linear scan and the tables are half again as long, with a second scan for Object's row when a class has none of its own; that is a few microseconds per call site, and the singleton-def index is one pass over the tree per table; invisible on a program this size.

## Left alone, on purpose

- An in-range shape no arm matches — `[1].find(1) { }`, `[1].zip { }`, `h.update` with no argument, `File.delete` with no path, `GC.stat(nil)`, a blockless `Mutex#synchronize`, `Fiber.new` without a block — is a different mechanism: a fallback for a supported method's unmatched shape, where this raises only where CRuby raises. Those still refuse to compile or miss as they did.
- `Queue#push`, `<<`, `enq` and `SizedQueue#max`: one kind stands for both queues and their counts differ (`push` takes 1 on a Queue, 1..2 on a SizedQueue), so they have no row; `q.push` with no argument still refuses to compile. `SizedQueue#push(v, true)` and `Thread#join(1)` are in-range shapes without an arm, found while writing the test.
- A method the prelude defines in Ruby owns its name the way any def does: `Set#each(1)` and `Symbol#to_proc(nil)` are answered by those defs today, and a wrong count there is the user-method arity check's, not this table's.
- A bare Kernel call reaches the guard where its value is consumed — `x = rand(1, 2)`, `p rand(1, 2)` — but not in statement position, where the emitter drops a call without effect, nor as a method's last expression, which the return path's own arm answers: `def g; rand(1, 2); end` still answers 0.
- `Method#call`, `Proc#call`, `Enumerator#each` and `Class#new` carry their target's counts, so they never fire; `m.call` with too few arguments either fills the missing parameters in or fails the C build, by where the method is defined, on master and here alike, `pr.===(1, 2)` on a lambda of two is the unsupported call it was (the `===` arm below the guard has the one-argument shape), and `m.===()` on a Method still answers nil.
- A CRuby rejection worded otherwise than "wrong number of arguments" — `format` with no arguments ("too few arguments"), `:a.upcase(1)` ("invalid option") — the probe leaves unguarded, as it always has; a bare `format` is a NameError here.
- `Data#with(1)`: Data's own emitter takes the call, which is keywords-only, before the guard sees it. A singleton def on a class `Struct.new` answered — `def S1.members(x)`, or the same inside `class << S1` — is collected before the struct class exists and nothing dispatches it, on master and here alike; the guard stands down for it, so `S1.members(9)` is the unsupported call it was rather than a raise.
- A rescue modifier whose value is nil-typed fails the C build on master — `x = (nil rescue nil)` declares a `void` temp — and a refused Kernel call under one, `x = binding(1) rescue nil`, now types nil and reaches that failure where master refused the call as unsupported; both stop the build, and the modifier's temp is the emitter's own.
- The guard counts before the method checks its receiver, as the rows are CRuby's counts alone: `$stdout.flock` with a wrong count (the IO rows are a File's), `f.wait_writable(1, 2)` on a file opened for reading and `$stdout.wait_priority(1, 2)`, `5.define_singleton_method(:a, :b, :c)` raise ArgumentError where CRuby's is NoMethodError, IOError, TypeError; master refused the first as unsupported, answered the next two, and refused the last with its own diagnostic. Likewise a reopened *subclass* of a kind — `class KeyError; def itself(a)` — or an `attr_reader` in a reopened builtin — `class Regexp; attr_reader :match` — is not asked, and the row fires where master refused the program; a reopened Exception or a def in a reopened Regexp is.
- A blockless iterator with an argument, `(1..5).each_with_index("x")`, types poly and takes the run-time route ahead of the guard, so it stays a NoMethodError miss; `p Fiber.current(nil)`, `p cv.signal(1)` and `p t.join(1)` are refused because `p` has no emitter for a handle value, whatever the count; `x = cv.signal(1)` raises.
- Five class-method rows that ba4a3415 and cea93a40 wrote into the table by hand — `Process.spawn`, `Process.waitpid2`, `Socket.pack_sockaddr_in`, `Socket.sockaddr_un`, `Socket.pack_sockaddr_un` — come from the probe now, so a regeneration keeps them. Four are the same; `waitpid2`'s said "expected 1" and CRuby accepts 0..2, so `Process.waitpid2` with no argument, which waits for any child in CRuby, is no longer an ArgumentError here but the unsupported call it is (the emitter has the one-argument arm).
- Found on the way, not touched: a class-level `def srand(a, b)` called bare inside its class is answered by the Kernel `srand` arm, arguments dropped, on master and here alike (the bare-call arm asks the enclosing chain only for the names it routes to `emit_method_call`, and the guard stands down for that def as it should); `12.method(:to_s).call(2)` answers `"12"`, the argument dropped; a `class << self; attr_accessor :name` on a class does not dispatch (`Foo.name` answers the class's name on master and here), so the guard's stand-down for it defers to an arm that is not there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved argument-count validation for a broad range of built-in methods and classes.
  * Invalid calls now consistently raise clear `ArgumentError` messages with the provided and expected counts.
  * Expressions used as receivers or arguments are evaluated correctly before an arity error is raised.
  * User-defined methods and overrides continue to dispatch correctly, including top-level and extended methods.
* **Tests**
  * Added comprehensive coverage for valid and invalid built-in method calls across core types and APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->