### PR TITLE
Bind a Method object's call to its target's parameters

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -12263,10 +12263,13 @@ int builtin_arity_violation(Compiler *c, int id) {
   return arity_violation(c, id, exp, sizeof exp, &eval_recv);
 }
 
-int emit_builtin_arity_guard(Compiler *c, int id, Buf *b) {
+/* The raise for a count a method refuses: the receiver (when asked) and the
+   arguments evaluated in order, as CRuby evaluates them before it checks the
+   count, then the ArgumentError with `exp` as the range, yielding the call's
+   default value. Shared by the builtin guard and a call through a Method
+   object whose target is known. */
+static void emit_wrong_count(Compiler *c, int id, const char *exp, int eval_recv, Buf *b) {
   const NodeTable *nt = c->nt;
-  char exp[32]; int eval_recv;
-  if (!arity_violation(c, id, exp, sizeof exp, &eval_recv)) return 0;
   int recv = nt_ref(nt, id, "receiver");
   int anode = nt_ref(nt, id, "arguments");
   int argc = 0; const int *argv = anode >= 0 ? nt_arr(nt, anode, "arguments", &argc) : NULL;
@@ -12280,7 +12283,61 @@ int emit_builtin_arity_guard(Compiler *c, int id, Buf *b) {
   buf_printf(b, "sp_raise_cls(\"ArgumentError\","
                 " \"wrong number of arguments (given %d, expected %s)\"); %s; })",
              argc, exp, dv ? dv : "0");
+}
+
+int emit_builtin_arity_guard(Compiler *c, int id, Buf *b) {
+  char exp[32]; int eval_recv;
+  if (!arity_violation(c, id, exp, sizeof exp, &eval_recv)) return 0;
+  emit_wrong_count(c, id, exp, eval_recv, b);
   return 1;
+}
+
+/* The synthesized wrapper a bound builtin's Method resolves to
+   (`"a b".method(:split)`): its parameter list holds the receiver alone, and
+   the builtin's own arguments pass through it unlisted, so no count can be
+   read off it. */
+static int bam_wrapper(const Scope *tm) {
+  return tm->name && strncmp(tm->name, "__bam_", 6) == 0;
+}
+
+/* Does a call through a Method object hand its statically-known target a
+   count it cannot take? Judged for the plain positional shape only: a splat's
+   count is the array's, a keyword hash binds by name, and a keyword or
+   synthesized parameter, or a required one after the rest, binds by other
+   rules; and never the wrapper of a bound builtin, the one target whose self
+   carries a parameter. `exp` receives the range in CRuby's words. */
+static int method_call_count_violation(Compiler *c, Scope *tm, int argc,
+                                       const int *argv, char *exp, size_t cap) {
+  const NodeTable *nt = c->nt;
+  if (tm->kwrest_idx >= 0 || tm->npost_rest > 0 || tm->cs_synth || bam_wrapper(tm)) return 0;
+  for (int k = 0; k < argc; k++) {
+    const char *at = nt_type(nt, argv[k]);
+    if (at && (sp_streq(at, "SplatNode") || sp_streq(at, "KeywordHashNode") ||
+               sp_streq(at, "BlockArgumentNode") || sp_streq(at, "ForwardingArgumentsNode")))
+      return 0;
+  }
+  int nfixed = 0, nreq = 0;
+  for (int i = 0; i < tm->nparams; i++) {
+    if (i == tm->rest_idx) continue;
+    if (!tm->pnames[i] || (tm->pnames[i][0] == '_' && tm->pnames[i][1] == '_') ||
+        callee_has_kwarg(c, tm, tm->pnames[i])) return 0;
+    nfixed++;
+    if (!tm->pdefault || tm->pdefault[i] < 0) nreq++;
+  }
+  if (argc >= nreq && (tm->rest_idx >= 0 || argc <= nfixed)) return 0;
+  if (tm->rest_idx >= 0) snprintf(exp, cap, "%d+", nreq);
+  else if (nreq == nfixed) snprintf(exp, cap, "%d", nfixed);
+  else snprintf(exp, cap, "%d..%d", nreq, nfixed);
+  return 1;
+}
+
+/* A default the trampoline of Method#to_proc can fill in from its own frame:
+   a literal, which reads nothing of the frame it was written in. */
+static int literal_default(Compiler *c, int node) {
+  const char *ty = node >= 0 ? nt_type(c->nt, node) : NULL;
+  return ty && (sp_streq(ty, "IntegerNode") || sp_streq(ty, "FloatNode") ||
+                sp_streq(ty, "StringNode") || sp_streq(ty, "SymbolNode") ||
+                sp_streq(ty, "NilNode") || sp_streq(ty, "TrueNode") || sp_streq(ty, "FalseNode"));
 }
 
 /* The guards for an argument whose static class the method cannot take: raise
@@ -13174,19 +13231,39 @@ int emit_unresolved_call(Compiler *c, int id, Buf *b) {
       if (grt == TY_POLY && nm && (ret == TY_POLY || ret == TY_UNKNOWN) &&
           g_cls_tag_skip != id) {
         int ccls[64], cmi[64], cdef[64], nc = 0;
-        int cargc = 0;
+        int cargc = 0, csplat = 0;
         { int ca = nt_ref(nt, id, "arguments");
-          if (ca >= 0) nt_arr(nt, ca, "arguments", &cargc); }
+          const int *cav = ca >= 0 ? nt_arr(nt, ca, "arguments", &cargc) : NULL;
+          for (int a = 0; a < cargc; a++) {
+            const char *aty5 = cav ? nt_type(nt, cav[a]) : NULL;
+            if (aty5 && sp_streq(aty5, "SplatNode")) csplat = 1;
+            /* a double splat: the raise stands down for it, a plain keyword
+               hash still counts as one positional */
+            if (aty5 && sp_streq(aty5, "KeywordHashNode")) {
+              int en5 = 0; const int *el5 = nt_arr(nt, cav[a], "elements", &en5);
+              for (int e = 0; e < en5; e++)
+                if (el5 && nt_type(nt, el5[e]) && sp_streq(nt_type(nt, el5[e]), "AssocSplatNode"))
+                  csplat = 1;
+            }
+          } }
         for (int k = 0; k < c->nclasses && nc < 64; k++) {
           int dc = -1;
           int mi = comp_cmethod_in_chain(c, k, nm, &dc);
           if (mi < 0 || !scope_has_callable_symbol(c, mi)) continue;
           /* A class method that cannot take this call's arguments is not a
              candidate: emitting its arm put the arity raise in the prelude,
-             where it fired before the tag was even tested (#3520). */
+             where it fired before the tag was even tested (#3520). A rest
+             parameter lifts the upper bound, not the shortfall -- and a splat
+             or double splat at the site makes the count dynamic, so a rest
+             candidate is kept then, its arm carrying no count check that
+             could fire. A fixed-arity candidate's arm checks a trailing
+             splat's length at run time in that same prelude, so which of
+             those arms may be emitted is the question it always was; their
+             counting stands. */
           { Scope *cs4 = &c->scopes[mi];
-            if (cs4->rest_idx < 0 &&
-                (cargc > cs4->nparams || cargc < cs4->nrequired)) continue; }
+            int rreq = rest_shortfall_required(c, cs4);
+            if (cs4->rest_idx < 0 ? (cargc > cs4->nparams || cargc < cs4->nrequired)
+                                  : (!csplat && cargc < rreq)) continue; }
           ccls[nc] = k; cmi[nc] = mi; cdef[nc] = dc; nc++;
         }
         if (nc > 0) {
@@ -16148,13 +16225,36 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
       /* a bound __bam wrapper carries param[0] in the Method's self slot:
          proc arg k maps to param[k + shift] */
       int shift = method_call_param_shift(c, mn, target);
-      /* a float/poly parameter reads back from the boxed side-channel the
-         force_poly call site publishes */
+      /* A proc call hands over whatever count its site has, so the binding is
+         a lambda body's: the count checked in CRuby's words, an omitted
+         optional filled from its default, a rest parameter given the surplus
+         as one array read from the boxed side-channel every proc call
+         publishes. Bound one C argument per slot, `m.to_proc.call(1, 2)` on
+         `def r(*v)` read the Integer as the array and crashed, `def o(a, b =
+         2)` called with one answered from an unset b, and a wrong count went
+         through unchecked. A keyword parameter, a required one after the
+         rest, a default that is not a literal, more parameters than the
+         channel's 16 slots, or a bound builtin's wrapper keep the plain
+         positional binding. */
+      int bind = tm->kwrest_idx < 0 && tm->npost_rest == 0 && !tm->cs_synth && !bam_wrapper(tm) &&
+                 np - shift <= 16;
+      int nreq = 0, nfixed = 0;
+      for (int k = shift; k < np && bind; k++) {
+        if (k == tm->rest_idx) continue;
+        if (!tm->pnames[k] || (tm->pnames[k][0] == '_' && tm->pnames[k][1] == '_') ||
+            callee_has_kwarg(c, tm, tm->pnames[k])) { bind = 0; break; }
+        nfixed++;
+        if (!tm->pdefault || tm->pdefault[k] < 0) nreq++;
+        else if (!literal_default(c, tm->pdefault[k])) bind = 0;
+      }
+      /* a float/poly parameter, or the rest's surplus, reads back from the
+         boxed side-channel the call site publishes */
       int needs_slot = 0;
       for (int k = shift; k < np; k++) {
         LocalVar *pp = scope_local(tm, tm->pnames[k]);
         TyKind pt = pp ? pp->type : TY_INT;
-        if (pt == TY_POLY || pt == TY_FLOAT) needs_slot = 1;
+        if (pt == TY_POLY || pt == TY_FLOAT || (bind && (k == tm->rest_idx || proc_slot_via_poly(c, pt))))
+          needs_slot = 1;
       }
       if (needs_slot && !g_needs_proc_poly_argslot) {
         g_needs_proc_poly_argslot = 1;
@@ -16162,7 +16262,48 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
       }
       Buf *pb = &g_procs;
       buf_printf(pb, "static sp_int _mtp_%d(void *cap, sp_int argc, sp_int *args) {\n", tid);
+      if (bind && tm->rest_idx >= 0) buf_puts(pb, "  SP_GC_SAVE();\n");
       buf_puts(pb, "  sp_BoundMethod *_m = (sp_BoundMethod *)cap; (void)_m; (void)argc; (void)args;\n");
+      if (bind) {
+        char expb[32];
+        if (tm->rest_idx >= 0) snprintf(expb, sizeof expb, "%d+", nreq);
+        else if (nreq == nfixed) snprintf(expb, sizeof expb, "%d", nfixed);
+        else snprintf(expb, sizeof expb, "%d..%d", nreq, nfixed);
+        if (nreq > 0 || tm->rest_idx < 0) {
+          buf_printf(pb, "  if (argc < %d", nreq);
+          if (tm->rest_idx < 0) buf_printf(pb, " || argc > %d", nfixed);
+          buf_printf(pb, ") { const char *_e = sp_sprintf(\"wrong number of arguments"
+                         " (given %%lld, expected %s)\", (long long)argc); SP_GC_ROOT_STR(_e);"
+                         " sp_raise_cls(\"ArgumentError\", _e); }\n", expb);
+        }
+        for (int k = shift; k < np; k++) {
+          int j = k - shift;
+          if (k == tm->rest_idx) {
+            buf_printf(pb, "  sp_PolyArray *_a%d = sp_PolyArray_new(); SP_GC_ROOT(_a%d);"
+                           " for (sp_int _i = %d; _i < argc && _i < 16; _i++)"
+                           " sp_PolyArray_push(_a%d, _sp_proc_poly_args[_i]);\n", j, j, j, j);
+            continue;
+          }
+          LocalVar *pp = scope_local(tm, tm->pnames[k]);
+          TyKind pt = pp ? pp->type : TY_INT;
+          char slot[48]; snprintf(slot, sizeof slot, "_sp_proc_poly_args[%d]", j);
+          buf_puts(pb, "  "); emit_ctype(c, pt, pb);
+          buf_printf(pb, " _a%d = (argc > %d) ? ", j, j);
+          if (pt == TY_POLY) buf_puts(pb, slot);
+          else if (pt == TY_FLOAT) buf_printf(pb, "sp_poly_to_f(%s)", slot);
+          else if (pt == TY_SYMBOL) buf_printf(pb, "(sp_sym)args[%d]", j);
+          else if (proc_slot_is_ptr(pt)) { buf_puts(pb, "("); emit_ctype(c, pt, pb); buf_printf(pb, ")(uintptr_t)args[%d]", j); }
+          else if (proc_slot_via_poly(c, pt)) emit_unbox_text(c, pt, slot, pb);
+          else buf_printf(pb, "args[%d]", j);
+          buf_puts(pb, " : ");
+          if (tm->pdefault && tm->pdefault[k] >= 0) emit_arg_or_default(c, tm, k, -1, pb);
+          else buf_puts(pb, pt == TY_RANGE ? "(sp_Range){0}" : default_value(pt));
+          buf_puts(pb, ";\n");
+        }
+        /* the channel is consumed, as a lambda body leaves it */
+        if (needs_slot)
+          buf_puts(pb, "  for (sp_int _i = 0; _i < argc && _i < 16; _i++) _sp_proc_poly_args[_i] = sp_box_nil();\n");
+      }
       /* the call expression: sp_<name>(args...) for a top-level target, else
          the typed fn cast through _m->fn with _m->self first */
       Buf cb = {0};
@@ -16187,7 +16328,8 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
         if (k > shift) buf_puts(&cb, ", ");
         LocalVar *pp = scope_local(tm, tm->pnames[k]);
         TyKind pt = pp ? pp->type : TY_INT;
-        if (pt == TY_POLY) buf_printf(&cb, "_sp_proc_poly_args[%d]", k - shift);
+        if (bind) buf_printf(&cb, "_a%d", k - shift);
+        else if (pt == TY_POLY) buf_printf(&cb, "_sp_proc_poly_args[%d]", k - shift);
         else if (pt == TY_FLOAT) buf_printf(&cb, "sp_poly_to_f(_sp_proc_poly_args[%d])", k - shift);
         else if (pt == TY_SYMBOL) buf_printf(&cb, "(sp_sym)args[%d]", k - shift);
         else if (proc_slot_is_ptr(pt)) {
@@ -16622,46 +16764,37 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
     int target = mn >= 0 ? method_obj_target_mi(c, mn) : -1;
     int target_recvless = (mn >= 0 && nt_ref(nt, mn, "receiver") < 0);
     if (target >= 0 && target_recvless) {
-      /* A trailing splat argument (`m[*args]` / `m.call(*args)`) expands into
-         the remaining declared params at runtime: the target's arity is
-         static, so read the splatted array element-by-element into each slot
-         -- passing the raw array was a fixed-arity C call with one pointer
-         arg (#3248). */
-      int splat_at = -1;
-      for (int k = 0; k < argc; k++) {
-        const char *aty2 = nt_type(nt, argv[k]);
-        if (aty2 && sp_streq(aty2, "SplatNode")) { splat_at = k; break; }
-      }
-      if (splat_at >= 0 && splat_at == argc - 1) {
-        Scope *tms = &c->scopes[target];
-        int ts = ++g_tmp;
-        buf_printf(b, "({ sp_PolyArray *_t%d = ", ts);
-        emit_expr(c, argv[splat_at], b);   /* splat-to-array, normalized poly */
-        buf_printf(b, "; SP_GC_ROOT(_t%d); ", ts);
-        emit_method_cname(c, tms, b);
-        buf_puts(b, "(");
-        for (int k = 0; k < tms->nparams; k++) {
-          if (k) buf_puts(b, ", ");
-          if (k < splat_at) { emit_arg_or_default(c, tms, k, argv[k], b); continue; }
-          LocalVar *pp = tms->pnames ? scope_local(tms, tms->pnames[k]) : NULL;
-          TyKind pt2 = pp ? pp->type : TY_INT;
-          char el[64];
-          snprintf(el, sizeof el, "sp_PolyArray_get(_t%d, %d)", ts, k - splat_at);
-          if (pt2 == TY_POLY) buf_puts(b, el);
-          else emit_unbox_text(c, pt2, el, b);
-        }
-        buf_puts(b, "); })");
-        return;
-      }
-      /* top-level / self method: direct call sp_<name>(args). Coerce each arg to
-         the target's parameter type (emit_arg_or_default boxes an int arg into a
-         poly param widened under promote, etc.). */
-      emit_method_cname(c, &c->scopes[target], b);
+      /* A top-level target is called the way its name would be: the ordinary
+         argument lowering binds the site's arguments to the target's
+         parameters -- an omitted optional takes its default, a rest parameter
+         takes the surplus as one array, a keyword lands in its own slot, a
+         splat spreads at run time -- and a count or keyword the target cannot
+         take is CRuby's ArgumentError ahead of the call. Handed over one C
+         argument per site argument, `def f(*a)` took a raw Integer in its
+         array pointer, `def f(a, b = 2)` was a C call one argument short, and
+         a wrong count was the C compiler's error. */
+      Scope *tms = &c->scopes[target];
+      emit_method_cname(c, tms, b);
       buf_puts(b, "(");
-      for (int k = 0; k < argc; k++) {
-        if (k) buf_puts(b, ", ");
-        if (k < c->scopes[target].nparams) emit_arg_or_default(c, &c->scopes[target], k, argv[k], b);
-        else emit_expr(c, argv[k], b);
+      emit_args_filled(c, target, nt_ref(nt, id, "arguments"), "", b);
+      /* an out-of-line callee keeping a &block parameter takes the site's
+         literal block, or a Proc passed with &, or none */
+      if (tms->blk_param && tms->blk_param[0] && !tms->yields) {
+        int bn = nt_ref(nt, id, "block");
+        const char *bty = bn >= 0 ? nt_type(nt, bn) : NULL;
+        int bx = (bty && sp_streq(bty, "BlockArgumentNode")) ? nt_ref(nt, bn, "expression") : -1;
+        if (tms->nparams > 0) buf_puts(b, ", ");
+        if (bty && sp_streq(bty, "BlockNode")) {
+          int tb = ++g_tmp;
+          Buf pv; memset(&pv, 0, sizeof pv);
+          emit_proc_literal(c, bn, &pv);
+          emit_indent(g_pre, g_indent);
+          buf_printf(g_pre, "sp_Proc *_t%d = %s; SP_GC_ROOT(_t%d);\n", tb, pv.p ? pv.p : "NULL", tb);
+          free(pv.p);
+          buf_printf(b, "_t%d", tb);
+        }
+        else if (bx >= 0 && comp_ntype(c, bx) == TY_PROC) emit_expr(c, bx, b);
+        else buf_puts(b, "NULL");
       }
       buf_puts(b, ")");
       return;
@@ -16677,6 +16810,16 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
     /* a bound __bam wrapper carries param[0] in the Method's self slot:
        call arg k is coerced to param[k + shift] */
     int shift = target >= 0 ? method_call_param_shift(c, mn, target) : 0;
+    /* A count the target cannot take is CRuby's ArgumentError before any
+       call: bound positionally, `def z; end` took `m.call(1)` and answered,
+       and `def o(a, b = 2)` answered `m.call` from its defaults. */
+    if (tm) {
+      char exp9[32];
+      if (method_call_count_violation(c, tm, argc, argv, exp9, sizeof exp9)) {
+        emit_wrong_count(c, id, exp9, 1, b);
+        return;
+      }
+    }
     /* When the target is unresolved under promote, fall back to the poly ABI
        (sp_RbVal self/args/return) rather than the legacy sp_int ABI: every
        method is poly-signatured in promote, so a `(void*, sp_int)->sp_int`

--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -6542,10 +6542,15 @@ void emit_rest_pack_kwh(Compiler *c, int from, int pos_argc, const int *argv, in
     if (aty && sp_streq(aty, "SplatNode")) {
       int inner = nt_ref(nt, argv[i], "expression");
       Buf arr; memset(&arr, 0, sizeof arr);
-      TyKind at;
-      if (inner >= 0) { at = comp_ntype(c, inner); emit_expr(c, inner, &arr); }
-      else if (emit_anon_rest_ref(c, argv[i], &arr)) at = TY_POLY_ARRAY;  /* anonymous `*` */
-      else at = TY_UNKNOWN;
+      TyKind at = inner >= 0 ? comp_ntype(c, inner) : TY_UNKNOWN;
+      /* render the operand only for the arms that read this rendering: a
+         render writes the operand's setup into the statement prelude, so a
+         discarded one still ran there, and a side-effecting operand ran
+         twice */
+      int reads_arr = at == TY_INT_ARRAY || at == TY_STR_ARRAY ||
+                      at == TY_FLOAT_ARRAY || at == TY_POLY_ARRAY;
+      if (inner >= 0 && reads_arr) emit_expr(c, inner, &arr);
+      else if (inner < 0 && emit_anon_rest_ref(c, argv[i], &arr)) at = TY_POLY_ARRAY;  /* anonymous `*` */
       const char *ap = arr.p ? arr.p : "NULL";
       if (at == TY_INT_ARRAY)
         buf_printf(b, " { sp_IntArray *_sa = %s; for (sp_int _si = 0; _si < _sa->len; _si++) sp_PolyArray_push(_t%d, sp_box_int(_sa->data[_sa->start+_si])); }", ap, t);
@@ -6555,6 +6560,15 @@ void emit_rest_pack_kwh(Compiler *c, int from, int pos_argc, const int *argv, in
         buf_printf(b, " { sp_FloatArray *_sa = %s; for (sp_int _si = 0; _si < _sa->len; _si++) sp_PolyArray_push(_t%d, sp_box_float(_sa->data[_si])); }", ap, t);
       else if (at == TY_POLY_ARRAY)
         buf_printf(b, " { sp_PolyArray *_sa = %s; for (sp_int _si = 0; _si < _sa->len; _si++) sp_PolyArray_push(_t%d, _sa->data[_si]); }", ap, t);
+      /* a boxed operand is an array only at run time: the splat's lowering
+         normalizes it, and its elements are the rest's, where the operand
+         once went in whole as one element */
+      else if (inner >= 0 && (at == TY_POLY || at == TY_UNKNOWN)) {
+        Buf el; memset(&el, 0, sizeof el);
+        emit_expr(c, argv[i], &el);
+        buf_printf(b, " { sp_PolyArray *_sa = %s; SP_GC_ROOT(_sa); for (sp_int _si = 0; _si < _sa->len; _si++) sp_PolyArray_push(_t%d, _sa->data[_si]); }", el.p ? el.p : "NULL", t);
+        free(el.p);
+      }
       else { /* scalar splat: single element */
         Buf el; memset(&el, 0, sizeof el);
         emit_boxed(c, inner, &el);
@@ -7026,6 +7040,25 @@ static void args_raise(const char *fmt, ...) {
   buf_printf(g_pre, "sp_raise_cls(\"ArgumentError\", \"%s\");\n", msg);
 }
 
+/* The positional count a rest-parameter method requires, when a call that
+   supplies fewer is judged: the parameters without a default, the rest and
+   any keyword left out. -1 when it is not judged -- no rest, a keyword or
+   keyword-rest parameter (those bind by other rules), a synthesized
+   parameter or scope. One rule for the raise in emit_args_filled and for a
+   dispatch that lists candidates by what the call's count allows, so a
+   candidate the raise would refuse is never emitted as an arm (#3520). */
+int rest_shortfall_required(Compiler *c, Scope *m) {
+  if (m->rest_idx < 0 || m->kwrest_idx >= 0 || m->cs_synth) return -1;
+  int nreq = 0;
+  for (int i = 0; i < m->nparams; i++) {
+    if (i == m->rest_idx) continue;
+    if (!m->pnames[i] || (m->pnames[i][0] == '_' && m->pnames[i][1] == '_') ||
+        callee_has_kwarg(c, m, m->pnames[i])) return -1;
+    if (!m->pdefault || m->pdefault[i] < 0) nreq++;
+  }
+  return nreq;
+}
+
 void emit_args_filled(Compiler *c, int callee_idx, int argsNode, const char *lead, Buf *out) {
   Scope *m = &c->scopes[callee_idx];
   const NodeTable *nt = c->nt;
@@ -7103,7 +7136,15 @@ void emit_args_filled(Compiler *c, int callee_idx, int argsNode, const char *lea
       nfixed++;
       if (!m->pdefault || m->pdefault[i] < 0) nreq++;
     }
-    if (!has_splat && !has_ds && !synth &&
+    /* A target with a rest parameter has no upper bound, so only its shortfall
+       is judged: `def f(a, *r)` called bare ran the body with a padded a. */
+    int rest_req = rest_shortfall_required(c, m);
+    if (!has_splat && !has_ds && rest_req >= 0) {
+      int eff_pos = pos_argc + (kwh >= 0 ? 1 : 0);
+      if (eff_pos < rest_req)
+        args_raise("wrong number of arguments (given %d, expected %d+)", eff_pos, rest_req);
+    }
+    else if (!has_splat && !has_ds && !synth &&
         m->rest_idx < 0 && m->kwrest_idx < 0 && !m->cs_synth) {
       int kw_matches = 0;
       if (kwh >= 0)
@@ -7200,7 +7241,13 @@ void emit_args_filled(Compiler *c, int callee_idx, int argsNode, const char *lea
         Buf anon; memset(&anon, 0, sizeof anon);
         int is_anon = inner < 0 && emit_anon_rest_ref(c, argv[k], &anon);
         if (is_anon) splat_at = TY_POLY_ARRAY;
-        if (is_anon || ty_is_array(splat_at) || splat_at == TY_POLY_ARRAY) {
+        /* a boxed operand -- a block parameter, a value read out of a
+           container -- is an array only at run time: the splat's own
+           lowering normalizes it (nil to [], a scalar to [v], an array kept),
+           where it once fell through as one positional argument */
+        int boxed = !is_anon && inner >= 0 && (splat_at == TY_POLY || splat_at == TY_UNKNOWN);
+        if (boxed) splat_at = TY_POLY_ARRAY;
+        if (is_anon || boxed || ty_is_array(splat_at) || splat_at == TY_POLY_ARRAY) {
           splat_tmp = ++g_tmp;
           /* Evaluate the splat operand into a side buffer: a literal array or a
              call result emits its own setup (a fresh `_tN = ..._new()` decl)
@@ -7213,7 +7260,7 @@ void emit_args_filled(Compiler *c, int callee_idx, int argsNode, const char *lea
           }
           else {
             Buf sb; memset(&sb, 0, sizeof sb);
-            emit_expr(c, inner, &sb);
+            emit_expr(c, boxed ? argv[k] : inner, &sb);
             emit_ctype(c, splat_at, g_pre);
             buf_printf(g_pre, " _t%d = %s;\n", splat_tmp, sb.p ? sb.p : "");
             free(sb.p);
@@ -7670,7 +7717,10 @@ void emit_dispatch(Compiler *c, int cid, const char *name,
       Buf anon; memset(&anon, 0, sizeof anon);
       int is_anon = inner < 0 && emit_anon_rest_ref(c, argv[k], &anon);
       if (is_anon) splat_at_d = TY_POLY_ARRAY;
-      if (is_anon || ty_is_array(splat_at_d) || splat_at_d == TY_POLY_ARRAY) {
+      /* a boxed operand is normalized by the splat's own lowering, as above */
+      int boxed = !is_anon && inner >= 0 && (splat_at_d == TY_POLY || splat_at_d == TY_UNKNOWN);
+      if (boxed) splat_at_d = TY_POLY_ARRAY;
+      if (is_anon || boxed || ty_is_array(splat_at_d) || splat_at_d == TY_POLY_ARRAY) {
         splat_idx_d = k;
         splat_tmp_d = ++g_tmp;
         emit_indent(g_pre, g_indent);
@@ -7680,7 +7730,7 @@ void emit_dispatch(Compiler *c, int cid, const char *name,
         }
         else {
           Buf sb; memset(&sb, 0, sizeof sb);
-          emit_expr(c, inner, &sb);
+          emit_expr(c, boxed ? argv[k] : inner, &sb);
           emit_ctype(c, splat_at_d, g_pre);
           buf_printf(g_pre, " _t%d = %s;\n", splat_tmp_d, sb.p ? sb.p : "");
           free(sb.p);

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -412,6 +412,7 @@ void emit_rat_coerce(Compiler *c, int node, Buf *b);
 void emit_super(Compiler *c, int id, Buf *b);
 int  emit_super_inline(Compiler *c, int id, Buf *b, int indent, int as_expr);
 void emit_args_filled(Compiler *c, int callee_idx, int argsNode, const char *lead, Buf *out);
+int rest_shortfall_required(Compiler *c, Scope *m);
 /* Emit a hash key, unboxing a poly value to the typed-hash's key type. */
 void emit_hash_key(Compiler *c, int key, TyKind kt, Buf *b);
 int hash_key_misses(Compiler *c, int key, TyKind kt);

--- a/test/method_call_shapes.rb
+++ b/test/method_call_shapes.rb
@@ -1,0 +1,134 @@
+# A call through a Method object binds its arguments to the target's
+# parameters the way a call by name does: an omitted optional takes its
+# default, a rest parameter takes the surplus as one array, a keyword lands
+# in its slot, a splat spreads, and a count the target cannot take is CRuby's
+# ArgumentError -- for Method#call, [], .(), ===, a Method passed with &,
+# and the Proc Method#to_proc answers.
+
+def bad
+  yield
+  puts "no error"
+rescue ArgumentError => e
+  puts "#{e.class}: #{e.message}"
+end
+
+def rest(*v) = v.length
+def lead(a, *v) = [a, v]
+def opt(a, b = 2) = a + b
+def opts(a, b = 2, c = "x") = [a, b, c]
+def kw(x:, y: 1) = x + y
+def zero = 0
+def two(a, b) = a * b
+def keep(&b) = b
+
+# --- a top-level target, called through the Method object
+
+p method(:rest).call, method(:rest).call(1, 2, 3), method(:rest)[1, 2], method(:rest).(1)
+p method(:lead).call(1), method(:lead).call(1, 2, 3)
+p method(:opt).call(1), method(:opt).call(1, 5), method(:opts).call(1), method(:opts).call(1, 5, "y")
+p method(:kw).call(x: 2), method(:kw).call(x: 2, y: 3)
+p method(:opt) === 1, method(:two).call(2, 3)
+a = [1, 2]
+p method(:rest).call(*a), method(:two).call(*a), method(:opt).call(*[1]), method(:lead).call(*a, 3)
+p [[2, 3], [4, 5]].map { |pr| method(:two).call(*pr) }, [a].map { |x| rest(*x) }, [a].map { |x| two(*x) }
+$feeds = 0
+def feed(n) = ($feeds += 1; n > 0 ? [5, 6] : 7)
+p rest(*feed(1)), method(:rest).call(*feed(1)), $feeds
+p method(:keep).call { 7 }.call, method(:keep).call.nil?
+m = method(:opt)
+p m.call(1), m[1, 1]
+
+bad { method(:zero).call(1) }
+bad { method(:opt).call }
+bad { method(:opt).call(1, 2, 3) }
+bad { method(:two).call(1) }
+bad { method(:lead).call }
+bad { lead }
+
+# --- passed with &: the block's argument goes through the same binding
+
+p [1, 2].map(&method(:opt)), [[1, 2], [3, 4]].map(&method(:rest)), %w[a b].map(&method(:rest))
+
+# --- the Proc a Method answers binds its arguments the same way
+
+pr = method(:rest).to_proc
+po = method(:opts).to_proc
+pl = method(:lead).to_proc
+p pr.call, pr.call(1, 2), pr.lambda?, pr.arity
+p po.call(1), po.call(1, 5), po.call(1, 5, "y"), po.arity
+p pl.call(1), pl.call(1, 2, 3), pl.arity
+p [1, 2].map(&po), [[1, 2], [3]].map(&pl)
+bad { pr.call }
+bad { po.call }
+bad { po.call(1, 2, 3, 4) }
+bad { pl.call }
+bad { method(:two).to_proc.call(1) }
+bad { method(:zero).to_proc.call(1) }
+
+# --- a poly class receiver dispatches a class method by its run-time tag
+
+class CA
+  def self.tag(a, b) = "CA#{a}#{b}"
+end
+class CB
+  def self.tag(x, y, *rest) = "CB#{x}#{y}#{rest.length}"
+end
+[CA, CB, 1].each do |m|
+  begin
+    p m.tag(1, 2)
+  rescue NoMethodError
+    puts "NoMethodError"
+  end
+end
+sp = [7, 8, 9]
+p [CB].map { |m| m.tag(*sp) }
+two = [CA, CB]
+p two.map { |m| m.tag(3, 4) }
+[CB].each do |m|
+  begin
+    p m.tag(1)
+  rescue NoMethodError, ArgumentError
+    puts "count error"
+  end
+end
+
+# --- a bound builtin's Method carries its arguments through unlisted
+
+p "a b".method(:split).call(" "), [3, 1].method(:rotate).call(1)
+p "a b".method(:split).to_proc.call(" "), [1, [2]].method(:flatten).to_proc.call(1)
+
+# --- an object-bound target: the same binding, and the count checked
+
+class K
+  def initialize(base) = @base = base
+  def r(*v) = [@base, v]
+  def o(a, b = 2) = @base + a + b
+  def w(x, y = 1.5) = [x, y]
+  def k(x:, y: 1) = @base + x + y
+  def z = @base
+  def show(v) = (puts "show #{v}"; v)
+end
+k = K.new(10)
+p k.method(:r).call, k.method(:r).call(1, 2), k.method(:o).call(1), k.method(:o).call(1, 5)
+p k.method(:k).call(x: 2), k.method(:k).call(x: 2, y: 3), k.method(:z).call
+p k.method(:z).unbind.bind(K.new(20)).call
+p [1, 2].map(&k.method(:o))
+
+bad { k.method(:z).call(1) }
+bad { k.method(:o).call }
+bad { k.method(:o).call(1, 2, 3) }
+p k.method(:r).to_proc.call(1, 2)
+
+kr = k.method(:r).to_proc
+ko = k.method(:o).to_proc
+kw = k.method(:w).to_proc
+p kr.call, kr.call(1, 2), ko.call(1), ko.call(1, 5), kw.call(2), kw.call(2, 0.25)
+bad { ko.call }
+bad { ko.call(1, 2, 3) }
+bad { kw.call }
+bad { k.method(:z).to_proc.call(1) }
+
+# --- the receiver and the arguments are evaluated, in order, before the raise
+
+bad { k.method(:show).call(k.show(1), k.show(2)) }
+bad { k.method(:z).call(k.show(3)) }

--- a/test/method_call_shapes.rb.expected
+++ b/test/method_call_shapes.rb.expected
@@ -1,0 +1,94 @@
+0
+3
+2
+1
+[1, []]
+[1, [2, 3]]
+3
+6
+[1, 2, "x"]
+[1, 5, "y"]
+3
+5
+3
+6
+2
+2
+3
+[1, [2, 3]]
+[6, 20]
+[2]
+[2]
+2
+2
+2
+7
+true
+3
+2
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 0, expected 1..2)
+ArgumentError: wrong number of arguments (given 3, expected 1..2)
+ArgumentError: wrong number of arguments (given 1, expected 2)
+ArgumentError: wrong number of arguments (given 0, expected 1+)
+ArgumentError: wrong number of arguments (given 0, expected 1+)
+[3, 4]
+[1, 1]
+[1, 1]
+0
+2
+true
+-1
+[1, 2, "x"]
+[1, 5, "x"]
+[1, 5, "y"]
+-2
+[1, []]
+[1, [2, 3]]
+-2
+[[1, 2, "x"], [2, 2, "x"]]
+[[[1, 2], []], [[3], []]]
+no error
+ArgumentError: wrong number of arguments (given 0, expected 1..3)
+ArgumentError: wrong number of arguments (given 4, expected 1..3)
+ArgumentError: wrong number of arguments (given 0, expected 1+)
+ArgumentError: wrong number of arguments (given 1, expected 2)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+"CA12"
+"CB120"
+NoMethodError
+["CB781"]
+["CA34", "CB340"]
+count error
+["a", "b"]
+[1, 3]
+["a", "b"]
+[1, 2]
+[10, []]
+[10, [1, 2]]
+13
+16
+13
+15
+10
+20
+[13, 14]
+ArgumentError: wrong number of arguments (given 1, expected 0)
+ArgumentError: wrong number of arguments (given 0, expected 1..2)
+ArgumentError: wrong number of arguments (given 3, expected 1..2)
+[10, [1, 2]]
+[10, []]
+[10, [1, 2]]
+13
+16
+[2, 1.5]
+[2, 0.25]
+ArgumentError: wrong number of arguments (given 0, expected 1..2)
+ArgumentError: wrong number of arguments (given 3, expected 1..2)
+ArgumentError: wrong number of arguments (given 0, expected 1..2)
+ArgumentError: wrong number of arguments (given 1, expected 0)
+show 1
+show 2
+ArgumentError: wrong number of arguments (given 2, expected 1)
+show 3
+ArgumentError: wrong number of arguments (given 1, expected 0)


### PR DESCRIPTION
## Why

Passing a method around as a value — `m = method(:f)` and later `m.call(1)`, or the everyday `[1, 2].map(&method(:f))` — is ordinary Ruby: it is how callbacks, dispatch tables and block shorthand get written. In Spinel it only worked when the target took a fixed number of plain arguments and the call supplied exactly that many. Give the target an optional parameter, a rest, or a keyword — or pass a wrong count — and the program did not fail politely: the C build broke with a compiler error, or the binary segfaulted, or the call silently answered from an unset parameter. This change makes a call through a Method object bind its arguments the way a call by name always has, so the whole family works, and a count the method refuses is the same rescuable ArgumentError CRuby raises.

Concretely: `method(:f).call(1)`, `m[1]`, `m.(1)`, `[1, 2].map(&method(:f))` and `m.to_proc.call(1)` are all `f(1)`, and none of them was. A call through the Method object of a top-level def handed the target one C argument per site argument, whatever the target's parameters were, so anything but an exact fixed count failed the C build or crashed: `def f(*a)` took a raw Integer in its array pointer (`error: incompatible integer to pointer conversion`), `def f(a, b = 2)` called with one argument was a C call one argument short, `def f(x:)` put the keyword hash in a positional slot, and a count the method refuses — `def f(a)` called bare — was `error: too few arguments to function call` from the C compiler rather than CRuby's rescuable `ArgumentError`. `[1, 2].map(&method(:f))` on a method with an optional parameter is the same failure, since a Method passed with `&` forwards through the same call. The Proc that `Method#to_proc` answers bound its arguments the same way: `m.to_proc.call(1, 2)` on `def r(*v)` read the Integer as the array and segfaulted, `def o(a, b = 2)` called with one answered from an unset `b`, and a wrong count went through unchecked. A call on an object-bound Method bound its shapes but never checked the count: `k.method(:z).call(1)` on `def z; end` answered, and `k.method(:o).call` on `def o(a, b = 2)` answered from the defaults.

The ordinary call path already does all of this for a call by name — `emit_args_filled` fills defaults, packs a rest parameter, binds keywords to their slots, spreads a splat at run time and raises for a count or keyword the target refuses, in CRuby's words — so the fix for the top-level arm is to use it. The trampoline behind `to_proc` gets the binding a lambda body has. And the lowering had two gaps of its own that the new test found: its count check skipped any target with a rest parameter, so `def f(a, *r)` called bare ran the body with a padded `a` (`pair(1)` on `def pair(first, second, *rest)` answered where CRuby raises); and a splat whose operand is boxed — a block parameter, a value read out of a container — was handed over as one positional argument or as one element of the rest, so `[[2, 3]].map { |pr| mul(*pr) }` on `def mul(a, b)` and `[a].map { |x| r(*x) }` on `def r(*v)` answered wrongly by name, and the Method object's hand-rolled arm was the one place that got it right.

## What

- `method(:f).call(...)`, `m[...]`, `m.(...)`, `m === x` and `map(&method(:f))` on a top-level def take every shape the call by name takes: an omitted optional takes its default, a rest parameter takes the surplus as one array, a keyword lands in its slot, a trailing splat spreads (with the length checked at run time, as `f(*a)` does), and a `&block` parameter the callee keeps out of line receives the site's block. A count the target refuses is `ArgumentError: wrong number of arguments (given 0, expected 1..2)`, `(given 1, expected 2)`, `(given 0, expected 1+)`, and a keyword hash that leaves a required keyword out `missing keyword: :x` — rescuable, where each was a C build failure.
- `Method#to_proc` on a known target answers a Proc that binds the same way: `pr.call(1, 2)` on `def r(*v)` answers 2 where it crashed, `po.call(1)` on `def o(a, b = 2)` answers `1 + 2`, and a wrong count is the ArgumentError above where it went through unchecked — for a top-level and an object-bound target alike.
- A wrong count on an object-bound Method — `k.method(:z).call(1)`, `k.method(:o).call`, `k.method(:o).call(1, 2, 3)` — is the ArgumentError, raised after the receiver and the arguments are evaluated in order, where it answered.
- A call by name to a top-level def with fewer arguments than its rest-parameter signature requires — `pair(1)` on `def pair(first, second, *rest)` — is `ArgumentError: wrong number of arguments (given 1, expected 2+)` where it ran the body with a zero.
- A splat with a boxed operand — `m.call(*pr)` or `mul(*pr)` on a block parameter, `r(*x)` on a value read out of a container — spreads the array it holds at run time, by name and through a Method alike: `[[2, 3], [4, 5]].map { |pr| mul(*pr) }` answers `[6, 20]` where it raised `TypeError: no implicit conversion of Integer into Array`, and `[a].map { |x| r(*x) }` on `def r(*v)` answers `[20]` for a twenty-element `a` where it answered `[1]`.
- A bound builtin's Method — `"a b".method(:split).call(" ")`, `[3, 1].method(:rotate).call(1)`, and their `to_proc` — answers as it did: the wrapper such a Method resolves to lists only its receiver, so neither count check reads it.

## How

- **The top-level arm** (`emit_call_body`, `src/codegen_call.c`): the hand-rolled argument loop and its trailing-splat special case give way to `emit_method_cname` + `emit_args_filled`, the lowering a call by name gets, so the two cannot drift; the arm adds only what that path's caller adds, the `sp_Proc *` for a callee that keeps a `&block` parameter (the site's literal block, a Proc passed with `&`, or NULL).
- **The object-bound arm**: `method_call_count_violation` judges the plain positional shape against the target's parameters — no splat, keyword hash, block-pass or forwarding at the site; no keyword, synthesized or post-rest parameter on the target; not the `__bam_` wrapper a bound builtin's Method resolves to, whose parameter list holds the receiver alone while the builtin's own arguments pass through it unlisted — and `emit_wrong_count`, the emission half of the builtin arity guard split out to be shared, evaluates the receiver and the arguments and raises with CRuby's range. The arm's binding of keywords, defaults and the rest is unchanged.
- **The trampoline** (`_mtp_N`, the same function): for a target with no keyword parameter, no required parameter after the rest, literal defaults, at most the channel's 16 slots, and not a bound builtin's wrapper, the body checks the count in CRuby's words, binds each parameter from its slot when the call supplied it — an int from `args[]`, a float or poly value from the boxed side-channel, as a lambda body does — and from its default otherwise, packs the rest from the side-channel into one array (rooted, under `SP_GC_SAVE`), and clears the channel the way a lambda body leaves it. A target outside that shape keeps the positional binding it had.
- **The by-name check** (`emit_args_filled`, `src/codegen_fold.c`): a target with a rest parameter has no upper bound and a keyword beside the rest binds by other rules, so only the shortfall of a keyword-less one is judged, by `rest_shortfall_required`: fewer positional arguments than parameters without a default raises `(given N, expected R+)`. The fixed-arity check is as it was. The poly class-method dispatch, which emits one arm per candidate class against the same argument list and hoists each arm's count raise into the prelude, reads the same rule when it lists its candidates, so a rest candidate the raise would refuse is never emitted (the rule its fixed-arity filter already followed), and a splat or double splat at the site — where the raise stands down — leaves a rest candidate unjudged, where counting the splat as one argument would drop the arm the runtime would have picked. A fixed-arity candidate keeps the counting it had: its arm carries a run-time check of a trailing splat's length into the dispatch's shared prelude, so which arms may be emitted on a splat site is the same question it always was, and this change confines itself to the arms that emit no check.
- **A boxed splat operand** (`emit_args_filled` and its dispatch mirror, `emit_rest_pack_kwh`): the expansion into fixed parameters accepted only a statically typed array, and the rest packing pushed anything else as one element. A boxed operand now goes through the splat's own lowering — `sp_splat_to_array`, nil to `[]`, a scalar to `[v]`, an array kept — into a rooted poly array, and is expanded or packed from there.
- **Rooting**: the trampoline holds its formatted message in a root before the raise, as `sp_raise` does, and the rest packing roots the normalized array while it pushes from it; both found by the test under `SPINEL_GC_STRESS=1`.

## Validation

- A new test, `test/method_call_shapes` (expectations generated by CRuby 4.0.6; runs in well under a second): every shape above through `call`, `[]`, `.()`, `===`, a splat (typed, and boxed from a block parameter, by name and through a Method), a `&block` callee, a Method passed with `&`, a bound builtin's Method with an argument, `to_proc` on a top-level and an object-bound target, twenty rescued ArgumentErrors, the by-name rest shortfall, and the receiver and the arguments evaluated before the raise. On master it fails the C build at its first Method call.
- Full suite: 3,374 pass, 0 fail, from a cleared results cache, at `-O2`; the same at the gate's `-O1`. The new test passes under `SPINEL_GC_STRESS=1`.
- Generated C against master over the suite, the benchmarks and optcarrot (3,389 programs): 14 differ, every one a test of Method objects, procs or forwarding (`method_call_splat_args`, `proc_method_wave10`, `issue_3249`, `issue_3290_method_curry`, `method_to_proc_curry_stored`, `proc_compose_curry_forward`, `block_forward_poly`, `forwarded_block_to_iterator`, `proc_as_block_arg`, `proc_param_container_input`, `implicit_conversion_narrowing`, `issue_3183`, `issue_3304_method_reflection`, `map_result_widened_by_composition`), all passing: each trampoline gains its count check and guarded bindings, and a top-level `m.call(*args)` gains the run-time length check the call by name has. The 61 benchmarks and optcarrot are byte-identical, so no hot path changes.
- Against the differential corpus of ~2,100 minimized programs the campaign has been working from: 757 → 762 match, 5 gained and 0 lost: `method(:f).call(1)` on a rest method, `.call(x: 2)` on a keyword method, `.call` on an optional one, `.call` with no argument on `def identity(value)` rescued, and the rest-parameter shortfall by name.

## Left alone, on purpose

- A Method object of a method that yields (`def each; yield 1; end`): such a method is inlined at every call and has no out-of-line body, so `k.method(:each)` references a function that does not exist and the C build fails, as before. Giving it a body is a separate change.
- A Method built on a boxed receiver — `o = [C.new, 0][0]; o.method(:foo).call(2)` — carries no target and fails the C build, as before; the arms here need a target the compiler can name.
- An instance-method call by name — `P.new.m`, `m` or `self.m` inside the class, `send(:m)` — has its own argument lowering, which still takes fewer arguments than a rest-parameter signature requires (`def m(x, *y)` called bare answers `[0, []]`); the shortfall check here is the top-level lowering's, which `Method#call` on a top-level def now shares.
- `method(:helper)` inside a class body, naming an instance method through the implicit self, fails the C build as before.
- The top-level arm raises a wrong count before the site's arguments are evaluated, as a call by name does; the object-bound arm evaluates the receiver and the arguments first, as the builtin guard does. CRuby evaluates them first in both.
- A trampoline for a target with a keyword parameter, a required parameter after the rest, a default that is not a literal (`def f(a, b = a * 2)`), or a bound builtin's wrapper keeps the positional binding it had; the first two bind by rules the trampoline does not implement, the third reads a frame the trampoline does not have, and the wrapper lists no parameter to bind.
- `Method#to_proc.parameters` on a known target answers `[]`, as before; `Method#parameters` itself is right.
- A call with no arguments at all to a method with a required keyword — `kw()` or `method(:kw).call` on `def kw(x:)` — is `wrong number of arguments (given 0, expected 1)` where CRuby says `missing keyword: :x`, by name and through a Method alike; the keyword-message family is untouched.
- The proc-call channel carries sixteen arguments, so the Proc a Method answers sees the first sixteen of a longer call, as a lambda or proc does today: `pr.call(*(1..20).to_a)` on `def r(*v)` answers 16, the same as `->(*v) { v.size }`; on master that call crashed. `method(:r).call(*(1..20).to_a)`, the call by name, answers 20.
- `[1, 2].each_with_index.map(&method(:f))` and `map(&method(:f).to_proc)` are NoMethodErrors as before: the first forwards through an Enumerator the value-callable desugar does not cover, the second is an inline `&expr` that is neither a local nor a `method(:sym)` node.
- A poly class dispatch with a splat at the site still counts the splat as one argument when it filters fixed-arity candidates, as before — either way that filter errs, the arm it keeps hoists a length check that can fire for a class the runtime did not pick, and the arm it drops can be the one the runtime wanted; both are the dispatch's pre-existing trade, untouched here.
- A poly class receiver none of whose candidates can take the site's count answers `NoMethodError: undefined method 'tag' for an instance of Class` where CRuby raises the class's own ArgumentError — for a fixed-arity candidate as before, and for a rest candidate where master ran the arm with the shortfall padded, an error in place of a silently wrong answer; the dispatch has no arm to land the count raise in.
- `Method#curry` on a rest method and `method(:puts)` on a builtin are as they were.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved method-call argument validation for defaults, rest and keyword arguments, splats, blocks, and bound methods.
  - Added clearer CRuby-style `ArgumentError` handling for invalid argument counts.
  - Corrected runtime handling of dynamically typed splat values.

- **Tests**
  - Added comprehensive coverage for `Method`, `Method#to_proc`, rebinding, built-ins, evaluation order, keyword arguments, blocks, and arity errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->