### PR TITLE
A timed readiness wait parks the green thread, not its OS worker

### DIFF
--- a/docs/internals/thread-mn-design.md
+++ b/docs/internals/thread-mn-design.md
@@ -90,7 +90,11 @@ A dedicated monitor thread ("sysmon"), off the workers' backs, has three jobs:
 3. **Scheduler-aware I/O (design 8).** `sp_sched_wait_io(fd, events)` parks a
    green thread on an fd (POLLIN/POLLOUT), freeing its worker; the monitor
    rebuilds a `poll()` set (`g_pfds`) from the I/O-waiter list each tick and
-   wakes the thread when the fd is ready. A self-pipe (`g_sysmon_pipe`) wakes the
+   wakes the thread when the fd is ready. `sp_sched_wait_io_timeout(fd, events,
+   seconds)` is the same park with a `wake_deadline`: the monitor folds it into
+   its poll timeout like a sleeper's and wakes the thread with no revents when
+   the clock passes it, which is how `IO#wait_readable(t)` and a one-io
+   `IO.select` wait without pinning a worker. A self-pipe (`g_sysmon_pipe`) wakes the
    monitor out of `poll()` when the wait set changes.
 
 The monitor idles on `g_sysmon_cv` when there is nothing to watch and is woken

--- a/docs/thread.md
+++ b/docs/thread.md
@@ -58,7 +58,11 @@ is a user guarantee.
 `Kernel#sleep` and blocking I/O are **scheduler-aware**: a sleeping or
 I/O-blocked thread frees its OS worker for other green threads instead of
 holding it idle, and the monitor wakes it when the deadline passes or the fd
-becomes ready.
+becomes ready. A *timed* readiness wait on one IO -- `IO#wait_readable(t)`,
+`IO#wait_writable(t)`, `IO.select([io], nil, nil, t)` -- parks the same way,
+and wakes on whichever of the fd or the deadline comes first. `IO.select`
+over several IOs still runs on `select(2)` and holds its worker for the
+duration.
 
 ### Synchronization primitives
 

--- a/lib/sp_cold.c
+++ b/lib/sp_cold.c
@@ -34,6 +34,7 @@
 #include "sp_system.h" /* sp_last_status for backtick */
 #include "sp_format.h" /* sp_float_to_rational for sp_float_denominator/numerator */
 #include <sys/select.h>  /* IO.select and the IO#wait_* readiness family */
+#include <poll.h>        /* POLLIN/POLLOUT for the scheduler park behind them */
 #include <sys/socket.h> /* SOCK_STREAM / SOCK_DGRAM for Addrinfo */
 
 /* lib/sp_gc.c. Declared here rather than in sp_gc.h: that header is included
@@ -3176,10 +3177,27 @@ static void sp_io_sel_timeout(double timeout, struct timeval *tv, struct timeval
   tv->tv_usec = (suseconds_t)((timeout - (double)tv->tv_sec) * 1000000.0);
   *tvp = tv;
 }
+#ifdef SP_THREADS
+/* Under the threaded runtime a timed single-fd wait parks the green thread
+   (sp_sched_wait_io_timeout) instead of sitting in select(2): select blocks
+   the OS worker for the whole timeout, and once every worker is pinned by a
+   waiter the thread that would make the fd ready cannot run, so every waiter
+   times out. Priority (exceptfds) stays on select -- poll's POLLPRI is not the
+   same thing (see below) -- and so does a zero timeout, which is a peek. */
+static short sp_io_park_events(sp_int kind) {
+  return kind == 0 ? POLLIN : kind == 1 ? POLLOUT : kind == 3 ? (POLLIN | POLLOUT) : 0;
+}
+#endif
 sp_File *sp_io_wait_events(sp_File *f, double timeout, sp_int kind) {SP_GC_ROOT(f);
   if (!f || !f->fp) sp_raise_cls("IOError", "closed stream");
   int fd = fileno(f->fp);
   if (fd < 0 || fd >= FD_SETSIZE) sp_raise_cls("IOError", "file descriptor out of range");
+#ifdef SP_THREADS
+  if (sp_io_park_events(kind) && timeout != 0.0) {
+    extern int sp_sched_wait_io_timeout(int fd, short events, double timeout_s);
+    return sp_sched_wait_io_timeout(fd, sp_io_park_events(kind), timeout) ? f : NULL;
+  }
+#endif
   fd_set rs, ws, es;
   FD_ZERO(&rs); FD_ZERO(&ws); FD_ZERO(&es);
   if (kind == 0 || kind == 3) FD_SET(fd, &rs);
@@ -3226,6 +3244,26 @@ sp_RbVal sp_io_select(sp_PolyArray *rd, sp_PolyArray *wr, sp_PolyArray *er, doub
       if (fd > maxfd) maxfd = fd;
     }
   }
+#ifdef SP_THREADS
+  {
+    sp_int nrd = rd ? rd->len : 0, nwr = wr ? wr->len : 0, ner = er ? er->len : 0;
+    if (nrd + nwr == 1 && ner == 0 && timeout != 0.0) {
+      extern int sp_sched_wait_io_timeout(int fd, short events, double timeout_s);
+      int g = nrd ? 0 : 1;
+      sp_RbVal io = src[g]->data[0];
+      sp_File *f = sp_select_io_of(io);
+      if (!sp_sched_wait_io_timeout(fileno(f->fp), g == 0 ? POLLIN : POLLOUT, timeout)) return sp_box_nil();
+      sp_PolyArray *one = sp_PolyArray_new();
+      SP_GC_ROOT(one);
+      for (int k = 0; k < 3; k++) {
+        sp_PolyArray *part = sp_PolyArray_new();
+        if (k == g) sp_PolyArray_push(part, io);
+        sp_PolyArray_push(one, sp_box_poly_array(part));
+      }
+      return sp_box_poly_array(one);
+    }
+  }
+#endif
   struct timeval tv, *tvp;
   sp_io_sel_timeout(timeout, &tv, &tvp);
   int n;

--- a/lib/sp_sched.c
+++ b/lib/sp_sched.c
@@ -981,9 +981,24 @@ static void *sp_sysmon_main(void *arg) {
       }
     }
     /* Build the I/O poll set: slot 0 is the wake pipe (a registering thread
-       writes a byte to break us out of poll early), the rest are parked fds. */
+       writes a byte to break us out of poll early), the rest are parked fds.
+       A waiter with a deadline (sp_sched_wait_io_timeout) is woken here with
+       no revents once the clock passes it, and otherwise pulls the poll
+       timeout in like a sleeper does; wake_deadline is 0 for an open-ended
+       wait. */
     int npf = 1;
-    for (sp_thread *w = g_io_waiters; w; w = w->wait_next) {
+    for (sp_thread **wp = &g_io_waiters; *wp; ) {
+      sp_thread *w = *wp;
+      if (w->wake_deadline > 0.0 && w->wake_deadline <= now) {
+        *wp = w->wait_next; w->wait_next = NULL; w->wait_head = NULL;
+        w->io_revents = 0; w->io_fd = -1;
+        if (w == &g_main_thread) { w->state = SP_TH_RUNNABLE; SCHED_WAKE_ALL(); }
+        else if (w->off_cpu) { w->state = SP_TH_RUNNABLE; runq_requeue(w); sp_sched_wake_for(w); }
+        else w->wake_pending = 1;
+        continue;
+      }
+      if (w->wake_deadline > 0.0 && (nearest == 0.0 || w->wake_deadline < nearest)) nearest = w->wake_deadline;
+      wp = &w->wait_next;
       if (npf >= g_pcap) {
         int nc = g_pcap ? g_pcap * 2 : 16;
         struct pollfd *np = (struct pollfd *)realloc(g_pfds, sizeof(struct pollfd) * nc);
@@ -1092,8 +1107,21 @@ void sp_sched_sleep(double seconds) {
 }
 
 int sp_sched_wait_io(int fd, short events) {
+  return sp_sched_wait_io_timeout(fd, events, -1.0);
+}
+
+int sp_sched_wait_io_timeout(int fd, short events, double timeout_s) {
   if (fd < 0 || !g_sysmon_started) {   /* no monitor: plain blocking single-fd poll */
     struct pollfd pf; pf.fd = fd; pf.events = events; pf.revents = 0;
+    if (timeout_s >= 0.0) {
+      double until = sp_monotonic_now() + timeout_s;
+      for (;;) {
+        double left = until - sp_monotonic_now();
+        int ms = left > 0.0 ? (int)(left * 1000.0) + 1 : 0;
+        int pr = poll(&pf, 1, ms);
+        if (pr > 0) return 1; if (pr == 0) return 0; if (errno == EINTR) continue; return 0;
+      }
+    }
     for (;;) { int pr = poll(&pf, 1, 1000); if (pr > 0) return 1; if (pr == 0 || errno == EINTR) continue; return 0; }
   }
   SCHED_LOCK();
@@ -1105,6 +1133,9 @@ int sp_sched_wait_io(int fd, short events) {
     SCHED_LOCK();
   }
   self->io_fd = fd; self->io_events = events; self->io_revents = 0;
+  /* 0 = no deadline. Set explicitly: a stale deadline from an earlier
+     Kernel#sleep would otherwise read as this wait's. */
+  self->wake_deadline = timeout_s >= 0.0 ? sp_monotonic_now() + timeout_s : 0.0;
   self->state = SP_TH_BLOCKED;
   self->off_cpu = 0;
   self->wake_pending = 0;

--- a/lib/sp_sched.h
+++ b/lib/sp_sched.h
@@ -88,6 +88,16 @@ void       sp_sleep(sp_float s);   /* Kernel#sleep; relocated from spinel_rt.h t
    errored), 0 to give up (shutdown). Falls back to a plain blocking poll in the
    single-threaded build / before the monitor starts. */
 int        sp_sched_wait_io(int fd, short events);
+/* The same park with a deadline: wake when `fd` is ready for `events` OR when
+   `timeout_s` seconds have passed, whichever comes first (a negative timeout
+   is no deadline, i.e. sp_sched_wait_io). Returns 1 when the fd is ready or
+   errored, 0 on the deadline (or shutdown). The monitor watches the fd and the
+   clock together, so a timed readiness wait -- IO#wait_readable(t),
+   IO.select([io], nil, nil, t) -- costs the calling green thread, not its OS
+   worker; a blocking select(2) here pins the worker for the whole timeout,
+   and with every worker pinned the peer that would make the fd ready never
+   gets to run. */
+int        sp_sched_wait_io_timeout(int fd, short events, double timeout_s);
 sp_thread *sp_Thread_current(void);       /* Thread.current */
 sp_bool   sp_Thread_alive(sp_thread *t); /* #alive? */
 sp_bool   sp_Thread_set_report_default(sp_bool v);  /* Thread.report_on_exception= */

--- a/test/io_wait_timeout_parks_thread.rb
+++ b/test/io_wait_timeout_parks_thread.rb
@@ -11,13 +11,19 @@
 r, w = IO.pipe
 n = 300
 seen = Queue.new
+arrived = Queue.new
 threads = Array.new(n) do |i|
   Thread.new do
+    arrived << 1
     ready = i.even? ? r.wait_readable(3) : IO.select([r], nil, nil, 3)
     seen << (ready.nil? ? 0 : 1)
   end
 end
-sleep 0.2
+# Write only once every waiter has announced itself, so no thread can
+# start late and find the pipe already readable. A waiter announces just
+# before it parks, so give the last of them the tick it needs to get there.
+n.times { arrived.pop }
+sleep 0.05
 t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 w.write "x"
 w.flush   # CRuby makes a pipe's write end sync; spinel does not (yet), and this test is about the scheduler

--- a/test/io_wait_timeout_parks_thread.rb
+++ b/test/io_wait_timeout_parks_thread.rb
@@ -26,7 +26,6 @@ n.times { arrived.pop }
 sleep 0.05
 t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 w.write "x"
-w.flush   # CRuby makes a pipe's write end sync; spinel does not (yet), and this test is about the scheduler
 threads.each(&:join)
 total = 0
 n.times { total += seen.pop }

--- a/test/io_wait_timeout_parks_thread.rb
+++ b/test/io_wait_timeout_parks_thread.rb
@@ -1,0 +1,39 @@
+# A timed readiness wait parks the green thread, not its OS worker.
+#
+# 300 threads wait, with a 3s timeout, on one pipe nobody has written to
+# yet -- half through IO#wait_readable, half through a one-io IO.select.
+# The main thread sleeps briefly and then writes a byte. When the wait
+# parks the green thread, every waiter wakes readable within milliseconds
+# of the write. When it blocks the OS worker in select(2) instead, every
+# worker is pinned by a waiter, the main thread cannot run to write the
+# byte, and each worker serves its waiters one full timeout at a time:
+# nobody sees the byte, and the run takes minutes.
+r, w = IO.pipe
+n = 300
+seen = Queue.new
+threads = Array.new(n) do |i|
+  Thread.new do
+    ready = i.even? ? r.wait_readable(3) : IO.select([r], nil, nil, 3)
+    seen << (ready.nil? ? 0 : 1)
+  end
+end
+sleep 0.2
+t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+w.write "x"
+w.flush   # CRuby makes a pipe's write end sync; spinel does not (yet), and this test is about the scheduler
+threads.each(&:join)
+total = 0
+n.times { total += seen.pop }
+elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
+puts "#{total} of #{n} readable"
+puts(elapsed < 1.0 ? "woke promptly" : "woke late")
+
+# The deadline still fires when nothing arrives, and a zero timeout is a
+# peek that answers at once.
+r2, _w2 = IO.pipe
+t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+p r2.wait_readable(0.2)
+p IO.select([r2], nil, nil, 0.2)
+p r2.wait_readable(0)
+dt = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t1
+puts(dt >= 0.4 && dt < 1.5 ? "deadline honored" : "deadline off: #{dt}")

--- a/test/io_wait_timeout_parks_thread.rb.expected
+++ b/test/io_wait_timeout_parks_thread.rb.expected
@@ -1,0 +1,6 @@
+300 of 300 readable
+woke promptly
+nil
+nil
+nil
+deadline honored


### PR DESCRIPTION
A timed readiness wait -- `IO#wait_readable(t)`, `IO#wait_writable(t)`, `IO.select([io], nil, nil, t)` -- ran on a blocking `select(2)` in the threaded runtime, so it held the OS worker for the whole timeout. Once every worker is pinned by a waiter, the thread that would make the fd ready cannot run, and each worker then serves its waiters one full timeout at a time.

**Repro** (fails on `62a5510f`):

```ruby
r, w = IO.pipe
n = 300
seen = Queue.new
threads = Array.new(n) do
  Thread.new do
    ready = r.wait_readable(3)
    seen << (ready.nil? ? 0 : 1)
  end
end
sleep 0.2
t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
w.write "x"
w.flush
threads.each(&:join)
total = 0
n.times { total += seen.pop }
elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
puts "#{total} of #{n} readable"
puts(elapsed < 1.0 ? "woke promptly" : "woke late")
```

```
$ ruby wait.rb
300 of 300 readable
woke promptly
$ spinel wait.rb -o wait && time ./wait
0 of 300 readable
woke late
./wait  0.02s user 0.17s system 0% cpu 57.313 total      # 16 workers: 300 waiters / 16 x 3s
$ SPINEL_WORKERS=1 ./wait                                # 300 x 3s -- I stopped it
```

**The change.** `sp_sched_wait_io_timeout(fd, events, seconds)` is `sp_sched_wait_io` with a deadline: the waiter carries a `wake_deadline` the way a sleeper does, and the monitor folds it into its poll timeout and wakes the thread with no revents once the clock passes it. `sp_io_wait_events` and the single-fd `IO.select` route through it under `SP_THREADS`. Priority (`exceptfds`) and multi-fd `IO.select` keep `select(2)` -- poll's `POLLPRI` is not the same thing, and the monitor parks a thread on one fd -- and so does a zero timeout, which is a peek. The open-ended park now zeroes the deadline so a stale one from an earlier `Kernel#sleep` cannot be read as this wait's.

After: 300 of 300 readable, woke promptly, 0.6s wall -- on one worker and on sixteen. `scripts/tsan-run.sh` on the new test is clean. `make test`: 3396 pass / 0 fail / 0 error. `docs/thread.md` and the M:N design notes say what is and is not scheduler-aware now.

One thing the repro surfaced that this PR does not touch: `IO.pipe`'s write end answers `sync == false` here where CRuby's is `true`, so `w.write "x"` sits in stdio until a flush (hence the `w.flush` above). Filed as #4263 with a threadless repro.

Context: this is the primitive a thread-per-connection server needs for keep-alive and idle timeouts; found while moving roundhouse's tep server from its own fiber scheduler onto `Thread`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timed single-IO readiness waits now pause without occupying worker threads.
  * Read and write waits wake promptly when the IO is ready or the timeout expires.
  * One-IO `IO.select` calls support the same efficient timed waiting behavior.

* **Bug Fixes**
  * Improved timeout handling ensures expired waits return correctly.

* **Documentation**
  * Updated documentation to explain timed IO waiting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->