### PR TITLE
The main thread's thread-local storage survives a collection

### DIFF
--- a/lib/sp_sched.c
+++ b/lib/sp_sched.c
@@ -416,6 +416,12 @@ static void reg_remove(sp_thread *t) {
 static void (*g_prev_globals_hook)(void) = NULL;
 static void sp_sched_globals_mark(void) {
   for (sp_thread *t = g_all; t; t = t->all_next) sp_gc_mark(t);
+  /* The main thread is a static struct, not a registry entry, so nothing
+     above marks what hangs off it -- and its thread-local map
+     (Thread.current[:k] = v on the main thread) is a GC object. Unmarked, a
+     collection freed the map while g_main_thread.tls still pointed at it,
+     and the next Thread#[]= wrote into freed memory. */
+  if (g_main_thread.tls) sp_gc_mark(g_main_thread.tls);
 #ifdef SP_THREADS
   /* Mark each parked worker's published roots. Reaches the per-worker root fibers
      (idle/main workers) that are not on sp_fiber_list_head; green-thread fibers

--- a/test/thread_tls_survives_gc.rb
+++ b/test/thread_tls_survives_gc.rb
@@ -1,0 +1,26 @@
+# Thread-local storage must survive a garbage collection. Set a key,
+# allocate enough to collect several times while writing another key
+# repeatedly, then read the first key back.
+class Holder
+  attr_accessor :name
+  def initialize(name)
+    @name = name
+  end
+end
+def churn(label)
+  Thread.current[:keep] = Holder.new(label)
+  junk = []
+  i = 0
+  while i < 400_000
+    junk << ("y" * 64) + i.to_s
+    junk = [] if junk.length > 2000
+    Thread.current[:counter] = i
+    i += 1
+  end
+  kept = Thread.current[:keep]
+  puts "#{label}: #{kept.nil? ? 'LOST' : kept.name} counter=#{Thread.current[:counter]}"
+end
+churn("main")
+t = Thread.new { churn("worker") }
+t.join
+puts "done"

--- a/test/thread_tls_survives_gc.rb.expected
+++ b/test/thread_tls_survives_gc.rb.expected
@@ -1,0 +1,3 @@
+main: main counter=399999
+worker: worker counter=399999
+done


### PR DESCRIPTION
`Thread.current[:k] = v` on the MAIN thread does not survive a collection: the map is freed under the thread and the next write lands in freed memory.

**Repro** (fails on `5316b495`; CRuby prints two lines and `done`):

```ruby
class Holder
  attr_accessor :name
  def initialize(name)
    @name = name
  end
end
def churn(label)
  Thread.current[:keep] = Holder.new(label)
  junk = []
  i = 0
  while i < 400_000
    junk << ("y" * 64) + i.to_s
    junk = [] if junk.length > 2000
    Thread.current[:counter] = i
    i += 1
  end
  kept = Thread.current[:keep]
  puts "#{label}: #{kept.nil? ? 'LOST' : kept.name} counter=#{Thread.current[:counter]}"
end
churn("main")
t = Thread.new { churn("worker") }
t.join
puts "done"
```

```
$ spinel tls_gc.rb -o tls_gc && ./tls_gc; echo $?
138
```

Skip `churn("main")` and the worker line prints; under guard malloc the fault is in `sp_Thread_tls_set`.

**Why.** A green thread is a GC object and `sp_thread_scan` marks its `tls` map. The main thread is `g_main_thread`, a static struct outside the registry, and the mark hook roots `g_all` -- so nothing marks `g_main_thread.tls`, the map (`sp_gc_alloc`ed in `sp_Thread_tls_set`) is collected with its keys and values freed by `sp_tls_fin`, and the dangling pointer is written through on the next set.

**The change.** The hook marks `g_main_thread.tls` beside the registry walk -- one line -- and `test/thread_tls_survives_gc.rb` is the program above. `make test`: 3401 pass / 0 fail; TSan-clean on the new test.

Found on roundhouse: campfire's compiled test programs run their whole suite on the main thread and started keeping per-request state in `Thread.current` when the server moved to a thread per connection; every test binary corrupted its heap inside sqlite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where main-thread thread-local data could be reclaimed during garbage collection, potentially causing later thread-local updates to fail or corrupt memory.
  - Thread-local values now remain available reliably through garbage collection in both main and worker threads.

- **Tests**
  - Added regression coverage for thread-local storage behavior during heavy allocation and garbage collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->