### PR TITLE
Keep the caught exception and the raise message rooted across the allocations inside rescue and raise

### DIFF
--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -8026,6 +8026,26 @@ static void *sp_exc_recover_named(const char *cls, const char *msg);
 SP_NORETURN SP_COLD void sp_raise_cls(const char *cls, const char *msg);
 #else
 SP_NORETURN SP_COLD void sp_raise_cls(const char *cls, const char *msg) {
+  /* Launder the message onto the string heap and root the copy before anything
+     below allocates. `msg` is the caller's own pointer and comes in one of two
+     shapes, neither of which survives a collection here. A raiser that formats
+     its text -- sp_sprintf, as sp_raise_poly_nomethod and its kin do -- hands
+     over a heap string nothing roots, so the sweep inside sp_exc_recover_named,
+     inside sp_exc_apply_staged, or inside the slot store below freed it under
+     the reads that follow. A bare C literal, the other shape and by far the commoner one, cannot simply
+     be rooted instead: it has no marker byte, so sp_mark_string would read -- and sometimes write -- the
+     byte in front of it. Copying first and rooting the copy is the idiom
+     lib/sp_exc.c documents above sp_exc_new; sp_msg_heapify allocates without
+     giving the collector a turn, so there is no window between the two. The
+     no-message sentinel keeps its identity: that identity is what tells an
+     empty message apart from no message at all (#3711).
+     The root is never popped, because this function longjmps -- and that costs
+     nothing: every exception landing restores sp_gc_nroots to the watermark it
+     recorded before its own setjmp (sp_exc_rootmark, or a C local in the
+     Kernel#loop and enumerator landings), which discards this entry, and a
+     fiber's trampoline hands the whole root stack back to its resumer. */
+  if (msg != sp_exc_no_msg) msg = sp_msg_heapify(msg);
+  SP_GC_ROOT_STR(msg);
 #if SP_BT_AVAILABLE
   if (sp_bt_enabled) sp_bt_n = backtrace(sp_bt_buf, 256);
 #endif
@@ -8055,15 +8075,13 @@ SP_NORETURN SP_COLD void sp_raise_cls(const char *cls, const char *msg) {
   if (sp_pending_exc_flags && msg && cls && sp_exc_top > 0)
     sp_pending_exc_obj = sp_exc_apply_staged(cls, msg, sp_pending_exc_obj);
   sp_pending_exc_flags = 0;
-  /* The message can be a plain C literal -- every raise the runtime issues
-     itself passes one -- and a literal has no marker byte in front of it, so
-     the [-1] read sp_mark_string uses to decide whether a string is a GC one
-     walks off the end of its rodata section (ASAN: global-buffer-overflow,
-     and a segfault when the literal starts a page). Copy onto the string
-     heap, where it has a marker and the mark is meaningful. */
-  /* the bare-raise sentinel is already a marked literal, and its identity is
-     what tells an empty message apart from no message at all (#3711) */
-  if (sp_exc_top > 0) { sp_exc_msg[sp_exc_top-1] = msg == sp_exc_no_msg ? msg : msg ? sp_str_dup_external(msg) : NULL; sp_exc_cls[sp_exc_top-1] = cls; sp_exc_obj[sp_exc_top-1] = sp_pending_exc_obj; sp_pending_exc_obj = NULL; sp_pending_cause = sp_explicit_cause_set ? sp_explicit_cause : (sp_cur_handled() ? sp_cur_handled() : sp_inflight_cause); sp_inflight_cause = NULL; sp_explicit_cause = NULL; sp_explicit_cause_set = 0; sp_last_exc_cls = cls; longjmp(sp_exc_stack[sp_exc_top-1], 1); }
+  /* The slot takes the laundered copy made at the top of this function (or the
+     bare-raise sentinel, or NULL) as it stands: it is already a string-heap
+     one with a marker byte, so sp_mark_in_flight_exceptions can mark it from
+     here to the landing, and copying it a second time would only reintroduce
+     an allocation between the last read of the caller's pointer and this
+     store. */
+  if (sp_exc_top > 0) { sp_exc_msg[sp_exc_top-1] = msg; sp_exc_cls[sp_exc_top-1] = cls; sp_exc_obj[sp_exc_top-1] = sp_pending_exc_obj; sp_pending_exc_obj = NULL; sp_pending_cause = sp_explicit_cause_set ? sp_explicit_cause : (sp_cur_handled() ? sp_cur_handled() : sp_inflight_cause); sp_inflight_cause = NULL; sp_explicit_cause = NULL; sp_explicit_cause_set = 0; sp_last_exc_cls = cls; longjmp(sp_exc_stack[sp_exc_top-1], 1); }
   /* Uncaught SystemExit terminates silently with its status (Kernel#exit). */
   if (strcmp(cls, "SystemExit") == 0) exit(sp_exc_exit_status(sp_pending_exc_obj));
   /* Uncaught: CRuby's tail format "<message> (<ClassName>)", prefixed by the

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -5724,6 +5724,19 @@ void emit_rescue(Compiler *c, int id, Buf *b, int indent, int fr, const char *re
     buf_printf(b, "sp_Exception *_ce_%d = sp_exc_obj[sp_exc_top] ? (sp_Exception *)sp_exc_obj[sp_exc_top]"
                   " : sp_exc_new_for_catch(_rcls_%d, _rmsg_%d);\n", rc, rc, rc);
   emit_indent(b, indent);
+  /* Push the exception onto sp_exc_handling FIRST: the push is what roots it.
+   * A raise that carried no object -- every `raise Cls, "msg"` and every
+   * runtime raise -- leaves the object the line above just built reachable
+   * from nothing but a C local, and the marker walks sp_exc_handling (see
+   * sp_mark_in_flight_exceptions), not the C stack. Anything that allocates
+   * before the push therefore collects the object the emission is about to
+   * write into, which is what the backtrace backfill below does.
+   * The push also makes $! (which reads sp_cur_handled) the same object the
+   * arm binds to `e`; it is popped at arm exit (sp_rescue_sp-- below). The
+   * carried-object path (sp_exc_obj[sp_exc_top] != NULL) reuses the same
+   * object both for $! and for the rescue binding, so $!.equal?(e) is true. */
+  buf_printf(b, "sp_rescue_push((void *)_ce_%d);\n", rc);
+  emit_indent(b, indent);
   /* A rescued exception's #backtrace returns [] (not nil) so that
    * chained methods like .first / .length / .empty? work without nil
    * checks. Spinel doesn't track per-exception frames (#895), so
@@ -5733,16 +5746,9 @@ void emit_rescue(Compiler *c, int id, Buf *b, int indent, int fr, const char *re
    * backtrace == NULL and set_backtrace explicitly writes it.
    * Skipping the backfill when the carry slot is present would
    * leave a re-raised object with whatever backtrace its previous
-   * owner set, which is what #895 documents. */
+   * owner set, which is what #895 documents. The array allocation is
+   * why this stands after the push and not before it. */
   buf_printf(b, "if (_ce_%d->backtrace == NULL) _ce_%d->backtrace = sp_StrArray_new();\n", rc, rc);
-  emit_indent(b, indent);
-  /* Push the rescue variable onto sp_exc_handling so $! (which reads
-   * sp_cur_handled) points at the same object the arm bound to `e`.
-   * The push is popped at arm exit (sp_rescue_sp-- below). The
-   * carried-object path (sp_exc_obj[sp_exc_top] != NULL) reuses
-   * the same object both for $! and for the rescue binding, so
-   * $!.equal?(e) is true. */
-  buf_printf(b, "sp_rescue_push((void *)_ce_%d);\n", rc);
   emit_indent(b, indent);
   /* an exception never loses a cause it already carries (#3745) */
   buf_printf(b, "if (!_ce_%d->cause) _ce_%d->cause = (sp_Exception *)sp_pending_cause; sp_pending_cause = NULL;\n", rc, rc);

--- a/test/rescue_roots_under_collection.rb
+++ b/test/rescue_roots_under_collection.rb
@@ -1,0 +1,69 @@
+# The exception being handled and the message being raised are each reachable
+# from nothing but a C local for one allocation: the object between the landing
+# that materializes it and the push that roots it, the message between the
+# raiser that formats it and the slot the marker reads. Every pin below raises
+# after enough allocation for a collection to land in one of those windows.
+
+# an unspecialized `rescue => e` arm, on a raise that carries no object
+pad = Array.new(64) { |i| (10 ** 20) + i }
+q = pad.map { |x| x.to_s.length }
+begin
+  raise TypeError, "coerce must return [x, y]"
+rescue => e
+  p [e.class, e.message, e.backtrace.class]
+  p $!.equal?(e)
+end
+p q.sum
+
+# a specialized arm -- one arm, one user subclass -- which the landing
+# materializes through a differently sized allocation
+class Refused < StandardError
+end
+begin
+  raise Refused, "no such rate"
+rescue Refused => e
+  p [e.class, e.message, e.backtrace.class]
+  p $!.equal?(e)
+end
+
+# a runtime-formatted message: the raiser builds the text itself, so what it
+# hands over is a heap string, not a literal
+churn = []
+box = [Complex(3, 4)]
+8.times do |i|
+  churn << "s#{i}" * 3
+  begin
+    box[0].div(2)
+  rescue => e
+    p [e.class, e.message]
+  end
+end
+p churn.size
+
+# a formatted message the raise path also reads back, to recover #name onto
+# the carried exception
+begin
+  Object.const_get("NoSuchRateTable")
+rescue NameError => e
+  p [e.class, e.message]
+end
+
+# Each window is one allocation wide, so it opens only when a collection lands
+# inside it. Raising this many times against a heap that keeps growing puts a
+# natural collection there without SPINEL_GC_STRESS: this answers
+# [RuntimeError, ""] a handful of times per 20000 rounds when the handled
+# exception is not rooted.
+bad = 0
+keep = []
+20000.times do |i|
+  keep << [i] if i % 100 == 0
+  begin
+    raise TypeError, "coerce must return [x, y]"
+  rescue => e
+    unless e.class == TypeError && e.message == "coerce must return [x, y]" && e.backtrace.class == Array
+      bad += 1
+      p [i, e.class, e.message] if bad < 4
+    end
+  end
+end
+p [bad, keep.size]

--- a/test/rescue_roots_under_collection.rb.expected
+++ b/test/rescue_roots_under_collection.rb.expected
@@ -1,0 +1,16 @@
+[TypeError, "coerce must return [x, y]", Array]
+true
+1344
+[Refused, "no such rate", Array]
+true
+[NoMethodError, "undefined method 'div' for an instance of Complex"]
+[NoMethodError, "undefined method 'div' for an instance of Complex"]
+[NoMethodError, "undefined method 'div' for an instance of Complex"]
+[NoMethodError, "undefined method 'div' for an instance of Complex"]
+[NoMethodError, "undefined method 'div' for an instance of Complex"]
+[NoMethodError, "undefined method 'div' for an instance of Complex"]
+[NoMethodError, "undefined method 'div' for an instance of Complex"]
+[NoMethodError, "undefined method 'div' for an instance of Complex"]
+8
+[NameError, "uninitialized constant NoSuchRateTable"]
+[0, 200]


### PR DESCRIPTION
## Why

Two places in the exception machinery hold a live object in a C local, allocate, and then use it. The collector does not walk the C stack, so both are one collection away from writing into, or reading out of, memory it has already freed.

The first is the rescue landing. Eight lines segfault on it, every run, against an untouched runtime under `SPINEL_GC_STRESS=1`:

```ruby
pad = Array.new(64) { |i| (10 ** 20) + i }
q = pad.map { |x| x.to_s.length }
begin
  raise TypeError, "coerce must return [x, y]"
rescue => e
  p [e.class, e.message]
end
p q.sum
```

It does not need GC stress to go wrong, either — it needs a heap big enough for an ordinary collection to land in the window. Raising twenty thousand times against a heap that keeps growing does that on its own: master answers `[RuntimeError, ""]` about ten times over that run, for a `raise TypeError` that never mentions RuntimeError.

The second is `sp_raise_cls`, and it shows up wherever the runtime formats the message it is raising with. Ten lines reproduce it:

```ruby
pad = Array.new(200) { |i| "s#{i}" * 3 }
x = [Complex(3, 4)]
20.times do
  begin
    x[0].div(2)
  rescue => e
    p [e.class, e.message]
  end
end
p pad.size
```

Under ASAN with GC stress that is a heap-use-after-free with every frame in master's raise path: the string sweep frees the `sp_sprintf` message, and `sp_raise_cls` then copies it into the handler frame's slot.

## What

The landing pushes the exception onto the handler stack before it fills in the empty backtrace, instead of after. The push is what roots the object — that is now what the comment says.

`sp_raise_cls` copies its message onto the string heap and roots the copy before it does anything else, and everything below reads the copy. The copy it used to make into the message slot goes away, since the message arriving there is already a heap one.

## How

The landing materializes the exception the arm is about to bind — the object the raise carried, or a fresh one built from the class and message in the frame — then fills `[]` into its backtrace if it has none, then pushes it onto `sp_exc_handling`. The marker walks `sp_exc_handling` and `sp_exc_obj`; it does not walk the C stack. So on a raise that carried no object — every `raise Cls, "msg"`, and every raise the runtime issues itself — the object between the materialize and the push is reachable from a C local and nothing else, while the backfill in the middle allocates an array. When that allocation collects, the array is fine and the exception is gone, and the store that installs the array writes into freed memory. A carried object was never exposed: it is already in `sp_exc_obj`, inside the window `sp_mark_in_flight_exceptions` walks. And until the backtrace backfill went in with #4249, nothing between those two lines allocated at all, which is why this is recent rather than ancient. Emitting the push first closes it. Nothing else about the landing moves, and the object's identity does not change, so `$!.equal?(e)` still holds on the carried and the materialized path alike. The two rescue-modifier landings (`expr rescue fallback`, one emitted from `src/codegen_expr.c` and one from `src/codegen_stmt.c`) have no backfill — the only statement between their materialize and their push is a pointer store — so both are left exactly as they were.

`sp_raise_cls` receives the message as the caller's own pointer, in one of two shapes. A raiser that formats its text hands over a heap string that nothing roots: `sp_raise_poly_nomethod` builds "undefined method 'div' for an instance of Complex" with `sp_sprintf` and passes it straight in, and so do its neighbours. A raiser with fixed text passes a bare C literal. Three things in the function then allocate before the message is read for the last time: the recovery that lifts a NoMethodError's or NameError's `#name` back out of the message text, the staging that writes a receiver or a key onto the carried object, and the copy into the handler frame's slot. Any of those can collect. The formatted message is not rooted, so the sweep takes it, and what follows reads freed bytes.

Rooting the caller's pointer where it stands is not the alternative, because of the other shape: a bare literal has no marker byte in front of it, and the mark walker for string slots decides what to do by reading the byte before the string — for a literal that is a read past the end of the preceding object, and a write over it whenever that byte happens to read as an unmarked heap string. `lib/sp_exc.c` already documents the way round and every exception constructor in it follows the same one-liner: copy onto the string heap through the allocator that gives the collector no turn, then root the copy. `sp_raise_cls` now opens with that line. The no-message sentinel keeps its identity, because that identity is what tells an empty message apart from no message at all, and a NULL message stays NULL.

The root is never popped, because the function longjmps. That is not a leak: every exception landing restores the root-stack depth to a watermark it recorded before its own `setjmp`, and does it as the first thing in the landing, before the landing allocates. All ten generated landings do — `begin/rescue` with and without an ensure, the statement and expression forms of `expr rescue fallback`, both `Kernel#loop` forms, the ensure regions around an iterator block and around `Mutex#synchronize`, the enumerator-driving fold, and the extension try-helper — eight of them from `sp_exc_rootmark` beside the handler slot, and the statement-form `Kernel#loop` and the fold from a C local snapshot taken before the frame was pushed. The eleventh handler is the fiber trampoline's, which does not restore anything itself because the fiber is dead by then; its resumer restores the whole root stack it saved before the switch. So the entry this adds is discarded at the landing in every case.

## Validation

- Tests 3401 pass, 0 fail, 0 error. Benchmarks 61 pass. Optcarrot OK on its usual checksum. ext-cruby, rbs-seed and the rubyspec gate pass; the macOS-only spin-e2e leg fails identically on untouched master. Inference fixpoint converges on every suite program, with no round-count change anywhere.
- The push move changes the generated C of every program that has a rescue arm: 480 of the 3417 test, benchmark and optcarrot programs, 1673 push lines in all. That each of those diffs is *only* the moved line is checked mechanically rather than by eye — take master's C, move every `sp_rescue_push` that directly follows its matching backfill line to directly before it, and compare against the branch's C byte for byte. All 480 match exactly; 0 programs are left with any other difference, and 0 fail to compile on either side. The message rooting changes no generated C at all.
- The new test, `test/rescue_roots_under_collection.rb`, is CRuby-generated and matches plain, under `SPINEL_GC_STRESS=1`, and under ASAN+UBSAN both plain and with GC stress. It runs in 0.02s plain and 0.21s under ASAN with stress. On master it diverges in the *plain* leg — ten rounds of its twenty-thousand-round loop answer `[RuntimeError, ""]` — and segfaults outright under GC stress, printing nothing at all.
- Under ASAN+UBSAN with GC stress, five programs are clean on this branch: both reproducers above, the new test, `test/numeric_coerce_protocol.rb` and `test/bignum_boxed_division.rb`. Four of them are not clean on master, all with a heap-use-after-free; only `test/bignum_boxed_division.rb` is clean there, because it deliberately avoids the rescue. The eight-line one reports a heap-use-after-free whose write is the backfill store, freed by `sp_gc_collect` under `sp_gc_alloc` under `sp_StrArray_new`, allocated by `sp_exc_new` under `sp_exc_new_for_catch` one line earlier. The ten-line one reports a 49-byte read at `sp_raise_cls`, freed by `sp_str_sweep_gen` under `sp_gc_collect` under `sp_str_alloc` called from `sp_raise_cls` itself, allocated by `sp_sprintf` under `sp_raise_poly_nomethod`. `test/numeric_coerce_protocol.rb` reports the same defect through the other window: the read is inside `sp_exc_apply_staged`, and the free is the collection inside the `sp_exc_recover_named` call three lines above it.
- On the differential corpus of roughly 2,100 minimized programs that behave differently under CRuby 4.0.6 and Spinel: nothing gained, nothing lost. That is expected — the corpus runs without GC stress, and its programs are minimized to be small, so their heaps never reach the window.

## Left alone, on purpose

- **`test/bignum_boxed_division.rb` still says it is dodging this crash.** Its closing comment explains that the zero-divisor raises are not pinned because a `begin`/`rescue` after those bignum operations trips a GC-stress crash in the rescue machinery. That is the first defect here, and the dodge is no longer needed — but adding those pins is that test's business, not this change's, so the comment stands.
- **`p e.class` on a rescued exception can render empty under GC stress.** Appending the zero-divisor rescue that the test above dodges answers `[, "divided by 0"]` with GC stress on, while `e.class.to_s`, `e.class.name` and `e.is_a?(ZeroDivisionError)` are all correct and the plain run is correct. It is not caused by anything here: it reproduces with only the landing half of this change applied, and master cannot be compared because it segfaults before reaching the rescue. It wants its own change, and looks like the class-name string behind a boxed Class value going unrooted across an array build.
- **`Exception#backtrace` is still `[]` rather than real frames.** The backfill this reorders is what produces that empty array, and it keeps producing it.
- **`sp_sprintf` re-reads its arguments after allocating, when the result is over 4KB.** It renders into a stack buffer first and copies, so the ordinary path never reads an argument after the allocation; the oversize path re-arms the argument list and renders again into the fresh string. A formatted message long enough to take that path has the same shape of bug as the one fixed here. Nothing in the tree produces one today.
- **Two thin raise shims root the caller's pointer as it stands** — the `sp_raise` in `lib/sp_fiber.c` and `sp_marv_raise` in `lib/sp_cold.c` — which is the read-the-byte-before-a-literal hazard `lib/sp_exc.c` documents. Now that `sp_raise_cls` copies immediately, those roots protect nothing that needs protecting, but removing them is a separate tidy-up.
- **A fiber's exception context does not swap the root watermarks.** The per-fiber save/restore of the exception, catch and break stacks leaves `sp_exc_rootmark`, `sp_rescue_mark` and `sp_catch_rootmark` shared, so two fibers with a frame at the same depth overwrite each other's recorded root-stack depth — the very watermark the landings restore. No probe here made it misbehave, and this change does not alter it; noted because the argument above leans on those watermarks.
- **Three more pre-existing exception-machinery bugs surfaced under this change's review probes, none touched here:** a raise unwinding out of `catch` never pops the catch stack, so sixty-four of them overflow it (no GC stress needed); the exception-frame depth is unchecked, so sixty-five nested `begin` frames write past the watermark arrays; and in the threaded build four threads raising and rescuing under GC stress read a swept string inside the marker. Each has a short reproducer, and each is its own change.
- **The two programs whose inference fixpoint hits its round cap on master** (`test/ivar_array_pushed_via_singleton.rb`, `test/proc_curry_arity.rb`) are unchanged, and still cap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved exception handling during garbage collection to prevent formatted error messages from being lost or corrupted.
  - Ensured rescued exceptions consistently preserve their messages, backtraces, and identity through recovery.
  - Improved reliability for repeated raises and errors involving name lookup, coercion, and arithmetic operations.

- **Tests**
  - Added regression coverage for exception recovery under allocation and garbage-collection pressure, including literal and dynamically generated messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->