### PR TITLE
packages/openssl: fix compatibility with libressl 3.1.x

### DIFF
--- a/packages/openssl/sp_openssl.c
+++ b/packages/openssl/sp_openssl.c
@@ -38,8 +38,8 @@
    #error says so rather than leaving a page of diagnostics about missing
    declarations. */
 #if defined(LIBRESSL_VERSION_NUMBER)
-# if LIBRESSL_VERSION_NUMBER < 0x3050000fL
-#  error "sp_openssl.c needs LibreSSL 3.5 or newer"
+# if LIBRESSL_VERSION_NUMBER < 0x3010000fL
+#  error "sp_openssl.c needs LibreSSL 3.1 or newer"
 # endif
 # define SP_SSL_PEER_CERT(ssl) SSL_get_peer_certificate(ssl)
 #elif OPENSSL_VERSION_NUMBER < 0x10100000L


### PR DESCRIPTION
everything builds, except the new *_AEAD_* macros, which are just alias for the corresponding *_GCM_* macros in newer releases. work around those, and lower the bar to 3.1 as minimal supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Added support for LibreSSL versions 3.1 and newer.
  * Improved compatibility with LibreSSL releases that use legacy GCM controls for authenticated encryption operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->