### PR TITLE
Bind an object call to a rest parameter

### DIFF
--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -7059,6 +7059,22 @@ int rest_shortfall_required(Compiler *c, Scope *m) {
   return nreq;
 }
 
+/* The count a call with a trailing splat supplies, in a temp: `lead` positional
+   arguments plus whatever the array holds. */
+static int emit_rest_given_count(int lead, int splat_tmp) {
+  int gv = ++g_tmp;
+  emit_indent(g_pre, g_indent);
+  buf_printf(g_pre, "sp_int _t%d = %d + (_t%d ? _t%d->len : 0);\n", gv, lead, splat_tmp, splat_tmp);
+  return gv;
+}
+/* The run-time half of the rest shortfall check: refuse the measured count. */
+static void emit_rest_shortfall_raise(int given_tmp, int req) {
+  emit_indent(g_pre, g_indent);
+  buf_printf(g_pre,
+             "if (_t%d < %d) sp_raise_cls(\"ArgumentError\", sp_sprintf(\"wrong number of arguments (given %%lld, expected %d+)\", (long long)_t%d));\n",
+             given_tmp, req, req, given_tmp);
+}
+
 void emit_args_filled(Compiler *c, int callee_idx, int argsNode, const char *lead, Buf *out) {
   Scope *m = &c->scopes[callee_idx];
   const NodeTable *nt = c->nt;
@@ -7268,6 +7284,13 @@ void emit_args_filled(Compiler *c, int callee_idx, int argsNode, const char *lea
           emit_indent(g_pre, g_indent);
           buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", splat_tmp);
           free(anon.p);
+          /* A rest target's shortfall, when the count is in the splat: the
+             same rule the static check below applies, judged at run time. */
+          if (m->rest_idx >= 0 && kwh < 0 && k == pos_argc - 1) {
+            int rreq = rest_shortfall_required(c, m);
+            if (rreq >= 0)
+              emit_rest_shortfall_raise(emit_rest_given_count(splat_idx, splat_tmp), rreq);
+          }
           /* Arity check: splatting into a fixed-arity (no-rest) method must
              supply a valid element count, else CRuby raises ArgumentError.
              Only emit when the splat is the last positional group, so the
@@ -7588,6 +7611,23 @@ int dispatch_impl_count(Compiler *c, int cid, const char *name) {
   return n;
 }
 
+/* The smallest count any implementation this dispatch may enter requires of a
+   rest-parameter call, or -1 when one of them binds by other rules and stands
+   the check down. A switch cannot know which arm it takes, so the arm that
+   asks least sets the bar; a direct call reads its own target instead. */
+static int dispatch_min_rest_required(Compiler *c, int cid, const char *name) {
+  int req = -1, seen = 0;
+  for (int k = 0; k < c->nclasses; k++) {
+    if (!is_descendant(c, k, cid)) continue;
+    int kmi = comp_method_in_chain(c, k, name, NULL);
+    if (kmi < 0) continue;
+    int kreq = rest_shortfall_required(c, &c->scopes[kmi]);
+    if (kreq < 0) return -1;
+    if (!seen || kreq < req) { req = kreq; seen = 1; }
+  }
+  return seen ? req : -1;
+}
+
 /* Append `, <arg>` for dispatch arm `arm`'s parameter `a`, coercing the shared
    pre-evaluated temp `atmp[a]` (of C type `from`) to that arm's declared param
    type: a concrete value flowing into an sp_RbVal (untyped/poly) param is boxed,
@@ -7638,6 +7678,20 @@ void emit_dispatch(Compiler *c, int cid, const char *name,
 
   int argc = 0;
   const int *argv = argsNode >= 0 ? nt_arr(nt, argsNode, "arguments", &argc) : NULL;
+  /* Force a runtime switch when there is no base implementation (m == NULL):
+     a template method defined only in subclasses cannot be called directly as
+     sp_<base>_<name>, so even a single descendant impl must dispatch virtually. */
+  int impl_n = dispatch_impl_count(c, cid, name);
+  /* A void/nil-returning method that subclasses override must still dispatch on
+     the runtime class -- an implicit-self call to it from a base method (e.g.
+     `def run; validate; end` where each subclass overrides `validate`) would
+     otherwise bind statically to the base impl and skip the override (#1443).
+     The GCC statement-expression wrapper can't declare a `void` result, so a
+     void dispatch uses a dummy int temp (its value is discarded). */
+  int ret_is_void = (ret == TY_VOID || ret == TY_NIL);
+  TyKind disp_ret = ret_is_void ? TY_INT : ret;
+  int virtual = (is_scalar_ret(ret) || ret_is_void) && (impl_n > 1 || (!m && impl_n >= 1));
+
   /* Arity check, the same one the free-function path already made: an over- or
      under-supplied instance call went through with the extra arguments simply
      dropped (#3677). Static shapes only -- any splat, keyword hash, rest or
@@ -7688,6 +7742,50 @@ void emit_dispatch(Compiler *c, int cid, const char *name,
       sp_streq(nt_type(nt, argv[argc - 1]), "KeywordHashNode")) {
     kwh_d = argv[argc - 1]; pos_argc_d = argc - 1;
   }
+  /* The count a rest-parameter target refuses for lack of arguments, by the
+     rule the by-name lowering follows: a rest lifts the upper bound, not the
+     requirement below it, and `P.new.m` on `def m(x, *y)` ran the body with a
+     padded x. A direct call knows its target and is judged by that method
+     alone. A switch may enter any arm below the receiver's static class, and an
+     override with a default where the base has a required parameter takes a
+     call the base refuses -- so a switch is judged by the smallest count its
+     arms require, and one arm that binds by other rules (a keyword parameter,
+     a synthesized one) stands the check down. */
+  int rest_req_d = virtual ? dispatch_min_rest_required(c, cid, name)
+                           : (m ? rest_shortfall_required(c, m) : -1);
+  /* The parameters AFTER the rest are the call's last arguments -- as long as
+     those can be named here. An argument that spreads at run time (a splat, a
+     forwarded `...`), or a keyword hash that degrades into one more positional
+     at the tail, leaves their positions to a length only the call knows. The
+     binding stays as it was in that case: the rest takes everything spread and
+     each post its default, rather than a post fed the spreading node itself,
+     which is not one argument at all. */
+  int posts_dyn_d = 0;
+  if (m && m->rest_idx >= 0 && m->npost_rest > 0 && kwh_d >= 0)
+    posts_dyn_d = 1;   /* the hash may degrade to one more positional at the tail */
+  if (argv && m && m->rest_idx >= 0 && m->npost_rest > 0 && !posts_dyn_d)
+    for (int k = pos_argc_d - m->npost_rest; k < pos_argc_d; k++) {
+      const char *at = k >= 0 ? nt_type(nt, argv[k]) : NULL;
+      if (at && (sp_streq(at, "SplatNode") || sp_streq(at, "ForwardingArgumentsNode")))
+        { posts_dyn_d = 1; break; }
+    }
+  /* An argument the static count cannot measure: a splat's own run-time check
+     below judges it, and a forwarded or double-splatted list stands the check
+     down. A block argument is counted here only because pos_argc_d counts it
+     as a positional. */
+  int dyn_argc_d = 0;
+  for (int k = 0; argv && k < argc && !dyn_argc_d; k++) {
+    const char *at = nt_type(nt, argv[k]);
+    if (!at) continue;
+    if (sp_streq(at, "SplatNode") || sp_streq(at, "ForwardingArgumentsNode") ||
+        sp_streq(at, "BlockArgumentNode")) dyn_argc_d = 1;
+    else if (sp_streq(at, "KeywordHashNode")) {
+      int en = 0; const int *els = nt_arr(nt, argv[k], "elements", &en);
+      for (int e = 0; e < en && !dyn_argc_d; e++)
+        if (els && nt_type(nt, els[e]) && sp_streq(nt_type(nt, els[e]), "AssocSplatNode"))
+          dyn_argc_d = 1;
+    }
+  }
   /* Materialize a forwarded `**hash` inside kwh_d so keyword params extract
      from it and a `**kwrest` callee param collects it -- the same handling
      emit_args_filled applies (previously this path dropped every keyword
@@ -7706,12 +7804,25 @@ void emit_dispatch(Compiler *c, int cid, const char *name,
   const char *saved_self = g_self;
   /* A positional SplatNode `obj.f(*args)` expands across the fixed params, the
      same way emit_args_filled handles it for free-function calls: pre-evaluate
-     the array to a rooted temp and fill each param from it. Scoped to a fixed-
-     arity callee (no rest param). */
+     the array to a rooted temp and fill each param from it. A splat reaching a
+     rest parameter needs the same expansion for the fixed params ahead of it --
+     without it the array went into the first parameter whole, an ill-typed one
+     as a C build failure -- but only for `obj.m(*args)` outright. The
+     pre-evaluation hoists the operand, so an argument written to its left would
+     run after it; anything to its right slides by a length only the array
+     knows; a keyword hash beside it belongs at the rest's tail, which this
+     packing does not carry; and a target whose shortfall cannot be judged (a
+     keyword parameter, a synthesized one) would run padded where the call is
+     refused today. A splat at or past the rest slot needs no expansion at all:
+     the rest collection spreads the operand itself. */
   int splat_idx_d = -1, splat_tmp_d = -1; TyKind splat_at_d = TY_UNKNOWN;
-  for (int k = 0; m && m->rest_idx < 0 && k < pos_argc_d; k++) {
+  int rest_given_d = -1;   /* the measured count, refused after the arguments run */
+  for (int k = 0; m && k < pos_argc_d; k++) {
     if (argv && nt_type(nt, argv[k]) && sp_streq(nt_type(nt, argv[k]), "SplatNode") &&
-        k < m->nparams) {
+        (m->rest_idx >= 0
+           ? (k == 0 && pos_argc_d == 1 && kwh_d < 0 && k < m->rest_idx &&
+              !posts_dyn_d && rest_req_d >= 0)
+           : k < m->nparams)) {
       int inner = nt_ref(nt, argv[k], "expression");
       splat_at_d = inner >= 0 ? comp_ntype(c, inner) : TY_UNKNOWN;
       Buf anon; memset(&anon, 0, sizeof anon);
@@ -7739,8 +7850,14 @@ void emit_dispatch(Compiler *c, int cid, const char *name,
         buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", splat_tmp_d);
         free(anon.p);
         /* Arity check when the splat is the last positional group: the total
-           given count is splat_idx + array length. */
-        if (k == pos_argc_d - 1) {
+           given count is splat_idx + array length. A rest target has no upper
+           bound, so only its shortfall is judged. */
+        /* measure here, where the array is; refuse below, once the other
+           arguments have run -- CRuby evaluates them all before the count is
+           judged, and this loop is ahead of them */
+        if (m->rest_idx >= 0 && rest_req_d >= 0 && kwh_d < 0 && k == pos_argc_d - 1)
+          rest_given_d = emit_rest_given_count(splat_idx_d, splat_tmp_d);
+        else if (m->rest_idx < 0 && k == pos_argc_d - 1) {
           int pos_required = 0, pos_params = 0;
           positional_arity(c, m, &pos_required, &pos_params);
           char expbuf[48];
@@ -7769,10 +7886,29 @@ void emit_dispatch(Compiler *c, int cid, const char *name,
          unconsumed keyword hash degrades to one positional hash at the rest's
          tail -- the same rule the other call path follows. Dropping it here
          made `c.splat_only(id: :desc)` run with no arguments at all, silently,
-         while the identical top-level call kept it (#3503). */
-      emit_rest_pack_kwh(c, k, pos_argc_d, argv, rest_kwh_tail(c, m, kwh_d, pos_argc_d), &ab);
+         while the identical top-level call kept it (#3503). The parameters
+         AFTER the rest are the call's last arguments, so the rest stops before
+         them: it collected them too, and each post then read the argument one
+         place to its left. */
+      int rest_end_d = posts_dyn_d ? pos_argc_d : pos_argc_d - m->npost_rest;
+      if (splat_tmp_d >= 0)
+        emit_rest_from_splat_and_argv(splat_tmp_d, splat_at_d, k - splat_idx_d,
+                                      c, splat_idx_d + 1, rest_end_d, argv, &ab);
+      else
+        emit_rest_pack_kwh(c, k, rest_end_d, argv, rest_kwh_tail(c, m, kwh_d, pos_argc_d), &ab);
       emit_indent(g_pre, g_indent);
       buf_printf(g_pre, "sp_PolyArray *_t%d = %s;\n", atmp[k], ab.p ? ab.p : "sp_PolyArray_new()");
+      /* The packed rest is a fresh array in a plain C temporary: a splat's
+         packing roots its accumulator only while it builds it, and the other
+         packing's shortcuts (a lone typed splat converted whole, an empty
+         rest) hand back an allocation with no root at all. Root it whenever
+         the call still has something to evaluate -- a parameter after the
+         rest, or a block literal -- because each of those allocates, and a
+         collected rest is recycled straight into the next array. */
+      if (k < np - 1 || blk_node >= 0) {
+        emit_indent(g_pre, g_indent);
+        buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", atmp[k]);
+      }
       atmp_ty[k] = TY_POLY_ARRAY;
     }
     else if (fwd_encl && fwd_base_d + k < fwd_encl->nparams) {
@@ -7803,6 +7939,21 @@ else {
          Mirrors the callee_param_is_declared_kwarg guard in emit_args_filled. */
       int is_declkw_d = m && callee_param_is_declared_kwarg(c, m, m->pnames[k]);
       int _sl = arg_slot_for_param(c, m, k, pos_argc_d);
+      /* a parameter after the rest is filled from the END of the call's
+         positionals -- the rest takes the middle (#3204's neighbour rule, the
+         one emit_args_filled and the inline lowerings already follow) */
+      int is_post_d = m && m->rest_idx >= 0 && m->npost_rest > 0 && !posts_dyn_d &&
+                      k > m->rest_idx && k <= m->rest_idx + m->npost_rest;
+      if (is_post_d) {
+        int aidx = pos_argc_d - m->npost_rest + (k - m->rest_idx - 1);
+        _sl = (aidx >= 0 && aidx < pos_argc_d) ? aidx : -1;
+      }
+      /* the posts are funded from the end, so the parameters ahead of the rest
+         reach only the arguments before them: an optional that read past that
+         point took the post's argument as well, binding it twice */
+      else if (m && m->rest_idx >= 0 && m->npost_rest > 0 && !posts_dyn_d &&
+               k < m->rest_idx && _sl >= pos_argc_d - m->npost_rest)
+        _sl = -1;
       int provided = kv >= 0 ? kv : ((_sl >= 0 && !is_declkw_d) ? argv[_sl] : -1);
       /* Options-hash idiom: a trailing keyword hash whose keys name no
          parameter collapses into the first unfilled positional param when
@@ -7823,8 +7974,11 @@ else {
         /* keyword param fed by a forwarded `**hash`: extract by name. */
         emit_ds_param_extract(c, m, k, ds_tmp_d, ds_type_d, &ab);
       }
-      else if (splat_tmp_d >= 0 && k >= splat_idx_d) {
-        /* fill this fixed param from the splatted array at offset k-splat_idx */
+      else if (splat_tmp_d >= 0 && k >= splat_idx_d && kv < 0 && !is_declkw_d &&
+               (m->rest_idx < 0 || k < m->rest_idx)) {
+        /* fill this fixed param from the splatted array at offset k-splat_idx.
+           Only the parameters ahead of a rest are filled this way: a keyword
+           binds by name and a post from the end of the call. */
         int off = k - splat_idx_d;
         TyKind set = ty_array_elem(splat_at_d);
         Buf eb; memset(&eb, 0, sizeof eb);
@@ -7889,6 +8043,17 @@ else {
     free(ab.p);
   }
 
+  /* Too few arguments for a rest-parameter target: CRuby's ArgumentError,
+     where the body ran with the missing parameters padded out. The raise sits
+     after the argument temps because CRuby evaluates a call's arguments before
+     the method refuses their count. */
+  int eff_pos_d = pos_argc_d + (kwh_d >= 0 ? 1 : 0);
+  if (rest_given_d >= 0) emit_rest_shortfall_raise(rest_given_d, rest_req_d);
+  if (rest_req_d >= 0 && !dyn_argc_d && eff_pos_d < rest_req_d) {
+    emit_indent(g_pre, g_indent);
+    buf_printf(g_pre, "sp_raise_cls(\"ArgumentError\", \"wrong number of arguments (given %d, expected %d+)\");\n",
+               eff_pos_d, rest_req_d);
+  }
   /* &block param that escapes: pre-evaluate the block as sp_Proc * temp.
      When the call site has no block, blk_tmp stays -1 and we pass NULL. */
   int blk_tmp = -1;
@@ -7908,20 +8073,6 @@ else {
 
   /* The aliased name may differ from the defining method's real name. */
   const char *mname = m ? m->name : name;
-
-  /* Force a runtime switch when there is no base implementation (m == NULL):
-     a template method defined only in subclasses cannot be called directly as
-     sp_<base>_<name>, so even a single descendant impl must dispatch virtually. */
-  int impl_n = dispatch_impl_count(c, cid, name);
-  /* A void/nil-returning method that subclasses override must still dispatch on
-     the runtime class -- an implicit-self call to it from a base method (e.g.
-     `def run; validate; end` where each subclass overrides `validate`) would
-     otherwise bind statically to the base impl and skip the override (#1443).
-     The GCC statement-expression wrapper can't declare a `void` result, so a
-     void dispatch uses a dummy int temp (its value is discarded). */
-  int ret_is_void = (ret == TY_VOID || ret == TY_NIL);
-  TyKind disp_ret = ret_is_void ? TY_INT : ret;
-  int virtual = (is_scalar_ret(ret) || ret_is_void) && (impl_n > 1 || (!m && impl_n >= 1));
 
   if (!virtual) {
     /* a value-type receiver is passed by value (no pointer cast) */
@@ -7954,6 +8105,18 @@ else {
        class can't be the receiver here anyway. Same guard as the poly-dispatch
        loops in codegen_call.c (issue #1583). */
     if (!scope_has_callable_symbol(c, kmi)) continue;
+    /* The count is judged again per arm, because the switch knows the receiver
+       the check above could only guess at: with arms that disagree -- an
+       override with a default where the base has a required parameter -- the
+       smallest requirement kept the call, and a receiver of the stricter class
+       then ran with a padded parameter. Each arm answers for its own method,
+       the way the class-method dispatch does. */
+    { int areq = !dyn_argc_d ? rest_shortfall_required(c, &c->scopes[kmi]) : -1;
+      if (areq >= 0 && eff_pos_d < areq) {
+        buf_printf(b, " case %d: sp_raise_cls(\"ArgumentError\", \"wrong number of arguments (given %d, expected %d+)\"); break;",
+                   k, eff_pos_d, areq);
+        continue;
+      } }
     TyKind arm_ret = (TyKind)c->scopes[kmi].ret;
     const char *kfn = mc(c->scopes[kmi].name);
     if (method_is_void(&c->scopes[kmi])) {

--- a/test/object_call_rest_params.rb
+++ b/test/object_call_rest_params.rb
@@ -1,0 +1,154 @@
+# A call on an object receiver binds a rest-parameter method the way a call by
+# name does: the parameters after the rest take the call's last arguments, a
+# splat spreads across the ones ahead of it, and a count below what the target
+# requires is CRuby's ArgumentError -- where the body ran with the missing
+# parameters padded out.
+
+def bad
+  yield
+  puts "no error"
+rescue ArgumentError => e
+  puts "#{e.class}: #{e.message}"
+end
+
+class Talker
+  def one(a, *rest) = [a, rest]
+  def two(a, b, *rest) = [a, b, rest]
+  def opt(a, b = 2, *rest) = [a, b, rest]
+  def post(*rest, z) = [rest, z]
+  def mid(a, *rest, z) = [a, rest, z]
+  def own = one           # implicit self, the same lowering
+  def blk(a, *rest, &b) = [a, rest, b ? b.call : nil]
+  def two_post(a, *rest, y, z) = [a, rest, y, z]
+  def optpost(a, b = 1, *rest, z) = [a, b, rest, z]
+  def kwr(a, *rest, **opts) = [a, rest, opts]
+  def kwd(a, *rest, k: churn(1)) = [a, rest, k.length]
+  def nk(a, b, k: 9) = [a, b, k]
+end
+
+class Echo < Talker
+  def one(a, *rest) = super
+end
+
+# An override that takes a smaller count answers for itself: the arm the
+# receiver selects judges the count, not the laxest one in the hierarchy.
+class Strict
+  def count(a, *rest) = a + rest.length
+end
+
+class Loose < Strict
+  def count(a = 0, *rest) = a + rest.length + 100
+end
+
+# A subclass that takes a smaller count keeps the call for the whole hierarchy.
+class Soft
+  def one(a, *rest) = [:soft, a, rest]
+end
+
+class Softer < Soft
+  def one(a = 0, *rest) = [:softer, a, rest]
+end
+
+class Louder < Talker
+  def one(a, *rest) = [:loud, a, rest]
+end
+
+Point = Struct.new(:x) do
+  def scale(f, *more) = [x * f, more]
+end
+
+def top(a, *rest) = [a, rest]
+
+module Greeter
+  def greet(name, *rest) = [name, rest]
+end
+
+class Host
+  include Greeter
+end
+
+def side
+  puts "side"
+  1
+end
+
+def churn(n)
+  a = []
+  120.times { |i| a << i + n }
+  a
+end
+
+t = Talker.new
+
+# counts the target takes
+p t.one(1)
+p t.one(1, 2, 3)
+p t.two(1, 2)
+p t.opt(1)
+p t.opt(1, 5, 6)
+p t.post(1, 2, 3)
+p t.mid(1, 2, 3, 4)
+p Louder.new.one(1, 2)
+p Host.new.greet("hi")
+p Softer.new.one
+p Loose.new.count
+p Strict.new.count(5)
+p Echo.new.one(1, 2)
+p t.blk(1, 2) { 7 }
+p t.blk(1)
+p t.send(:one, 1, 2)
+p t.two_post(1, 2, 3, 4, 5)
+p t.two_post(1, 2, 3)
+p Point.new(3).scale(2, 9)
+p t.optpost(1, 2)
+p t.optpost(1, 2, 3, 4)
+p t.kwr(1, 2, k: 3)
+p t.nk(*[1, 2], k: 7)
+p t.nk(*[1, 2])
+
+# a splat spreads across the fixed parameters, its tail fills the rest
+args = [1, 2, 3]
+p t.one(*args)
+p t.one(*[7])
+p t.mid(1, *[2, 3], 9)
+p t.two(*args)
+p top(*[1, 2])
+h = { k: [1, 2, 3] }
+p t.one(*h[:k])
+poly = [1, "a", :b]
+p t.one(*poly)
+
+# the packed rest stays live while the arguments after it are evaluated
+live = 0
+40.times do
+  a, r, z = t.mid(1, *[2, 3], churn(7))
+  live += 1 if a == 1 && r == [2, 3] && z.length == 120
+  r2, z2 = t.post(churn(8))
+  live += 1 if r2 == [] && z2.length == 120
+  b, r3, n = t.kwd(1, *[2, 3])
+  live += 1 if b == 1 && r3 == [2, 3] && n == 120
+end
+p live
+
+# a shortfall is refused, not padded
+bad { t.one }
+bad { t.two(1) }
+bad { t.opt }
+bad { t.post }
+bad { t.mid }
+bad { t.own }
+bad { Louder.new.one }
+bad { Strict.new.count }
+bad { Host.new.greet }
+bad { t.one { 1 } }
+bad { t.one(*[]) }
+bad { t.two(*[1]) }
+bad { t.send(:one) }
+bad { t.two_post(1, 2) }
+bad { Echo.new.one }
+bad { Point.new(3).scale }
+empty = [1, 2].select { |v| v > 9 }
+bad { top(*empty) }
+
+# the arguments are evaluated before the count is refused
+bad { t.two(side) }

--- a/test/object_call_rest_params.rb.expected
+++ b/test/object_call_rest_params.rb.expected
@@ -1,0 +1,51 @@
+[1, []]
+[1, [2, 3]]
+[1, 2, []]
+[1, 2, []]
+[1, 5, [6]]
+[[1, 2], 3]
+[1, [2, 3], 4]
+[:loud, 1, [2]]
+["hi", []]
+[:softer, 0, []]
+100
+5
+[1, [2]]
+[1, [2], 7]
+[1, [], nil]
+[1, [2]]
+[1, [2, 3], 4, 5]
+[1, [], 2, 3]
+[6, [9]]
+[1, 1, [], 2]
+[1, 2, [3], 4]
+[1, [2], {k: 3}]
+[1, 2, 7]
+[1, 2, 9]
+[1, [2, 3]]
+[7, []]
+[1, [2, 3], 9]
+[1, 2, [3]]
+[1, [2]]
+[1, [2, 3]]
+[1, ["a", :b]]
+120
+ArgumentError: wrong number of arguments (given 0, expected 1+)
+ArgumentError: wrong number of arguments (given 1, expected 2+)
+ArgumentError: wrong number of arguments (given 0, expected 1+)
+ArgumentError: wrong number of arguments (given 0, expected 1+)
+ArgumentError: wrong number of arguments (given 0, expected 2+)
+ArgumentError: wrong number of arguments (given 0, expected 1+)
+ArgumentError: wrong number of arguments (given 0, expected 1+)
+ArgumentError: wrong number of arguments (given 0, expected 1+)
+ArgumentError: wrong number of arguments (given 0, expected 1+)
+ArgumentError: wrong number of arguments (given 0, expected 1+)
+ArgumentError: wrong number of arguments (given 0, expected 1+)
+ArgumentError: wrong number of arguments (given 1, expected 2+)
+ArgumentError: wrong number of arguments (given 0, expected 1+)
+ArgumentError: wrong number of arguments (given 2, expected 3+)
+ArgumentError: wrong number of arguments (given 0, expected 1+)
+ArgumentError: wrong number of arguments (given 0, expected 1+)
+ArgumentError: wrong number of arguments (given 0, expected 1+)
+side
+ArgumentError: wrong number of arguments (given 1, expected 2+)


### PR DESCRIPTION
## Why

Ruby code passes a receiver's method a variable number of arguments all the time — `logger.log("boot", *tags)`, `record.update(:name, *rest)`, `def visit(node, *args)`. Spinel bound those calls correctly when they were written as plain function calls, and left the receiver form behind: the same method reached through an object ran with its parameters shifted, or padded out with zeros, or refused to build at all. Nothing announced it — the program compiled and printed the wrong numbers.

Concretely:

- `P.new.m` on `def m(x, *y)` ran the body with a padded `x` (0, `nil`, an empty string — whatever the parameter's type zeroes to) where Ruby raises `ArgumentError: wrong number of arguments (given 0, expected 1+)`. The identical call to a top-level `def` has raised since #4238.
- `def m(*y, z)` called `obj.m(1, 2, 3)` answered `y = [1, 2, 3]`, `z = 2`: the rest collected the argument the trailing parameter was owed, and `z` then read the one to its left. Ruby answers `y = [1, 2]`, `z = 3`.
- `obj.m(*args)` on `def m(x, *y)` was a C build failure — `incompatible pointer to integer conversion` — because the array went into `x` whole instead of spreading. The same call by name works.
- `obj.m(*args)` where `args` turned out empty put the array itself into the first parameter rather than raising, and `f(*args)` by name ran padded: a count carried in a splat was never measured against a rest target.

## What

- A call on an object receiver now binds a rest-parameter method the way a call by name does: `obj.m(*args)` spreads across the parameters ahead of the rest with its tail filling the rest; the rest stops before the parameters that follow it, and each of those takes its argument from the end of the call; and a count below what the target requires is CRuby's `ArgumentError`, with CRuby's `expected N+` wording.
- A direct call is judged by the method it calls, and a dispatch that lowers to a switch judges the count again in each arm, so an override with a default keeps the call while a receiver of the stricter class is still refused — the answer CRuby gives for each.
- The raise sits after the call's arguments are evaluated, the order CRuby refuses the call in: `obj.m(side_effect)` prints what the argument prints before the raise. A count carried in a splat is measured where the array is and refused once the rest of the arguments have run.
- An argument that funds a parameter after the rest no longer also funds an optional before it: `obj.m(1, 2)` on `def m(a, b = 1, *y, z)` answers Ruby's `[1, 1, [], 2]`, where the `2` used to land in both `b` and `z`.
- A splat's elements fill positional parameters only, which fixes a keyword spelled beside one: `obj.m(*[1, 2], k: 7)` on `def m(a, b, k: 9)` answers `[1, 2, 7]`, where the keyword was overwritten by the array's element and `k` came back as its default.
- By name, a shortfall carried in a trailing splat is measured at run time, where only the static count was judged before.

## How

- `emit_dispatch` (src/codegen_fold.c) reads `rest_shortfall_required` — the rule #4238 introduced for the by-name lowering and the poly class-method dispatch — and emits CRuby's raise when the call cannot be taken. A direct call reads its own target. A switch judges twice: the prelude reads `dispatch_min_rest_required`, the smallest count its arms ask for, so a call no arm can take is refused before any of them is chosen; and each arm then answers for its own method, the way the class-method dispatch already does, so a receiver of a stricter class is refused where a laxer sibling would have kept the call. An arm that binds by other rules (a keyword parameter, a synthesized one) stands its own check down. The virtual-dispatch decision is hoisted above the argument binding so the prelude can tell a switch from a direct call.
- Its splat pre-evaluation, which was scoped to fixed-arity callees, now also runs for a splat ahead of a rest parameter — but only for `obj.m(*args)` outright: one positional argument, no keyword hash beside it, and a target whose shortfall this rule can judge. The operand is evaluated once into a rooted temp, the parameters ahead of the rest read their elements out of it, and the rest takes the tail through `emit_rest_from_splat_and_argv`, the helper the by-name path already calls. Every other spelling would hoist the operand past an argument written to its left, slide the parameters to its right by a run-time length, drop a keyword hash that belongs at the rest's tail, or pad a call that is refused today — so each keeps the lowering it had.
- The packed rest is rooted for as long as the call still has something to evaluate — a parameter after the rest, or a block literal. Both packings hand back a fresh array in a plain C temporary (one roots its accumulator only while it builds it, the other's shortcuts not at all), and a collected array is recycled straight into the next allocation, so the receiver read its own rest back as the next argument's value. That closes a hole master has today as well: `def m(a, *rest, k: <allocates>)` called `m(1, *[2, 3])` loses its rest under `SPINEL_GC_STRESS=1` on master, and the test pins it.
- The splat element fill is scoped to the parameters ahead of a rest, and skips any parameter a keyword binds by name — the guard `emit_args_filled` has always had. The rest collection stops at `pos_argc - npost_rest`, and a parameter after the rest takes `argv[pos_argc - npost_rest + j]` — the same two lines already carried by `emit_args_filled`, by the constructor inlining in codegen_call.c, and by the block lowering in codegen_iter.c. An argument that spreads at run time (a splat, a forwarded `...`) reaching those parameters leaves their positions unknowable, so that shape keeps the binding it had.
- `emit_args_filled` gains the run-time arm of the shortfall check, beside the fixed-arity one that has always measured a trailing splat's length. Both paths measure the count through one helper and refuse it through another.

## Validation

- `make test`: green — 3,385 pass, 0 fail, 0 error, and `make gate`'s other legs with it (61 benchmarks, the rubyspec gates, ext-cruby, rbs-seed, optcarrot OK at checksum 59662) — including the new `test/object_call_rest_params.rb` — 48 CRuby-generated expectations, run plain and under `SPINEL_GC_STRESS=1`; master does not compile the file at all.
- Generated-C sweep across the 3,402 pre-existing suite and benchmark programs, plus optcarrot's packed source: byte-identical for 3,392, and for optcarrot. Of the ten that differ, eight gain only a `SP_GC_ROOT` on a packed rest array that the call still has arguments to evaluate after; the other two, `test/splat_call.rb` and #4238's `test/method_call_shapes.rb`, also gain the new run-time length check (twice in the first), with the temp renumbering that follows it. All ten still match their expectations.
- Differential corpus of ~2,100 minimized programs (same corpus behind #3999/#4003/#4029): 779 -> 779, nothing gained and nothing lost. This shape is a correctness hole rather than a corpus family: the programs it breaks print wrong numbers or fail to build, and the corpus has no minimized case for either.

## Left alone, on purpose

- A rest target that also declares keywords (`def m(x, *y, k: 1)`), or that yields (a block parameter is synthesized for it), stands the check down on both paths — `rest_shortfall_required` reports "not judged" there, because those bind by rules this count does not model. CRuby raises the same shortfall in both shapes; closing them belongs with the keyword and block binding rules rather than here.
- A splat is spread into a rest target only for `obj.m(*args)` outright. `obj.m(1, *args)`, `obj.m(*args, 9)`, `obj.m(*args, k: 1)` and a splat into a keyword-carrying or yielding rest target all keep the binding — in several shapes the build refusal — they already had, each for the reason above: a moved evaluation, a run-time slide, a dropped keyword hash, or a shortfall no rule here can judge. The same is true of the parameters after a rest when a splat, a forwarded `...`, or any keyword hash reaches them: Ruby fills those from the end of the flattened list, and that end is a run-time slice this change does not attempt.
- A rest-parameter method reached through an included module keeps its old post binding: the per-includer copy of the scope carries the parameters but not the post count, so the rule reads zero posts there. That is an analyzer gap ahead of every lowering, not this one's to close.
- A boxed (poly) receiver keeps its own dispatch: a candidate whose arity cannot take the call is dropped from the switch, so a shortfall there raises `NoMethodError` rather than `ArgumentError`, and a zero-argument call to a rest method passes the rest as `NULL`, which inspects as `nil` instead of `[]`. Both predate this change and live in a different emitter.
- By name, the raise still precedes the argument evaluation, and a splat operand is still evaluated ahead of the positional arguments written before it — both pre-existing, and neither reachable without restructuring that emitter's prelude.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of method calls with splat arguments and rest parameters.
  * Correctly binds arguments that follow rest parameters.
  * Raises `ArgumentError` when too few arguments are provided, including during dynamic dispatch.
  * Preserves argument evaluation order before reporting invalid argument counts.

* **Tests**
  * Added coverage for fixed, optional, rest, post-rest, keyword, and block parameters across inheritance and module scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->