### PR TITLE
Give Proc#curry CRuby's completion rules

### DIFF
--- a/lib/sp_proc.c
+++ b/lib/sp_proc.c
@@ -61,6 +61,41 @@ sp_Curry *sp_curry_new(sp_Proc *p) {
   SP_GC_ROOT(p);  /* the target proc has no other root across this alloc */
   sp_Curry *c = (sp_Curry *)sp_gc_alloc(sizeof(sp_Curry), NULL, sp_curry_scan);
   c->target = p; c->nargs = 0;
+  /* no count given: realize at the target's required-parameter count (CRuby's
+     min arity; a negative arity encodes it as -req-1) */
+  c->arity = p ? (p->arity < 0 ? -p->arity - 1 : p->arity) : 0;
+  return c;
+}
+/* Proc#curry(n): the count overrides the default. CRuby validates n against
+   a lambda's min..max arity at the curry call, before anything is applied.
+   The min comes off the target's arity; the max only the compiler can see
+   (an optional widens it, a rest lifts it), so the call site passes it in --
+   max < 0 means unlimited-or-unknown, and the message then says "min+". */
+sp_Curry *sp_curry_new_n(sp_Proc *p, sp_int n, sp_int max) {
+  /* an int-typed slot's nil sentinel is CRuby's nil count: no count at all */
+  if (n == SP_INT_NIL) return sp_curry_new(p);
+  if (p && p->lambda_p) {
+    sp_int min = p->arity < 0 ? -p->arity - 1 : p->arity;
+    sp_int mx = max >= 0 ? max : (p->arity >= 0 ? p->arity : -1);
+    /* the max is the compiler's guess from a visible parameter list; the min
+       is the target's own truth. A guess below it names a different write of
+       the same name -- trust the target, drop the guess. */
+    if (mx >= 0 && mx < min) mx = -1;
+    if (n < min || (mx >= 0 && n > mx)) {
+      const char *want = mx < 0 ? sp_sprintf("%lld+", (long long)min)
+                       : mx == min ? sp_sprintf("%lld", (long long)min)
+                       : sp_sprintf("%lld..%lld", (long long)min, (long long)mx);
+      /* both strings live on the collected heap; the second sp_sprintf and
+         the raise path itself allocate, so root them across those */
+      SP_GC_ROOT_STR(want);
+      const char *msg = sp_sprintf("wrong number of arguments (given %lld, expected %s)",
+                                   (long long)n, want);
+      SP_GC_ROOT_STR(msg);
+      sp_raise_cls("ArgumentError", msg);
+    }
+  }
+  sp_Curry *c = sp_curry_new(p);
+  c->arity = n < 0 ? 0 : n;
   return c;
 }
 /* Each accumulated argument is stored boxed so a non-int arg (a String, an

--- a/lib/sp_proc.h
+++ b/lib/sp_proc.h
@@ -23,7 +23,11 @@
 #include "sp_alloc.h"   /* sp_PolyArray, sp_box_sym, sp_box_poly_array, sp_raise_cls */
 
 typedef struct sp_Proc { void *fn; void *cap; void (*cap_scan)(void *); sp_int arity; sp_bool lambda_p; sp_int param_count; const sp_sym *param_kinds; const sp_sym *param_names; sp_bool frozen; /* Object#freeze observed (sp_gc_alloc zero-fills) */ void *origin; /* dup/clone lineage root for Proc#== (NULL: self is the root) */ } sp_Proc;
-typedef struct { sp_Proc *target; sp_int nargs; sp_RbVal args[16]; } sp_Curry;
+/* arity: the count this accumulator realizes at -- Proc#curry(n)'s n, else
+   the target's required-parameter count (CRuby's min arity, so a variadic
+   base realizes on its first call). Carried here so a curry that travels
+   through a container or an untyped slot still knows when it is done. */
+typedef struct { sp_Proc *target; sp_int arity; sp_int nargs; sp_RbVal args[16]; } sp_Curry;
 
 sp_int sp_proc_call(sp_Proc *p, sp_int argc, sp_int *args);   /* defined in the generated TU */
 extern SP_TLS sp_RbVal _sp_proc_poly_args[16];                   /* defined in the generated TU */
@@ -45,6 +49,7 @@ sp_PolyArray *sp_proc_parameters_ids(sp_Proc *p, int mode, sp_sym req_id, sp_sym
 sp_PolyArray *sp_proc_parameters(sp_Proc *p);
 void sp_curry_scan(void *p);
 sp_Curry *sp_curry_new(sp_Proc *p);
+sp_Curry *sp_curry_new_n(sp_Proc *p, sp_int n, sp_int max);
 sp_Curry *sp_curry_apply(sp_Curry *c, sp_RbVal arg);
 void sp_curry_publish_args(sp_Curry *c);
 

--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -5619,9 +5619,13 @@ static void sp_PolyPolyHash_grow(sp_PolyPolyHash*h){ sp_gc_wb((void*)h);sp_RbVal
 static SP_NOINLINE sp_RbVal sp_PolyPolyHash_miss(sp_PolyPolyHash*h,sp_RbVal k){if(h->dproc)return h->dproc(h,k,h->dproc_self);return h->default_v;}
 static sp_RbVal sp_PolyPolyHash_get(sp_PolyPolyHash*h,sp_RbVal k){if(!h)return sp_box_nil();SP_GC_ROOT(h);SP_GC_ROOT_RBVAL(k);sp_int hs=sp_hash_slot(sp_rbval_hash_key(k));sp_int idx=(sp_int)(hs&h->mask);while(h->occ[idx]){if(h->hs[idx]==hs&&sp_rbval_eql_key(h->keys[idx],k))return h->vals[idx];idx=(idx+1)&h->mask;}return sp_PolyPolyHash_miss(h,k);}
 static sp_bool sp_PolyPolyHash_has_value(sp_PolyPolyHash*h,sp_RbVal v){if(!h)return FALSE;for(sp_int i=0;i<h->len;i++)if(sp_poly_eq(h->vals[h->order[i]],v))return TRUE;return FALSE;}
+/* defined with the curry machinery below; the key-typed reads and the cold
+   index path all apply a curried receiver through it */
+static sp_RbVal sp_curry_call_poly(sp_Curry *c, sp_int argc, const sp_RbVal *args);
 static sp_RbVal sp_poly_get_sym(sp_RbVal v, sp_sym key) {
   if (v.tag != SP_TAG_OBJ) return sp_box_nil();
   switch (v.cls_id) {
+    case SP_BUILTIN_CURRY: return sp_curry_call_poly((sp_Curry *)v.v.p, 1, (sp_RbVal[]){sp_box_sym(key)});
     case SP_BUILTIN_SYM_POLY_HASH: return sp_SymPolyHash_get((sp_SymPolyHash*)v.v.p, key);
     case SP_BUILTIN_POLY_POLY_HASH: return sp_PolyPolyHash_get((sp_PolyPolyHash*)v.v.p, sp_box_sym(key));
     /* an OpenStruct read as poly (e.g. returned from a method that can also
@@ -5949,6 +5953,7 @@ static sp_RbVal sp_poly_shift(sp_RbVal v) {
 static sp_RbVal sp_poly_get_str(sp_RbVal v, const char *key) {
   if (v.tag != SP_TAG_OBJ) return sp_box_nil();
   switch (v.cls_id) {
+    case SP_BUILTIN_CURRY: return sp_curry_call_poly((sp_Curry *)v.v.p, 1, (sp_RbVal[]){sp_box_str(key)});
     case SP_BUILTIN_STR_POLY_HASH: return sp_StrPolyHash_get((sp_StrPolyHash*)v.v.p, key);
     case SP_BUILTIN_STR_STR_HASH: { const char *s = sp_StrStrHash_get((sp_StrStrHash*)v.v.p, key); return s ? sp_box_str(s) : sp_box_nil(); }
     case SP_BUILTIN_STR_INT_HASH: { sp_int i = sp_StrIntHash_get_opt((sp_StrIntHash*)v.v.p, key); return i == SP_INT_NIL ? sp_box_nil() : sp_box_int(i); }
@@ -6265,6 +6270,10 @@ static SP_NOINLINE sp_RbVal sp_poly_arr_get_hash_cold(sp_RbVal a, sp_int i) {
     sp_IntStrHash *h = (sp_IntStrHash *)a.v.p;
     return sp_IntStrHash_has_key(h, i) ? sp_box_str(sp_IntStrHash_get(h, i)) : sp_box_nil();
   }
+  /* a curried Proc read out of a container: [] applies the argument,
+     realizing once the accumulator reaches its count */
+  if (a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_CURRY)
+    return sp_curry_call_poly((sp_Curry *)a.v.p, 1, (sp_RbVal[]){sp_box_int(i)});
   /* bm[arg]: a boxed bound Method called with the (single) int argument. */
   if (a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_METHOD) {
     sp_BoundMethod *m = (sp_BoundMethod *)a.v.p;
@@ -6315,6 +6324,10 @@ static sp_RbVal sp_poly_dig_list(sp_RbVal recv, sp_PolyArray *keys) {
 }
 /* poly[poly_key]: dispatch on key tag at runtime. */
 static sp_RbVal sp_poly_index_poly(sp_RbVal recv, sp_RbVal idx) {
+  /* a curried Proc applies its [] argument whatever the key kind -- claimed
+     here, before the key-typed dispatch below coerces it to an index */
+  if (recv.tag == SP_TAG_OBJ && recv.cls_id == SP_BUILTIN_CURRY)
+    return sp_curry_call_poly((sp_Curry *)recv.v.p, 1, &idx);
   /* an Integer index into an array is the common read, and it matches nothing
      below until the very last line (array kinds are builtin, so the Struct arm
      with its cls_id >= 0 test cannot claim it) */
@@ -7945,8 +7958,13 @@ SP_NORETURN SP_COLD void sp_raise_cls(const char *cls, const char *msg) {
 static void sp_raise(const char *msg) { sp_raise_cls("RuntimeError", msg); }
 
 /* Unwrap a boxed Proc -- one read out of a container (#3655). */
+static sp_Proc *sp_curry_to_proc(sp_Curry *cy);   /* with the curry machinery below */
 static sp_Proc *sp_poly_to_proc(sp_RbVal v) {
   if (v.tag == SP_TAG_OBJ && v.cls_id == SP_BUILTIN_PROC) return (sp_Proc *)v.v.p;
+  /* a curried Proc converts to the deferring wrapper, so &partial drives a
+     block wherever a proc would (#3864) */
+  if (v.tag == SP_TAG_OBJ && v.cls_id == SP_BUILTIN_CURRY)
+    return sp_curry_to_proc((sp_Curry *)v.v.p);
   sp_raise_cls("TypeError", "callable object is expected");
   return NULL;
 }
@@ -10302,13 +10320,22 @@ static sp_RbVal sp_curry_realize_poly(sp_Curry *c) {
    reaches the target's arity, and answer the new curry boxed otherwise. The
    static paths kept answering a Curry for a saturating call, so a method taking
    a curried Proc returned a Proc where CRuby returns the value (#4068). */
+/* Proc#curry with a count that arrives BOXED (an untyped slot, a container
+   read): nil is no count, everything else converts through the Integer
+   argument protocol -- CRuby's to_int, the user-object bridge and its exact
+   TypeErrors included. */
+static sp_Curry *sp_curry_new_v(sp_Proc *p, sp_RbVal n, sp_int max) {
+  if (n.tag == SP_TAG_NIL || (n.tag == SP_TAG_INT && n.v.i == SP_INT_NIL))
+    return sp_curry_new(p);
+  return sp_curry_new_n(p, sp_poly_arg_int_chk(n), max);
+}
 static sp_RbVal sp_curry_call_poly(sp_Curry *c, sp_int argc, const sp_RbVal *args) {
   if (!c) return sp_box_nil();
   SP_GC_ROOT(c);
   for (sp_int i = 0; i < argc; i++) c = sp_curry_apply(c, args[i]);
-  sp_int want = c->target ? c->target->arity : 0;
-  if (want < 0) want = -want - 1;   /* variadic: the required count */
-  if (c->nargs >= want) return sp_curry_realize_poly(c);
+  /* the accumulator carries its own completion count -- curry(n)'s n, else
+     the target's required count, stamped at creation */
+  if (c->nargs >= c->arity) return sp_curry_realize_poly(c);
   return sp_box_obj((void *)c, SP_BUILTIN_CURRY);
 }
 
@@ -10319,8 +10346,10 @@ static sp_RbVal sp_curry_call_poly(sp_Curry *c, sp_int argc, const sp_RbVal *arg
 static sp_int sp_curry_proc_fn(void *cap, sp_int argc, sp_int *args) {
   sp_Curry *cy = (sp_Curry *)cap;
   (void)args;
-  for (sp_int i = 0; i < argc && i < 16; i++) cy = sp_curry_apply(cy, _sp_proc_poly_args[i]);
-  _sp_proc_poly_ret = sp_curry_realize_poly(cy);
+  /* apply-and-decide, like every other application path: a call that does
+     not reach the accumulator's count answers the next curry, not the
+     target called short */
+  _sp_proc_poly_ret = sp_curry_call_poly(cy, argc < 16 ? argc : 16, _sp_proc_poly_args);
   return sp_poly_to_i(_sp_proc_poly_ret);
 }
 /* sp_Proc_scan calls cap_scan WITHOUT marking the capture first, so this hook
@@ -10336,11 +10365,13 @@ static sp_Proc *sp_curry_to_proc(sp_Curry *cy) {
    carries, #3885) takes the arguments and realizes once it has them, the way
    the typed `curry[x]` path does. */
 static sp_RbVal sp_poly_callable_call(sp_RbVal v, sp_int n, const sp_int *args) {
-  if (v.tag == SP_TAG_OBJ && v.cls_id == SP_BUILTIN_CURRY) {
-    sp_Curry *cy = (sp_Curry *)v.v.p;
-    for (sp_int i = 0; i < n; i++) cy = sp_curry_apply(cy, _sp_proc_poly_args[i]);
-    return sp_curry_realize_poly(cy);
-  }
+  if (v.tag == SP_TAG_OBJ && v.cls_id == SP_BUILTIN_CURRY)
+    return sp_curry_call_poly((sp_Curry *)v.v.p, n < 16 ? n : 16, _sp_proc_poly_args);
+  /* anything else that is not a Proc is CRuby's NoMethodError -- the raw
+     cast below read a boxed Integer as a proc pointer and crashed (a
+     realized curry applied once more used to reach it) */
+  if (v.tag != SP_TAG_OBJ || !v.v.p || v.cls_id != SP_BUILTIN_PROC)
+    sp_raise_cls("NoMethodError", sp_nomethod_msg("call", v));
   sp_int slots[16];
   for (sp_int i = 0; i < n && i < 16; i++) slots[i] = args[i];
   sp_proc_call((sp_Proc *)v.v.p, n, slots);

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -12508,6 +12508,7 @@ void analyze_program(Compiler *c) {
     ch |= desugar_builtin_class_var_recv(c);   /* k = Array; k.new(..) -> Array.new(..) */
     ch |= desugar_compose_method_operand(c);   /* proc >> meth -> proc >> meth.to_proc */
     ch |= desugar_method_curry(c);             /* meth.curry -> meth.to_proc.curry */
+    ch |= desugar_curry_arity_to_int(c);       /* proc.curry(obj) -> proc.curry(obj.to_int) */
     ch |= desugar_int_enum_with_index(c);      /* n.times.with_index -> n.times.each.with_index */
     ch |= widen_shared_cmp_params(c);          /* multi-class <=> takes its operand boxed */
     ch |= desugar_reduce_proc_arg(c);          /* reduce(&pr) -> reduce { |a,b| pr.call(a,b) } */

--- a/src/analyze.h
+++ b/src/analyze.h
@@ -125,7 +125,7 @@ TyKind ewo_memo_elem_type(Compiler *c, int callid);
 /* For a curry-application node, whether it completes the curry (reaches the base
    proc's arity) and the proc's return type. Returns 1 for a recognized chain. */
 int curry_apply_info(Compiler *c, int node, int *out_complete, TyKind *out_ret);
-int curry_base_info(Compiler *c, int recv, int *nreq, int *variadic, int *is_lambda);
+int curry_count_max(Compiler *c, int recv);
 int ewo_memo_passed_to_callable(Compiler *c, int callid);
 int an_program_builds_methods(Compiler *c);   /* the program builds Method objects at all */
 int ewo_memo_passed_to_callable_at(Compiler *c, int callid, int pidx);

--- a/src/analyze_desugar.c
+++ b/src/analyze_desugar.c
@@ -171,6 +171,52 @@ int desugar_compose_method_operand(Compiler *c) {
   return changed;
 }
 
+/* proc.curry(obj) -> proc.curry(obj.to_int): CRuby converts a non-Integer
+   count through to_int (a to_int-less count is its TypeError). The rewrite
+   fires once per argument -- an arg already spelled to_int, an Integer, or
+   a literal nil (curry's no-count spelling) is left alone. */
+int desugar_curry_arity_to_int(Compiler *c) {
+  NodeTable *nt = (NodeTable *)c->nt;
+  int changed = 0;
+  int n0 = nt->count;
+  for (int id = 0; id < n0; id++) {
+    if (nt_kind(nt, id) != NK_CallNode) continue;
+    const char *nm = nt_str(nt, id, "name");
+    if (!nm || !sp_streq(nm, "curry")) continue;
+    int recv = nt_ref(nt, id, "receiver");
+    if (recv < 0 || infer_type(c, recv) != TY_PROC) continue;
+    int args = nt_ref(nt, id, "arguments");
+    int an = 0; const int *av = args >= 0 ? nt_arr(nt, args, "arguments", &an) : NULL;
+    if (an != 1 || !av) continue;
+    int a0 = av[0];
+    /* Integer, nil-typed and BOXED counts are read at run time
+       (sp_curry_new_v), so only a count of some other settled type -- a
+       to_int object, a Float -- converts here. TY_UNKNOWN waits: the rewrite
+       is irreversible, and firing before the count's type settles wrapped a
+       later-nil method in to_int. */
+    TyKind a0t = infer_type(c, a0);
+    if (nt_kind(nt, a0) == NK_NilNode || a0t == TY_INT || a0t == TY_NIL ||
+        a0t == TY_POLY || a0t == TY_UNKNOWN) continue;
+    const char *anm = nt_kind(nt, a0) == NK_CallNode ? nt_str(nt, a0, "name") : NULL;
+    if (anm && sp_streq(anm, "to_int")) continue;
+    int base = nt->count;
+    int ti = nt_new_node(nt, "CallNode");
+    int na = nt_new_node(nt, "ArgumentsNode");
+    if (ti < 0 || na < 0) continue;
+    nt_node_set_ref(nt, ti, "receiver", a0);
+    nt_node_set_str(nt, ti, "name", "to_int");
+    nt_node_set_ref(nt, ti, "arguments", -1);
+    nt_node_set_ref(nt, ti, "block", -1);
+    nt_node_set_arr(nt, na, "arguments", &ti, 1);
+    nt_node_set_ref(nt, id, "arguments", na);
+    comp_grow_node_arrays(c);
+    int encl = c->nscope[id];
+    for (int j = base; j < nt->count; j++) c->nscope[j] = encl;
+    changed = 1;
+  }
+  return changed;
+}
+
 /* method.curry -> method.to_proc.curry: the Proc curry machinery (arity
    typing, boxed accumulation, param widening) then applies unchanged. The
    rewrite fires once: afterwards curry's receiver is the synthesized

--- a/src/analyze_infer_recv.c
+++ b/src/analyze_infer_recv.c
@@ -278,6 +278,8 @@ int infer_numeric_call(Compiler *c, int id, TyKind rt, TyKind *out) {
   /* A curried proc reports as a lambda Proc (#2651). */
   if (rt == TY_CURRY && argc == 0 && sp_streq(name, "arity")) { *out = TY_INT; return 1; }
   if (rt == TY_CURRY && argc == 0 && sp_streq(name, "lambda?")) { *out = TY_BOOL; return 1; }
+  if (rt == TY_CURRY && argc == 0 && sp_streq(name, "to_proc")) { *out = TY_PROC; return 1; }
+  if (rt == TY_CURRY && argc == 0 && sp_streq(name, "parameters")) { *out = TY_POLY_ARRAY; return 1; }
 
   /* clamp(lo, hi) with a nil (open) bound returns the receiver or the applied
      bound unchanged, boxed to preserve its class (#2588). */

--- a/src/analyze_internal.h
+++ b/src/analyze_internal.h
@@ -260,6 +260,7 @@ int desugar_instance_eval_builtin(Compiler *c);
 int desugar_builtin_class_var_recv(Compiler *c);
 int desugar_compose_method_operand(Compiler *c);
 int desugar_method_curry(Compiler *c);
+int desugar_curry_arity_to_int(Compiler *c);
 int desugar_int_enum_with_index(Compiler *c);
 int widen_shared_cmp_params(Compiler *c);
 int desugar_reduce_proc_arg(Compiler *c);

--- a/src/analyze_pass.c
+++ b/src/analyze_pass.c
@@ -5675,36 +5675,51 @@ TyKind ewo_memo_elem_type(Compiler *c, int callid) {
   return acc2;
 }
 
-/* The arity and body-return type of the proc a curry was built from. */
-/* The base proc of a curry: its required-parameter count, whether it takes a
-   rest param (`*a`, so any arity is acceptable), and whether it is a lambda.
-   Answers 0 when `recv` is not a recognizable proc/lambda definition. */
-int curry_base_info(Compiler *c, int recv, int *nreq, int *variadic, int *is_lambda) {
+/* The maximum count Proc#curry(n) may name for `recv`'s base: requireds +
+   optionals + posts of a visible definition -- CRuby's max_arity, which only
+   the AST can see (the runtime meta carries no maximum). -1: unlimited (a
+   rest), unknown (untraceable, keywords), or already fixed (the runtime
+   validates a non-negative target arity by itself). */
+int curry_count_max(Compiler *c, int recv) {
   NodeTable *nt = (NodeTable *)c->nt;
   int body = -1, pn = -1;
-  if (!fwd_callable_def(c, recv, &body, &pn)) return 0;
-  int rn = 0; if (pn >= 0) nt_arr(nt, pn, "requireds", &rn);
-  if (nreq) *nreq = rn;
-  if (variadic) *variadic = pn >= 0 && nt_ref(nt, pn, "rest") >= 0;
-  if (is_lambda) {
-    const char *bt = nt_type(nt, body);
-    (void)bt;
-    *is_lambda = 0;
-    /* a LambdaNode's body is owned by the lambda node itself */
-    for (int k = 0; k < nt->count; k++) {
-      if (nt_kind(nt, k) != NK_LambdaNode) continue;
-      if (nt_ref(nt, k, "body") == body) { *is_lambda = 1; break; }
-    }
-  }
-  return 1;
+  /* the walker's return demands a body; the max only needs the params, and
+     an empty lambda (`->(x, y = 2) { }`) has params but no body */
+  (void)fwd_callable_def(c, recv, &body, &pn);
+  if (pn < 0) return -1;
+  if (nt_ref(nt, pn, "rest") >= 0) return -1;
+  /* CRuby's max counts the whole keyword hash -- required, optional or
+     **rest -- as one more slot */
+  int kn = 0; nt_arr(nt, pn, "keywords", &kn);
+  int kw1 = (kn > 0 || nt_ref(nt, pn, "keyword_rest") >= 0) ? 1 : 0;
+  int rn = 0, on = 0, po = 0;
+  nt_arr(nt, pn, "requireds", &rn);
+  nt_arr(nt, pn, "optionals", &on);
+  nt_arr(nt, pn, "posts", &po);
+  return rn + on + po + kw1;
 }
 
+/* The arity and body-return type of the proc a curry was built from. */
 static int curry_proc_base(Compiler *c, int recv, int *arity, TyKind *ret) {
   NodeTable *nt = (NodeTable *)c->nt;
   int body = -1, pn = -1;
   if (!fwd_callable_def(c, recv, &body, &pn)) return 0;
-  int rn = 0; if (pn >= 0) nt_arr(nt, pn, "requireds", &rn);
-  *arity = rn;
+  /* CRuby's curry completes at the MIN arity, which counts trailing posts
+     (`->(a, *r, z)`: 2) and required keywords (`->(a, b:)`: 2) alongside the
+     leading requireds -- an undercount realized the curry early, calling the
+     target short. */
+  int rn = 0, po = 0, kreq = 0;
+  if (pn >= 0) {
+    nt_arr(nt, pn, "requireds", &rn);
+    nt_arr(nt, pn, "posts", &po);
+    int kn = 0; const int *kws = nt_arr(nt, pn, "keywords", &kn);
+    for (int k = 0; k < kn && !kreq; k++) {
+      const char *kty = kws ? nt_type(nt, kws[k]) : NULL;
+      /* however many required keywords, CRuby's min counts the one hash */
+      if (kty && sp_streq(kty, "RequiredKeywordParameterNode")) kreq = 1;
+    }
+  }
+  *arity = rn + po + kreq;
   int bn = 0; const int *bb = body >= 0 ? nt_arr(nt, body, "body", &bn) : NULL;
   *ret = bn > 0 ? infer_type(c, bb[bn - 1]) : TY_NIL;
   return 1;
@@ -5727,18 +5742,18 @@ static int curry_chain(Compiler *c, int node, int *applied, int *arity, TyKind *
       /* `curry(n)` fixes the arity the chain completes at, whatever the base
          proc declares -- a `proc { |a, b, c| }` curried at 2 realizes after
          two applications, and a variadic lambda takes its arity from n only
-         (#3680) */
+         (#3680). `curry(nil)` is CRuby's spelling of no count at all. With
+         no count the chain completes at the base's REQUIRED count -- CRuby's
+         min arity -- so a variadic base realizes on its first call, however
+         many arguments it carries (`->(*a) { }.curry.call` invokes). A count
+         the chain cannot read here (a variable, a to_int object) makes
+         saturation a run-time property: hand the chain to the poly path. */
       int ca = nt_ref(nt, node, "arguments");
       int cac = 0; const int *cav = ca >= 0 ? nt_arr(nt, ca, "arguments", &cac) : NULL;
       if (cac == 1 && cav && nt_kind(nt, cav[0]) == NK_IntegerNode)
         *arity = (int)nt_int(nt, cav[0], "value", *arity);
-      else if (*arity == 0) {
-        /* a VARIADIC base with no count takes its arity from the first
-           application; a genuinely zero-arity base realizes with none */
-        int vr = 0;
-        curry_base_info(c, recv, NULL, &vr, NULL);
-        if (vr) *arity = 1;
-      }
+      else if (cac >= 1 && !(cac == 1 && cav && nt_kind(nt, cav[0]) == NK_NilNode))
+        return 0;
       *applied = 0;
       return 1;
     }

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -3120,21 +3120,32 @@ static int emit_complex_rational_call(Compiler *c, int id, Buf *b) {
         return 1;
       }
     }
-    /* Proc#curry and curry application. */
+    /* Proc#curry and curry application. curry(nil) -- literal or a nil-typed
+       variable -- is CRuby's spelling of no count; a real count rides into
+       the accumulator (sp_curry_new_n), whose constructor raises CRuby's
+       ArgumentError when the count leaves the lambda's min..max -- literal
+       and computed counts take the same path, and the AST supplies the max
+       the runtime meta cannot see. */
     if (crt == TY_PROC && sp_streq(name, "curry") &&
-        (argc == 0 || (argc == 1 && comp_ntype(c, argv[0]) == TY_INT))) {
-      /* curry(n) fixes the arity the chain completes at (#3680). A LAMBDA has
-         a fixed arity, so a count that disagrees with it is an ArgumentError
-         -- CRuby raises at the curry call, before anything is applied. */
-      if (argc == 1 && nt_kind(nt, argv[0]) == NK_IntegerNode) {
-        int nreq = 0, variadic = 0, is_lambda = 0;
-        if (curry_base_info(c, recv, &nreq, &variadic, &is_lambda) && is_lambda && !variadic &&
-            (int)nt_int(nt, argv[0], "value", nreq) != nreq) {
-          buf_puts(b, "({ (void)("); emit_expr(c, recv, b);
-          buf_puts(b, "); sp_raise_cls(\"ArgumentError\", \"wrong number of arguments\");"
-                      " (sp_Curry *)NULL; })");
-          return 1;
-        }
+        (argc == 0 ||
+         (argc == 1 && (comp_ntype(c, argv[0]) == TY_INT ||
+                        comp_ntype(c, argv[0]) == TY_NIL ||
+                        comp_ntype(c, argv[0]) == TY_POLY ||
+                        nt_kind(nt, argv[0]) == NK_NilNode)))) {
+      if (argc == 1 && nt_kind(nt, argv[0]) != NK_NilNode) {
+        /* the receiver is usually built right here; root it while the count
+           expression runs, which may allocate (the compose-operand hazard).
+           An int-typed count validates directly; a nil-typed or boxed one is
+           decided at run time, exactly as CRuby's proc_curry reads it. */
+        TyKind cty = comp_ntype(c, argv[0]);
+        int tcn = ++g_tmp;
+        buf_printf(b, "({ sp_Proc *_t%d = ", tcn); emit_expr(c, recv, b);
+        buf_printf(b, "; SP_GC_ROOT(_t%d); sp_curry_new_%s(_t%d, ", tcn,
+                   cty == TY_INT ? "n" : "v", tcn);
+        if (cty == TY_INT) emit_int_expr(c, argv[0], b);
+        else emit_boxed(c, argv[0], b);
+        buf_printf(b, ", %d); })", curry_count_max(c, recv));
+        return 1;
       }
       buf_puts(b, "sp_curry_new("); emit_expr(c, recv, b); buf_puts(b, ")");
       return 1;
@@ -3151,6 +3162,23 @@ static int emit_complex_rational_call(Compiler *c, int id, Buf *b) {
       buf_printf(b, "({ sp_Curry *_t%d = ", tcl); emit_expr(c, recv, b);
       buf_printf(b, "; (sp_bool)(_t%d && _t%d->target ? _t%d->target->lambda_p : 0); })",
                  tcl, tcl, tcl);
+      return 1;
+    }
+    if (crt == TY_CURRY && argc == 0 && sp_streq(name, "to_proc")) {
+      /* the wrapping proc applies its call's arguments and realizes (#3864) */
+      buf_puts(b, "sp_curry_to_proc("); emit_expr(c, recv, b); buf_puts(b, ")");
+      return 1;
+    }
+    if (crt == TY_CURRY && argc == 0 && sp_streq(name, "parameters")) {
+      /* a curried proc's parameters are CRuby's [[:rest]], whatever the base.
+         The sym table is sealed by now, so :rest interns at run time. */
+      int tro = ++g_tmp, tri = ++g_tmp;
+      buf_puts(b, "({ (void)("); emit_expr(c, recv, b);
+      buf_printf(b, "); sp_PolyArray *_t%d = sp_PolyArray_new(); SP_GC_ROOT(_t%d);"
+                    " sp_PolyArray *_t%d = sp_PolyArray_new(); SP_GC_ROOT(_t%d);"
+                    " sp_PolyArray_push(_t%d, sp_box_sym(sp_sym_intern_n(\"rest\", 4)));"
+                    " sp_PolyArray_push(_t%d, sp_box_poly_array(_t%d)); _t%d; })",
+                 tro, tro, tri, tri, tri, tro, tri, tro);
       return 1;
     }
     /* A zero-argument application is legal: it applies nothing, and on a

--- a/test/proc_curry_arity.rb
+++ b/test/proc_curry_arity.rb
@@ -1,0 +1,144 @@
+# Proc#curry with no count realizes at the base's REQUIRED count -- CRuby's
+# min arity -- so a variadic base invokes on its first call, however many
+# arguments that call carries.
+p ->(*v) { v.length }.curry.call
+p ->(*v) { v.sum }.curry[5]
+p ->(x, *r) { [x, r] }.curry.call(1)
+p ->(x, y = 2) { [x, y] }.curry.call(1)
+
+# A Method curries through the same machinery.
+def count_values(*values)
+  values.length
+end
+p method(:count_values).curry.call.class
+
+# curry(nil) is the no-count spelling; a real count fixes the completion
+# point, and a fixed-arity lambda validates it up front.
+p proc { |x| x }.curry(nil).call(2)
+begin
+  ->(x) { x }.curry(2)
+rescue ArgumentError => e
+  p [e.class, e.message]
+end
+p ->(*v) { v.length }.curry(3).class
+p ->(*v) { v.length }.curry(3)[1][2][3]
+p proc { |x| x }.curry(5).class
+
+# The count can be computed, or anything with a to_int -- and it is honored:
+# a computed 3 on a two-parameter proc realizes at 3, leniently.
+n = 2
+add = ->(a, b) { a + b }
+p add.curry(n)[3][4]
+n3 = 3
+pr = proc { |a, b| [a, b] }
+p pr.curry(n3)[1][2][3]
+class Arity
+  def to_int
+    1
+  end
+end
+p proc { |value| value }.curry(Arity.new).call(7)
+def count_values2(*values)
+  values.length
+end
+p method(:count_values2).curry(Arity.new)[9]
+
+# A computed count still validates against the lambda's min..max, the count
+# expression may allocate while the fresh receiver waits, and non-Integer
+# applications of a counted curry apply rather than index.
+def alloc_two(x)
+  ("a" * x).length
+end
+p ->(a, b) { a + b }.curry(alloc_two(2))[1][2]
+begin
+  cv = ->(x, y = 2) { }.curry(3)
+  p cv.class
+rescue ArgumentError => e
+  p [e.class, e.message]
+end
+p ->(x, y = 2) { [x, y] }.curry(2)[7][8]
+p add.curry(n)["x"]["y"]
+p add.curry(n)[1.5][2.5]
+
+# A count that arrives boxed is read at run time, CRuby's way: an Integer
+# counts, nil is no count, anything else is the TypeError -- and the boxed
+# path works even beside the user to_int above.
+hc = { i: 2, f: 2.7, z: nil, s: "two" }
+p add.curry(hc[:i])[3][4]
+p add.curry(hc[:z])[3][4]
+arr2 = [1, 2]
+p add.curry(arr2[10])[1][2]
+hA = { o: Arity.new, t: true }
+p proc { |v| v }.curry(hA[:o]).call(7)
+begin
+  add.curry(hA[:t])
+rescue TypeError => e
+  p [e.class, e.message]
+end
+begin
+  add.curry(hc[:s])
+rescue TypeError => e
+  p [e.class, e.message]
+end
+def no_count(tag)
+  nil
+end
+p add.curry(no_count("a"))[1][2]
+
+# The max sees a keyword hash as one more slot, a required-keyword hash
+# counts once toward the min, and a mistraced max defers to the target.
+begin
+  cv = ->(a, **k) { a }.curry(5)
+  p cv.class
+rescue ArgumentError => e
+  p [e.class, e.message]
+end
+k2 = ->(a, x:, y:) { [a, x, y] }
+begin
+  p k2.curry[1][2].class
+rescue ArgumentError => e
+  p e.class
+end
+sh = ->(x) { x }
+sh = ->(a, b, e2) { a + b + e2 }
+p sh.curry(3).call(1).call(2).call(3)
+
+# A partial application keeps its manners: to_proc defers, a block-pass
+# operand drives elementwise -- at any chain depth -- and a container call
+# site completes. A realized value applied once more refuses loudly.
+q4 = ->(a, b, c1, d) { a + b + c1 + d }.curry(idn = 4)
+part3 = q4[1][2][3]
+p [1, 2].map(&part3)
+def keeper(&blk)
+  blk.call(30)
+end
+p keeper(&q4[1][2][3])
+begin
+  proc { |*a| [a] }.curry(1)[1].call(2)
+rescue NoMethodError => e
+  p [e.class, e.message]
+end
+partial = add.curry(n)
+part10 = partial[10]
+p [1, 2, 3].map(&part10)
+c2 = ->(a, b) { a + b }.curry
+p c2.to_proc.call(1).class
+g2 = { f: c2 }[:f]
+p g2.call(1)[2]
+
+# The completion count sees trailing posts and required keywords.
+pz = ->(a, *r, z) { [a, r, z] }
+p pz.curry[1][2]
+kw = ->(a, b:) { [a, b] }
+p kw.curry[1].class
+
+# A curried proc travels through a container and keeps applying.
+f = ->(a, b) { a + b }.curry
+h = { f: f[1] }
+p h[:f][2]
+
+# Reflection: parameters is CRuby's [[:rest]] whatever the base; to_proc
+# wraps the accumulator in a callable Proc.
+c = ->(a, b) { a + b }.curry
+p c.parameters
+p c.to_proc.call(1, 2)

--- a/test/proc_curry_arity.rb.expected
+++ b/test/proc_curry_arity.rb.expected
@@ -1,0 +1,40 @@
+0
+5
+[1, []]
+[1, 2]
+Integer
+2
+[ArgumentError, "wrong number of arguments (given 2, expected 1)"]
+Proc
+3
+Proc
+7
+[1, 2]
+7
+1
+3
+[ArgumentError, "wrong number of arguments (given 3, expected 1..2)"]
+[7, 8]
+"xy"
+4.0
+7
+7
+3
+7
+[TypeError, "no implicit conversion of true into Integer"]
+[TypeError, "no implicit conversion of String into Integer"]
+3
+[ArgumentError, "wrong number of arguments (given 5, expected 1..2)"]
+ArgumentError
+6
+[7, 8]
+36
+[NoMethodError, "undefined method 'call' for an instance of Array"]
+[11, 12, 13]
+Proc
+3
+[1, [], 2]
+Proc
+3
+[[:rest]]
+3


### PR DESCRIPTION
## Why

Currying is how Ruby code builds specialized functions from general ones — `add.curry[1]` and friends show up in ordinary functional code. Spinel's curry deferred forever on the shapes CRuby completes: `->(*values) { values.length }.curry.call` answered a Proc where Ruby invokes and answers 0, so a program that curried anything variadic (or a Method, which curries through the same machinery) silently got an accumulator object where it expected a result. `curry(nil)` and any computed count refused to compile, and a curried proc stored in a hash came back unusable.

Concretely:

- A zero-required variadic base was special-cased to realize only after a first application, so `curry.call` with no arguments handed back another accumulator, typed Proc, where CRuby invokes at the minimum arity — zero — and answers the value.
- A *computed* count compiled but was silently ignored: the static chain traced the base's own arity instead, so `pr.curry(n)[1][2][3]` with n = 3 answered nil. And the compile-time count check mis-fired on optional-parameter lambdas: `->(x, y = 2) { [x, y] }.curry(2)[7][8]` raised ArgumentError where CRuby answers `[7, 8]`.
- `curry(nil)` (CRuby's no-count spelling) and `curry(obj)` with a `to_int`-answering object were unsupported-call compile errors.
- `h = { f: add.curry[1] }; h[:f][2]` answered nil — the poly index path had no idea a boxed curry applies rather than indexes.
- `curried.parameters` was a compile error (CRuby: `[[:rest]]`) and `curried.to_proc.call` a runtime NoMethodError.

## What

- A curry now completes exactly where CRuby's does: at `curry(n)`'s n when given, else the base's min arity — required parameters, trailing posts and required keywords included. The count is stamped into the accumulator and every application path defers or realizes by it: the static chain, the runtime saturation helper, `to_proc`'s wrapper, boxed callable calls, and container reads.
- A curried proc read out of a container applies its `[]` argument whatever the key kind — String, Symbol, Float and object keys used to fall into the key-typed hash reads and answer nil.
- A partial carried in a container or an untyped slot now converts under `&` — into user `&blk` methods, `yield` and `.call` — via a curry arm in `sp_poly_to_proc`, the `&obj` conversion point (partials bound to a local already drove builtin iterators through the block-arg desugar). And calling a boxed non-callable raises CRuby's exact NoMethodError — for every value kind, curry or not: a realized curry applied once more used to crash on a raw proc cast, and `h[:z].call` on a nil answered 0 where CRuby raises.
- `curry(nil)`, computed counts, boxed counts out of containers, and `to_int`-convertible counts all work and are honored; a boxed count is read at run time exactly as CRuby's `proc_curry` reads it — nil (an int-typed slot's nil sentinel included) is no count, and everything else converts through the runtime's Integer argument protocol, the user-object `to_int` bridge and CRuby's exact TypeErrors included, and the count validates against the lambda's min..max up front with CRuby's ArgumentError and its exact expected form (`1`, `1..2`, `1+`; a keyword hash counts as one more slot) — replacing the compile-time check that raised a countless message, mis-fired on optional-parameter lambdas CRuby accepts, and skipped computed counts (and their side effects) entirely.
- A curried proc read out of a container applies through `[]`, realizing when it completes.
- `parameters` answers `[[:rest]]` whatever the base; `to_proc` hands back the callable wrapper the runtime already had.

## How

- `sp_Curry` (lib/sp_proc.h) carries its completion count, stamped at creation: `sp_curry_new` derives the min from the target's arity (negatives encode it as `-req-1`); the new `sp_curry_new_n` validates an explicit count against min..max — the max passed in by the compiler, which alone can see optionals (a compile-time guess below the target's own min defers to the target) — and stores it; and `sp_curry_new_v` reads a boxed count at run time through `sp_poly_arg_int_chk`, the runtime's existing Integer argument protocol. `sp_curry_call_poly` reads the stored count, `sp_curry_apply`'s struct copy carries it, and the `to_proc` trampoline and `sp_poly_callable_call` both delegate to the same saturation decision instead of realizing count-blind. The `curry(n)` emission roots the receiver while the count expression runs — a freshly built proc was otherwise collectible under an allocating count.
- The static curry chain (src/analyze_pass.c) drops its variadic special case (arity from the required count now), reads `curry(nil)` as no count, and declines to trace a computed count — those chains fall to the runtime saturation path, which decides with the stored count. The compile-time count check and `curry_base_info`, its last caller, are deleted in favor of the constructor's runtime check.
- A new desugar (src/analyze_desugar.c) rewrites `proc.curry(obj)` to `proc.curry(obj.to_int)` only for a count of some settled non-Integer type (a `to_int` object, a Float) — Integer, nil, boxed and not-yet-settled counts are left for the arm, so the rewrite never fires on the wrong fixpoint round; the codegen curry arm accepts nil and any int-typed, nil-typed or boxed count expression.
- The poly index paths (lib/spinel_rt.h) gain curry arms — the boxed-key entry point ahead of its key-typed dispatch, the String- and Symbol-keyed reads, and the cold integer path — so one rule covers every key kind: a curried receiver applies, everything else indexes.
- Two small TY_CURRY codegen arms: `to_proc` emits the existing `sp_curry_to_proc`; `parameters` builds `[[:rest]]`, interning `:rest` at run time (the TU's symbol table is sealed before this arm runs).

## Validation

- `make test`: green, including the new `test/proc_curry_arity.rb` (40 expected lines, CRuby-4.0.6-generated, plain and under `SPINEL_GC_STRESS=1`).
- Generated-C sweep across all 3,394 pre-existing suite/benchmark programs: byte-identical except three curry tests whose diff is the counted constructor (receiver rooted, static max supplied) at their `curry(n)` sites — all three still match CRuby end-to-end.
- Differential corpus of ~2,100 minimized programs (same corpus behind #3999/#4003/#4029): 766 -> 774 match, 8 gained and 0 lost — the variadic curry invocations (Proc and Method), curry(nil), both to_int counts, the container-carried application, parameters, and to_proc. Nothing lost in any of the four full replays run during development.

## Left alone, on purpose

- A TYPED count with no `to_int` raises `NoMethodError: undefined method 'to_int'` where CRuby raises `TypeError: no implicit conversion into Integer` — the desugar spells CRuby's conversion, not its refusal message; a boxed count gets CRuby's TypeError through the argument protocol (whose existing family renderings differ from CRuby's on a `to_int` answering the wrong type or raising, and truncate a bignum count where CRuby raises RangeError). A `to_int` answering a statically non-nil non-Integer stays a compile error; one whose return infers nil — or returns nil at run time — reads as no count where CRuby raises, the price of the nil-sentinel rule. The conversion runs once, on both paths, where CRuby re-runs it per application.
- The count validates against the max only where the compiler can see the parameter list; a curry built from an untraceable optional-parameter base checks the min alone, with the `min+` message form.
- Nil counts of every provenance — literals, nil-typed expressions, nil-holding locals, boxed nils, and an int-typed slot's nil sentinel (`curry(arr[10])`) — read as no count.
- A curry counted above the 16-slot argument channel (`curry(17)`) can never realize — the accumulator caps at 16 applications, a family-wide limit that an explicit count now makes visible.
- An INLINE partial application as a block operand on a builtin iterator (`[1, 2].map(&partial[10])` with a run-time count) refuses at run time, and the refusal renders as the iterator's own NoMethodError rather than pointing at the operand; bind the partial to a local first. This is the one shape master answered better: ignoring the computed count gave right answers exactly when the count equaled the base's arity. A boxed partial has the same builtin-iterator gap (`map(&h[:p])`), identical on master; `find`/`detect`/`find_index` with any `&partial` fail the C build on master and branch alike; and with a user `#call` defined anywhere, block-passing any poly-carried callable into a builtin iterator misses — the pre-existing user-dispatch stand-down.
- A count expression that needs statement hoisting evaluates its hoisted part before the receiver — the emitter's pre-statement buffer, shared with other call shapes; the receiver-first order holds for inline counts, and master dropped such counts entirely.
- Reflection on a curry read out of a container (`h[:f].arity`, `.parameters`) still misses — the poly reflection arms know Proc and Method but not the curry, a pre-existing asymmetry; `class` answers Proc correctly. Likewise `curried.curry` (CRuby allows re-currying), explicit `inspect`/`to_s` and `puts` on a curry, `p` printing without CRuby's `(lambda)` marker, and `curry.to_proc.parameters` (`[]` vs `[[:rest]]`) predate this change.
- Under `--int-overflow=promote` the test now compiles (boxed counts fixed the former build refusal); the run still stops partway there on the pre-existing promote-mode arithmetic family shared with other suite tests (nothing in CI sets the mode, and the Makefile's mode filter is the precedent for excluding such tests if it ever does).
- The curry arms link ~1.3KB of text into programs whose poly index cold path is reachable, and nothing into programs where it is not (object files byte-identical); generated C stays byte-identical, and the hot inline path is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved `Proc#curry` and `Method#curry` arity handling, including explicit counts and `nil`.
  - Added support for computed and convertible curry counts.
  - Enhanced partial application, container calls, `to_proc`, and parameter reflection.
  - Added validation for optional, keyword, post, and variadic arguments.

- **Bug Fixes**
  - Corrected curry completion behavior across boxed and polymorphic values.
  - Added clearer errors for invalid curry counts and unsupported callable receivers.
  - Improved handling of keyword hashes and block arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->