### PR TITLE
Kernel#caller: accept integer Range literal as window

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -14973,8 +14973,40 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
 
   /* loop { break val } as expression: emit pre-statement for-loop, result via break var */
   /* Kernel#caller / caller(start) / caller(start, len) -> the current stack
-     (method-granularity, via sp_caller_now). Bare `caller` is `caller(1)`. */
+     (method-granularity, via sp_caller_now). Bare `caller` is `caller(1)`.
+     Also accepts caller(0..n) / caller(0...n) -- a Range literal with
+     integer endpoints -- and rewrites it to the (start, len) form. */
   if (recv < 0 && sp_streq(name, "caller") && argc <= 2 && !bare_call_class_owned(c, id)) {
+    /* Range literal: caller(lo..hi) or caller(lo...hi) -> caller(lo, len). */
+    if (argc == 1 && nt_type(c->nt, argv[0]) &&
+        sp_streq(nt_type(c->nt, argv[0]), "RangeNode")) {
+      int rid = argv[0];
+      int left = nt_ref(c->nt, rid, "left");
+      int right = nt_ref(c->nt, rid, "right");
+      int excl = (int)(nt_int(c->nt, rid, "flags", 0) & 4) ? 1 : 0;
+      if (left >= 0 && right >= 0 &&
+          comp_ntype(c, left) == TY_INT && comp_ntype(c, right) == TY_INT) {
+        buf_puts(b, "sp_caller(");
+        emit_int_expr(c, left, b);
+        buf_puts(b, ", 1, (");
+        emit_int_expr(c, right, b);
+        buf_puts(b, " - ");
+        emit_int_expr(c, left, b);
+        if (excl) buf_puts(b, ")");
+        else buf_puts(b, " + 1)");
+        buf_puts(b, ")");
+        return;
+      }
+      unsupported_feature(c, id,
+        "caller(Range) only supports Range literals with integer endpoints "
+        "(e.g. caller(0..5)); pass start and length instead: caller(start, len)");
+    }
+    /* Non-literal Range argument: compile error instead of a runtime
+       crash with "no implicit conversion of Range into Integer". */
+    if (argc >= 1 && comp_ntype(c, argv[0]) == TY_RANGE)
+      unsupported_feature(c, id,
+        "caller(Range) only supports Range literals with integer endpoints "
+        "(e.g. caller(0..5)); pass start and length instead: caller(start, len)");
     buf_puts(b, "sp_caller(");
     if (argc >= 1) emit_int_expr(c, argv[0], b); else buf_puts(b, "1");
     if (argc == 2) { buf_puts(b, ", 1, "); emit_int_expr(c, argv[1], b); }

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -14986,15 +14986,20 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
       int excl = (int)(nt_int(c->nt, rid, "flags", 0) & 4) ? 1 : 0;
       if (left >= 0 && right >= 0 &&
           comp_ntype(c, left) == TY_INT && comp_ntype(c, right) == TY_INT) {
-        buf_puts(b, "sp_caller(");
-        emit_int_expr(c, left, b);
-        buf_puts(b, ", 1, (");
-        emit_int_expr(c, right, b);
-        buf_puts(b, " - ");
-        emit_int_expr(c, left, b);
-        if (excl) buf_puts(b, ")");
-        else buf_puts(b, " + 1)");
-        buf_puts(b, ")");
+        /* Evaluate left and right into temps in source order so a
+           side-effecting endpoint (e.g. caller(foo()..bar())) runs each
+           call exactly once, left before right. */
+        int lt = ++g_tmp, rt = ++g_tmp;
+        Buf lb = expr_buf(c, left);
+        emit_indent(g_pre, g_indent);
+        buf_printf(g_pre, "sp_int _t%d = %s;\n", lt, lb.p ? lb.p : "0");
+        free(lb.p);
+        Buf rb = expr_buf(c, right);
+        emit_indent(g_pre, g_indent);
+        buf_printf(g_pre, "sp_int _t%d = %s;\n", rt, rb.p ? rb.p : "0");
+        free(rb.p);
+        buf_printf(b, "sp_caller(_t%d, 1, (_t%d - _t%d%s))", lt, rt, lt,
+                   excl ? "" : " + 1");
         return;
       }
       unsupported_feature(c, id,

--- a/test/caller_range.rb
+++ b/test/caller_range.rb
@@ -1,0 +1,9 @@
+# Kernel#caller accepts an integer Range literal as a window.
+# The Range is rewritten to the (start, len) form. Frame *content*
+# is only populated in --debug builds (release returns []), so this
+# checks the dispatch shape: caller(0..3) returns an Array, and the
+# window is honored (length <= 4 for a 0..3 window).
+
+frames = caller(0..3)
+puts frames.is_a?(Array)
+puts frames.length <= 4

--- a/test/caller_range.rb
+++ b/test/caller_range.rb
@@ -1,9 +1,30 @@
 # Kernel#caller accepts an integer Range literal as a window.
-# The Range is rewritten to the (start, len) form. Frame *content*
-# is only populated in --debug builds (release returns []), so this
-# checks the dispatch shape: caller(0..3) returns an Array, and the
-# window is honored (length <= 4 for a 0..3 window).
+# The Range is rewritten to the (start, len) form: caller(lo..hi) becomes
+# sp_caller(lo, 1, hi - lo + 1) and caller(lo...hi) becomes
+# sp_caller(lo, 1, hi - lo). Frame *content* is only populated in --debug
+# builds, so we verify the window by checking that the length never exceeds
+# the requested count, and that the dispatch shape is an Array.
 
 frames = caller(0..3)
 puts frames.is_a?(Array)
 puts frames.length <= 4
+
+frames = caller(0...3)
+puts frames.is_a?(Array)
+puts frames.length <= 3
+
+# Regression: integer-typed endpoint expressions must be evaluated
+# exactly once and in source order. The codegen previously emitted
+# the left endpoint twice (once for start, once for the subtraction),
+# which double-evaluated side effects and let C reorder the calls.
+log = []
+def lo(log)
+  log << :lo
+  0
+end
+def hi(log)
+  log << :hi
+  3
+end
+caller(lo(log)..hi(log))
+puts(log == [:lo, :hi])

--- a/test/caller_range.rb.expected
+++ b/test/caller_range.rb.expected
@@ -1,0 +1,2 @@
+true
+true

--- a/test/caller_range.rb.expected
+++ b/test/caller_range.rb.expected
@@ -1,2 +1,5 @@
 true
 true
+true
+true
+true


### PR DESCRIPTION
caller(0..n) / caller(0...n) used to crash at runtime with "no implicit conversion of Range into Integer" because the codegen routed the Range argument through sp_caller's integer path (emit_int_expr). The Range is now recognised and rewritten to the (start, len) form: sp_caller(lo, 1, hi - lo + 1) for inclusive ranges, sp_caller(lo, 1, hi - lo) for exclusive.

Non-integer or non-literal Range arguments get a clear compile error via unsupported_feature, listing the supported form. The bare caller / caller(n) / caller(n, m) forms are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `caller` now supports literal integer ranges using inclusive (`..`) and exclusive (`...`) syntax.
  - Range endpoints are evaluated once, in source order, providing predictable behavior when they include side effects.

- **Bug Fixes**
  - Invalid or unsupported caller ranges now produce clear compile-time errors instead of failing during runtime conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->