### PR TITLE
fix missing stdint.h inclusion, fixes build on musl

### DIFF
--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -16,6 +16,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <stdarg.h>
 #include <setjmp.h>


### PR DESCRIPTION
src/codegen.c:1542:8: error: unknown type name 'int8_t'
 1542 | static int8_t *g_cm_selfcls = NULL;
      |        ^~~~~~
src/codegen.c: In function 'cmethod_takes_self_cls':
src/codegen.c:1550:21: error: 'int8_t' undeclared (first use in this function)
 1550 |     g_cm_selfcls = (int8_t *)calloc((size_t)c->nscopes, 1);
      |                     ^~~~~~
src/codegen.c:2:1: note: 'int8_t' is defined in header '<stdint.h>'; did you forget to '#include <stdint.h>'?
    1 | #include "codegen_internal.h"
  +++ |+#include <stdint.h>
    2 |
src/codegen.c:1550:21: note: each undeclared identifier is reported only once for each function it appears in
 1550 |     g_cm_selfcls = (int8_t *)calloc((size_t)c->nscopes, 1);
      |                     ^~~~~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal compatibility for fixed-width integer type usage.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->