### PR TITLE
Keep the container's own strings when the alias stands down

### DIFF
--- a/src/analyze.c
+++ b/src/analyze.c
@@ -10094,14 +10094,19 @@ static int promote_shared_stored_strings(Compiler *c) {
        reads as a string append. Require the container to actually hold a
        string somewhere before treating the binding as a string alias. */
     if (!strbuf_container_stores_string(c, contn5, conts5)) continue;
-    /* ...and holds NOTHING BUT strings. A heterogeneous container passes the
-       test above on its string element while the local is bound from another
-       one: `box = [Frag.new(h), "s"]; f = box[0]; f.replace(sel)` bound f to a
-       string handle and ran String#replace on a Frag, answering the argument
-       (#4240). The alias only means what it says when every element is a
-       string. */
-    if (strbuf_container_stores_nonstring(c, contn5, conts5)) continue;
+    /* The stores that ARE strings become handles either way: the container's
+       own String element is mutated through it (`s = box[1]; s.replace(x)`),
+       and refusing that before the gate below left it a plain box, so the
+       mutation landed in a copy and the array never saw it. */
     changed |= strbuf_demand_container_stores(c, contn5, conts5);
+    /* The BINDING, though, only means what it says when the container holds
+       nothing but strings. A heterogeneous one passes the test above on its
+       string element while the local is bound from another: `box =
+       [Frag.new(h), "s"]; f = box[0]; f.replace(sel)` bound f to a string
+       handle and ran String#replace on a Frag, answering the argument
+       (#4240). Leave such a local poly -- the call site then dispatches on
+       the element's own class. */
+    if (strbuf_container_stores_nonstring(c, contn5, conts5)) continue;
     if (!c->strbuf_box[wv]) { c->strbuf_box[wv] = 1; changed = 1; }
     if (llv5->type != TY_POLY && (llv5->type != TY_STRBUF || !llv5->str_shared))
       {  llv5->type = TY_STRBUF; llv5->str_shared = 1; changed = 1;  }

--- a/test/container_alias_mixed_string_element.rb
+++ b/test/container_alias_mixed_string_element.rb
@@ -1,0 +1,31 @@
+# The heterogeneity gate that keeps a user method reachable through an untyped
+# slot (#4240) must not cost the container's OWN strings their handles. `box`
+# holds a Frag and a mutable String: refusing the container wholesale left the
+# String element a plain frozen box, so `s.replace` answered the receiver and
+# the array never saw the mutation. Demand the stores into handles first, then
+# decline to narrow the LOCAL -- the Frag keeps its own #replace, and the
+# String element still mutates in place.
+class Frag
+  def initialize(html)
+    @html = html
+  end
+
+  def replace(selector)
+    "user-replace:" + selector + ":" + @html
+  end
+end
+
+box = [Frag.new("abc"), +"just a string"]
+
+f = box[0]
+puts f.replace("sel")
+
+s = box[1]
+s.replace("swapped")
+puts s
+puts box[1]
+
+# the append shape reaches the same alias binding
+n = box[1]
+n << "!"
+puts box[1]

--- a/test/container_alias_mixed_string_element.rb.expected
+++ b/test/container_alias_mixed_string_element.rb.expected
@@ -1,0 +1,4 @@
+user-replace:sel:abc
+swapped
+swapped
+swapped!


### PR DESCRIPTION
Follow-up to c178fc15 — the second of the two neighbours noted in the #4240 close comment ("a plain String element's `#replace` answers the receiver rather than replacing it").

## What

The heterogeneity gate added with #4240 refuses the container-read alias promotion wholesale when the container stores something provably non-string. That is right for the **local** — binding `f = box[0]` to a string handle is exactly what ran `String#replace` on the `Frag` — but it also costs the container's **own** String element the handle it had:

```ruby
box = [Frag.new("abc"), +"just a string"]
s = box[1]
s.replace("swapped")
p s        # "just a string" on master, "swapped" in CRuby
p box[1]   # "just a string" on master, "swapped" in CRuby
```

The element never becomes a shared handle, so the mutation lands in a copy and the array never sees it.

## The change

Run `strbuf_demand_container_stores` **before** the gate rather than after it. The stores that are strings keep their handles; the gate then still declines to narrow the local, so the user method still owns the name at the call site. One line, plus the comment split to match.

```diff
-    if (strbuf_container_stores_nonstring(c, contn5, conts5)) continue;
     changed |= strbuf_demand_container_stores(c, contn5, conts5);
+    if (strbuf_container_stores_nonstring(c, contn5, conts5)) continue;
```

## Verification

`test/container_alias_mixed_string_element.rb` covers a `Frag` and a mutable String reached through the same untyped slot, in both the `replace` and the `<<` shape.

The #4240 repro is unaffected — both of its columns still answer CRuby's output, as does the no-block form and the `[Frag, 42]` variant that has no string in the container at all.

`make test`: 3379 pass, 0 fail, 0 error (plus the new test through the harness; it postdates that run's wildcard).

Neighbour #1 from the same comment — a frozen string literal bound through this alias — is unrelated to the ordering and is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kwS4WizPEpFCJTmyvHARf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed string mutations within mixed-type containers so they update the original container element correctly.
  - Preserved custom behavior for non-string elements in the same container.
  - Ensured both replacement and append operations produce the expected results.

- **Tests**
  - Added coverage for mixed containers containing custom objects and mutable strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->