### PR TITLE
Reach a user #replace through an untyped slot

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -9024,6 +9024,27 @@ static int strbuf_mut_kind(Compiler *c, const char *vn, Scope *vs) {
                                    vs ? (int)(vs - c->scopes) : -1, 0);
   return v ? *v : 0;
 }
+/* True when the mutator evidence for local `vn` rests on a name a USER class
+   also defines. The mutator table is keyed on the NAME alone, so `f.replace(x)`
+   reads as String#replace whatever `f` holds; on a slot whose type is still
+   poly/unknown -- an element read out of a heterogeneous container -- that is
+   not evidence the value is a string, and narrowing the slot to the handle
+   applied the builtin's semantics to a user object (#4240). */
+static int strbuf_mut_name_user_owned(Compiler *c, const char *vn, Scope *vs) {
+  const NodeTable *nt = c->nt;
+  if (!vn) return 0;
+  NT_FOREACH_KIND(nt, NK_CallNode, u) {
+    int ur = nt_ref(nt, u, "receiver");
+    if (ur < 0 || nt_kind(nt, ur) != NK_LocalVariableReadNode) continue;
+    const char *urn = nt_str(nt, ur, "name");
+    if (!urn || !sp_streq(urn, vn) || comp_scope_of(c, ur) != vs) continue;
+    const char *un = nt_str(nt, u, "name");
+    if (!un || !sp_str_mutator(un, SP_MUT_LOCAL)) continue;
+    if (an_user_defines_method(c, un)) return 1;
+  }
+  return 0;
+}
+
 /* In-place mutation status of ivar `nm` of class `cid` (same contract as
    strbuf_mut_kind). The supported set is narrower: the shadow-copy shim
    cannot rename an ivar, so []=/insert/slice!/setbyte disqualify. */
@@ -10042,6 +10063,15 @@ static int promote_shared_stored_strings(Compiler *c) {
        string somewhere before treating the binding as a string alias. */
     if (!strbuf_container_stores_string(c, contn5, conts5)) continue;
     changed |= strbuf_demand_container_stores(c, contn5, conts5);
+    /* An untyped element bound out of a HETEROGENEOUS container, mutated by a
+       name a user class also defines: the name is not evidence that THIS
+       binding is a string, and narrowing the slot ran String#replace on the
+       user object -- its contents became the argument, silently (#4240). The
+       container's own string stores stay handles (the demand above), so a
+       genuine String element still mutates in place; the local keeps its poly
+       type so the call site builds the cls_id dispatch instead. */
+    if ((llv5->type == TY_UNKNOWN || llv5->type == TY_POLY) &&
+        strbuf_mut_name_user_owned(c, lname5, ls5)) continue;
     if (!c->strbuf_box[wv]) { c->strbuf_box[wv] = 1; changed = 1; }
     if (llv5->type != TY_POLY && (llv5->type != TY_STRBUF || !llv5->str_shared))
       {  llv5->type = TY_STRBUF; llv5->str_shared = 1; changed = 1;  }

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -6005,6 +6005,30 @@ else {
           buf_printf(b, " case SP_BUILTIN_INT_ARRAY: _t%d = sp_IntArray_get((sp_IntArray *)_t%d.v.p, %s); break;", tr, tv, idxref);
         }
       }
+      /* String#replace / Array#replace on a poly value when a user class owns
+         the name: a genuine String or Array reaching this dispatch has no
+         user-class arm, and without one of its own it landed on the raise
+         default -- or, before the dispatch was opened at all, took the
+         builtin's path with the builtin's semantics applied to the user
+         object (#4240). The argument rides its already-materialised temp, as
+         the IO arms below do; the helper is the one the no-user-class path
+         emits. */
+      if (sp_streq(name, "replace") && pos_argc == 1 && kwh < 0) {
+        Buf ab; memset(&ab, 0, sizeof ab);
+        char tn[32]; snprintf(tn, sizeof tn, "_t%d", atmp[0]);
+        if (atmp_ty[0] == TY_POLY) buf_puts(&ab, tn);
+        else emit_boxed_text(c, atmp_ty[0], tn, &ab);
+        buf_printf(b, " case SP_BUILTIN_STRBUF: case SP_BUILTIN_INT_ARRAY:"
+                      " case SP_BUILTIN_FLT_ARRAY: case SP_BUILTIN_STR_ARRAY:"
+                      " case SP_BUILTIN_POLY_ARRAY:");
+        if (ret == TY_POLY)
+          buf_printf(b, " _t%d = sp_poly_replace(_t%d, %s); break;", tr, tv,
+                     ab.p ? ab.p : "sp_box_nil()");
+        else
+          buf_printf(b, " sp_poly_replace(_t%d, %s); break;", tv,
+                     ab.p ? ab.p : "sp_box_nil()");
+        free(ab.p);
+      }
       /* IO#write on a poly value when a user class owns the name: a Socket or
          File from Socket.pair/File.open has no user-class arm in the switch,
          but the dispatch was still opened (some other class does define

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -12934,8 +12934,13 @@ int emit_poly_call(Compiler *c, int id, Buf *b) {
     buf_puts(b, ", "); emit_expr(c, argv[0], b); buf_puts(b, ")");
     return 1;
   }
-  /* poly receiver: replace(other) -> runtime dispatch (nullable array). */
-  if (recv >= 0 && rt == TY_POLY && sp_streq(name, "replace") && argc == 1) {
+  /* poly receiver: replace(other) -> runtime dispatch (nullable array).
+     Stands down for a user class that defines the name: the arm applied
+     String#replace's semantics to the user object -- the receiver's contents
+     became the argument -- where CRuby entered the user method (#4240). The
+     dispatch below builds the cls_id switch with an arm for the class. */
+  if (recv >= 0 && rt == TY_POLY && sp_streq(name, "replace") && argc == 1 &&
+      !user_defines_or_reads(c, name)) {
     buf_puts(b, "sp_poly_replace("); emit_expr(c, recv, b);
     buf_puts(b, ", "); emit_boxed(c, argv[0], b); buf_puts(b, ")");
     return 1;

--- a/test/poly_slot_user_replace.rb
+++ b/test/poly_slot_user_replace.rb
@@ -1,0 +1,33 @@
+# A user method named after a builtin, reached through an UNTYPED slot. The
+# evidence that narrowed the slot is the NAME -- `replace` is String's -- so an
+# element read out of a heterogeneous array became a string handle and the call
+# ran String#replace on the Frag: the receiver's contents became the argument,
+# silently. A name a user class owns must not decide an untyped slot's type,
+# and the poly dispatch keeps arms for a genuine String/Array receiver so the
+# builtin's own answer is unchanged (#4240).
+class Frag
+  def initialize(html)
+    @html = html
+  end
+
+  def replace(selector)
+    r = yield
+    Frag.new("user-replace:" + selector + ":" + r.to_s)
+  end
+
+  def to_s
+    @html
+  end
+end
+
+f1 = Frag.new("abc")
+puts f1.replace("sel") { nil }.to_s    # typed receiver
+
+box = [Frag.new("abc"), +"just a string"]
+f2 = box[0]
+puts f2.replace("sel") { nil }.to_s    # untyped slot
+
+s = box[1]                             # a genuine String through the same slot
+s.replace("swapped")
+puts s
+puts box[1]

--- a/test/poly_slot_user_replace.rb.expected
+++ b/test/poly_slot_user_replace.rb.expected
@@ -1,0 +1,4 @@
+user-replace:sel:
+user-replace:sel:
+swapped
+swapped


### PR DESCRIPTION
Fixes #4240.

## What happened

A user method named after a builtin ran the **builtin** when the receiver arrived through an untyped slot. `f = box[0]; f.replace("sel")` on a `Frag` answered `"sel"` — `String#replace`'s semantics applied to a non-String: the receiver's contents became the argument.

The block in the issue's repro turns out to be incidental. The discriminator is the **name**: `replace`, `concat`, `prepend`, `clear` and the bang forms are the set spinel's string-handle (strbuf) machinery keys on. `upcase` and friends through the same slot already dispatched correctly.

## Why

Two independent paths, both the "a user class owns this name" rule the neighbouring code already follows (#3459, #4071):

1. **`src/analyze.c`** — the container-read alias rule (#3941) narrowed `f = box[0]` to a string handle on name-keyed evidence alone (`f.replace(…)` "must be" `String#replace`). The slot's static type became `sp_String *`, so the user candidate was never in play. Gate the narrowing on the slot still being poly *and* the mutator name being one a user class defines — placed **after** the container's own stores are demanded into handles, so a genuine `String` element still mutates in place.

2. **`src/codegen_call_recv.c`** — the poly-receiver `replace` arm emitted `sp_poly_replace(…)` unconditionally, unlike `join` / `pack` / `delete` beside it, which stand down via `user_defines_or_reads`. Give it the same guard.

Standing that arm down opens the `cls_id` dispatch — where a *genuine* `String` or `Array` receiver then had no arm of its own and landed on the raise default. So:

3. **`src/codegen_call.c`** — give the dispatch a builtin `replace` arm, next to the `IO#write` / `read_nonblock` arms and on the same terms already stated there: a user class owning a name must not change what a builtin receiver does.

## Test

`test/poly_slot_user_replace.rb` covers all three: the typed receiver, the untyped slot, and a genuine mutable `String` reached through the same slot (whose `#replace` must still mutate the array's element in place).

`make test`: **3378 pass, 0 fail, 0 error**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kwS4WizPEpFCJTmyvHARf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect method dispatch for `replace` when untyped values can refer to user-defined classes.
  * Preserved built-in `String` and `Array` replacement behavior while correctly invoking matching user-defined methods.
  * Prevented user-defined `replace` methods from being mistaken for built-in string operations.

* **Tests**
  * Added coverage for replacement dispatch through untyped values and user-defined methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->