### PR TITLE
Route a numeric operation with a coercing operand through the hook

### DIFF
--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -2093,6 +2093,21 @@ static int sp_brat_cmp_poly(sp_RbVal a, sp_RbVal b) { sp_Bigint *an,*ad,*bn,*bd;
 /* A failed boxed arithmetic dispatch must not manufacture Integer zero. Ruby
    distinguishes receivers with no such method from methods that reject the
    operand, so preserve that distinction at the dynamic fallback. */
+/* The ops a Complex receiver takes through the coerce protocol. CRuby's
+   Complex has `+ - * / ** <=> quo fdiv` and nothing else -- the ordered
+   comparisons, % and the named division family raise NoMethodError with no
+   coerce call, so admitting them here answered where CRuby raises. quo and
+   fdiv are left out on the other grounds: their boxed entries have no
+   Complex arm, so routing the pair through them answered a wrong number
+   ((0/1), Infinity) where master's refusal at least failed loudly. */
+static sp_bool sp_complex_coerce_op_p(const char *op) {
+  static const char *const set[] = {
+    "+", "-", "*", "/", "**", "<=>", NULL};
+  for (int i = 0; set[i]; i++) {
+    if (strcmp(op, set[i]) == 0) return TRUE;
+  }
+  return FALSE;
+}
 static sp_bool sp_poly_has_binop(sp_RbVal recv, const char *op) {
   if (recv.tag == SP_TAG_INT || recv.tag == SP_TAG_FLT || recv.tag == SP_TAG_BIGINT)
     return TRUE;
@@ -2100,6 +2115,10 @@ static sp_bool sp_poly_has_binop(sp_RbVal recv, const char *op) {
     return strcmp(op, "+") == 0 || strcmp(op, "*") == 0;
   if (recv.tag == SP_TAG_OBJ && recv.v.p) {
     if (sp_poly_is_rational(recv) || sp_poly_is_brat(recv)) return TRUE;
+    /* the same admitted set: saying no to the rest turns the failure into
+       CRuby's NoMethodError, saying yes to these turns an operand Complex
+       cannot coerce into CRuby's TypeError. */
+    if (recv.cls_id == SP_BUILTIN_COMPLEX) return sp_complex_coerce_op_p(op);
     if (sp_poly_is_array_kind(recv.cls_id)) return TRUE;
   }
   return FALSE;
@@ -2140,13 +2159,21 @@ static sp_user_binop_fn sp_user_binop_hook = NULL;
    this is the same protocol for an operand that only reads poly (#3960). */
 typedef sp_RbVal (*sp_user_coerce_fn)(const char *op, sp_RbVal recv, sp_RbVal obj, sp_bool *handled);
 static sp_user_coerce_fn sp_user_coerce_hook = NULL;
+static sp_bool sp_poly_numeric_p(sp_RbVal v);  /* fwd: the coerce guard below is numeric-only */
 static sp_RbVal sp_poly_binop_bad(const char *op, sp_RbVal recv, sp_RbVal arg) {
   if (recv.tag == SP_TAG_OBJ && recv.cls_id >= 0 && sp_user_binop_hook) {
     sp_bool _h = FALSE;
     sp_RbVal _r = sp_user_binop_hook(op, recv, arg, &_h);
     if (_h) return _r;
   }
+  /* and only a NUMBER asks: String#+ and Array#+ raise for an operand they
+     cannot convert, however willing it is to coerce. The check matters more
+     now that a #coerce answering a homogeneously-typed pair gets a dispatch
+     arm, which is what let `"abc" + obj` reach this at all. */
   if (arg.tag == SP_TAG_OBJ && arg.cls_id >= 0 && sp_user_coerce_hook &&
+      (sp_poly_numeric_p(recv) || sp_poly_is_rational(recv) || sp_poly_is_brat(recv) ||
+       (recv.tag == SP_TAG_OBJ && recv.cls_id == SP_BUILTIN_COMPLEX &&
+        sp_complex_coerce_op_p(op))) &&
       !(recv.tag == SP_TAG_OBJ && recv.cls_id >= 0)) {
     sp_bool _h = FALSE;
     sp_RbVal _r = sp_user_coerce_hook(op, recv, arg, &_h);
@@ -2174,14 +2201,14 @@ static inline int sp_poly_is_user_obj(sp_RbVal v) {
   return v.tag == SP_TAG_OBJ && v.cls_id >= 0;
 }
 static int sp_poly_user_cmp(const char *op, sp_RbVal a, sp_RbVal b, sp_RbVal *out);  /* fwd */
-static sp_RbVal sp_poly_add(sp_RbVal a, sp_RbVal b) { /* Two plain numbers are what a boxed arithmetic loop actually holds, and the tower checks below cannot match either tag: answer them first rather than after eight of them (#3984). */ if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f + b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(add, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f + (sp_float)b.v.i); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i + b.v.f); if ((a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_COMPLEX) || (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_COMPLEX)) return sp_box_complex(sp_complex_add(sp_poly_as_complex(a), sp_poly_as_complex(b))); if ((sp_poly_is_brat(a) || sp_poly_is_brat(b))) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) + sp_poly_to_f(b)); return sp_brat_add_poly(a, b); } if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && a.tag != SP_TAG_FLT && b.tag != SP_TAG_FLT) return sp_box_rational(sp_rational_add(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT)) return sp_box_float(sp_poly_to_f_with_rational(a) + sp_poly_to_f_with_rational(b)); if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) + sp_poly_to_f(b)); return sp_box_bigint(sp_bigint_add(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); } if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(add, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f + b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i + b.v.f); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f + (sp_float)b.v.i); if (a.tag == SP_TAG_STR && b.tag == SP_TAG_STR) return sp_box_str(sp_str_concat(a.v.s, b.v.s)); if (a.tag == SP_TAG_OBJ && sp_poly_is_array_kind(a.cls_id) && b.tag == SP_TAG_OBJ && sp_poly_is_array_kind(b.cls_id)) { SP_GC_ROOT_RBVAL(a); SP_GC_ROOT_RBVAL(b); sp_PolyArray *pa = sp_poly_to_poly_array(a); SP_GC_ROOT(pa); sp_PolyArray *pb = sp_poly_to_poly_array(b); SP_GC_ROOT(pb); return sp_box_poly_array(sp_PolyArray_concat(pa, pb)); } if (a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_TIME) { if (b.tag == SP_TAG_INT) return sp_box_time(sp_time_add_i(*(sp_Time *)a.v.p, b.v.i)); if (b.tag == SP_TAG_FLT) return sp_box_time(sp_time_add_f(*(sp_Time *)a.v.p, b.v.f)); } if (sp_poly_is_strbuf(a) || sp_poly_is_strbuf(b)) return sp_poly_add(sp_poly_strbuf_deref(a), sp_poly_strbuf_deref(b)); return sp_poly_binop_bad("+", a, b); }
-static sp_RbVal sp_poly_sub(sp_RbVal a, sp_RbVal b) { /* Two plain numbers are what a boxed arithmetic loop actually holds, and the tower checks below cannot match either tag: answer them first rather than after eight of them (#3984). */ if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f - b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(sub, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f - (sp_float)b.v.i); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i - b.v.f); if ((a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_COMPLEX) || (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_COMPLEX)) return sp_box_complex(sp_complex_sub(sp_poly_as_complex(a), sp_poly_as_complex(b))); if ((sp_poly_is_brat(a) || sp_poly_is_brat(b))) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) - sp_poly_to_f(b)); return sp_brat_sub_poly(a, b); } if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && a.tag != SP_TAG_FLT && b.tag != SP_TAG_FLT) return sp_box_rational(sp_rational_sub(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT)) return sp_box_float(sp_poly_to_f_with_rational(a) - sp_poly_to_f_with_rational(b)); if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) - sp_poly_to_f(b)); return sp_box_bigint(sp_bigint_sub(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); } if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(sub, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f - b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i - b.v.f); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f - (sp_float)b.v.i); if (a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_TIME) { if (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_TIME) return sp_box_float(sp_time_sub_t(*(sp_Time *)a.v.p, *(sp_Time *)b.v.p)); if (b.tag == SP_TAG_INT) return sp_box_time(sp_time_sub_i(*(sp_Time *)a.v.p, b.v.i)); if (b.tag == SP_TAG_FLT) return sp_box_time(sp_time_add_f(*(sp_Time *)a.v.p, -b.v.f)); }
+static sp_RbVal sp_poly_add(sp_RbVal a, sp_RbVal b) { /* Two plain numbers are what a boxed arithmetic loop actually holds, and the tower checks below cannot match either tag: answer them first rather than after eight of them (#3984). */ if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f + b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(add, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f + (sp_float)b.v.i); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i + b.v.f); /* a user object on either side belongs to the binop hook and the coerce protocol, not to the tower branches below -- those match on the RECEIVER kind and would convert the object to a number of that kind */ if (SP_UNLIKELY(sp_poly_is_user_obj(a) || sp_poly_is_user_obj(b))) return sp_poly_binop_bad("+", a, b); if ((a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_COMPLEX) || (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_COMPLEX)) return sp_box_complex(sp_complex_add(sp_poly_as_complex(a), sp_poly_as_complex(b))); if ((sp_poly_is_brat(a) || sp_poly_is_brat(b))) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) + sp_poly_to_f(b)); return sp_brat_add_poly(a, b); } if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && a.tag != SP_TAG_FLT && b.tag != SP_TAG_FLT) return sp_box_rational(sp_rational_add(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT)) return sp_box_float(sp_poly_to_f_with_rational(a) + sp_poly_to_f_with_rational(b)); if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) + sp_poly_to_f(b)); return sp_box_bigint(sp_bigint_add(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); } if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(add, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f + b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i + b.v.f); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f + (sp_float)b.v.i); if (a.tag == SP_TAG_STR && b.tag == SP_TAG_STR) return sp_box_str(sp_str_concat(a.v.s, b.v.s)); if (a.tag == SP_TAG_OBJ && sp_poly_is_array_kind(a.cls_id) && b.tag == SP_TAG_OBJ && sp_poly_is_array_kind(b.cls_id)) { SP_GC_ROOT_RBVAL(a); SP_GC_ROOT_RBVAL(b); sp_PolyArray *pa = sp_poly_to_poly_array(a); SP_GC_ROOT(pa); sp_PolyArray *pb = sp_poly_to_poly_array(b); SP_GC_ROOT(pb); return sp_box_poly_array(sp_PolyArray_concat(pa, pb)); } if (a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_TIME) { if (b.tag == SP_TAG_INT) return sp_box_time(sp_time_add_i(*(sp_Time *)a.v.p, b.v.i)); if (b.tag == SP_TAG_FLT) return sp_box_time(sp_time_add_f(*(sp_Time *)a.v.p, b.v.f)); } if (sp_poly_is_strbuf(a) || sp_poly_is_strbuf(b)) return sp_poly_add(sp_poly_strbuf_deref(a), sp_poly_strbuf_deref(b)); return sp_poly_binop_bad("+", a, b); }
+static sp_RbVal sp_poly_sub(sp_RbVal a, sp_RbVal b) { /* Two plain numbers are what a boxed arithmetic loop actually holds, and the tower checks below cannot match either tag: answer them first rather than after eight of them (#3984). */ if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f - b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(sub, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f - (sp_float)b.v.i); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i - b.v.f); /* a user object on either side belongs to the binop hook and the coerce protocol, not to the tower branches below -- those match on the RECEIVER kind and would convert the object to a number of that kind */ if (SP_UNLIKELY(sp_poly_is_user_obj(a) || sp_poly_is_user_obj(b))) return sp_poly_binop_bad("-", a, b); if ((a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_COMPLEX) || (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_COMPLEX)) return sp_box_complex(sp_complex_sub(sp_poly_as_complex(a), sp_poly_as_complex(b))); if ((sp_poly_is_brat(a) || sp_poly_is_brat(b))) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) - sp_poly_to_f(b)); return sp_brat_sub_poly(a, b); } if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && a.tag != SP_TAG_FLT && b.tag != SP_TAG_FLT) return sp_box_rational(sp_rational_sub(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT)) return sp_box_float(sp_poly_to_f_with_rational(a) - sp_poly_to_f_with_rational(b)); if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) - sp_poly_to_f(b)); return sp_box_bigint(sp_bigint_sub(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); } if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(sub, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f - b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i - b.v.f); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f - (sp_float)b.v.i); if (a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_TIME) { if (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_TIME) return sp_box_float(sp_time_sub_t(*(sp_Time *)a.v.p, *(sp_Time *)b.v.p)); if (b.tag == SP_TAG_INT) return sp_box_time(sp_time_sub_i(*(sp_Time *)a.v.p, b.v.i)); if (b.tag == SP_TAG_FLT) return sp_box_time(sp_time_add_f(*(sp_Time *)a.v.p, -b.v.f)); }
   /* two Arrays: the set difference, mirroring the concat branch sp_poly_add
      has. Without it a poly-carried Array pair reached the failure message,
      which then read "no implicit conversion of Array into Array" (#3475). */
   if (a.tag == SP_TAG_OBJ && sp_poly_is_array_kind(a.cls_id) && b.tag == SP_TAG_OBJ && sp_poly_is_array_kind(b.cls_id)) { SP_GC_ROOT_RBVAL(a); SP_GC_ROOT_RBVAL(b); sp_PolyArray *pa = sp_poly_to_poly_array(a); SP_GC_ROOT(pa); sp_PolyArray *pb = sp_poly_to_poly_array(b); SP_GC_ROOT(pb); return sp_box_poly_array(sp_PolyArray_difference(pa, pb)); }
   return sp_poly_binop_bad("-", a, b); }
-static sp_RbVal sp_poly_mul(sp_RbVal a, sp_RbVal b) { /* Two plain numbers are what a boxed arithmetic loop actually holds, and the tower checks below cannot match either tag: answer them first rather than after eight of them (#3984). */ if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f * b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(mul, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f * (sp_float)b.v.i); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i * b.v.f); if ((a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_COMPLEX) || (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_COMPLEX)) return sp_box_complex(sp_complex_mul(sp_poly_as_complex(a), sp_poly_as_complex(b))); if ((sp_poly_is_brat(a) || sp_poly_is_brat(b))) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) * sp_poly_to_f(b)); return sp_brat_mul_poly(a, b); } if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && a.tag != SP_TAG_FLT && b.tag != SP_TAG_FLT) return sp_box_rational(sp_rational_mul(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT)) return sp_box_float(sp_poly_to_f_with_rational(a) * sp_poly_to_f_with_rational(b)); if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) * sp_poly_to_f(b)); return sp_box_bigint(sp_bigint_mul(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); } if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(mul, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f * b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i * b.v.f); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f * (sp_float)b.v.i); if (a.tag == SP_TAG_STR && b.tag == SP_TAG_INT) return a.v.s ? sp_box_str(sp_str_repeat(a.v.s, b.v.i)) : a; /* String#*; NULL is the empty string */ if (sp_poly_is_strbuf(a) || sp_poly_is_strbuf(b)) return sp_poly_mul(sp_poly_strbuf_deref(a), sp_poly_strbuf_deref(b)); return sp_poly_binop_bad("*", a, b); }
+static sp_RbVal sp_poly_mul(sp_RbVal a, sp_RbVal b) { /* Two plain numbers are what a boxed arithmetic loop actually holds, and the tower checks below cannot match either tag: answer them first rather than after eight of them (#3984). */ if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f * b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(mul, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f * (sp_float)b.v.i); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i * b.v.f); /* a user object on either side belongs to the binop hook and the coerce protocol, not to the tower branches below -- those match on the RECEIVER kind and would convert the object to a number of that kind */ if (SP_UNLIKELY(sp_poly_is_user_obj(a) || sp_poly_is_user_obj(b))) return sp_poly_binop_bad("*", a, b); if ((a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_COMPLEX) || (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_COMPLEX)) return sp_box_complex(sp_complex_mul(sp_poly_as_complex(a), sp_poly_as_complex(b))); if ((sp_poly_is_brat(a) || sp_poly_is_brat(b))) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) * sp_poly_to_f(b)); return sp_brat_mul_poly(a, b); } if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && a.tag != SP_TAG_FLT && b.tag != SP_TAG_FLT) return sp_box_rational(sp_rational_mul(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT)) return sp_box_float(sp_poly_to_f_with_rational(a) * sp_poly_to_f_with_rational(b)); if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) * sp_poly_to_f(b)); return sp_box_bigint(sp_bigint_mul(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); } if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(mul, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f * b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i * b.v.f); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f * (sp_float)b.v.i); if (a.tag == SP_TAG_STR && b.tag == SP_TAG_INT) return a.v.s ? sp_box_str(sp_str_repeat(a.v.s, b.v.i)) : a; /* String#*; NULL is the empty string */ if (sp_poly_is_strbuf(a) || sp_poly_is_strbuf(b)) return sp_poly_mul(sp_poly_strbuf_deref(a), sp_poly_strbuf_deref(b)); return sp_poly_binop_bad("*", a, b); }
 static SP_NOINLINE sp_int sp_poly_to_i_cold(sp_RbVal v);
 /* Int and float are what an unboxed integer slot is fed in a hot loop; every
    other kind -- bigint, a numeric string, a Rational, a Time -- goes out of
@@ -2854,8 +2881,37 @@ static int sp_poly_user_cmp(const char *op, sp_RbVal a, sp_RbVal b, sp_RbVal *ou
   return 1;
 }
 #define SP_POLY_USER_CMP(OP) do { sp_RbVal _u; if (sp_poly_user_cmp(OP, a, b, &_u)) return sp_poly_truthy(_u); } while (0)
+/* The numeric coerce protocol from the ARGUMENT side: `5 < obj` is CRuby's
+   `a, b = obj.coerce(5); a < b`, and `5.div(obj)` the same with div. Only the
+   arithmetic operators consulted the hook (through sp_poly_binop_bad, #3960):
+   sp_poly_cmp knows no ordering that pairs a number with a user object, and
+   the named methods below converted the object to a number, so both answered
+   where CRuby coerces. The receiver must NOT itself be a user object: that
+   side is sp_poly_user_cmp's, and taking both here would let a coerce that
+   answers its own operand recurse. */
+static int sp_poly_coerce_binop(const char *op, sp_RbVal a, sp_RbVal b, sp_RbVal *out) {
+  /* Only a NUMBER asks. CRuby reaches coerce from Numeric's own operators, so
+     `"abc" < money` is a failed comparison however willing the object is to
+     coerce -- and these entries serve every boxed value, not just numbers.
+     Without this the protocol answered for a String, Symbol, Time or Array
+     receiver: exactly the silent wrong answer it exists to remove. */
+  if (!(sp_poly_numeric_p(a) || sp_poly_is_rational(a) || sp_poly_is_brat(a) ||
+        (a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_COMPLEX &&
+         sp_complex_coerce_op_p(op)))) return 0;
+  if (sp_poly_is_user_obj(a) || !sp_poly_is_user_obj(b) || !sp_user_coerce_hook) return 0;
+  sp_bool h = FALSE;
+  sp_RbVal r = sp_user_coerce_hook(op, a, b, &h);
+  if (!h) return 0;
+  *out = r;
+  return 1;
+}
+#define SP_POLY_COERCE_CMP(OP) do { sp_RbVal _u; if (sp_poly_coerce_binop(OP, a, b, &_u)) return sp_poly_truthy(_u); } while (0)
+/* the same guard for a method whose answer is the boxed value itself */
+#define SP_POLY_COERCE_NUM(OP) do { sp_RbVal _u; if (sp_poly_coerce_binop(OP, a, b, &_u)) return _u; } while (0)
 static sp_int sp_poly_spaceship(sp_RbVal a, sp_RbVal b) {
   { sp_RbVal _u; if (sp_poly_user_cmp("<=>", a, b, &_u))
+      return _u.tag == SP_TAG_NIL ? SP_INT_NIL : sp_poly_to_i(_u); }
+  { sp_RbVal _u; if (sp_poly_coerce_binop("<=>", a, b, &_u))
       return _u.tag == SP_TAG_NIL ? SP_INT_NIL : sp_poly_to_i(_u); }
   sp_bool comparable; sp_int cmp = sp_poly_cmp(a, b, &comparable);
   if (comparable) return cmp;
@@ -2867,10 +2923,24 @@ static sp_int sp_poly_spaceship(sp_RbVal a, sp_RbVal b) {
   if (sp_poly_eq(a, b)) return 0;
   return SP_INT_NIL;
 }
-static sp_bool sp_poly_lt(sp_RbVal a, sp_RbVal b) { SP_POLY_USER_CMP("<"); sp_bool comparable; sp_int cmp = sp_poly_cmp(a, b, &comparable); if (!comparable) sp_poly_cmp_fail(a, b); return cmp < 0; }
-static sp_bool sp_poly_le(sp_RbVal a, sp_RbVal b) { SP_POLY_USER_CMP("<="); sp_bool comparable; sp_int cmp = sp_poly_cmp(a, b, &comparable); if (!comparable) sp_poly_cmp_fail(a, b); return cmp <= 0; }
-static sp_bool sp_poly_gt(sp_RbVal a, sp_RbVal b) { SP_POLY_USER_CMP(">"); sp_bool comparable; sp_int cmp = sp_poly_cmp(a, b, &comparable); if (!comparable) sp_poly_cmp_fail(a, b); return cmp > 0; }
-static sp_bool sp_poly_ge(sp_RbVal a, sp_RbVal b) { SP_POLY_USER_CMP(">="); sp_bool comparable; sp_int cmp = sp_poly_cmp(a, b, &comparable); if (!comparable) sp_poly_cmp_fail(a, b); return cmp >= 0; }
+static sp_bool sp_poly_lt(sp_RbVal a, sp_RbVal b) { SP_POLY_USER_CMP("<"); SP_POLY_COERCE_CMP("<"); sp_bool comparable; sp_int cmp = sp_poly_cmp(a, b, &comparable); if (!comparable) sp_poly_cmp_fail(a, b); return cmp < 0; }
+static sp_bool sp_poly_le(sp_RbVal a, sp_RbVal b) { SP_POLY_USER_CMP("<="); SP_POLY_COERCE_CMP("<="); sp_bool comparable; sp_int cmp = sp_poly_cmp(a, b, &comparable); if (!comparable) sp_poly_cmp_fail(a, b); return cmp <= 0; }
+static sp_bool sp_poly_gt(sp_RbVal a, sp_RbVal b) { SP_POLY_USER_CMP(">"); SP_POLY_COERCE_CMP(">"); sp_bool comparable; sp_int cmp = sp_poly_cmp(a, b, &comparable); if (!comparable) sp_poly_cmp_fail(a, b); return cmp > 0; }
+static sp_bool sp_poly_ge(sp_RbVal a, sp_RbVal b) { SP_POLY_USER_CMP(">="); SP_POLY_COERCE_CMP(">="); sp_bool comparable; sp_int cmp = sp_poly_cmp(a, b, &comparable); if (!comparable) sp_poly_cmp_fail(a, b); return cmp >= 0; }
+/* Comparable#between? is defined on `<=>` alone: CRuby computes
+   `(self <=> min) >= 0 && (self <=> max) <= 0` and raises "comparison failed"
+   when either answers nil. Lowering it to `>=` and `<=` instead would
+   answer for a class that defines those two and no `<=>`, where CRuby raises. */
+static sp_bool sp_poly_cmp_ge0(sp_RbVal a, sp_RbVal b) {
+  sp_int c = sp_poly_spaceship(a, b);
+  if (c == SP_INT_NIL) sp_poly_cmp_fail(a, b);
+  return c >= 0;
+}
+static sp_bool sp_poly_cmp_le0(sp_RbVal a, sp_RbVal b) {
+  sp_int c = sp_poly_spaceship(a, b);
+  if (c == SP_INT_NIL) sp_poly_cmp_fail(a, b);
+  return c <= 0;
+}
 /* ORDERING (min / max / sort and their _by forms), as distinct from the
    Comparable OPERATORS above. nil defines #<=> and not #<=, so CRuby answers
    `nil <=> nil` with 0 -- [nil, nil].min is nil, .sort is the identity, and a
@@ -2982,9 +3052,9 @@ static void sp_sort_idx_by_poly(sp_int *idx, const sp_RbVal *keys, sp_int n) {
   if (src != idx) for (sp_int x = 0; x < n; x++) idx[x] = src[x];   /* odd #levels: result is in tmp */
   free(tmp);
 }
-static sp_RbVal sp_poly_div(sp_RbVal a, sp_RbVal b) { if ((sp_poly_is_brat(a) || sp_poly_is_brat(b))) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) / sp_poly_to_f(b)); return sp_brat_div_poly(a, b); } if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && a.tag != SP_TAG_FLT && b.tag != SP_TAG_FLT) return sp_box_rational(sp_rational_div(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_COMPLEX) || (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_COMPLEX)) return sp_box_complex(sp_complex_div(sp_poly_as_complex(a), sp_poly_as_complex(b))); if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f_with_rational(a) / sp_poly_to_f_with_rational(b)); if (sp_poly_is_user_obj(a) || sp_poly_is_user_obj(b)) return sp_poly_binop_bad("/", a, b); if ((a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT)) return sp_box_bigint(sp_bigint_div(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); return sp_box_int(sp_idiv(sp_poly_to_i(a), sp_poly_to_i(b))); }
+static sp_RbVal sp_poly_div(sp_RbVal a, sp_RbVal b) { /* before the tower branches, which match on the receiver kind and would convert a user object to a number of that kind */ if (SP_UNLIKELY(sp_poly_is_user_obj(a) || sp_poly_is_user_obj(b))) return sp_poly_binop_bad("/", a, b); if ((sp_poly_is_brat(a) || sp_poly_is_brat(b))) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) / sp_poly_to_f(b)); return sp_brat_div_poly(a, b); } if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && a.tag != SP_TAG_FLT && b.tag != SP_TAG_FLT) return sp_box_rational(sp_rational_div(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_COMPLEX) || (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_COMPLEX)) return sp_box_complex(sp_complex_div(sp_poly_as_complex(a), sp_poly_as_complex(b))); if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f_with_rational(a) / sp_poly_to_f_with_rational(b)); if ((a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT)) return sp_box_bigint(sp_bigint_div(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); return sp_box_int(sp_idiv(sp_poly_to_i(a), sp_poly_to_i(b))); }
 static sp_RbVal sp_poly_str_mod(sp_RbVal a, sp_RbVal b);  /* fwd: defined beside the format helper */
-static sp_RbVal sp_poly_mod(sp_RbVal a, sp_RbVal b) { if (a.tag == SP_TAG_STR || sp_poly_is_strbuf(a)) return sp_poly_str_mod(sp_poly_strbuf_deref(a), b); if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_fmod(sp_poly_to_f(a), sp_poly_to_f(b))); if (sp_poly_is_user_obj(a) || sp_poly_is_user_obj(b)) return sp_poly_binop_bad("%", a, b); if (sp_poly_is_rational(a) || sp_poly_is_rational(b)) return sp_box_rational(sp_rational_mod(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT)) return sp_box_bigint(sp_bigint_mod(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); return sp_box_int(sp_imod(sp_poly_to_i(a), sp_poly_to_i(b))); }  /* sp_fmod: CRuby divisor-sign result + zero-divisor raise */
+static sp_RbVal sp_poly_mod(sp_RbVal a, sp_RbVal b) { if (a.tag == SP_TAG_STR || sp_poly_is_strbuf(a)) return sp_poly_str_mod(sp_poly_strbuf_deref(a), b); /* the user-object arm has to come before the float one: a Float on either side otherwise converted the object to a number (0.0) and answered a division by zero where CRuby coerces. */ if (sp_poly_is_user_obj(a) || sp_poly_is_user_obj(b)) return sp_poly_binop_bad("%", a, b); if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_fmod(sp_poly_to_f(a), sp_poly_to_f(b))); if (sp_poly_is_rational(a) || sp_poly_is_rational(b)) return sp_box_rational(sp_rational_mod(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT)) return sp_box_bigint(sp_bigint_mod(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); return sp_box_int(sp_imod(sp_poly_to_i(a), sp_poly_to_i(b))); }  /* sp_fmod: CRuby divisor-sign result + zero-divisor raise */
 /* divmod / quo on a boxed receiver. The typed paths build these inline per
    receiver kind; the poly path had neither, so an exact Rational reaching them
    through a block parameter raised NoMethodError on a method it answers (#3512).
@@ -2994,10 +3064,12 @@ static sp_PolyArray *sp_PolyArray_new(void);                     /* fwd */
 static void sp_PolyArray_push(sp_PolyArray *a, sp_RbVal v);      /* fwd */
 /* Numeric#fdiv: both operands as Floats, always a Float result (#3767). */
 static sp_float sp_poly_fdiv(sp_RbVal a, sp_RbVal b) {
+  { sp_RbVal _u; if (sp_poly_coerce_binop("fdiv", a, b, &_u)) return sp_poly_to_f(_u); }
   if (!sp_poly_numeric_p(a)) sp_raise_poly_nomethod("fdiv", a);
   return sp_poly_to_f_with_rational(a) / sp_poly_to_f_with_rational(b);
 }
 static sp_RbVal sp_poly_divmod(sp_RbVal a, sp_RbVal b) {
+  SP_POLY_COERCE_NUM("divmod");
   sp_PolyArray *out = sp_PolyArray_new();
   SP_GC_ROOT(out);
   if (sp_poly_is_rational(a) || sp_poly_is_rational(b)) {
@@ -3037,6 +3109,7 @@ static sp_RbVal sp_poly_divmod(sp_RbVal a, sp_RbVal b) {
    operands are (7.0.div(3) => 2). Distinct from `/`, which keeps the operand
    kind, and from #fdiv, which is always a Float (#3800). */
 static sp_RbVal sp_poly_div_m(sp_RbVal a, sp_RbVal b) {
+  SP_POLY_COERCE_NUM("div");
   if (!sp_poly_numeric_p(a) && !sp_poly_is_rational(a) && !sp_poly_is_brat(a))
     sp_raise_poly_nomethod("div", a);
   if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT ||
@@ -3055,6 +3128,7 @@ static sp_RbVal sp_poly_div_m(sp_RbVal a, sp_RbVal b) {
 /* Numeric#remainder: the remainder with the sign of the RECEIVER, which is
    what distinguishes it from #modulo ((-7).remainder(3) is -1, not 2). */
 static sp_RbVal sp_poly_remainder(sp_RbVal a, sp_RbVal b) {
+  SP_POLY_COERCE_NUM("remainder");
   if (!sp_poly_numeric_p(a) && !sp_poly_is_rational(a) && !sp_poly_is_brat(a))
     sp_raise_poly_nomethod("remainder", a);
   if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT ||
@@ -3093,6 +3167,7 @@ static sp_RbVal sp_poly_coerce(sp_RbVal a, sp_RbVal b) {
   return sp_box_poly_array(out);
 }
 static sp_RbVal sp_poly_quo(sp_RbVal a, sp_RbVal b) {
+  SP_POLY_COERCE_NUM("quo");
   if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT)
     return sp_box_float(sp_poly_to_f_with_rational(a) / sp_poly_to_f_with_rational(b));
   return sp_box_rational(sp_rational_div(sp_poly_as_rational(a), sp_poly_as_rational(b)));
@@ -3468,10 +3543,29 @@ static sp_RbVal sp_poly_binop_apply(const char *op, sp_RbVal a, sp_RbVal b) {
       case '*': return sp_poly_mul(a, b);
       case '/': return sp_poly_div(a, b);
       case '%': return sp_poly_mod(a, b);
+      case '<': return sp_box_bool(sp_poly_lt(a, b));
+      case '>': return sp_box_bool(sp_poly_gt(a, b));
       default: break;
     }
   }
   if (strcmp(op, "**") == 0) return sp_poly_pow(a, b);
+  /* The ordered comparisons and the named numeric methods finish the protocol
+     the same way the operators do -- CRuby routes all of them through coerce,
+     and each already has a boxed helper here. Left out, the pair #coerce
+     answered was computed and then thrown away for every operation but the
+     six arithmetic ones. */
+  if (strcmp(op, "<=") == 0) return sp_box_bool(sp_poly_le(a, b));
+  if (strcmp(op, ">=") == 0) return sp_box_bool(sp_poly_ge(a, b));
+  if (strcmp(op, "<=>") == 0) {
+    sp_int _c = sp_poly_spaceship(a, b);
+    return _c == SP_INT_NIL ? sp_box_nil() : sp_box_int(_c);
+  }
+  if (strcmp(op, "div") == 0) return sp_poly_div_m(a, b);
+  if (strcmp(op, "modulo") == 0) return sp_poly_mod(a, b);
+  if (strcmp(op, "remainder") == 0) return sp_poly_remainder(a, b);
+  if (strcmp(op, "quo") == 0) return sp_poly_quo(a, b);
+  if (strcmp(op, "fdiv") == 0) return sp_box_float(sp_poly_fdiv(a, b));
+  if (strcmp(op, "divmod") == 0) return sp_poly_divmod(a, b);
   return sp_box_nil();
 }
 static sp_int sp_PolyArray_length(sp_PolyArray *a) { if (!a) return 0; return a->len; }
@@ -3581,6 +3675,12 @@ static sp_RbVal sp_poly_arr_get(sp_RbVal a, sp_int i) {
    a poly receiver whose array-ness is only known at runtime. */
 static sp_PolyArray *sp_poly_to_poly_array(sp_RbVal v) {
   if (v.tag == SP_TAG_OBJ && v.cls_id == SP_BUILTIN_POLY_ARRAY) return (sp_PolyArray *)v.v.p;
+  /* v is read AFTER the allocation below, and every caller hands it over as a
+     bare temporary -- a freshly built typed array whose only root was the
+     frame that returned it. Without this the new array's allocation collected
+     the source, the pool handed the block on, and the copy read a different
+     object. The early return above stays free of the root. */
+  SP_GC_ROOT_RBVAL(v);
   sp_PolyArray *r = sp_PolyArray_new(); SP_GC_ROOT(r);
   sp_int n = sp_poly_arr_len(v);
   for (sp_int i = 0; i < n; i++) sp_PolyArray_push(r, sp_poly_arr_get(v, i));

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -5497,7 +5497,21 @@ else {
       int acls = ty_object_class(a0);
       if (comp_method_in_chain(c, acls, "coerce", NULL) >= 0) {
         int op_mi = comp_method_in_chain(c, acls, name, NULL);
-        if (op_mi >= 0) return (TyKind)c->scopes[op_mi].ret;
+        /* Only when the pair is of the object's own class does its operator
+           decide the type. The documented plain-number idiom never reaches
+           that method -- the pair's receiver is a Float -- so taking the
+           method's return there answered one operator from the class and
+           another from the pair. */
+        if (op_mi >= 0 && !class_has_coerce_shape(c, acls))
+          return (TyKind)c->scopes[op_mi].ret;
+        /* The standard idiom answers a pair of plain NUMBERS and defines no
+           operator of its own, so the result is whatever the pair computes --
+           known only at run time. Left UNKNOWN, the expression emitted a nil
+           and `5 + obj` answered nil instead of the coerced sum. The emittable
+           test is the one emit_numeric_coerce_call makes, so a #coerce this TU
+           cannot call keeps the type it had rather than promising a pair that
+           never gets computed. */
+        return TY_POLY;
       }
     }
     /* a poly operand makes the +,-,*,/ result poly: codegen lowers these to

--- a/src/analyze_infer_recv.c
+++ b/src/analyze_infer_recv.c
@@ -217,6 +217,24 @@ int infer_numeric_call(Compiler *c, int id, TyKind rt, TyKind *out) {
   if (args >= 0) argv = nt_arr(nt, args, "arguments", &argc);
   (void)argv; (void)recv; (void)nt;
   if (!name) return 0;
+  /* A numeric receiver and a coercing user object: the answer is whatever the
+     pair #coerce hands back computes, and that is a run-time class -- CRuby's
+     own `def coerce(v) = [2.0, v]` turns an Integer receiver's #modulo into a
+     Float. Typed from the receiver instead, the named methods reinterpreted
+     the boxed result under the wrong tag: 5.modulo(obj) read the bits of 2.0
+     as an Integer and printed 4611686018427387904. The comparisons keep their
+     bool and `<=>` its int, which the protocol cannot widen. This mirrors
+     emit_numeric_coerce_call's guard so the two agree on every shape. */
+  if (argc == 1 && recv >= 0 && is_numeric_coerce_op(name) &&
+      !is_cmp_op(name) && !sp_streq(name, "<=>") &&
+      nt_ref(nt, id, "block") < 0 &&
+      (rt == TY_INT || rt == TY_FLOAT || rt == TY_RATIONAL || rt == TY_BIGINT)) {
+    TyKind ac = comp_ntype(c, argv[0]);
+    if (ty_is_object(ac) && class_has_coerce_shape(c, ty_object_class(ac))) {
+      *out = TY_POLY;
+      return 1;
+    }
+  }
   if (rt == TY_INT && argc == 1 && comp_ntype(c, argv[0]) == TY_COMPLEX) {
     if (sp_streq(name, "+") || sp_streq(name, "-") || sp_streq(name, "*") || sp_streq(name, "/")) { *out = TY_COMPLEX; return 1; }
     if (sp_streq(name, "==") || sp_streq(name, "!=")) { *out = TY_BOOL; return 1; }

--- a/src/analyze_internal.h
+++ b/src/analyze_internal.h
@@ -88,6 +88,9 @@ int is_arith_op(const char *op);
 int node_is_empty_container(const NodeTable *nt, int node);
 int bind_coerce_operator_params(Compiler *c);
 int is_cmp_op(const char *op);
+int is_numeric_coerce_op(const char *op);
+int class_coerce_emittable(Compiler *c, int k);
+int class_has_coerce_shape(Compiler *c, int k);
 int is_eq_op(const char *op);
 int is_void_call(const char *name);
 /* Resolve a struct member from a literal key node: a SymbolNode names a

--- a/src/analyze_pass.c
+++ b/src/analyze_pass.c
@@ -3579,7 +3579,7 @@ int bind_coerce_operator_params(Compiler *c) {
   }
   NT_FOREACH_KIND(nt, NK_CallNode, id) {
     const char *nm = nt_str(nt, id, "name");
-    if (!nm || !is_arith_op(nm) || nt_ref(nt, id, "block") >= 0) continue;
+    if (!nm || !is_numeric_coerce_op(nm) || nt_ref(nt, id, "block") >= 0) continue;
     int recv = nt_ref(nt, id, "receiver");
     if (recv < 0) continue;
     TyKind rt = infer_type(c, recv);
@@ -3614,7 +3614,15 @@ int bind_coerce_operator_params(Compiler *c) {
     if (m->nparams < 1 || !m->pnames[0]) continue;
     LocalVar *p = scope_local(m, m->pnames[0]);
     if (!p || p->rbs_seeded) continue;
-    TyKind merged = ty_unify(p->type, a0);
+    /* Every operation reaches the class through the boxed hook now, which
+       hands the second pair element over as an sp_RbVal -- and which VALUE
+       that is depends on the idiom: `[Klass.new(v), self]` makes it the
+       object, `[Klass.new, v]` makes it the NUMBER. Narrowing the parameter
+       to the object's class guards the dispatch arm on that class, so the
+       second idiom's arm falls through and `5 + obj` raises NoMethodError on
+       a `+` the class defines (found by matz reviewing #4265). The parameter
+       has to be poly. */
+    TyKind merged = ty_unify(p->type, TY_POLY);
     if (merged != p->type) { p->type = merged; changed = 1; }
   }
   return changed;

--- a/src/analyze_util.c
+++ b/src/analyze_util.c
@@ -273,6 +273,47 @@ int is_cmp_op(const char *op) {
   static const char *const set[] = {"<", ">", "<=", ">=", NULL};
   return str_in(op, set);
 }
+/* The numeric operations CRuby routes through #coerce: the arithmetic
+   operators, the ordered comparisons and `<=>`, and the named division family.
+   `==` is deliberately absent -- Numeric#== answers false for an operand it
+   cannot coerce rather than asking, so routing it here would turn a plain
+   false into the coerced comparison. */
+int is_numeric_coerce_op(const char *op) {
+  static const char *const set[] = {
+    "+", "-", "*", "/", "%", "**",
+    "<", ">", "<=", ">=", "<=>",
+    "div", "modulo", "remainder", "quo", "fdiv", "divmod", NULL};
+  return str_in(op, set);
+}
+/* 1 if class k defines a #coerce whose SHAPE the protocol can use: one
+   parameter, no rest. Nothing here consults reachability or the return type,
+   because compute_reachable runs long after the type fixpoint -- a predicate
+   that asked would answer 0 for every call the fixpoint makes and the rule
+   would be dormant exactly where it is needed. Typing and emission both ask
+   this, so they agree at every point in the pipeline; whether the coerce
+   dispatch ends up carrying an arm for the class is a separate question that
+   only codegen needs (class_coerce_emittable), and a class that fails it finds
+   the hook unhandled and gets the TypeError CRuby raises for it anyway. */
+int class_has_coerce_shape(Compiler *c, int k) {
+  int mi = comp_method_in_chain(c, k, "coerce", NULL);
+  if (mi < 0) return 0;
+  Scope *m = &c->scopes[mi];
+  return m->nparams == 1 && m->rest_idx < 0;
+}
+/* 1 if class k defines a #coerce this TU emits and can call from the runtime
+   hook: one parameter, no rest, an array return (the [other, self] pair).
+   The coerce protocol needs it for `5 + obj` where obj only reads poly. */
+int class_coerce_emittable(Compiler *c, int k) {
+  int defcls = -1;
+  int mi = comp_method_in_chain(c, k, "coerce", &defcls);
+  if (mi < 0) return 0;
+  Scope *m = &c->scopes[mi];
+  if (!m->reachable || m->yields || scope_is_shadowed(c, mi) || m->is_transplanted_source)
+    return 0;
+  if (m->nparams != 1 || m->rest_idx >= 0) return 0;
+  if (!ty_is_array(m->ret) && m->ret != TY_POLY_ARRAY) return 0;
+  return 1;
+}
 int is_eq_op(const char *op) {
   static const char *const set[] = {"==", "!=", "===", NULL};
   return str_in(op, set);

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -7137,7 +7137,13 @@ static void emit_user_binop_dispatch(Compiler *c, Buf *b) {
           TyKind cpt = (cp2 && cp2->type != TY_UNKNOWN) ? cp2->type : TY_POLY;
           const char *ccn = c->classes[cmp_defcls].c_name;
           int cvt = c->classes[cmp_defcls].is_value_type;
-          if (ty_is_object(cpt) || cpt == TY_POLY) {
+          /* the arm compares the spaceship's answer with 0, so that answer has
+             to BE a number -- an int, or a float as emit_obj_cmp_dispatch
+             already allows. A `<=>` that can return nil is typed poly (or has
+             no value at all), and `sp_X_cmp(...) == 0` on it is ill-typed C
+             -- reachable as soon as the class also defines #coerce. */
+          int cmp_ret_ok = (cm2->ret == TY_INT || cm2->ret == TY_FLOAT);
+          if (cmp_ret_ok && (ty_is_object(cpt) || cpt == TY_POLY)) {
             char cargs[160];
             const char *cguard = NULL;
             static char cgb[64];
@@ -7161,21 +7167,6 @@ static void emit_user_binop_dispatch(Compiler *c, Buf *b) {
     buf_puts(b, "      break;\n    }\n");
   }
   buf_puts(b, "    default: break;\n  }\n  return sp_box_nil();\n}\n");
-}
-
-/* 1 if class k defines a #coerce this TU emits and can call from the runtime
-   hook: one parameter, no rest, a poly-array return (the [other, self] pair).
-   The coerce protocol needs it for `5 + obj` where obj only reads poly. */
-static int class_coerce_emittable(Compiler *c, int k) {
-  int defcls = -1;
-  int mi = comp_method_in_chain(c, k, "coerce", &defcls);
-  if (mi < 0) return 0;
-  Scope *m = &c->scopes[mi];
-  if (!m->reachable || m->yields || scope_is_shadowed(c, mi) || m->is_transplanted_source)
-    return 0;
-  if (m->nparams != 1 || m->rest_idx >= 0) return 0;
-  if (m->ret != TY_POLY_ARRAY) return 0;
-  return 1;
 }
 
 /* Generate sp_user_to_io_dispatch: the cls_id switch behind IO.select's
@@ -7229,12 +7220,31 @@ static void emit_user_coerce_dispatch(Compiler *c, Buf *b) {
     else if (pt == TY_FLOAT) arg = "sp_poly_to_f(recv)";
     else continue;
     const char *dcn = c->classes[defcls].c_name;
-    buf_printf(b, "    case %d: _pr = sp_%s_coerce(%s(sp_%s *)obj.v.p, %s); break;\n",
-               comp_class_index(c, c->classes[k].name), dcn,
-               c->classes[defcls].is_value_type ? "*" : "", dcn, arg);
+    /* a #coerce that answers a homogeneously-typed pair -- `[9.0, v.to_f]` is
+       a Float array -- is just as valid as a poly one, and rejecting it left
+       the operation lowered against the object's address. Convert it. */
+    Scope *cm = &c->scopes[mi];
+    int cidx = comp_class_index(c, c->classes[k].name);
+    if (cm->ret == TY_POLY_ARRAY) {
+      buf_printf(b, "    case %d: _pr = sp_%s_coerce(%s(sp_%s *)obj.v.p, %s); break;\n",
+                 cidx, dcn, c->classes[defcls].is_value_type ? "*" : "", dcn, arg);
+    }
+    else {
+      Buf callb = {0}, boxb = {0};
+      buf_printf(&callb, "sp_%s_coerce(%s(sp_%s *)obj.v.p, %s)",
+                 dcn, c->classes[defcls].is_value_type ? "*" : "", dcn, arg);
+      emit_boxed_text(c, cm->ret, callb.p, &boxb);
+      buf_printf(b, "    case %d: _pr = sp_poly_to_poly_array(%s); break;\n",
+                 cidx, boxb.p ? boxb.p : "sp_box_nil()");
+      free(callb.p); free(boxb.p);
+    }
   }
   buf_puts(b, "    default: break;\n  }\n");
-  buf_puts(b, "  if (!_pr || _pr->len < 2) return sp_box_nil();\n");
+  /* a #coerce that answered something, but not a pair, is CRuby's TypeError --
+     distinct from a class with no usable #coerce at all, which leaves the hook
+     unhandled so the caller's own error stands. */
+  buf_puts(b, "  if (_pr && _pr->len != 2) sp_raise_cls(\"TypeError\", \"coerce must return [x, y]\");\n");
+  buf_puts(b, "  if (!_pr) return sp_box_nil();\n");
   buf_puts(b, "  SP_GC_ROOT(_pr);\n");
   /* The pair's own operator finishes the job: for the usual [Klass(other),
      self] that is the class's own method, reached through the binop hook. */
@@ -9934,10 +9944,19 @@ char *codegen_program(const NodeTable *nt) {
   {
     static const char *const uops[] = {
       "+", "-", "*", "/", "%", "**", "<<", ">>", "&", "|", "^", NULL };
+    /* A class that defines a #coerce needs the table for its COMPARISONS too:
+       the protocol routes `5 < obj` to the boxed entry, which reaches the
+       class through this hook. Only for such a class, though -- an ordinary
+       Comparable defines <=> and no coerce, is never reached this way, and
+       would only gain a dispatch table it has no use for. */
+    static const char *const cops[] = { "<", ">", "<=", ">=", "<=>", NULL };
     for (int k = 0; k < c->nclasses && !g_has_user_binop; k++) {
       if (!c->classes[k].instantiated) continue;
       for (int u = 0; uops[u]; u++)
         if (comp_method_in_chain(c, k, uops[u], NULL) >= 0) { g_has_user_binop = 1; break; }
+      if (g_has_user_binop || !class_has_coerce_shape(c, k)) continue;
+      for (int u = 0; cops[u]; u++)
+        if (comp_method_in_chain(c, k, cops[u], NULL) >= 0) { g_has_user_binop = 1; break; }
     }
   }
   g_has_user_coerce = 0;

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -14038,6 +14038,151 @@ static int cls_arm_takes_argc(Scope *s, int argc) {
   return argc >= s->nrequired && argc <= s->nparams;
 }
 
+/* 1 if this operand is a user object whose class defines a #coerce with a
+   usable SHAPE (one parameter, no rest). Deliberately not class_coerce_emittable:
+   that asks whether the coerce dispatch will carry an arm for the class, which
+   depends on reachability -- and reachability is computed long after the type
+   fixpoint that has to answer this same question. Asking the shape keeps the
+   typing rule and this emission in step at every point in the pipeline; a class
+   whose #coerce turns out to have no arm simply finds the hook unhandled and
+   gets the ordinary TypeError, which is what CRuby raises for it too. */
+static int coercing_object_arg(Compiler *c, int node) {
+  TyKind t = comp_ntype(c, node);
+  if (!ty_is_object(t)) return 0;
+  return class_has_coerce_shape(c, ty_object_class(t));
+}
+
+/* The boxed runtime entry for each operation the coerce protocol routes, and
+   the C type it answers. Going through these rather than calling #coerce here
+   is what keeps the emission independent of the operand's static class: the
+   dispatch behind them switches on cls_id, so it casts a subclass correctly,
+   ignores a nil operand, and needs no return-type agreement from the method. */
+static const char *numeric_coerce_fn(const char *op, TyKind *answers) {
+  *answers = TY_POLY;
+  if (sp_streq(op, "+")) return "sp_poly_add";
+  if (sp_streq(op, "-")) return "sp_poly_sub";
+  if (sp_streq(op, "*")) return "sp_poly_mul";
+  if (sp_streq(op, "/")) return "sp_poly_div";
+  if (sp_streq(op, "%") || sp_streq(op, "modulo")) return "sp_poly_mod";
+  if (sp_streq(op, "**")) return "sp_poly_pow";
+  if (sp_streq(op, "div")) return "sp_poly_div_m";
+  if (sp_streq(op, "remainder")) return "sp_poly_remainder";
+  if (sp_streq(op, "quo")) return "sp_poly_quo";
+  if (sp_streq(op, "divmod")) return "sp_poly_divmod";
+  *answers = TY_BOOL;
+  if (sp_streq(op, "<")) return "sp_poly_lt";
+  if (sp_streq(op, ">")) return "sp_poly_gt";
+  if (sp_streq(op, "<=")) return "sp_poly_le";
+  if (sp_streq(op, ">=")) return "sp_poly_ge";
+  *answers = TY_INT;
+  if (sp_streq(op, "<=>")) return "sp_poly_spaceship";
+  *answers = TY_FLOAT;
+  if (sp_streq(op, "fdiv")) return "sp_poly_fdiv";
+  return NULL;
+}
+
+/* `recv <op> arg` where recv is a builtin numeric and arg is a user object
+   defining #coerce: Ruby asks the object for the pair `a, b = arg.coerce(recv)`
+   and answers `a.<op>(b)`.
+
+   This runs ahead of the per-method numeric branches because the protocol is
+   ONE rule for all of them, while each of those branches would otherwise apply
+   its own lowering to an object POINTER. Only the six arithmetic operators
+   consulted coerce at a typed call site at all, so everything else reached a
+   branch that treated the pointer as a number: `5 < obj` became a C ordered
+   comparison against the object's ADDRESS -- a silent answer that tracks the
+   allocator and inverts as soon as coerce's pair disagrees with it -- while
+   `5.0 + obj` became ill-typed C.
+
+   All this emission does is refuse to lower the operation against a pointer,
+   and hand both sides to the boxed entry instead. The protocol itself lives in
+   the runtime, where the hook already dispatches on cls_id; nothing here needs
+   to know the operand's class, which is what keeps an inherited #coerce, a nil
+   operand and a #coerce whose pair is not a poly array from each needing a
+   special case of their own. */
+static int emit_numeric_coerce_call(Compiler *c, int id, Buf *b) {
+  const NodeTable *nt = c->nt;
+  const char *name = nt_str(nt, id, "name");
+  int recv = nt_ref(nt, id, "receiver");
+  int argc;
+  const int *argv = call_args(nt, id, &argc);
+  if (recv < 0 || !name || nt_ref(nt, id, "block") >= 0) return 0;
+  TyKind rt = comp_ntype(c, recv);
+  if (rt != TY_INT && rt != TY_FLOAT && rt != TY_RATIONAL && rt != TY_BIGINT) return 0;
+
+  /* Comparable#between? is `(self <=> min) >= 0 && (self <=> max) <= 0` -- the
+     spaceship and nothing else, which is why a class that defines `>=` and `<=`
+     but no `<=>` gets CRuby's "comparison failed" rather than an answer. The
+     numeric branches lowered it against each bound's ADDRESS, the same silent
+     answer the operators gave one method over. The receiver is bound to a temp
+     because it is compared twice, and rooted because both bounds are evaluated
+     after it and each may allocate: a Rational or Bignum box carries a heap
+     pointer that has to survive them. */
+  if (argc == 2 && sp_streq(name, "between?") &&
+      (coercing_object_arg(c, argv[0]) || coercing_object_arg(c, argv[1]))) {
+    int tr = ++g_tmp, tl = ++g_tmp, th = ++g_tmp;
+    buf_printf(b, "({ sp_RbVal _t%d = ", tr);
+    emit_boxed(c, recv, b);
+    /* The bounds are spilled and rooted like the binary path's operand: each
+       is read again deep inside its own #coerce, and the second bound must
+       survive the first comparison's allocations. Ruby, too, evaluates both
+       bound expressions before the first <=> runs. */
+    buf_printf(b, "; SP_GC_ROOT_RBVAL(_t%d); sp_RbVal _t%d = ", tr, tl);
+    emit_boxed(c, argv[0], b);
+    buf_printf(b, "; SP_GC_ROOT_RBVAL(_t%d); sp_RbVal _t%d = ", tl, th);
+    emit_boxed(c, argv[1], b);
+    buf_printf(b, "; SP_GC_ROOT_RBVAL(_t%d);"
+                  " sp_poly_cmp_ge0(_t%d, _t%d) && sp_poly_cmp_le0(_t%d, _t%d); })",
+               th, tr, tl, tr, th);
+    return 1;
+  }
+
+  if (argc != 1) return 0;
+  if (!coercing_object_arg(c, argv[0])) return 0;
+  TyKind answers;
+  const char *fn = numeric_coerce_fn(name, &answers);
+  if (!fn) return 0;
+
+  int tr = ++g_tmp, to = ++g_tmp;
+  TyKind res = comp_ntype(c, id);
+  /* Both sides are spilled into rooted temps, and the receiver first -- which
+     is Ruby's own order.
+
+     The receiver has to be rooted because the operand is commonly a fresh
+     allocation: emitting the two as bare arguments to one call left the
+     receiver's box, which for a Rational or Bignum carries a heap pointer,
+     unrooted while that allocation ran.
+
+     The operand has to be rooted because the protocol reads it again deep
+     inside the call. The generated #coerce roots its parameter but not its
+     SELF, and the idiomatic body allocates -- `[Klass.new(v), self]` builds an
+     object and an array before `self` is read. With the operand unrooted the
+     collector took it there and the pool handed the block to the object the
+     method had just built, so `self` became a different live object and the
+     operation answered a plausible wrong number. */
+  buf_printf(b, "({ sp_RbVal _t%d = ", tr);
+  emit_boxed(c, recv, b);
+  buf_printf(b, "; SP_GC_ROOT_RBVAL(_t%d); sp_RbVal _t%d = ", tr, to);
+  emit_boxed(c, argv[0], b);
+  buf_printf(b, "; SP_GC_ROOT_RBVAL(_t%d); ", to);
+  Buf call = {0};
+  buf_printf(&call, "%s(_t%d, _t%d)", fn, tr, to);
+  /* box the entry's own answer, then let the slot take it back in its type --
+     `<=>` answers an int sentinel for nil, so the nilable form is the one that
+     lands a nil on the slot's own nil rather than under the payload. */
+  if (res == TY_POLY || res == TY_UNKNOWN) emit_boxed_text(c, answers, call.p, b);
+  else if (answers == res) buf_puts(b, call.p);
+  else {
+    Buf boxed = {0};
+    emit_boxed_text(c, answers, call.p, &boxed);
+    emit_unbox_nilable_text(c, res, boxed.p, b);
+    free(boxed.p);
+  }
+  free(call.p);
+  buf_puts(b, "; })");
+  return 1;
+}
+
 static void emit_call_body(Compiler *c, int id, Buf *b) {
   /* deep-return pickup (#3227 P6): a marked receiverless call to a method
      whose every return path yields a shared handle -- reset the side
@@ -14821,6 +14966,8 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
     buf_puts(b, ")).v.p))");
     return;
   }
+
+  if (emit_numeric_coerce_call(c, id, b)) return;
 
   if (emit_complex_rational_call(c, id, b)) return;
 
@@ -26569,6 +26716,18 @@ else {
         buf_puts(b, "))), FALSE)");
         return;
       }
+      /* the same failure for a user object, which CRuby names by its class
+         (sp_cmperr_desc makes that distinction). Lowered as a byte compare,
+         the object's pointer went to sp_str_cmp_bytes and the build failed
+         -- or, before that, compared as bytes (found by matz reviewing #4265) */
+      if (ty_is_object(sat)) {
+        buf_puts(b, "((void)("); emit_expr(c, recv, b);
+        buf_puts(b, "), sp_raise_cls(\"ArgumentError\", sp_sprintf("
+                    "\"comparison of String with %s failed\", sp_cmperr_desc(");
+        emit_boxed(c, argv[0], b);
+        buf_puts(b, "))), FALSE)");
+        return;
+      }
       buf_puts(b, "(sp_str_cmp_bytes(");
       emit_expr(c, recv, b); buf_puts(b, ", "); emit_expr(c, argv[0], b);
       buf_printf(b, ") %s 0)", name);
@@ -26957,6 +27116,23 @@ else {
 
   /* between?(lo, hi): lo <= self <= hi */
   if (sp_streq(name, "between?") && argc == 2) {
+    if (rt == TY_STRING &&
+        (ty_is_object(comp_ntype(c, argv[0])) || ty_is_object(comp_ntype(c, argv[1])))) {
+      /* Comparable#between? is two <=>s, and String#<=> against an object
+         that answers neither <=> nor to_str is nil: CRuby's "comparison
+         failed", named after the first bad bound. Both bounds are still
+         evaluated, once each, in order -- Ruby evaluates the arguments before
+         between? runs -- so each is spilled to a temp first. */
+      int t0 = ++g_tmp, t1 = ++g_tmp;
+      int bad = ty_is_object(comp_ntype(c, argv[0])) ? t0 : t1;
+      buf_puts(b, "({ (void)("); emit_expr(c, recv, b);
+      buf_printf(b, "); sp_RbVal _t%d = ", t0); emit_boxed(c, argv[0], b);
+      buf_printf(b, "; sp_RbVal _t%d = ", t1); emit_boxed(c, argv[1], b);
+      buf_printf(b, "; (void)_t%d; (void)_t%d; sp_raise_cls(\"ArgumentError\", sp_sprintf("
+                    "\"comparison of String with %%s failed\", sp_cmperr_desc(_t%d))); FALSE; })",
+                 t0, t1, bad);
+      return;
+    }
     if (rt == TY_STRING) {
       int tv = ++g_tmp;
       buf_printf(b, "({ const char *_t%d = ", tv); emit_expr(c, recv, b);

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -356,6 +356,12 @@ extern int g_uses_threads;
 extern int g_has_user_cmp;
 extern int g_has_user_binop;
 extern int g_has_user_coerce;
+/* 1 if class k defines a #coerce this TU emits and can call: one parameter,
+   no rest, an array return -- the [other, self] pair, poly or homogeneously
+   typed. See analyze_util.c. */
+int class_coerce_emittable(Compiler *c, int k);
+int class_has_coerce_shape(Compiler *c, int k);
+int is_numeric_coerce_op(const char *op);
 extern int g_has_user_to_io;
 extern int g_gen_obj_hashkey; /* >=1 instantiated class defines #hash + #eql?: emit + install the obj hash/eql key hooks */
 extern int g_gen_obj_valeq;   /* >=1 instantiated Struct/Data class: emit + install the value-== hook so containers compare them by value */

--- a/test/numeric_coerce_protocol.rb
+++ b/test/numeric_coerce_protocol.rb
@@ -1,0 +1,294 @@
+# A numeric operation whose operand is a user object goes through that object's
+# #coerce: CRuby asks for the pair `a, b = obj.coerce(recv)` and answers
+# `a <op> b`. That covers the arithmetic operators, the ordered comparisons and
+# <=>, the named division family, and Comparable#between? -- for a receiver
+# anywhere in the numeric tower, held in a typed slot or read back boxed.
+#
+# The pins that matter most are the ordered comparisons: lowered as raw C they
+# compared the receiver against the object's ADDRESS, so the answer was silently
+# whatever the allocator arranged. Their operands are chosen so the coerced
+# answer DISAGREES with that address comparison rather than happening to agree.
+
+class Num                 # the standard idiom: a pair of plain numbers
+  def coerce(v) = [2.0, v]
+end
+
+# #coerce puts the receiver on the RIGHT of the operator, so a constant ABOVE
+# the receiver makes every ordered comparison disagree with the address
+# comparison the old lowering performed -- which is what these pin.
+class Hi
+  def coerce(v) = [9.0, v]
+end
+
+class Bound               # the two bounds of a between? differ
+  def initialize(v) = @v = v
+  def coerce(v) = [@v, v]
+end
+
+class Pair                # the other idiom: a pair of the class's own kind
+  def initialize(v) = @v = v
+  def value = @v
+  def coerce(v) = [Pair.new(v), self]
+  def +(o) = @v + o.value
+  def <(o) = @v < o.value
+end
+
+class Bad                 # a #coerce that answers a short pair at run time
+  def coerce(v) = [2.0, v].take(v > 0 ? 1 : 2)
+end
+
+def show
+  p(yield)
+rescue => e
+  p [e.class, e.message]
+end
+
+# --- the arithmetic operators, standard idiom (answered nil before) ---
+show { 5 + Num.new }
+show { 5 - Num.new }
+show { 5 * Num.new }
+show { 5 / Num.new }
+show { 5 % Num.new }
+show { 5 ** Num.new }
+
+# (This block sits ahead of the heavier pins on purpose: reading the raised
+# exception's class/message late in this file trips a pre-existing GC-stress
+# corruption in master's rescue machinery, present with this change or without.)
+# CRuby raises for any pair that is not exactly two long, in both directions.
+class TooMany
+  def coerce(v) = [1, 2, 3]
+end
+show { 5 + TooMany.new }
+
+# The pair's first element is an instance of the coercing class and its
+# SECOND is the number -- `[Money.new, v]` -- so the class's own operator runs
+# with a numeric argument. Its parameter therefore has to be poly: narrowed to
+# the class, the dispatch arm fell through and raised on a method the class
+# defines (matz, reviewing #4265). These sit early in the file for the same
+# reason the TooMany pin does.
+class Money
+  def coerce(v) = [Money.new, v]
+  def +(o) = "money+"
+end
+p(5 + Money.new)
+p(5.0 + Money.new)
+
+# Only a NUMBER asks. A String receiver with an operand that answers neither
+# <=> nor to_str is CRuby's "comparison failed" -- for the ordered operators
+# and for between?, whose typed lowering used to hand the object's pointer to
+# a byte compare. between? still evaluates both bounds, once each.
+money = Money.new
+show { "abc" < money }
+show { "abc" >= money }
+show { "abc".between?(money, "b") }
+
+# Comparable's == is <=> against 0, which is as valid for a Float answer as
+# for an Integer one
+class Gauge
+  include Comparable
+  attr_reader :v
+  def initialize(v) = @v = v
+  def coerce(n) = [Gauge.new(n), self]
+  def <=>(o) = (v - o.v).to_f
+end
+p(Gauge.new(2) == Gauge.new(2))
+p(Gauge.new(2) == Gauge.new(3))
+
+class Whole
+  def coerce(v) = [v, 3]
+end
+
+# Complex is part of the tower and CRuby's Complex#+ coerces; the receiver
+# guard has to admit it or a poly Complex loses its own answer.
+class Wrap
+  def initialize(v) = @v = v
+  def v = @v
+  def coerce(o) = [Wrap.new(o), self]
+  def +(o) = Wrap.new(@v + o.v)
+  def inspect = "Wrap(#{@v})"
+end
+cx = [Complex(3, 4)]
+cx.each { |x| show { x + Wrap.new(9) } }
+
+# ...and ONLY for + - * / ** <=>. The rest refuse rather than answer: %, div
+# and remainder match CRuby's NoMethodError byte for byte; the ordered
+# comparisons and divmod fail loudly with a different error class (recorded
+# in the PR); quo and fdiv keep master's refusal rather than gaining a wrong
+# number through boxed entries that have no Complex arm.
+class Inert; end
+cx.each { |x| show { x % Whole.new } }
+cx.each { |x| show { x.div(Whole.new) } }
+cx.each { |x| show { x.remainder(Whole.new) } }
+cx.each { |x| show { x + Inert.new } }
+
+# --- ordered comparisons: each disagrees with an address comparison ---
+show { 5 < Hi.new }
+show { 5 <= Hi.new }
+show { 5 > Hi.new }
+show { 5 >= Hi.new }
+show { 5 <=> Hi.new }
+show { 1.5 < Hi.new }
+show { 1.5 >= Hi.new }
+
+# --- Comparable#between?, two coerced comparisons ---
+show { 1.between?(Bound.new(2.0), Bound.new(0.0)) }
+show { 5.between?(Bound.new(2.0), Bound.new(9.0)) }
+show { 1.5.between?(Bound.new(2.0), Bound.new(0.0)) }
+
+# --- the named division family ---
+show { 5.div(Num.new) }
+show { 5.modulo(Num.new) }
+show { 5.remainder(Num.new) }
+show { 5.quo(Num.new) }
+show { 5.fdiv(Num.new) }
+show { 5.divmod(Num.new) }
+show { 5.0.div(Num.new) }
+show { 5.0.modulo(Num.new) }
+show { 5.0.quo(Num.new) }
+show { 5.0.divmod(Num.new) }
+
+# --- a Float receiver: the operators built ill-typed C before ---
+show { 5.0 + Num.new }
+show { 5.0 - Num.new }
+show { 5.0 * Num.new }
+show { 5.0 / Num.new }
+show { 5.0 % Num.new }
+
+# --- the rest of the tower ---
+show { Rational(3, 2) + Num.new }
+show { Rational(3, 2) < Hi.new }
+show { (10 ** 20) + Num.new }
+
+# --- a boxed receiver read back out of a container ---
+[5, 5.0].each do |v|
+  show { v + Num.new }
+  show { v < Hi.new }
+  show { v.div(Num.new) }
+end
+
+# --- the pair-of-its-own-class idiom keeps its own methods ---
+show { 1 + Pair.new(9) }
+show { 1 < Pair.new(9) }
+show { 9 < Pair.new(1) }
+
+# --- a #coerce that answers no pair is CRuby's TypeError ---
+show { 5 + Bad.new }
+
+# --- the pair stays live across an allocating operand ---
+def churn(n)
+  100.times { |i| [i, i.to_s, {i => i}] }
+  n
+end
+total = 0.0
+40.times { total += (5 + Num.new) + churn(1) }
+p total
+
+# #between? boxes its receiver and then evaluates both bounds, each of which
+# allocates. A Rational receiver's box carries a heap pointer and gets no root
+# from the operand-spill pass, so the emitter's own root is the only thing
+# keeping it alive across the bounds: without it this answers false.
+def churning_bound(v)
+  60.times { |i| [i, i.to_s, {i => i}] }
+  Bound.new(v)
+end
+hits = 0
+40.times { hits += 1 if Rational(3, 2).between?(churning_bound(2.0), churning_bound(1.0)) }
+p hits
+
+class Lo
+  def coerce(v) = [Rational(3, 4), v]
+end
+def allocating_bound
+  GC.start
+  8.times { [Rational(9, 10)] }
+  Lo.new
+end
+p(Rational(3, 4).between?(allocating_bound, 5))
+
+# The operand is usually a fresh object, and the RECEIVER is evaluated first.
+# Emitted as two bare arguments to one call the operand sat unrooted while the
+# receiver ran: a receiver that allocates collected it, the class pool handed
+# the block to the next object of that class, and #coerce answered from the
+# WRONG object -- a plausible number rather than a crash.
+class Rate
+  def initialize(n) = @n = n
+  def coerce(v) = [@n, v]
+end
+def allocating_recv(x)
+  GC.start
+  Rate.new(999)
+  x
+end
+p [allocating_recv(5) + Rate.new(7), allocating_recv(5) * Rate.new(7),
+   allocating_recv(5).divmod(Rate.new(7)), allocating_recv(100) < Rate.new(7)]
+
+# A #coerce may answer a homogeneously-typed pair -- an Int or Float array, not
+# a poly one -- which is converted rather than used directly. This covers that
+# arm, which the operators and the comparisons both reach. The conversion also
+# has to keep the array it was handed alive across its own allocation, since
+# that array's only root was the frame that returned it; this file does not
+# make that observable, but a loop of `5 + IntPair.new` on its own does.
+class IntPair
+  def coerce(v) = [100, 7]      # a FRESH Int array on every call
+end
+class FloatPair
+  def coerce(v) = [9.0, v.to_f]
+end
+bad = 0
+2000.times do
+  bad += 1 unless (5 + IntPair.new) == 107
+  bad += 1 unless (5 < IntPair.new) == false
+  bad += 1 unless (5 < FloatPair.new) == false   # the pair is [9.0, 5.0]
+  bad += 1 unless (5 > FloatPair.new) == true
+end
+p bad
+
+# A coerced Bignum runs on the boxed division family, whose Bignum arms are
+# the parent commit's own rule; the protocol only hands the pair over.
+show { (10 ** 25).div(Whole.new) }
+show { (10 ** 25).divmod(Whole.new) }
+
+# The pair-of-its-own-class idiom reads `self` after allocating both the new
+# object and the array, so the operand has to stay rooted across the call --
+# otherwise the collector takes it there and the pool hands its block to the
+# object the method has just built.
+class Own
+  def initialize(n = 0) = (@n = n)
+  def n = @n
+  def coerce(v)
+    junk = []
+    120.times { |i| junk << i.to_s }
+    [Own.new(v.to_i), self]
+  end
+  def +(o) = 1000 + o.n
+end
+bad = 0
+2000.times { bad += 1 unless (5 + Own.new(9)) == 1009 }
+p bad
+
+# between?'s bounds stay rooted across each bound's own #coerce: the protocol
+# reads the bound again (here through @v) after its coerce has allocated, so a
+# fresh unrooted bound could be recycled mid-call and answer from the wrong
+# object. 0 wrong answers over 400 rounds; the build that rooted only the
+# receiver answered wrong for 3 of them under GC stress.
+class FreshBound
+  def initialize(v); @v = v; end
+  def coerce(other)
+    junk = []
+    60.times { junk << FreshBound.new(-999) }
+    [other, @v]
+  end
+end
+hi = FreshBound.new(9)
+bad = 0
+400.times do
+  r = 5.between?(FreshBound.new(6), hi)
+  bad += 1 if r != false
+end
+p bad
+
+# Comparable's derived == on the BOXED path compares <=>'s Float answer with 0
+# (the typed path above already agrees on master; this arm did not exist for a
+# Float <=> before). Last on purpose: nothing raises after it.
+gs = [Gauge.new(2.0), Gauge.new(2)]
+p(gs[0] == gs[1])

--- a/test/numeric_coerce_protocol.rb.expected
+++ b/test/numeric_coerce_protocol.rb.expected
@@ -1,0 +1,67 @@
+7.0
+-3.0
+10.0
+0.4
+2.0
+32.0
+[TypeError, "coerce must return [x, y]"]
+"money+"
+"money+"
+[ArgumentError, "comparison of String with Money failed"]
+[ArgumentError, "comparison of String with Money failed"]
+[ArgumentError, "comparison of String with Money failed"]
+true
+false
+Wrap(12+4i)
+[NoMethodError, "undefined method '%' for an instance of Complex"]
+[NoMethodError, "undefined method 'div' for an instance of Complex"]
+[NoMethodError, "undefined method 'remainder' for an instance of Complex"]
+[TypeError, "Inert can't be coerced into Complex"]
+false
+false
+true
+true
+1
+false
+true
+true
+false
+true
+0
+2.0
+2.0
+0.4
+0.4
+[0, 2.0]
+0
+2.0
+0.4
+[0, 2.0]
+7.0
+-3.0
+10.0
+0.4
+2.0
+3.5
+false
+1.0e+20
+7.0
+false
+0
+7.0
+false
+0
+10
+true
+false
+[TypeError, "coerce must return [x, y]"]
+320.0
+40
+true
+[12, 35, [1, 2], true]
+0
+3333333333333333333333333
+[3333333333333333333333333, 1]
+0
+0
+true


### PR DESCRIPTION
## Why

When a numeric operation gets an operand it does not understand, Ruby asks that operand to coerce — `a, b = obj.coerce(recv)` — and then runs the operation on the pair. Note the order: the receiver ends up on the *right*.

Spinel has had that protocol in the runtime since #3960, reached from the arithmetic operators. What it did not have was a way in from a *typed* call site for anything else. There, only `+ - * / % **` consulted it, and only when the object's class also defined that same operator, so every other numeric operation lowered the object as though it were a number.

The worst of it was silent:

```ruby
class Rate
  def coerce(v) = [9.0, v]
end
p [5 < Rate.new, 5 > Rate.new, 5 <= Rate.new, 5 >= Rate.new]
```

CRuby answers `[false, true, false, true]` — the pair is `[9.0, 5]`, and 9.0 is not below 5. Spinel answered `[true, false, true, false]`, every one inverted, because what it compiled was `5 < (sp_Rate *)obj`. The C compiler warned about the pointer comparison on all four lines and the build carried on. `5.between?(lo, hi)` did the same thing one method over — `true` in CRuby, `false` here — and `5.quo(obj)` answered a Rational whose denominator was the object's address, a different number on every run.

Others failed loudly. `5.0 + obj` and `5.0 < obj` emitted C that does not compile (`invalid operands to binary expression ('double' and 'sp_Rate *')`), while `5.0.div(obj)` raised "can't convert Rate into Float" and a receiver read back out of a container refused `v.div(obj)` with "no implicit conversion of Rate into Integer" — a conversion Ruby never asks for here, having asked for coerce instead.

And a coerce that answers a pair of plain numbers, which needs no operator on the class at all, was not honoured at a typed call site: the static path wanted the class to define the operator so it could dispatch there, so `5 + obj` fell through the numeric ladder and evaluated to `nil`. Through a boxed receiver it already worked.

## What

This does not add a second implementation of the protocol. A typed call site now refuses to lower the operation against a pointer and hands both sides, boxed, to the same runtime entries a boxed receiver already used — `sp_poly_lt`, `sp_poly_add`, `sp_poly_divmod` and the rest. Nothing in the emission knows the operand's class, which is why an inherited `#coerce`, a nil operand, and a `#coerce` whose pair is not a poly array need no case of their own: the hook dispatches on cls_id, and it casts, ignores a nil and converts a typed pair itself.

## How

The runtime side is what grew. The helper that applies an operation to a coerced pair knew only the six arithmetic operators, so a pair handed to it for anything else was computed and then discarded; it now finishes the comparisons, `<=>`, and the div/modulo/remainder/quo/fdiv/divmod family. Those entries and the four comparison entries ask the coerce hook before they give up. `Comparable#between?` goes through `<=>` alone, as CRuby's does, so a class defining `>=` and `<=` and no `<=>` still gets CRuby's "comparison failed".

Only a number asks, on both halves. Those entries serve every boxed value, so without that check `"abc" < money` would enter the protocol and answer where CRuby raises — the same silent answer this set out to remove, arriving from the other side. A Complex receiver is admitted for `+ - * / ** <=>` and nothing more: the ordered comparisons, `%` and the named division family have no method on CRuby's Complex and raise with no coerce call, so admitting them would have answered where CRuby refuses; and CRuby's Complex does coerce for `quo` and `fdiv`, but the boxed entries behind those have no Complex arm, so admitting them routed the pair to a wrong number where master at least refused loudly.

Both sides of the call — and both of `between?`'s bounds — are spilled into rooted temps: the receiver because the operand is commonly a fresh allocation, the operand and each bound because the protocol reads them again deep inside their own `#coerce`. A generated `#coerce` roots its parameter but not its `self`, and the idiomatic `[Klass.new(v), self]` allocates twice before `self` is read; unrooted, the collector took it there and the pool handed its block to the object the method had just built. The test pins this with a 400-round churn that answers wrongly on a build rooting only the receiver.

The operator a coerced pair runs is the class's own, reached through the same hook — so its parameter is poly. Which value the pair's second element is depends on the idiom: `[Klass.new(v), self]` makes it the object, `[Klass.new, v]` makes it the number, and a parameter narrowed to the class left the second idiom's dispatch arm falling through, raising NoMethodError on a `+` the class defines (matz's review of the first version of this PR; the shape is now pinned).

A String receiver with an object operand that does not answer `to_str` is CRuby's `comparison of String with Money failed`, for the four ordered operators and for `between?`. The typed lowering used to hand the object's pointer to a byte compare — on master and on the first version of this branch alike, that fails the C build.

A coerced Bignum operation lands on the boxed division family, whose missing Bignum arms are #4261's own rule; this change only hands the pair over.

Three smaller things had to move with it. The tower branches in `sp_poly_add` and its siblings match on the *receiver's* kind, so a user object on the right was being converted by whichever branch the receiver selected; the object arm now sits above them, after the plain-number fast paths. The hook table was emitted only when some class defined an arithmetic operator, so a class defining only ordered comparisons got no table and failed on a method it defines — a coerce-defining class now qualifies on a comparison too. And the result of a coerced operation is known only at run time, so it is poly; the predicate deciding that asks the *shape* of `#coerce` rather than whether it is emittable, because emittability depends on reachability and that is computed long after the type fixpoint which has to answer the same question.

## Validation

- Tests 3400 pass, 0 fail, 0 error. Benchmarks 61 pass. Optcarrot OK on its usual checksum. ext-cruby, rbs-seed and the rubyspec gate pass; the macOS-only spin-e2e leg fails identically on untouched master. Inference fixpoint converges on every suite program.
- Generated C is byte-identical for 3405 of the 3415 pre-existing test and benchmark programs, plus optcarrot. The ten that differ all define `#coerce` or a user operator reached through it: coerce_factory_param_types, coerce_factory_and_explicit_call, coerce_operator_param, coerce_poly_operand, coerce_result_reader_local, numeric_coerce, numeric_method_displaced_by_user, poly_recv_user_operator_arg, rational_coerce_user_object, user_coerce_op_ivar — every one still matches its expected output. The new test does not compile on master.
- The new test is CRuby-generated, matches plain and under SPINEL_GC_STRESS=1, and runs in well under a second. Under ASAN+UBSAN it is clean plain; under ASAN+UBSAN *with* GC stress it trips two pre-existing master bugs in the exception machinery, not this change: the catch-side exception object is written after a collection frees it (a seven-line master-only reproducer segfaults), and `sp_raise_cls` reads an `sp_sprintf` message the string sweep has already collected (a ten-line master-only reproducer; every ASAN frame is in master's raise path, `sp_exc_apply_staged` ← `sp_raise_cls` ← `sp_raise_poly_nomethod`). Both surface at any pin that raises after enough allocation; the raising pins sit early in the file to keep the plain-stress run deterministic. Fixing them is its own change, which I would like to send next.
- This change's own rooted temps — receiver, operand, and both `between?` bounds — were verified under ASAN+UBSAN with GC stress by counterfactual: removing the receiver root crashes, removing the operand root gives silent wrong answers, as emitted is clean.
- On the differential corpus of ~2,100 minimized programs that behave differently under CRuby 4.0.6 and Spinel (the same corpus behind #3999/#4003/#4029): 20 findings flipped to matching, none lost (a twenty-first, a coerced Bignum division, already flips on #4261 alone).

## Left alone, on purpose

Unchanged by this, and recorded so nobody has to rediscover them:

- **`Float#coerce` and `Integer#coerce` ignoring a user `#to_f`** — the builtin's own coerce converting its argument, a different rule.
- **A Complex receiver.** Poly arithmetic on a Complex loses the float-ness of a whole real part: `(2+0i) + 2.0` answers a Complex whose `#real` is the Integer 4 where CRuby's is 4.0. A value gap, not a rendering one, and independent of this routing.
- **A boxed Float compared against a boxed Bignum.** The Float is converted through an `int64_t` cast, so once the coerced Float is past that range the comparison is decided on the wrapped value.
- **`clamp`, and a block on a numeric call** — both fail to build exactly as they do today.
- **A Complex receiver is admitted for `+ - * / ** <=>` and nothing more.** Its refused operations raise a different class than CRuby's: `Complex(2,3) < obj` fails the comparison (`ArgumentError`) where CRuby raises NoMethodError; `divmod` raises a conversion TypeError as master did; and `quo`/`fdiv` — which CRuby's Complex does coerce for — keep master's loud refusal, because the boxed quo/fdiv entries have no Complex arm and routing the pair through them answered a wrong number. Loud, master-equivalent or better, in every case.
- **`#quo` applies `quo` to the coerced pair; CRuby converts the receiver to Rational and applies `/`.** The two agree whenever the pair reflects the passed value, but a `#coerce` that ignores its argument over an Integer pair divides integrally in CRuby (`5.quo(w)` → `3`) where Spinel answers the Rational `(10/3)`.
- **A typed Complex receiver does not reach a coercing operand.** `Complex(3, 4) + Wrap.new(9)` at a typed call site refuses (`can't be coerced into Complex`), exactly as master does; only the boxed Complex receiver takes the protocol here. Admitting Complex at the typed site is the same op-gated rule at five inference/codegen sites and is left for its own change.
- **A String receiver's operand that answers `to_str`.** CRuby converts it and compares the strings; this branch raises the comparison error for any object, as master's boxed path did. Loud, and a follow-up.
- **A class defining `<=>` without `include Comparable` still gets a derived `==`** (`Gauge.new(2) == Gauge.new(2)` is true here, identity-false in CRuby). Pre-existing, unchanged; the test's Comparable class pins the case CRuby and Spinel agree on.
- **An ordered operator whose coerced pair lacks that operator.** `5 > obj`, where `#coerce` answers a pair of a class defining `<=>` but no `>`, raises NoMethodError in CRuby; Spinel's boxed comparison falls back to `<=>` and answers. That fallback predates this change (two such objects compared boxed answer the same way on master); this routing makes it reachable from typed sites, where the previous behavior was the inverted address comparison.

Changed, and still diverging from CRuby:

- **`Rational#%`, `#modulo` and `#divmod`** answer the coerced value where CRuby raises NoMethodError. CRuby reaches those through Numeric, which computes `self - other * (self / other).floor` and so touches the operand's own `#*` rather than the pair. The other ten Rational operations are exact, where none of the thirteen compiled before.
- **A `#coerce` whose pair contains the object itself** recurses until the stack goes. Master does this already for the arithmetic operators; this extends the set that can reach it.

