### PR TITLE
Convert a String comparison's operand through #to_str

### DIFF
--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -2321,6 +2321,55 @@ static SP_INLINE const char *sp_poly_arg_str(sp_RbVal v) {
   if (v.tag == SP_TAG_STR) return v.v.s;
   return sp_poly_arg_str_slow(v);
 }
+/* The object half of the check below, split out and kept off the inlined path
+   for the reason sp_poly_arg_str_obj is: the object case is the rare one.
+
+   The value is rooted across the bridge call. #to_str is user Ruby code and
+   allocates, and an object reaching a boxed comparison is often held in
+   nothing but the by-value sp_RbVal the caller passed -- a copy of the
+   caller's, but the collector is non-moving and marks through whatever slot it
+   is handed, so rooting this copy keeps that object alive. Both callers rely
+   on this one root: sp_poly_cmp_to_str below, and the poly casecmp arm the
+   emitter renders. */
+static SP_NOINLINE const char *sp_poly_check_str_obj(sp_RbVal v) {
+  SP_GC_ROOT_RBVAL(v);
+  return sp_obj_to_str_fn((int)v.cls_id, v.v.p);
+}
+/* CRuby's rb_check_string_type, which the String COMPARISONS ask where the
+   argument slots above ask the raising forms: a String answers itself, a user
+   object whose #to_str the conversion bridge carries answers its conversion,
+   and every other value answers NULL without raising. "Not a string" is a real
+   answer here -- it is `"abc" <=> obj`'s nil and `"abc" < obj`'s comparison
+   error -- where in an argument slot it is a TypeError.
+
+   The bridge carries only a #to_str whose static return is a String
+   (conv_bridge_callee), so an object whose #to_str the analysis could pin no
+   further than poly answers NULL here and converts on the TYPED side alone.
+   That asymmetry is deliberate for now, not an oversight to tidy away: giving
+   the bridge a boxed-answer entry is its own change. */
+static SP_INLINE const char *sp_poly_check_str(sp_RbVal v) {
+  if (v.tag == SP_TAG_STR) return v.v.s;
+  if (v.tag == SP_TAG_OBJ && v.cls_id >= 0 && v.v.p && sp_obj_to_str_fn)
+    return sp_poly_check_str_obj(v);
+  return NULL;
+}
+/* The ANSWER of a #to_str the analysis could pin no further than poly, on its
+   way into a String comparison. CRuby's rb_check_string_type checks the answer
+   as well as the method: nil is "no conversion", which is the comparison's own
+   nil or its ArgumentError and which the NULL here hands back to the caller's
+   refusal arm; any other non-String is a TypeError naming both classes. `obj`
+   is the operand itself, for that message -- a class name, so it is read
+   twice. A String answer that is the NULL string is nil to Ruby, and takes the
+   no-conversion path too. */
+static SP_NOINLINE const char *sp_str_cmp_conv(sp_RbVal r, sp_RbVal obj) {
+  if (r.tag == SP_TAG_STR) return r.v.s;
+  if (r.tag == SP_TAG_NIL) return NULL;
+  sp_raise_cls("TypeError",
+               sp_sprintf("can't convert %s to String (%s#to_str gives %s)",
+                          sp_poly_class_name(obj), sp_poly_class_name(obj),
+                          sp_poly_class_name(r)));
+  return NULL;
+}
 
 /* The strict argument forms: nil / true / false in a typed String or Integer
    slot are CRuby's TypeError (File.join("a", nil), [1].take(nil)), where the
@@ -2878,7 +2927,23 @@ typedef sp_int (*sp_obj_cmp_fn)(sp_RbVal a, sp_RbVal b, sp_bool *comparable);
 static sp_obj_cmp_fn sp_obj_cmp_hook = NULL;
 #define SP_IS_BUILTIN_ARRAY(id) ((id) == SP_BUILTIN_INT_ARRAY || (id) == SP_BUILTIN_STR_ARRAY || \
                                  (id) == SP_BUILTIN_FLT_ARRAY || (id) == SP_BUILTIN_POLY_ARRAY)
-static sp_int sp_poly_cmp(sp_RbVal a, sp_RbVal b, sp_bool *comparable) { /* same reasoning as the arithmetic fast paths: two plain numbers match no branch below until the numeric one, eight tests later */ if ((a.tag == SP_TAG_FLT || a.tag == SP_TAG_INT) && (b.tag == SP_TAG_FLT || b.tag == SP_TAG_INT)) { if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) { *comparable = TRUE; return (a.v.i > b.v.i) - (a.v.i < b.v.i); } sp_float _fa = a.tag == SP_TAG_FLT ? a.v.f : (sp_float)a.v.i; sp_float _fb = b.tag == SP_TAG_FLT ? b.v.f : (sp_float)b.v.i; *comparable = TRUE; return (_fa > _fb) - (_fa < _fb); } /* A user class's own `<=>` comes first, exactly as its own &/|/^ does (#3501): the Rational arm below answers for the RECEIVER's sake and a user object is not one of its operands, so `Fixed.new(1) < Rational(1,2)` reported the comparison as failed even though the class compares them perfectly well (#4038). */ if (a.tag == SP_TAG_OBJ && a.cls_id >= 0 && sp_obj_cmp_hook) return sp_obj_cmp_hook(a, b, comparable); if (sp_poly_is_brat(a) || sp_poly_is_brat(b) || sp_poly_is_rational(a) || sp_poly_is_rational(b)) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) { sp_float _af = sp_poly_to_f(a), _bf = sp_poly_to_f(b); *comparable = TRUE; return (_af > _bf) - (_af < _bf); } int _oka = sp_poly_is_brat(a) || sp_poly_is_rational(a) || a.tag == SP_TAG_INT || a.tag == SP_TAG_BIGINT; int _okb = sp_poly_is_brat(b) || sp_poly_is_rational(b) || b.tag == SP_TAG_INT || b.tag == SP_TAG_BIGINT; if (_oka && _okb) { *comparable = TRUE; return sp_brat_cmp_poly(a, b); } *comparable = FALSE; return 0; } if (a.tag == SP_TAG_OBJ && b.tag == SP_TAG_OBJ && SP_IS_BUILTIN_ARRAY(a.cls_id) && SP_IS_BUILTIN_ARRAY(b.cls_id)) return sp_poly_arr_cmp(a, b, comparable); if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { sp_Bigint *ba = sp_poly_as_bigint(a), *bb = sp_poly_as_bigint(b); if (ba && bb) { *comparable = TRUE; return sp_bigint_cmp(ba, bb); } if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) { sp_float af = sp_poly_to_f(a), bf = sp_poly_to_f(b); *comparable = TRUE; return (af > bf) - (af < bf); } *comparable = FALSE; return 0; } if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) { sp_float af = sp_poly_to_f(a), bf = sp_poly_to_f(b); *comparable = TRUE; return (af > bf) - (af < bf); } if (a.tag == SP_TAG_STR && b.tag == SP_TAG_STR) { if (a.v.s == NULL || b.v.s == NULL) { *comparable = (a.v.s == b.v.s); return 0; } *comparable = TRUE; return sp_str_cmp_bytes(a.v.s, b.v.s); } if (a.tag == SP_TAG_SYM && b.tag == SP_TAG_SYM) { *comparable = TRUE; if (sp_sym_name_fn) { /* byte-exact: a name may hold a NUL, and strcmp would call `:"a\0b"` equal to `:a` and order them arbitrarily (#nul symbols) */ const char *_na = sp_sym_name_fn((sp_sym)a.v.i), *_nb = sp_sym_name_fn((sp_sym)b.v.i); int _r = strcmp(_na, _nb); /* strcmp decides whenever the names differ before any NUL, and agrees with a byte-exact compare when it does. Only a TIE can hide a difference past an embedded NUL -- `:"a\0b"` against `:a` -- so the byte-exact compare runs just there (#nul symbols), keeping the ordinary comparison one pass. */ if (_r == 0) _r = sp_str_cmp_bytes(_na, _nb); return _r; } return (a.v.i > b.v.i) - (a.v.i < b.v.i); } if (sp_poly_is_strbuf(a) || sp_poly_is_strbuf(b)) return sp_poly_cmp(sp_poly_strbuf_deref(a), sp_poly_strbuf_deref(b), comparable); if (a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_TIME && b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_TIME && a.v.p && b.v.p) { *comparable = TRUE; return sp_time_cmp(*(sp_Time *)a.v.p, *(sp_Time *)b.v.p); } if (a.tag == SP_TAG_OBJ && sp_obj_cmp_hook) return sp_obj_cmp_hook(a, b, comparable); *comparable = FALSE; return 0; }
+/* A String compared with a user object that answers #to_str: CRuby's
+   String#<=> converts the operand and compares the strings, and every ordered
+   operator and #between? is built on that one method -- so the boxed side of
+   the rule lands here, once, rather than in each of their entries. The
+   receiver is rooted across the conversion: #to_str allocates, and the string
+   reaching a boxed comparison is often a fresh one the caller holds in
+   nothing but the argument. The OPERAND's root is one level down, inside
+   sp_poly_check_str_obj, which is where both boxed callers meet. */
+static int sp_poly_cmp_to_str(sp_RbVal a, sp_RbVal b, sp_int *out) {
+  if (a.tag != SP_TAG_STR || !a.v.s || b.tag != SP_TAG_OBJ || b.cls_id < 0) return 0;
+  SP_GC_ROOT_RBVAL(a);
+  const char *s = sp_poly_check_str(b);
+  if (!s) return 0;
+  *out = sp_str_cmp_bytes(a.v.s, s);
+  return 1;
+}
+static sp_int sp_poly_cmp(sp_RbVal a, sp_RbVal b, sp_bool *comparable) { /* same reasoning as the arithmetic fast paths: two plain numbers match no branch below until the numeric one, eight tests later */ if ((a.tag == SP_TAG_FLT || a.tag == SP_TAG_INT) && (b.tag == SP_TAG_FLT || b.tag == SP_TAG_INT)) { if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) { *comparable = TRUE; return (a.v.i > b.v.i) - (a.v.i < b.v.i); } sp_float _fa = a.tag == SP_TAG_FLT ? a.v.f : (sp_float)a.v.i; sp_float _fb = b.tag == SP_TAG_FLT ? b.v.f : (sp_float)b.v.i; *comparable = TRUE; return (_fa > _fb) - (_fa < _fb); } /* A user class's own `<=>` comes first, exactly as its own &/|/^ does (#3501): the Rational arm below answers for the RECEIVER's sake and a user object is not one of its operands, so `Fixed.new(1) < Rational(1,2)` reported the comparison as failed even though the class compares them perfectly well (#4038). */ if (a.tag == SP_TAG_OBJ && a.cls_id >= 0 && sp_obj_cmp_hook) return sp_obj_cmp_hook(a, b, comparable); if (sp_poly_is_brat(a) || sp_poly_is_brat(b) || sp_poly_is_rational(a) || sp_poly_is_rational(b)) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) { sp_float _af = sp_poly_to_f(a), _bf = sp_poly_to_f(b); *comparable = TRUE; return (_af > _bf) - (_af < _bf); } int _oka = sp_poly_is_brat(a) || sp_poly_is_rational(a) || a.tag == SP_TAG_INT || a.tag == SP_TAG_BIGINT; int _okb = sp_poly_is_brat(b) || sp_poly_is_rational(b) || b.tag == SP_TAG_INT || b.tag == SP_TAG_BIGINT; if (_oka && _okb) { *comparable = TRUE; return sp_brat_cmp_poly(a, b); } *comparable = FALSE; return 0; } if (a.tag == SP_TAG_OBJ && b.tag == SP_TAG_OBJ && SP_IS_BUILTIN_ARRAY(a.cls_id) && SP_IS_BUILTIN_ARRAY(b.cls_id)) return sp_poly_arr_cmp(a, b, comparable); if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { sp_Bigint *ba = sp_poly_as_bigint(a), *bb = sp_poly_as_bigint(b); if (ba && bb) { *comparable = TRUE; return sp_bigint_cmp(ba, bb); } if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) { sp_float af = sp_poly_to_f(a), bf = sp_poly_to_f(b); *comparable = TRUE; return (af > bf) - (af < bf); } *comparable = FALSE; return 0; } if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) { sp_float af = sp_poly_to_f(a), bf = sp_poly_to_f(b); *comparable = TRUE; return (af > bf) - (af < bf); } if (a.tag == SP_TAG_STR && b.tag == SP_TAG_STR) { if (a.v.s == NULL || b.v.s == NULL) { *comparable = (a.v.s == b.v.s); return 0; } *comparable = TRUE; return sp_str_cmp_bytes(a.v.s, b.v.s); } { sp_int _sc; if (sp_poly_cmp_to_str(a, b, &_sc)) { *comparable = TRUE; return _sc; } } if (a.tag == SP_TAG_SYM && b.tag == SP_TAG_SYM) { *comparable = TRUE; if (sp_sym_name_fn) { /* byte-exact: a name may hold a NUL, and strcmp would call `:"a\0b"` equal to `:a` and order them arbitrarily (#nul symbols) */ const char *_na = sp_sym_name_fn((sp_sym)a.v.i), *_nb = sp_sym_name_fn((sp_sym)b.v.i); int _r = strcmp(_na, _nb); /* strcmp decides whenever the names differ before any NUL, and agrees with a byte-exact compare when it does. Only a TIE can hide a difference past an embedded NUL -- `:"a\0b"` against `:a` -- so the byte-exact compare runs just there (#nul symbols), keeping the ordinary comparison one pass. */ if (_r == 0) _r = sp_str_cmp_bytes(_na, _nb); return _r; } return (a.v.i > b.v.i) - (a.v.i < b.v.i); } if (sp_poly_is_strbuf(a) || sp_poly_is_strbuf(b)) return sp_poly_cmp(sp_poly_strbuf_deref(a), sp_poly_strbuf_deref(b), comparable); if (a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_TIME && b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_TIME && a.v.p && b.v.p) { *comparable = TRUE; return sp_time_cmp(*(sp_Time *)a.v.p, *(sp_Time *)b.v.p); } if (a.tag == SP_TAG_OBJ && sp_obj_cmp_hook) return sp_obj_cmp_hook(a, b, comparable); *comparable = FALSE; return 0; }
 /* Lexicographic <=> between two boxed int arrays (Array#<=> over int elems),
    so Array#max/min/sort work on an array of int pairs ([delta, idx] tuples). */
 /* sp_poly_cmp_int_arrays: moved to lib/sp_cold.c */

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -5080,6 +5080,13 @@ else {
     if ((sp_streq(name, "casecmp") || sp_streq(name, "casecmp?")) && argc == 1) {
       TyKind at0 = infer_type(c, argv[0]);
       if (at0 == TY_POLY) return TY_POLY;  /* runtime tag decides: boxed result or nil */
+      /* an operand that answers #to_str is converted and compared
+         (rb_check_string_type). The call is typed POLY, not the Integer or
+         boolean a String operand gives, because the conversion can still
+         answer nothing: a #to_str answering nil is CRuby's nil casecmp. The
+         emitter takes the same shape test, so both agree. */
+      if (ty_is_object(at0) && class_has_to_str_shape(c, ty_object_class(at0)))
+        return TY_POLY;
       if (at0 != TY_STRING && at0 != TY_UNKNOWN) return TY_NIL;
       return sp_streq(name, "casecmp") ? TY_INT : TY_BOOL;
     }

--- a/src/analyze_infer_recv.c
+++ b/src/analyze_infer_recv.c
@@ -1530,6 +1530,13 @@ int infer_poly_call(Compiler *c, int id, TyKind rt, TyKind *out) {
     if (argc == 1 && (sp_streq(name, "casecmp") || sp_streq(name, "casecmp?"))) {
       TyKind at0 = argv ? infer_type(c, argv[0]) : TY_UNKNOWN;
       if (at0 == TY_POLY) { *out = TY_POLY; return 1; }
+      /* an operand that answers #to_str converts and compares, and answers
+         nil when its #to_str does -- the boxed result the emitter's arm
+         gives. Same shape test, same answer, as the typed-receiver rule. */
+      if (ty_is_object(at0) && class_has_to_str_shape(c, ty_object_class(at0))) {
+        *out = TY_POLY;
+        return 1;
+      }
       if (at0 != TY_STRING && at0 != TY_UNKNOWN) { *out = TY_NIL; return 1; }
       *out = sp_streq(name, "casecmp") ? TY_INT : TY_BOOL;
       return 1;

--- a/src/analyze_internal.h
+++ b/src/analyze_internal.h
@@ -91,6 +91,7 @@ int is_cmp_op(const char *op);
 int is_numeric_coerce_op(const char *op);
 int class_coerce_emittable(Compiler *c, int k);
 int class_has_coerce_shape(Compiler *c, int k);
+int class_has_to_str_shape(Compiler *c, int k);
 int is_eq_op(const char *op);
 int is_void_call(const char *name);
 /* Resolve a struct member from a literal key node: a SymbolNode names a

--- a/src/analyze_util.c
+++ b/src/analyze_util.c
@@ -314,6 +314,44 @@ int class_coerce_emittable(Compiler *c, int k) {
   if (!ty_is_array(m->ret) && m->ret != TY_POLY_ARRAY) return 0;
   return 1;
 }
+/* 1 if class k defines a #to_str whose SHAPE a String comparison can convert
+   through: no parameters, and an answer the String slot can take -- a static
+   String, or one the analysis could only pin to poly (a body reading a poly
+   ivar, or one with a nil branch), whose boxed answer takes the check CRuby
+   applies to the RESULT of #to_str. Like the coerce shape above, this
+   consults neither reachability nor emittability: it is asked by the type
+   rules for #casecmp and by every comparison arm the emitter renders, so the
+   TYPED side agrees at every point in the pipeline. The BOXED side does not
+   ask it and cannot: it reaches #to_str through the generated conversion
+   bridge, which carries only a #to_str whose static return is a String
+   (conv_bridge_callee), so a poly-returning one converts typed and answers
+   "no conversion" boxed. That asymmetry is deliberate -- widening the bridge
+   is its own change -- and it is named again where the bridge is asked, in
+   sp_poly_check_str.
+
+   A parameter of any kind is declined even though CRuby only needs #to_str to
+   be callable with none: `def to_str(x = 1)`, `def to_str(*a)` and
+   `def to_str(k: 1)` all fail the C build at the tree's existing conversion
+   site (`"x" + A.new("y")`, checked on all three), and this rule leaves them
+   where it found them rather than adding a new way in. An
+   `attr_reader :to_str` defines no method scope at all, so the lookup below
+   never sees it. A native class is excluded because the conversion is a
+   direct call to a method this TU compiles. */
+int class_has_to_str_shape(Compiler *c, int k) {
+  if (k < 0 || k >= c->nclasses || c->classes[k].is_native_class) return 0;
+  int mi = comp_method_in_chain(c, k, "to_str", NULL);
+  if (mi < 0) return 0;
+  Scope *m = &c->scopes[mi];
+  /* an ALIAS is not this shape yet: the conversion emitter names the call
+     after the protocol (sp_A_to_str) while `alias to_str raw` compiles one
+     function named sp_A_raw, and reachability seeds the implicit protocols by
+     the method's own name, so the aliased body is not emitted at all. Master
+     fails the C build on that pair already (`"x" + A.new("y")`); this rule
+     leaves it exactly where it found it rather than adding a new way in. */
+  if (!sp_streq(m->name, "to_str")) return 0;
+  return m->nparams == 0 && m->rest_idx < 0 &&
+         (m->ret == TY_STRING || m->ret == TY_POLY);
+}
 int is_eq_op(const char *op) {
   static const char *const set[] = {"==", "!=", "===", NULL};
   return str_in(op, set);

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -736,6 +736,91 @@ void emit_path_expr(Compiler *c, int node, Buf *b) {
   emit_str_expr(c, node, b);
 }
 
+/* The operand of a String COMPARISON -- #<=>, #casecmp, #casecmp?, and the
+   ordered operators and #between? Comparable builds on #<=>. CRuby asks a
+   non-String operand for #to_str (rb_check_string_type) and compares the
+   strings. Unlike the String argument slot above, a class that answers
+   nothing is not an error here: it is the comparison's own nil, or its
+   "comparison of String with X failed".
+
+   1 iff the operand is a user object whose class answers a #to_str this rule
+   converts through. The type rules ask the same predicate of the same class
+   (analyze_util.c), so typing and emission agree on the typed side. */
+int str_cmp_conv_shape(Compiler *c, int node) {
+  TyKind t = comp_ntype(c, node);
+  return ty_is_object(t) && class_has_to_str_shape(c, ty_object_class(t));
+}
+
+/* The conversion itself, reading the operand back out of the rooted sp_RbVal
+   temp the prologue below spilled it into rather than re-emitting the operand
+   expression: the object is otherwise reachable from nothing but the argument
+   being converted, and its own #to_str allocates before it reads self.
+
+   NULL means "no conversion", which each arm turns into its own refusal.
+   Four shapes answer it: a class with no usable #to_str (the literal NULL --
+   the arm is then the refusal, and the C compiler folds the compare away), a
+   #to_str typed String that answers the nil String, a #to_str typed poly that
+   answers nil, and a BOXED value that is neither a String nor an object the
+   conversion bridge carries. A poly answer that is neither nil nor a String
+   is CRuby's TypeError, which sp_str_cmp_conv raises.
+
+   A boxed operand asks the runtime's own rb_check_string_type, the same
+   sp_poly_check_str the boxed comparison and the poly casecmp arm ask, so a
+   poly slot holding a String compares and one holding an object converts
+   (rooted inside sp_poly_check_str_obj) rather than both being refused for
+   want of a static type. Only #between? reaches this with a boxed bound: the
+   other arms are entered on a statically OBJECT operand, and a boxed one goes
+   to sp_poly_lt / sp_poly_spaceship / the poly casecmp arm long before here.
+
+   The tag test on the object shapes keeps the direct call off a NULL self: an
+   object-typed slot a method left nil boxes as nil rather than as SP_TAG_OBJ,
+   and the refusal then names it "nil", which is CRuby's answer. The object is
+   a pointer, never the by-value layout: a class with an object-typed instance
+   in a call ARGUMENT -- which every one of these operands is -- is
+   disqualified from that layout (detect_value_types). */
+void emit_str_cmp_conv(Compiler *c, int node, int tmp, Buf *b) {
+  TyKind t = comp_ntype(c, node);
+  if (t == TY_POLY) { buf_printf(b, "sp_poly_check_str(_t%d)", tmp); return; }
+  if (!str_cmp_conv_shape(c, node)) { buf_puts(b, "NULL"); return; }
+  int def = -1;
+  int poly = obj_conv_method(c, t, "to_str", TY_STRING, &def) < 0;
+  if (poly) comp_method_in_chain(c, ty_object_class(t), "to_str", &def);
+  buf_printf(b, "(_t%d.tag == SP_TAG_OBJ ? ", tmp);
+  if (poly) buf_puts(b, "sp_str_cmp_conv(");
+  buf_printf(b, "sp_%s_to_str((sp_%s *)_t%d.v.p)",
+             c->classes[def].c_name, c->classes[def].c_name, tmp);
+  if (poly) buf_printf(b, ", _t%d)", tmp);
+  buf_puts(b, " : NULL)");
+}
+
+/* The prologue every String-comparison arm shares. It opens a statement
+   expression and emits, in Ruby's own evaluation order:
+
+     ({ const char *_tr = <recv>;   SP_GC_ROOT_STR(_tr);
+        sp_RbVal    _to = <operand>; SP_GC_ROOT_RBVAL(_to);
+        const char *_ts = <conversion, or NULL>; _ts ?
+
+   -- receiver, then operand, then #to_str, once each. Both spills are
+   load-bearing: #to_str allocates, so the receiver has to survive it (a
+   comparison's receiver is often a fresh string held in nothing else -- an
+   interpolation, a `+`), and so does the operand OBJECT, which reads self
+   after allocating. The conversion is deliberately NOT put in the call's
+   conversion hold: the hold would hoist it in front of the receiver, and
+   #between? needs it left where the compare that reads it is.
+
+   The caller closes with `<compare> : <fallback>; })`. Nothing may allocate
+   between the two -- the converted string is live only in _ts. */
+void emit_str_cmp_prologue(Compiler *c, const char *rtxt, int operand,
+                           int *tr, int *to, int *ts, Buf *b) {
+  *tr = ++g_tmp; *to = ++g_tmp; *ts = ++g_tmp;
+  buf_printf(b, "({ const char *_t%d = %s; SP_GC_ROOT_STR(_t%d); sp_RbVal _t%d = ",
+             *tr, rtxt, *tr, *to);
+  emit_boxed(c, operand, b);
+  buf_printf(b, "; SP_GC_ROOT_RBVAL(_t%d); const char *_t%d = ", *to, *ts);
+  emit_str_cmp_conv(c, operand, *to, b);
+  buf_printf(b, "; _t%d ? ", *ts);
+}
+
 /* A node entering a WRITE payload slot (IO#write, #pwrite, #write_nonblock):
    CRuby writes the operand's #to_s, so a String passes through and anything
    else renders the way puts renders it -- a user object through its own

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -26611,6 +26611,35 @@ else {
       buf_puts(b, "), SP_INT_NIL)");
       return;
     }
+    /* CRuby's String#<=> asks a non-String operand for #to_str
+       (rb_check_string_type) and compares the strings. There was no arm for
+       an object operand at all, so the call fell through to the object
+       dispatch below and raised NoMethodError naming String#<=> itself.
+
+       Only a CONVERTING class enters here, which is what makes the NULL
+       fallback below mean one thing: a #to_str that answered nil. An operand
+       whose class answers no usable #to_str keeps that NoMethodError. CRuby
+       has an answer for it -- nil, or -(other <=> self) when the class
+       defines #<=> (rb_invcmp) -- but that answer is Object#<=>'s rule, not
+       this conversion, and giving it here would also silence the classes this
+       rule deliberately declines (a #to_str with parameters, one returning an
+       Integer, one that raises), each of which CRuby answers differently
+       again. It goes as its own change. The ordered operators and #between?
+       below DO reach their fallback for a class with no #to_str, because
+       there a failed comparison is CRuby's own answer. */
+    if (lrt == TY_STRING && str_cmp_conv_shape(c, argv[0])) {
+      int tr, to, ts, tc = ++g_tmp;
+      int boxed_out = comp_ntype(c, id) == TY_POLY;
+      Buf rb = expr_buf(c, recv);
+      if (boxed_out) buf_puts(b, "sp_box_int_or_nil(");
+      emit_str_cmp_prologue(c, rb.p ? rb.p : "", argv[0], &tr, &to, &ts, b);
+      buf_printf(b, "({ int _t%d = sp_str_cmp_bytes(_t%d, _t%d);"
+                    " (sp_int)((_t%d > 0) - (_t%d < 0)); }) : SP_INT_NIL; })",
+                 tc, tr, ts, tc, tc);
+      if (boxed_out) buf_puts(b, ")");
+      free(rb.p);
+      return;
+    }
     if (lrt == TY_STRING && lat == TY_STRING) {
       int tc = ++g_tmp;
       buf_printf(b, "({ int _t%d = sp_str_cmp_bytes(", tc); emit_expr(c, recv, b); buf_puts(b, ", "); emit_expr(c, argv[0], b);
@@ -26755,16 +26784,25 @@ else {
         buf_puts(b, "))), FALSE)");
         return;
       }
-      /* the same failure for a user object, which CRuby names by its class
-         (sp_cmperr_desc makes that distinction). Lowered as a byte compare,
-         the object's pointer went to sp_str_cmp_bytes and the build failed
-         -- or, before that, compared as bytes (found by matz reviewing #4265) */
+      /* A user object: the <=> these are built on asks it for #to_str first,
+         so one that answers a string compares, and one that answers none is
+         the same failed comparison as above -- which CRuby names by its class
+         rather than its inspect (sp_cmperr_desc makes that distinction).
+         Lowered as a byte compare, the object's pointer went to
+         sp_str_cmp_bytes and the build failed -- or, before that, compared as
+         bytes (found by matz reviewing #4265). Both halves are one arm: the
+         refusal is the conversion answering NULL, so it is raised where the
+         <=> that failed is, not eagerly in front of it. */
       if (ty_is_object(sat)) {
-        buf_puts(b, "((void)("); emit_expr(c, recv, b);
-        buf_puts(b, "), sp_raise_cls(\"ArgumentError\", sp_sprintf("
-                    "\"comparison of String with %s failed\", sp_cmperr_desc(");
-        emit_boxed(c, argv[0], b);
-        buf_puts(b, "))), FALSE)");
+        int tr, to, ts;
+        Buf rb = expr_buf(c, recv);
+        emit_str_cmp_prologue(c, rb.p ? rb.p : "", argv[0], &tr, &to, &ts, b);
+        buf_printf(b, "sp_str_cmp_bytes(_t%d, _t%d) %s 0"
+                      " : (sp_raise_cls(\"ArgumentError\", sp_sprintf("
+                      "\"comparison of String with %%s failed\","
+                      " sp_cmperr_desc(_t%d))), FALSE); })",
+                   tr, ts, name, to);
+        free(rb.p);
         return;
       }
       buf_puts(b, "(sp_str_cmp_bytes(");
@@ -27157,19 +27195,54 @@ else {
   if (sp_streq(name, "between?") && argc == 2) {
     if (rt == TY_STRING &&
         (ty_is_object(comp_ntype(c, argv[0])) || ty_is_object(comp_ntype(c, argv[1])))) {
-      /* Comparable#between? is two <=>s, and String#<=> against an object
-         that answers neither <=> nor to_str is nil: CRuby's "comparison
-         failed", named after the first bad bound. Both bounds are still
-         evaluated, once each, in order -- Ruby evaluates the arguments before
-         between? runs -- so each is spilled to a temp first. */
-      int t0 = ++g_tmp, t1 = ++g_tmp;
-      int bad = ty_is_object(comp_ntype(c, argv[0])) ? t0 : t1;
-      buf_puts(b, "({ (void)("); emit_expr(c, recv, b);
-      buf_printf(b, "); sp_RbVal _t%d = ", t0); emit_boxed(c, argv[0], b);
-      buf_printf(b, "; sp_RbVal _t%d = ", t1); emit_boxed(c, argv[1], b);
-      buf_printf(b, "; (void)_t%d; (void)_t%d; sp_raise_cls(\"ArgumentError\", sp_sprintf("
-                    "\"comparison of String with %%s failed\", sp_cmperr_desc(_t%d))); FALSE; })",
-                 t0, t1, bad);
+      /* Comparable#between? is two <=>s and it STOPS at the first: when
+         `self >= lo` is false CRuby never asks hi for anything, so
+         `"abc".between?(W.new("abd"), Plain.new)` is false rather than the
+         second bound's comparison error. The bounds are still evaluated, once
+         each, in order -- Ruby evaluates the arguments before between? runs
+         -- so each is spilled to a temp up front, and only the CONVERSIONS
+         and the refusals are left inside the `&&`, where the compare that
+         reads them is. That is also why the conversions are not put in the
+         call's conversion hold, which would hoist both in front of the `&&`.
+
+         A String bound spills to a rooted `const char *` and compares as it
+         always did -- rooted because the OTHER bound's #to_str allocates
+         before this one is read; every other bound spills boxed, which is
+         both what the conversion reads and what sp_cmperr_desc names in the
+         message. A bound whose class answers no usable #to_str converts to
+         NULL, so its half of the `&&` IS the comparison error #4265 gives; a
+         BOXED bound asks the runtime's rb_check_string_type instead, so one
+         holding a String or a converting object compares here exactly as it
+         would as a boxed operand anywhere else. */
+      int tv = ++g_tmp, tb[2], tc[2], isstr[2];
+      for (int i = 0; i < 2; i++) { tb[i] = ++g_tmp; tc[i] = ++g_tmp; }
+      buf_printf(b, "({ const char *_t%d = ", tv); emit_expr(c, recv, b);
+      buf_printf(b, "; SP_GC_ROOT_STR(_t%d); ", tv);
+      for (int i = 0; i < 2; i++) {
+        isstr[i] = comp_ntype(c, argv[i]) == TY_STRING;
+        if (isstr[i]) {
+          buf_printf(b, "const char *_t%d = ", tb[i]); emit_expr(c, argv[i], b);
+          buf_printf(b, "; SP_GC_ROOT_STR(_t%d); ", tb[i]);
+        }
+        else {
+          buf_printf(b, "sp_RbVal _t%d = ", tb[i]); emit_boxed(c, argv[i], b);
+          buf_printf(b, "; SP_GC_ROOT_RBVAL(_t%d); ", tb[i]);
+        }
+      }
+      buf_puts(b, "(");
+      for (int i = 0; i < 2; i++) {
+        const char *op = i == 0 ? ">=" : "<=";
+        if (i) buf_puts(b, " && ");
+        if (isstr[i]) { buf_printf(b, "sp_str_cmp_bytes(_t%d, _t%d) %s 0", tv, tb[i], op); continue; }
+        buf_printf(b, "({ const char *_t%d = ", tc[i]);
+        emit_str_cmp_conv(c, argv[i], tb[i], b);
+        buf_printf(b, "; _t%d ? sp_str_cmp_bytes(_t%d, _t%d) %s 0"
+                      " : (sp_raise_cls(\"ArgumentError\", sp_sprintf("
+                      "\"comparison of String with %%s failed\","
+                      " sp_cmperr_desc(_t%d))), FALSE); })",
+                   tc[i], tv, tc[i], op, tb[i]);
+      }
+      buf_puts(b, "); })");
       return;
     }
     if (rt == TY_STRING) {

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -7129,15 +7129,39 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
       else if (sp_streq(name, "undump") && argc == 0) buf_printf(b, "sp_str_undump(%s)", r);
       else if ((sp_streq(name, "casecmp") || sp_streq(name, "casecmp?")) && argc == 1 &&
                comp_ntype(c, argv[0]) == TY_POLY) {
-        /* runtime tag decides: a string argument compares, anything else is
-           nil (the call typed TY_POLY) */
-        int tb2 = ++g_tmp;
-        buf_printf(b, "({ sp_RbVal _t%d = ", tb2); emit_expr(c, argv[0], b);
-        buf_printf(b, "; _t%d.tag == SP_TAG_STR ? ", tb2);
+        /* runtime tag decides: a string argument compares, a boxed object
+           that answers #to_str converts and compares (rb_check_string_type),
+           anything else is nil (the call typed TY_POLY). The receiver is
+           bound and rooted first: #to_str allocates, and the receiver may be
+           a fresh string nothing else holds. The OPERAND is rooted one level
+           down, inside sp_poly_check_str, which is where this arm and the
+           runtime's own boxed comparison meet. */
+        int ta2 = ++g_tmp, tb2 = ++g_tmp, tc2 = ++g_tmp;
+        buf_printf(b, "({ const char *_t%d = %s; SP_GC_ROOT_STR(_t%d);"
+                      " sp_RbVal _t%d = ", ta2, r, ta2, tb2);
+        emit_expr(c, argv[0], b);
+        buf_printf(b, "; const char *_t%d = sp_poly_check_str(_t%d);"
+                      " (_t%d || _t%d.tag == SP_TAG_STR) ? ", tc2, tb2, tc2, tb2);
         if (sp_streq(name, "casecmp"))
-          buf_printf(b, "sp_box_int(sp_str_casecmp(%s, _t%d.v.s ? _t%d.v.s : \"\"))", r, tb2, tb2);
+          buf_printf(b, "sp_box_int(sp_str_casecmp(_t%d, _t%d ? _t%d : \"\"))", ta2, tc2, tc2);
         else
-          buf_printf(b, "sp_box_bool(sp_str_casecmp(%s, _t%d.v.s ? _t%d.v.s : \"\") == 0)", r, tb2, tb2);
+          buf_printf(b, "sp_box_bool(sp_str_casecmp(_t%d, _t%d ? _t%d : \"\") == 0)", ta2, tc2, tc2);
+        buf_puts(b, " : sp_box_nil(); })");
+      }
+      /* an operand whose class answers #to_str: CRuby converts it and
+         compares, where the arm below discarded it and answered nil. The
+         answer is boxed because the conversion can still come back empty --
+         a #to_str that answers nil is CRuby's nil casecmp, not a comparison
+         with "" -- so the call is typed TY_POLY, as it is for a poly operand
+         above (analyze_infer.c, analyze_infer_recv.c). */
+      else if ((sp_streq(name, "casecmp") || sp_streq(name, "casecmp?")) && argc == 1 &&
+               str_cmp_conv_shape(c, argv[0])) {
+        int tr, to, ts;
+        emit_str_cmp_prologue(c, r, argv[0], &tr, &to, &ts, b);
+        if (sp_streq(name, "casecmp"))
+          buf_printf(b, "sp_box_int(sp_str_casecmp(_t%d, _t%d))", tr, ts);
+        else
+          buf_printf(b, "sp_box_bool(sp_str_casecmp(_t%d, _t%d) == 0)", tr, ts);
         buf_puts(b, " : sp_box_nil(); })");
       }
       else if ((sp_streq(name, "casecmp") || sp_streq(name, "casecmp?")) && argc == 1 &&

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -361,6 +361,7 @@ extern int g_has_user_coerce;
    typed. See analyze_util.c. */
 int class_coerce_emittable(Compiler *c, int k);
 int class_has_coerce_shape(Compiler *c, int k);
+int class_has_to_str_shape(Compiler *c, int k);
 int is_numeric_coerce_op(const char *op);
 extern int g_has_user_to_io;
 extern int g_gen_obj_hashkey; /* >=1 instantiated class defines #hash + #eql?: emit + install the obj hash/eql key hooks */
@@ -535,6 +536,13 @@ extern int g_unsup_probe;          /* silent emittability probe (drop a dynamic-
    must be. *def_out receives the defining class. Shared by the emitter and the
    native-argument check so both agree on which objects may cross. */
 int obj_conv_method(Compiler *c, TyKind t, const char *conv, TyKind want, int *def_out);
+/* A String comparison's operand: the shape test both the type rules and the
+   arms ask, the conversion emitted on a spilled temp, and the prologue the
+   arms share. See codegen.c. */
+int str_cmp_conv_shape(Compiler *c, int node);
+void emit_str_cmp_conv(Compiler *c, int node, int tmp, Buf *b);
+void emit_str_cmp_prologue(Compiler *c, const char *rtxt, int operand,
+                           int *tr, int *to, int *ts, Buf *b);
 /* 1 iff any class defines a usable #to_int / #to_str -- see codegen.c. */
 int prog_has_conv_method(Compiler *c, const char *conv, TyKind want);
 

--- a/test/string_comparison_to_str.rb
+++ b/test/string_comparison_to_str.rb
@@ -1,0 +1,316 @@
+# A String comparison converts an operand that answers #to_str
+# (CRuby's rb_check_string_type at String#<=>, #casecmp, #casecmp? and the
+# ordered operators and #between? Comparable builds on <=>). An operand that
+# answers no #to_str keeps the comparison's own refusal.
+
+class Wrap
+  def initialize(s)
+    @s = s
+  end
+
+  def to_str
+    @s
+  end
+end
+
+class Sub < Wrap
+end
+
+class Plain
+end
+
+# A #to_str the analysis types String that answers the nil String: CRuby's
+# rb_check_string_type reads a nil answer as "no conversion", so the
+# comparison refuses rather than reading it as "".
+class Maybe
+  def initialize(s = nil)
+    @s = s
+  end
+
+  def to_str
+    @s
+  end
+end
+
+# A #to_str the analysis can only pin to poly: CRuby checks the ANSWER as well
+# as the method, and one that is neither nil nor a String is a TypeError,
+# named after both classes.
+class Loose
+  def initialize(s, bad)
+    @s = s
+    @bad = bad
+  end
+
+  def to_str
+    return 42 if @bad
+    @s
+  end
+end
+
+# the same poly shape, answering nil -- which is "no conversion" and not an
+# error, so each method gives its own refusal
+class Vague
+  def initialize(s, none)
+    @s = s
+    @none = none
+  end
+
+  def to_str
+    return nil if @none
+    @s
+  end
+end
+
+def report
+  yield
+rescue => e
+  puts e.class
+end
+
+# where the message is the point: which class the comparison names, and
+# CRuby's own wording for a #to_str that answers the wrong class
+def report_msg
+  yield
+rescue => e
+  puts "#{e.class}: #{e.message}"
+end
+
+# --- the refusals first, so a GC-stress run reaches them before the churn ---
+report { puts("abc" < Plain.new) }
+report { puts("abc".between?(Plain.new, Plain.new)) }
+report { puts("abc" < 1) }
+report_msg { puts("abc" <=> Loose.new("abd", true)) }
+report_msg { puts("abc" < Loose.new("abd", true)) }
+report_msg { puts("abc".casecmp(Loose.new("ABD", true))) }
+
+# --- <=> converts and compares ---
+p("abc" <=> Wrap.new("abc"))
+p("abc" <=> Wrap.new("abd"))
+p("abc" <=> Wrap.new("abb"))
+
+# --- casecmp / casecmp? convert ---
+p("abc".casecmp(Wrap.new("ABC")))
+p("abc".casecmp(Wrap.new("ABD")))
+p("abc".casecmp?(Wrap.new("ABC")))
+p("abc".casecmp?(Wrap.new("ABD")))
+
+# --- the ordered operators, built on <=>, convert too ---
+p("abc" < Wrap.new("abd"))
+p("abc" <= Wrap.new("abc"))
+p("abc" > Wrap.new("abb"))
+p("abc" >= Wrap.new("abc"))
+p("abc" > Wrap.new("abd"))
+
+# --- between?, with object bounds and with one of each ---
+p("abc".between?(Wrap.new("aaa"), Wrap.new("abd")))
+p("abc".between?(Wrap.new("aaa"), "abd"))
+p("abc".between?("aaa", Wrap.new("abd")))
+p("abc".between?(Wrap.new("abd"), Wrap.new("abz")))
+
+# --- #to_str inherited from a superclass ---
+p("abc" <=> Sub.new("abc"))
+p("abc".casecmp(Sub.new("ABD")))
+p("abc" < Sub.new("abd"))
+
+# --- the operand reached through a method return ---
+def make(s)
+  Wrap.new(s)
+end
+
+p("abc" <=> make("abd"))
+p("abc" < make("abd"))
+p("abc".casecmp(make("ABD")))
+
+# --- a #to_str the analysis pins to poly, answering a String ---
+p("abc" <=> Loose.new("abd", false))
+p("abc".casecmp(Loose.new("ABD", false)))
+p("abc" < Loose.new("abd", false))
+
+# --- a BOXED operand: the element type is not settled ---
+mixed = [Wrap.new("abd"), 1]
+boxed = mixed[0]
+p("abc" <=> boxed)
+p("abc".casecmp(boxed))
+p("abc".casecmp?(boxed))
+p("abc" < boxed)
+p("abc" <= boxed)
+p("abc" > boxed)
+p("abc" >= boxed)
+
+# #between? through the boxed side needs a boxed receiver too: a typed
+# receiver with boxed bounds is the shape that does not compile at all
+boxed_lo = [Wrap.new("aaa"), 1][0]
+boxed_hi = [Wrap.new("abd"), 1][0]
+boxed_recv = ["abc", 1][0]
+p(boxed_recv.between?(boxed_lo, boxed_hi))
+
+# --- a boxed RECEIVER, converting a typed operand ---
+strs = ["abc", 1]
+recv = strs[0]
+p(recv <=> Wrap.new("abd"))
+p(recv.casecmp(Wrap.new("ABD")))
+
+# --- guards: a class answering no #to_str keeps every answer it had, at the
+#     seven methods where that answer is the comparison's own. #<=> is not
+#     pinned for such a class: it keeps master's NoMethodError, where CRuby
+#     answers Object#<=>'s nil (or -(obj <=> self) for a class defining <=>),
+#     which is a rule of its own and not this conversion ---
+p("abc".casecmp(Plain.new))
+p("abc".casecmp?(Plain.new))
+report_msg { puts("abc" <= Plain.new) }
+report_msg { puts("abc" > Plain.new) }
+report_msg { puts("abc" >= Plain.new) }
+p("abc" == Wrap.new("abc"))
+p("abc".eql?(Wrap.new("abc")))
+p("abc" <=> :abc)
+p("abc" <=> 1)
+report_msg { puts("abc" < :abc) }
+
+# an object-typed slot holding nil: nothing to ask for #to_str, and CRuby
+# names it "nil"
+def maybe_wrap(flag)
+  return nil unless flag
+  Wrap.new("abd")
+end
+
+p("abc" < maybe_wrap(true))
+p("abc" <=> maybe_wrap(false))
+report_msg { puts("abc" < maybe_wrap(false)) }
+
+plains = [Plain.new, 1]
+bp = plains[0]
+p("abc" <=> bp)
+p("abc".casecmp(bp))
+report { puts("abc" < bp) }
+
+# --- #to_str runs exactly once per comparison, and #between? stops at the
+#     first bound the way CRuby's two <=>s do ---
+$calls = []
+
+class Counted
+  def initialize(s)
+    @s = s
+  end
+
+  def to_str
+    $calls << @s
+    @s
+  end
+end
+
+("abc" <=> Counted.new("abd"))
+p $calls
+$calls = []
+("abc" < Counted.new("abd"))
+p $calls
+$calls = []
+"abc".between?(Counted.new("aaa"), Counted.new("abd"))
+p $calls
+$calls = []
+"abc".between?(Counted.new("zzz"), Counted.new("abd"))
+p $calls
+
+# --- a mixed #between?: CRuby stops at the first <=>, so a bound that
+#     answers no #to_str is never asked when the first bound settled it ---
+$calls = []
+p("abc".between?(Counted.new("abd"), Plain.new))
+p $calls
+$calls = []
+report_msg { puts("abz".between?(Counted.new("aaa"), Plain.new)) }
+p $calls
+$calls = []
+report_msg { puts("abc".between?(Plain.new, Counted.new("abz"))) }
+p $calls
+
+# --- a BOXED #between? bound beside a typed one: it asks the runtime's
+#     rb_check_string_type, as a boxed operand does anywhere else, so a slot
+#     holding a String or a converting object compares and any other value is
+#     the comparison error, named after what the slot actually held ---
+boxed_hi = ["abz", 1][0]
+boxed_lo = ["aaa", 1][0]
+boxed_hi_obj = [Wrap.new("abz"), 1][0]
+boxed_int = [5, "x"][0]
+boxed_nil = [nil, "x"][0]
+p("abc".between?(Wrap.new("aaa"), boxed_hi))
+p("abz".between?(Wrap.new("aaa"), boxed_hi))
+p("abc".between?(boxed_lo, Wrap.new("abz")))
+p("abc".between?(Wrap.new("aaa"), boxed_hi_obj))
+report_msg { puts("abc".between?(Wrap.new("aaa"), boxed_int)) }
+report_msg { puts("abc".between?(Wrap.new("aaa"), boxed_nil)) }
+
+# the boxed hi is never asked for a string when the typed lo already settled it
+$calls = []
+boxed_counted = [Counted.new("abz"), 1][0]
+p("abc".between?(Wrap.new("abd"), boxed_counted))
+p $calls
+
+# --- a #to_str typed String that answers the nil String, at all eight ---
+p("abc" <=> Maybe.new("abd"))
+p("abc" <=> Maybe.new)
+p("abc".casecmp(Maybe.new))
+p("abc".casecmp?(Maybe.new))
+report_msg { puts("abc" < Maybe.new) }
+report_msg { puts("abc" <= Maybe.new) }
+report_msg { puts("abc" > Maybe.new) }
+report_msg { puts("abc" >= Maybe.new) }
+report_msg { puts("abc".between?(Maybe.new, Maybe.new)) }
+
+# --- a #to_str typed poly that answers nil, at all eight ---
+p("abc" <=> Vague.new("abd", true))
+p("abc".casecmp(Vague.new("ABD", true)))
+p("abc".casecmp?(Vague.new("ABD", true)))
+report_msg { puts("abc" < Vague.new("abd", true)) }
+report_msg { puts("abc" <= Vague.new("abd", true)) }
+report_msg { puts("abc" > Vague.new("abd", true)) }
+report_msg { puts("abc" >= Vague.new("abd", true)) }
+report_msg { puts("abc".between?(Vague.new("aaa", true), Vague.new("abd", true))) }
+p("abc" <=> Vague.new("abd", false))
+p("abc" < Vague.new("abd", false))
+
+# --- a receiver that is itself a converting comparison's ternary ---
+p((("abc" < Wrap.new("abd")) ? "abc" : "zzz").casecmp(Wrap.new("ABC")))
+p((("abc" < Wrap.new("abd")) ? "abc" : "zzz") < Wrap.new("abd"))
+
+# --- the converted String is held across the compare: a churn loop whose
+#     #to_str allocates a fresh answer every round ---
+class Churn
+  def initialize(n)
+    @n = n
+  end
+
+  def to_str
+    "a" * @n
+  end
+end
+
+# the operand's own object has to survive its #to_str, which allocates
+# before it reads self -- the boxed side reaches the conversion with the
+# object held in nothing but the argument
+class Popped
+  def initialize(s)
+    @s = s
+  end
+
+  def to_str
+    pad = "y" * 64
+    @s + pad[0, 0]
+  end
+end
+
+popped = 0
+300.times do
+  q = [1, Popped.new("abd")]
+  popped += 1 if "abc" < q.pop
+end
+p popped
+
+churns = [Churn.new(4), 1]
+boxed_churn = churns[0]
+wrong = 0
+300.times do |i|
+  wrong += 1 if ("aaaa" <=> Churn.new(4)) != 0
+  wrong += 1 unless "#{'a' * 4}".between?(Churn.new(3), Churn.new(5))
+  wrong += 1 unless "#{'a' * 4}".casecmp(boxed_churn) == 0
+  wrong += 1 unless ("aaaa" + "").casecmp(Churn.new(4)) == 0
+end
+p wrong

--- a/test/string_comparison_to_str.rb.expected
+++ b/test/string_comparison_to_str.rb.expected
@@ -1,0 +1,98 @@
+ArgumentError
+ArgumentError
+ArgumentError
+TypeError: can't convert Loose to String (Loose#to_str gives Integer)
+TypeError: can't convert Loose to String (Loose#to_str gives Integer)
+TypeError: can't convert Loose to String (Loose#to_str gives Integer)
+0
+-1
+1
+0
+-1
+true
+false
+true
+true
+true
+true
+false
+true
+true
+true
+false
+0
+-1
+true
+-1
+true
+-1
+-1
+-1
+true
+-1
+-1
+false
+true
+true
+false
+false
+true
+-1
+-1
+nil
+nil
+ArgumentError: comparison of String with Plain failed
+ArgumentError: comparison of String with Plain failed
+ArgumentError: comparison of String with Plain failed
+false
+false
+nil
+nil
+ArgumentError: comparison of String with :abc failed
+true
+nil
+ArgumentError: comparison of String with nil failed
+nil
+nil
+ArgumentError
+["abd"]
+["abd"]
+["aaa", "abd"]
+["zzz"]
+false
+["abd"]
+ArgumentError: comparison of String with Plain failed
+["aaa"]
+ArgumentError: comparison of String with Plain failed
+[]
+true
+true
+true
+true
+ArgumentError: comparison of String with 5 failed
+ArgumentError: comparison of String with nil failed
+false
+[]
+-1
+nil
+nil
+nil
+ArgumentError: comparison of String with Maybe failed
+ArgumentError: comparison of String with Maybe failed
+ArgumentError: comparison of String with Maybe failed
+ArgumentError: comparison of String with Maybe failed
+ArgumentError: comparison of String with Maybe failed
+nil
+nil
+nil
+ArgumentError: comparison of String with Vague failed
+ArgumentError: comparison of String with Vague failed
+ArgumentError: comparison of String with Vague failed
+ArgumentError: comparison of String with Vague failed
+ArgumentError: comparison of String with Vague failed
+-1
+true
+0
+true
+300
+0


### PR DESCRIPTION
## Why

This is the follow-up promised on #4265. Reviewing that PR, matz raised `"abc" < money`, and #4265 answered the loud half: an object operand that a String cannot be compared with is CRuby's `comparison of String with Money failed`, not a byte compare against the object's address. CodeRabbit asked the other half, which #4265 left open — an object that *does* answer `#to_str` is not a failed comparison at all. CRuby converts it and compares the strings.

Spinel asked nothing, at any of the comparison methods, and each one was wrong in its own way:

```ruby
class Wrap
  def initialize(s) = @s = s
  def to_str = @s
end

p("abc" <=> Wrap.new("abd"))        # CRuby -1
p("abc".casecmp(Wrap.new("ABD")))   # CRuby -1
p("abc" < Wrap.new("abd"))          # CRuby true
p("abc".between?(Wrap.new("aaa"), Wrap.new("abd")))  # CRuby true
```

`#casecmp` and `#casecmp?` discarded the operand and answered `nil` — folded at compile time, so the call was not even emitted. `#<=>` had no arm for a non-String operand at all: it fell through to the generic object dispatch and raised `undefined method '<=>' for an instance of String` at run time, on a method String certainly has. The four ordered operators and `#between?` raised #4265's comparison error. Through a boxed operand — an element of a mixed array, a poly local — `#<=>` and the ordered operators answered `nil` or raised the same comparison error, and `#casecmp` answered `nil`.

## What

An operand that is not a String but whose class answers `#to_str` is converted, and the strings are compared, at `#<=>`, `#casecmp`, `#casecmp?`, `<`, `<=`, `>`, `>=` and `#between?`. A boxed operand — one whose static type is only `poly` — asks the runtime's own `rb_check_string_type` wherever it lands, including as a `#between?` bound, so a slot holding a String or a converting object compares there too. An operand that answers no usable `#to_str` keeps exactly the answer it had, at every one of the eight. `#==` does not convert in CRuby (`"abc" == Wrap.new("abc")` is false) and does not here.

## How

No new conversion machinery. The conversion is the direct call to the compiled `#to_str` that `obj_conv_method` and `emit_obj_conv_call_inline` (src/codegen.c) make at the tree's other statically-typed String conversions — `sp_Wrap_to_str((sp_Wrap *)…)` — with one difference: it is rendered on a spilled temp rather than on the operand's own expression.

That spill is what the eight entry points now share, as one prologue (`emit_str_cmp_prologue`, src/codegen.c): the receiver bound to a rooted `const char *`, then the operand spilled into a rooted `sp_RbVal`, then the conversion, then the compare. Both spills are load-bearing, because `#to_str` is user code that allocates. The receiver of a comparison is often a fresh string held in nothing else — an interpolation, a `+` — and the operand's own *object* is reachable from nothing but the argument slot being converted, while its `#to_str` allocates before it reads `self`. The order is also Ruby's own: receiver, operand, then `#to_str`, once each. The conversion is deliberately not put in the call's conversion hold, which would hoist it in front of the receiver and out of `#between?`'s short circuit.

The conversion answers `NULL` for "no conversion", and that one answer is what collapses the arms. CRuby's `rb_check_string_type` treats a `nil` from `#to_str` as *not a string*, and the comparison then gives its own answer: `nil` from `#<=>`, `#casecmp` and `#casecmp?`, `comparison of String with X failed` from the ordered operators and `#between?`. So the refusal is the fallback of the arm that converts, not a separate arm in front of it. The ordered operators and `#between?` reach that fallback for a class with no `#to_str` at all as well, because there a failed comparison is exactly what CRuby answers; `#<=>` does not — its arm is entered only by a class that converts, so its `NULL` can only be a `#to_str` that answered nil, and a class with no usable `#to_str` never reaches it. That is what makes `#between?` exact: `"abc".between?(Wrap.new("abd"), Plain.new)` is `false` in CRuby, because the first `<=>` settles it and the second bound is never asked for anything, and the conversions and refusals now render inside the `&&` where each compare is. It is also what keeps a nil-valued object slot right: `"abc" < obj` where `obj` is `nil` boxes as nil, converts to `NULL`, and raises `comparison of String with nil failed`, as master does. A `#between?` bound whose static type is only `poly` is not refused for want of a type either: it asks `sp_poly_check_str`, the same runtime check a boxed operand asks anywhere else, so `"abc".between?(Wrap.new("aaa"), hi)` with `hi` a poly slot holding `"abz"` is `true`, one holding `5` is `comparison of String with 5 failed`, and one holding `nil` names `nil` — each the value the slot actually held, where master named the other bound.

A `#to_str` the analysis can pin no further than poly is checked at run time by a new `sp_str_cmp_conv` (lib/spinel_rt.h) rather than by the strict String argument slot: `nil` is `NULL` (no conversion), a String is itself, and any other class raises CRuby's own `can't convert Wrap to String (Wrap#to_str gives Integer)`.

A boxed operand converts in the runtime instead. Every ordered operator, `#between?` and `#<=>` reach `sp_poly_cmp` for a boxed pair — six entry points — so "a String against a user object that answers `#to_str` compares the strings" is written once there, using a new `sp_poly_check_str`: `rb_check_string_type`, where a String answers itself, a user object answers its conversion through the generated bridge, and everything else answers NULL *without* raising, because "not a string" is a real answer to a comparison where in an argument slot it would be a TypeError. `#casecmp` does not go through `sp_poly_cmp`, so its poly arm asks that helper directly. The operand is rooted inside `sp_poly_check_str_obj`, the one point both boxed callers pass through, for the same reason the typed side spills it.

Typing had to move with it. `#casecmp` and `#casecmp?` were typed `nil` for any statically non-String operand, so the comparison's answer had nowhere to land; both the typed-receiver rule (src/analyze_infer.c) and the boxed-receiver rule (src/analyze_infer_recv.c) now type a converting operand's call `poly` — not the Integer or boolean a String operand gives, because a `#to_str` that answers nil makes the call `nil`. The predicate those rules share with the emitter, `class_has_to_str_shape` (src/analyze_util.c), asks the *shape* of `#to_str` — no parameters, answering a String or poly — and not whether the conversion is emittable, because emittability depends on reachability and that is computed long after the type fixpoint that has to answer the same question. It is the same split `#coerce` already uses. The boxed side does not ask that predicate and cannot: it reaches `#to_str` through the generated conversion bridge, which carries only a `#to_str` whose static return is a String, so a poly-returning one converts typed and answers "no conversion" boxed. That asymmetry is named in a comment at both ends.

## Validation

- Tests 3409 pass, 0 fail, 0 error. Benchmarks 61 pass. Optcarrot OK 59662. ext-cruby, rbs-seed and the rubyspec gate pass; the macOS-only spin-e2e leg is red on this machine for the reason it was during #4261 and #4265, progress output leaking onto stdout, independent of this change. No suite program changes its inference-fixpoint behaviour: over 3363 programs there are 0 new non-convergences, the two that hit the round cap hit it on master too, and one program's round count moves by one (test/enumerator_block_returns_self.rb, 4 to 3 — the known noise on that file, which comes and goes between runs).
- Generated C is byte-identical for 3422 of the 3424 pre-existing test and benchmark programs, plus optcarrot. Both files that differ produce byte-identical output on master and on this branch, and both still match their expected output. test/string_slice_casecmp_succ.rb passes `casecmp` and `casecmp?` a poly argument through a helper — the arm this change rewrote. test/numeric_coerce_protocol.rb has three String comparisons against an object with no `#to_str` (`"abc" < money`, `"abc" >= money`, `"abc".between?(money, "b")`): their refusal is now the converting arm's fallback rather than a separate eager arm, which is the same raise from a different shape of C.
- The new test is CRuby-generated and matches plain, under `SPINEL_GC_STRESS=1`, under ASAN+UBSAN plain, and under ASAN+UBSAN with GC stress. It runs in a few milliseconds. It does not compile on master at all: the compiler there refuses `("aaaa" + "").casecmp(Churn.new(4)) == 0` as an unsupported equality, because the arm that discarded the operand had folded the call to `nil`.
- It pins the shapes a review would ask about: `#to_str` inherited from a superclass, an operand reached through a method return, a boxed operand at all eight methods — `#between?` through a boxed receiver, because a typed receiver with both bounds boxed does not compile, see below — a boxed receiver, a receiver picked by a ternary whose condition is itself a converting comparison, `#to_str` called exactly once per comparison, and `#between?` stopping at the first bound with the call counts to prove it. Two shapes of "no conversion" are pinned at all eight methods each — a `#to_str` typed String that answers the nil String, and a `#to_str` typed poly that answers `nil` — and a class with no `#to_str` at the seven where its answer is the comparison's own, `#<=>` excepted because there it keeps master's NoMethodError. A `#to_str` typed poly answering an Integer pins CRuby's TypeError message at `#<=>`, `<` and `#casecmp`. A boxed `#between?` bound is pinned holding a String (matching and not matching), a converting object, an Integer, `nil`, and a `#to_str` counter that is never asked when the typed bound already settled the answer.
- The guards are pinned too: `#==` and `#eql?` are still false against a converting operand, #4265's Symbol and Integer operands are unchanged at `#<=>` and at `<`, a class with no `#to_str` still answers `nil` from `#casecmp` and raises the comparison error from `<`, and an object-typed slot holding `nil` raises `comparison of String with nil failed`.
- Both roots were verified by counterfactual under ASAN+UBSAN with GC stress and `SP_POOL_MAX=0`, since the per-class free list masks a collected-while-live object at the default cap: without the receiver root, a churn whose receiver is an interpolation is a heap-use-after-free; without the operand root, a 300-round loop comparing against a freshly popped boxed operand whose `#to_str` allocates before reading its ivar is one too. As emitted, that loop and the four typed churns are clean.
- On the differential corpus of 2,131 minimized programs that behave differently under CRuby 4.0.6 and Spinel (the same corpus behind #3999/#4003/#4029): 2 findings flipped to matching, none lost — the `casecmp` one and the `<=>` one.

## Left alone, on purpose

Recorded so nobody has to rediscover them. Each is master's behaviour; where this rule moved one of them, the bullet says so.

- **`"abc" <=> obj` for any class with no usable `#to_str`.** It still raises NoMethodError, as on master. CRuby has an answer there — `nil`, or `-(obj <=> "abc")` when the class defines `#<=>` (`rb_invcmp`, so with `def <=>(o) = -1` its `"abc" < obj` is `false`) — but that is `Object#<=>`'s rule, an answer rather than a conversion, and it needs its own change. Giving it here would also have silenced the shapes this rule deliberately declines, each of which CRuby answers differently again. A class defining both `#<=>` and a usable `#to_str` converts, as CRuby does — it asks `#to_str` first.
- **A `#to_str` reached by `alias`.** `alias to_str raw` compiles one function, named after `raw`, and reachability seeds the implicit protocols by the method's own name, so the aliased body is not emitted at all. Master already fails the C build on `"x" + A.new("y")` for exactly that reason; this rule declines the shape rather than adding a second way in. Worth its own change.
- **A `#to_str` that takes parameters, and `attr_reader :to_str`.** CRuby converts through `def to_str(x = 1)`, `def to_str(*a)`, `def to_str(k: 1)` and an `attr_reader`, since it only needs the method to be callable with no arguments. None of the four converts here. The three parameter shapes fail the C build at the tree's existing conversion site (`"x" + A.new("y")`) on master and on this branch alike, and an `attr_reader` defines no method scope for the lookup to find. At the comparisons they keep master's answers everywhere: NoMethodError from `#<=>`, the comparison error from the ordered operators and `#between?`, `nil` from `#casecmp`.
- **A `#to_str` whose static return is an Integer.** Not this shape, so it keeps master's answers (NoMethodError, `nil`, the comparison error) rather than CRuby's `can't convert Bad to String (Bad#to_str gives Integer)`. The poly-typed version of the same mistake does raise that, with CRuby's wording.
- **A boxed operand whose `#to_str` is poly-returning.** The conversion bridge the runtime reaches carries only methods whose static return is a String, so such an operand answers `nil` or the comparison error as it does on master, while the same object converts when its slot is typed. Widening the bridge is its own change.
- **A converting operand under a ternary receiver at `String#+`.** `((("abc" < "abd") ? "abc" : "zzz") + W.new("ABC")).length` is a heap-use-after-free on master under ASAN with GC stress and `SP_POOL_MAX=0`: `emit_operands_in_order` declines to spill an operand when an observable one is not a call node, and the fresh object then goes into `sp_W_to_str(sp_W_new(...))` unrooted. It belongs to the conversion machinery, not to any one method. The comparison arms in this change do not depend on that spill — they spill the operand themselves — so the same shape is clean at all eight of them.
- **`String#clamp` with object bounds.** CRuby raises `comparison of Wrap with Wrap failed` (it compares the two bounds first, and Wrap has no `#<=>`). Master fails the C build there — `sp_Wrap *` into a `const char *` — and so does this branch. A separate finding.
- **`String#between?` with a typed receiver and BOTH bounds boxed.** One boxed bound now converts, because the other bound being an object is what puts the call on the converting arm; with both bounds boxed there is no object to put it there, so the call still lowers to the old byte compare, passes an `sp_RbVal` into a `const char *`, and fails the C build exactly as on master. Through a boxed receiver the same comparison works, and the test pins that; the typed-receiver arm for two boxed bounds is its own fix. Two literal non-String bounds are the same pre-existing gap: `"abc".between?(1, 2)` and `"abc".between?(:a, :b)` are CRuby's `comparison of String with 1 failed` and `... with :a failed`, and fail the C build on master and here alike.
- **The other `#to_str` sites** — `Regexp#=~` and `#===`, `Thread#name=`, `IO#printf`'s format, `Kernel#String` on a boxed object, `ENV[]=`, `Array#join`'s elements. Each is its own rule and its own change; the String methods that already convert (`#start_with?`, `#include?`, `#+`) are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - String comparisons now support operands that provide a valid `to_str` conversion.
  - Updated `<=>`, `casecmp`, `casecmp?`, ordered comparisons, and `between?` to handle convertible objects consistently.
  - Improved handling of objects returning `nil` or invalid values from `to_str`, including appropriate comparison results and error messages.
  - Preserved Ruby-compatible evaluation order and conversion behavior for comparison bounds.

- **Tests**
  - Added comprehensive coverage for string comparison conversions, failures, return values, error messages, and conversion call counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->