### PR TITLE
add built-in tmpdir module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ export LD_LIBRARY_PATH := $(OPENSSL_PREFIX)/lib$(if $(LD_LIBRARY_PATH),:$(LD_LIB
 endif
 endif
 endif
-BUNDLED_NATIVE_OBJS = packages/json/sp_json.o packages/stringio/sp_stringio.o packages/strscan/sp_strscan.o packages/base64/sp_base64.o
+BUNDLED_NATIVE_OBJS = packages/json/sp_json.o packages/stringio/sp_stringio.o packages/strscan/sp_strscan.o packages/base64/sp_base64.o packages/tmpdir/sp_tmpdir.o
 ifeq ($(OPENSSL_AVAILABLE),yes)
 BUNDLED_NATIVE_OBJS += packages/openssl/sp_openssl.o
 endif
@@ -383,6 +383,15 @@ packages/base64/sp_base64.o: packages/base64/sp_base64.c \
 packages/base64/sp_base64_mt.o: packages/base64/sp_base64.c \
                                 lib/spinel/runtime.h lib/sp_alloc.h lib/sp_gc.h lib/sp_types.h
 	$(CC) -c $(COPT) -Wno-all $(SEC_FLAGS) $(PKG_MT_FLAGS) -Ilib packages/base64/sp_base64.c -o $@
+
+# tmpdir: Dir.tmpdir and Dir.mktmpdir, the system temp directory and a
+# unique-directory creator. Pure C, no struct.
+packages/tmpdir/sp_tmpdir.o: packages/tmpdir/sp_tmpdir.c \
+                             lib/spinel/runtime.h lib/sp_alloc.h lib/sp_gc.h lib/sp_types.h
+	$(CC) -c $(COPT) -Wno-all $(SEC_FLAGS) -Ilib packages/tmpdir/sp_tmpdir.c -o $@
+packages/tmpdir/sp_tmpdir_mt.o: packages/tmpdir/sp_tmpdir.c \
+                                lib/spinel/runtime.h lib/sp_alloc.h lib/sp_gc.h lib/sp_types.h
+	$(CC) -c $(COPT) -Wno-all $(SEC_FLAGS) $(PKG_MT_FLAGS) -Ilib packages/tmpdir/sp_tmpdir.c -o $@
 
 build/sp_cold.o: lib/sp_cold.c $(RT_HDRS)
 	@mkdir -p build

--- a/packages/tmpdir/sp_tmpdir.c
+++ b/packages/tmpdir/sp_tmpdir.c
@@ -1,0 +1,93 @@
+/* sp_tmpdir.c -- Dir.tmpdir / Dir.mktmpdir for the `tmpdir` spin package.
+
+   CRuby-compatible surface:
+   - Dir.tmpdir -> String, the system temp dir (TMPDIR or "/tmp")
+   - Dir.mktmpdir(prefix=NULL) -> String
+   - Dir.mktmpdir(prefix=NULL, parent=NULL) -> String
+     Creates a uniquely-named directory under parent (or Dir.tmpdir if
+     parent is NULL), optionally prefixed by `prefix`. Returns the path.
+     Raises Errno::EEXIST after TMPDIR_RETRIES (10000) failed attempts.
+
+   The block form is plain Ruby in tmpdir.rb; the native side just does
+   the create-and-return. */
+#include "spinel/runtime.h"
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <errno.h>
+#include <time.h>
+
+#define TMPDIR_RETRIES 10000
+
+/* Create a uniquely-named directory and return its path. The path is
+   "parent/dXXXXX" where XXXXX is 5 random lowercase letters. */
+static const char *tmpdir_mkdtemp(const char *prefix, const char *parent) {
+  size_t pre_len = prefix ? strlen(prefix) : 0;
+  size_t par_len = strlen(parent);
+  /* path = parent + "/" + prefix + "dXXXXX" + NUL. Stack-allocate: even
+     the longest practical parent + prefix fits in 512 bytes. */
+  char path[512];
+  if (par_len + 1 + pre_len + 7 > sizeof(path))
+    sp_raise_cls("ArgumentError", "tmpdir path too long");
+
+  /* Seed: time + pid + counter. */
+  unsigned int seed = (unsigned int)(time(NULL) ^ (getpid() << 16));
+
+  for (int i = 0; i < TMPDIR_RETRIES; i++) {
+    memcpy(path, parent, par_len);
+    path[par_len] = '/';
+    if (pre_len) memcpy(path + par_len + 1, prefix, pre_len);
+    char *suf = path + par_len + 1 + pre_len;
+    suf[0] = 'd';
+    unsigned int s = seed + i;
+    for (int j = 1; j < 6; j++) {
+      suf[j] = 'a' + (s % 26);
+      s /= 26;
+    }
+    suf[6] = '\0';
+
+    if (mkdir(path, 0700) == 0) {
+      size_t n = par_len + 1 + pre_len + 6;
+      char *r = sp_str_alloc_raw(n + 1);
+      memcpy(r, path, n);
+      r[n] = '\0';
+      sp_str_set_len(r, n);
+      return r;
+    }
+    if (errno != EEXIST) {
+      int saved = errno;
+      sp_raise_cls("Errno::ENOENT", strerror(saved));
+    }
+  }
+  sp_raise_cls("Errno::EEXIST", "too many temporary directory retries");
+  return sp_str_empty;  /* unreachable */
+}
+
+const char *sp_Dir_tmpdir(void) {
+  const char *env = getenv("TMPDIR");
+  if (env && *env) {
+    size_t n = strlen(env);
+    char *r = sp_str_alloc_raw(n + 1);
+    memcpy(r, env, n);
+    r[n] = '\0';
+    sp_str_set_len(r, n);
+    return r;
+  }
+  /* "/tmp" */
+  char *r = sp_str_alloc_raw(5);
+  memcpy(r, "/tmp", 4);
+  r[4] = '\0';
+  sp_str_set_len(r, 4);
+  return r;
+}
+
+const char *sp_Dir_mktmpdir(const char *prefix) {
+  const char *parent = sp_Dir_tmpdir();
+  return tmpdir_mkdtemp(prefix, parent);
+}
+
+const char *sp_Dir_mktmpdir_pp(const char *prefix, const char *parent) {
+  return tmpdir_mkdtemp(prefix, parent);
+}

--- a/packages/tmpdir/sp_tmpdir.c
+++ b/packages/tmpdir/sp_tmpdir.c
@@ -1,15 +1,8 @@
 /* sp_tmpdir.c -- Dir.tmpdir / Dir.mktmpdir for the `tmpdir` spin package.
 
-   CRuby-compatible surface:
-   - Dir.tmpdir -> String, the system temp dir (TMPDIR or "/tmp")
-   - Dir.mktmpdir(prefix=NULL) -> String
-   - Dir.mktmpdir(prefix=NULL, parent=NULL) -> String
-     Creates a uniquely-named directory under parent (or Dir.tmpdir if
-     parent is NULL), optionally prefixed by `prefix`. Returns the path.
-     Raises Errno::EEXIST after TMPDIR_RETRIES (10000) failed attempts.
-
-   The block form is plain Ruby in tmpdir.rb; the native side just does
-   the create-and-return. */
+   CRuby-compatible name format: "parent/prefixYYYYMMDD-pid-random[suffix]"
+   where random is 1-6 base-36 chars. On EEXIST, a "-N" counter is
+   appended before the suffix and retried up to max_try times. */
 #include "spinel/runtime.h"
 #include <stdlib.h>
 #include <string.h>
@@ -17,43 +10,114 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <errno.h>
+#include <limits.h>
 #include <time.h>
+#include <stdio.h>
 
 #define TMPDIR_RETRIES 10000
+#define MAX_RANDOM_BYTES 4  /* 32 bits -> 0..36^6 */
 
-/* Create a uniquely-named directory and return its path. The path is
-   "parent/dXXXXX" where XXXXX is 5 random lowercase letters. */
-static const char *tmpdir_mkdtemp(const char *prefix, const char *parent) {
+/* Read up to n random bytes from /dev/urandom. Falls back to time+pid
+   XOR if /dev/urandom is unavailable. Returns the number of bytes
+   read. */
+static int read_urandom(unsigned char *buf, int n) {
+  int got = 0;
+  FILE *f = fopen("/dev/urandom", "rb");
+  if (!f) return 0;
+  while (got < n) {
+    int r = (int)fread(buf + got, 1, n - got, f);
+    if (r <= 0) break;
+    got += r;
+  }
+  fclose(f);
+  return got;
+}
+
+/* Format a random base-36 string of up to 6 chars into `out`. Returns
+   the number of chars written. The space is 36^6 = 2176782336 < 2^32,
+   so we mask the random 32-bit value. */
+static int format_random(char *out) {
+  unsigned char buf[4] = {0};
+  if (read_urandom(buf, 4) != 4) {
+    /* Fallback: time + pid + counter. Not crypto-strong but unique
+       enough for temp dirs. */
+    static unsigned int fc = 0;
+    unsigned int v = (unsigned int)(time(NULL) ^ (getpid() << 16) ^ fc++);
+    buf[0] = v & 0xff;
+    buf[1] = (v >> 8) & 0xff;
+    buf[2] = (v >> 16) & 0xff;
+    buf[3] = (v >> 24) & 0xff;
+  }
+  unsigned int v = ((unsigned int)buf[0]) |
+                   ((unsigned int)buf[1] << 8) |
+                   ((unsigned int)buf[2] << 16) |
+                   ((unsigned int)buf[3] << 24);
+  v = v % 2176782336u;  /* 36^6 */
+  if (v == 0) v = 1;    /* avoid empty string */
+  char tmp[7];
+  int i = 0;
+  while (v > 0 && i < 6) {
+    unsigned int d = v % 36;
+    tmp[i++] = (d < 10) ? ('0' + d) : ('a' + d - 10);
+    v /= 36;
+  }
+  tmp[i] = '\0';
+  /* Reverse into out. */
+  for (int j = 0; j < i; j++) out[j] = tmp[i - 1 - j];
+  return i;
+}
+
+static const char *tmpdir_mkdtemp(const char *prefix, const char *suffix,
+                                  const char *parent, int max_try) {
   size_t pre_len = prefix ? strlen(prefix) : 0;
+  size_t suf_len = suffix ? strlen(suffix) : 0;
   size_t par_len = strlen(parent);
-  /* path = parent + "/" + prefix + "dXXXXX" + NUL. Stack-allocate: even
-     the longest practical parent + prefix fits in 512 bytes. */
-  char path[512];
-  if (par_len + 1 + pre_len + 7 > sizeof(path))
+
+  /* Format the date once: YYYYMMDD. */
+  char date[9];
+  time_t now = time(NULL);
+  struct tm tm;
+  gmtime_r(&now, &tm);  /* CRuby uses local time; gmtime for portability */
+  /* Actually CRuby uses Time.now which is local. Use localtime_r. */
+  localtime_r(&now, &tm);
+  snprintf(date, sizeof(date), "%04d%02d%02d",
+           tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday);
+
+  /* Pre-format the constant middle: "-pid-". */
+  char mid[32];
+  int mid_len = snprintf(mid, sizeof(mid), "-%d-", (int)getpid());
+
+  /* Build path pieces. The final path is:
+     parent + "/" + prefix + date + mid + random [+ "-N"] + suffix
+     Worst-case size: 4096 (parent) + 1 + 64 (prefix) + 8 (date) +
+                      32 (mid) + 6 (random) + 8 ("-NNNNNNN") + 64 (suffix) */
+  char path[PATH_MAX];
+  if (par_len + 1 + pre_len + 8 + 32 + 6 + 8 + suf_len >= sizeof(path))
     sp_raise_cls("ArgumentError", "tmpdir path too long");
 
-  /* Seed: time + pid + counter. */
-  unsigned int seed = (unsigned int)(time(NULL) ^ (getpid() << 16));
+  for (int n = 0; n < max_try; n++) {
+    char random[7];
+    int random_len = format_random(random);
 
-  for (int i = 0; i < TMPDIR_RETRIES; i++) {
-    memcpy(path, parent, par_len);
-    path[par_len] = '/';
-    if (pre_len) memcpy(path + par_len + 1, prefix, pre_len);
-    char *suf = path + par_len + 1 + pre_len;
-    suf[0] = 'd';
-    unsigned int s = seed + i;
-    for (int j = 1; j < 6; j++) {
-      suf[j] = 'a' + (s % 26);
-      s /= 26;
+    int pos = 0;
+    memcpy(path + pos, parent, par_len); pos += par_len;
+    path[pos++] = '/';
+    if (pre_len) { memcpy(path + pos, prefix, pre_len); pos += pre_len; }
+    memcpy(path + pos, date, 8); pos += 8;
+    memcpy(path + pos, mid, mid_len); pos += mid_len;
+    memcpy(path + pos, random, random_len); pos += random_len;
+    if (n > 0) {
+      /* "-N" counter. */
+      pos += snprintf(path + pos, sizeof(path) - pos, "-%d", n);
     }
-    suf[6] = '\0';
+    if (suf_len) { memcpy(path + pos, suffix, suf_len); pos += suf_len; }
+    path[pos] = '\0';
 
     if (mkdir(path, 0700) == 0) {
-      size_t n = par_len + 1 + pre_len + 6;
-      char *r = sp_str_alloc_raw(n + 1);
-      memcpy(r, path, n);
-      r[n] = '\0';
-      sp_str_set_len(r, n);
+      char *r = sp_str_alloc_raw(pos + 1);
+      memcpy(r, path, pos);
+      r[pos] = '\0';
+      sp_str_set_len(r, pos);
       return r;
     }
     if (errno != EEXIST) {
@@ -61,7 +125,7 @@ static const char *tmpdir_mkdtemp(const char *prefix, const char *parent) {
       sp_raise_cls("Errno::ENOENT", strerror(saved));
     }
   }
-  sp_raise_cls("Errno::EEXIST", "too many temporary directory retries");
+  sp_raise_cls("Errno::EEXIST", "cannot generate temporary directory name");
   return sp_str_empty;  /* unreachable */
 }
 
@@ -75,7 +139,6 @@ const char *sp_Dir_tmpdir(void) {
     sp_str_set_len(r, n);
     return r;
   }
-  /* "/tmp" */
   char *r = sp_str_alloc_raw(5);
   memcpy(r, "/tmp", 4);
   r[4] = '\0';
@@ -85,9 +148,10 @@ const char *sp_Dir_tmpdir(void) {
 
 const char *sp_Dir_mktmpdir(const char *prefix) {
   const char *parent = sp_Dir_tmpdir();
-  return tmpdir_mkdtemp(prefix, parent);
+  return tmpdir_mkdtemp(prefix, NULL, parent, TMPDIR_RETRIES);
 }
 
-const char *sp_Dir_mktmpdir_pp(const char *prefix, const char *parent) {
-  return tmpdir_mkdtemp(prefix, parent);
+const char *sp_Dir_mktmpdir_pps(const char *prefix, const char *parent,
+                                const char *suffix) {
+  return tmpdir_mkdtemp(prefix, suffix, parent, TMPDIR_RETRIES);
 }

--- a/packages/tmpdir/sp_tmpdir.c
+++ b/packages/tmpdir/sp_tmpdir.c
@@ -122,7 +122,17 @@ static const char *tmpdir_mkdtemp(const char *prefix, const char *suffix,
     }
     if (errno != EEXIST) {
       int saved = errno;
-      sp_raise_cls("Errno::ENOENT", strerror(saved));
+      const char *cls = "RuntimeError";
+      switch (saved) {
+        case EACCES:       cls = "Errno::EACCES"; break;
+        case EFAULT:       cls = "Errno::EFAULT"; break;
+        case ELOOP:        cls = "Errno::ELOOP"; break;
+        case ENAMETOOLONG: cls = "Errno::ENAMETOOLONG"; break;
+        case ENOENT:       cls = "Errno::ENOENT"; break;
+        case ENOTDIR:      cls = "Errno::ENOTDIR"; break;
+        case EROFS:        cls = "Errno::EROFS"; break;
+      }
+      sp_raise_cls(cls, strerror(saved));
     }
   }
   sp_raise_cls("Errno::EEXIST", "cannot generate temporary directory name");

--- a/packages/tmpdir/spin.toml
+++ b/packages/tmpdir/spin.toml
@@ -1,0 +1,5 @@
+[package]
+name = "tmpdir"
+
+# Pre-installed spin package: ships with the compiler, versioned with it.
+# Dir.tmpdir and Dir.mktmpdir, carried in C (sp_tmpdir.c).

--- a/packages/tmpdir/test/tmpdir_test.rb
+++ b/packages/tmpdir/test/tmpdir_test.rb
@@ -5,12 +5,16 @@ puts Dir.tmpdir.is_a?(String)
 puts !Dir.tmpdir.empty?
 
 # mktmpdir without a block: returns a newly-created directory path.
+date_before = Time.now.strftime("%Y%m%d")
 d = Dir.mktmpdir
 begin
   puts d.is_a?(String)
   puts Dir.exist?(d)
-  # Path includes date and pid.
-  puts d.include?(Time.now.strftime("%Y%m%d"))
+  # Path includes date and pid. The date token is captured before
+  # creation; if the test crosses midnight, the after-date is the
+  # valid alternative.
+  date_after = Time.now.strftime("%Y%m%d")
+  puts d.include?(date_before) || d.include?(date_after)
   puts d.include?(Process.pid.to_s)
 ensure
   Dir.rmdir(d) if d && Dir.exist?(d)
@@ -35,13 +39,15 @@ ensure
 end
 
 # mktmpdir with a block: yields the path, cleans up after.
+yielded_path = nil
 result = Dir.mktmpdir do |path|
+  yielded_path = path
   puts path.is_a?(String)
   puts Dir.exist?(path)
   :done
 end
 puts result == :done
-puts !Dir.exist?(Dir.tmpdir + "/d" + Time.now.strftime("%Y%m%d"))  # cleanup happened
+puts !Dir.exist?(yielded_path)  # cleanup happened
 
 # mktmpdir with parent_dir argument.
 parent = Dir.mktmpdir

--- a/packages/tmpdir/test/tmpdir_test.rb
+++ b/packages/tmpdir/test/tmpdir_test.rb
@@ -1,22 +1,35 @@
 require "tmpdir"
 
-# tmpdir: Dir.tmpdir returns a non-empty String (TMPDIR or "/tmp").
+# Dir.tmpdir returns a non-empty String.
 puts Dir.tmpdir.is_a?(String)
 puts !Dir.tmpdir.empty?
 
-# mktmpdir without a block returns a newly-created directory path.
+# mktmpdir without a block: returns a newly-created directory path.
 d = Dir.mktmpdir
 begin
   puts d.is_a?(String)
   puts Dir.exist?(d)
+  # Path includes date and pid.
+  puts d.include?(Time.now.strftime("%Y%m%d"))
+  puts d.include?(Process.pid.to_s)
 ensure
   Dir.rmdir(d) if d && Dir.exist?(d)
 end
 
-# mktmpdir with a prefix.
+# mktmpdir with a prefix string.
 d = Dir.mktmpdir("myapp-")
 begin
   puts File.basename(d).start_with?("myapp-")
+ensure
+  Dir.rmdir(d) if d && Dir.exist?(d)
+end
+
+# mktmpdir with [prefix, suffix] array.
+d = Dir.mktmpdir(["foo", "bar"])
+begin
+  base = File.basename(d)
+  puts base.start_with?("foo")
+  puts base.end_with?("bar")
 ensure
   Dir.rmdir(d) if d && Dir.exist?(d)
 end
@@ -28,3 +41,17 @@ result = Dir.mktmpdir do |path|
   :done
 end
 puts result == :done
+puts !Dir.exist?(Dir.tmpdir + "/d" + Time.now.strftime("%Y%m%d"))  # cleanup happened
+
+# mktmpdir with parent_dir argument.
+parent = Dir.mktmpdir
+begin
+  d = Dir.mktmpdir(nil, parent)
+  begin
+    puts File.dirname(d) == parent
+  ensure
+    Dir.rmdir(d) if Dir.exist?(d)
+  end
+ensure
+  Dir.rmdir(parent) if Dir.exist?(parent)
+end

--- a/packages/tmpdir/test/tmpdir_test.rb
+++ b/packages/tmpdir/test/tmpdir_test.rb
@@ -1,0 +1,30 @@
+require "tmpdir"
+
+# tmpdir: Dir.tmpdir returns a non-empty String (TMPDIR or "/tmp").
+puts Dir.tmpdir.is_a?(String)
+puts !Dir.tmpdir.empty?
+
+# mktmpdir without a block returns a newly-created directory path.
+d = Dir.mktmpdir
+begin
+  puts d.is_a?(String)
+  puts Dir.exist?(d)
+ensure
+  Dir.rmdir(d) if d && Dir.exist?(d)
+end
+
+# mktmpdir with a prefix.
+d = Dir.mktmpdir("myapp-")
+begin
+  puts File.basename(d).start_with?("myapp-")
+ensure
+  Dir.rmdir(d) if d && Dir.exist?(d)
+end
+
+# mktmpdir with a block: yields the path, cleans up after.
+result = Dir.mktmpdir do |path|
+  puts path.is_a?(String)
+  puts Dir.exist?(path)
+  :done
+end
+puts result == :done

--- a/packages/tmpdir/test/tmpdir_test.rb.expected
+++ b/packages/tmpdir/test/tmpdir_test.rb.expected
@@ -1,0 +1,14 @@
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true

--- a/packages/tmpdir/tmpdir.rb
+++ b/packages/tmpdir/tmpdir.rb
@@ -1,0 +1,48 @@
+# Spinel bundled `tmpdir` -- a carried-C spin package (Path B).
+#
+# Dir.tmpdir and Dir.mktmpdir live in this package's C (sp_tmpdir.c,
+# linked only when `require "tmpdir"` appears). The block form and
+# the Dir.mktmpdir default-parent fallback are plain Ruby.
+module TmpdirPackage
+  native_lib "tmpdir"
+  native_obj "packages/tmpdir/sp_tmpdir.o"
+  native_func :Dir_tmpdir,      [],         :string, "sp_Dir_tmpdir"
+  native_func :Dir_mktmpdir,    [:string],  :string, "sp_Dir_mktmpdir"
+  native_func :Dir_mktmpdir_pp, [:string, :string], :string, "sp_Dir_mktmpdir_pp"
+end
+
+# Plain Ruby surface on top of the C binding. Dir is a class in spinel
+# (not a module), so reopen it directly and add the singleton methods.
+class Dir
+  def self.tmpdir
+    TmpdirPackage.Dir_tmpdir
+  end
+
+  def self.mktmpdir(prefix_suffix = nil, parent_dir = nil)
+    prefix = ""
+    if prefix_suffix
+      s = prefix_suffix.to_s
+      # CRuby: the prefix is the part of the template before the trailing
+      # X's. For "dXXXXX" the prefix is "d". Most callers pass a static
+      # prefix like "myapp-", so just use the whole string.
+      prefix = s.sub(/X+\z/, "")
+    end
+    path = if parent_dir
+      TmpdirPackage.Dir_mktmpdir_pp(prefix, parent_dir.to_s)
+    else
+      TmpdirPackage.Dir_mktmpdir(prefix)
+    end
+    if block_given?
+      begin
+        yield path
+      ensure
+        # Best-effort cleanup. Only handles empty directories; callers
+        # with files inside should clean up themselves.
+        Dir.delete(path) if Dir.exist?(path) && Dir.empty?(path)
+      end
+    else
+      path
+    end
+  end
+end
+

--- a/packages/tmpdir/tmpdir.rb
+++ b/packages/tmpdir/tmpdir.rb
@@ -1,15 +1,18 @@
 # Spinel bundled `tmpdir` -- a carried-C spin package (Path B).
 #
 # Dir.tmpdir and Dir.mktmpdir live in this package's C (sp_tmpdir.c,
-# linked only when `require "tmpdir"` appears). The block form and
-# the Dir.mktmpdir default-parent fallback are plain Ruby.
+# linked only when `require "tmpdir"` appears). The block form,
+# prefix_suffix handling, and UNUSABLE_CHARS filtering are plain Ruby.
 module TmpdirPackage
   native_lib "tmpdir"
   native_obj "packages/tmpdir/sp_tmpdir.o"
-  native_func :Dir_tmpdir,      [],         :string, "sp_Dir_tmpdir"
-  native_func :Dir_mktmpdir,    [:string],  :string, "sp_Dir_mktmpdir"
-  native_func :Dir_mktmpdir_pp, [:string, :string], :string, "sp_Dir_mktmpdir_pp"
+  native_func :Dir_tmpdir,     [],         :string, "sp_Dir_tmpdir"
+  native_func :Dir_mktmpdir,   [:string],  :string, "sp_Dir_mktmpdir"
+  native_func :Dir_mktmpdir_pps, [:string, :string, :string], :string, "sp_Dir_mktmpdir_pps"
 end
+
+# Characters CRuby strips from prefix/suffix to keep paths portable.
+UNUSABLE_CHARS = "^,-.0-9A-Z_a-z~"
 
 # Plain Ruby surface on top of the C binding. Dir is a class in spinel
 # (not a module), so reopen it directly and add the singleton methods.
@@ -18,23 +21,45 @@ class Dir
     TmpdirPackage.Dir_tmpdir
   end
 
-  def self.mktmpdir(prefix_suffix = nil, parent_dir = nil)
-    prefix = ""
-    if prefix_suffix
-      s = prefix_suffix.to_s
-      # CRuby: the prefix is the part of the template before the trailing
-      # X's. For "dXXXXX" the prefix is "d". Most callers pass a static
-      # prefix like "myapp-", so just use the whole string.
-      prefix = s.sub(/X+\z/, "")
-    end
-    path = if parent_dir
-      TmpdirPackage.Dir_mktmpdir_pp(prefix, parent_dir.to_s)
+  def self.mktmpdir(prefix_suffix = nil, parent_dir = nil, *rest, **options, &block)
+    # Normalize prefix_suffix: nil -> "d", string -> s, array -> [a, b].
+    if prefix_suffix.nil?
+      prefix = "d"
+      suffix = nil
+    elsif prefix_suffix.is_a?(Array)
+      p0 = prefix_suffix[0]
+      prefix = p0.is_a?(String) ? p0 : (String.try_convert(p0) or
+        raise ArgumentError, "unexpected prefix: #{p0.inspect}")
+      p1 = prefix_suffix[1]
+      if p1
+        suffix = p1.is_a?(String) ? p1 : (String.try_convert(p1) or
+          raise ArgumentError, "unexpected suffix: #{p1.inspect}")
+      else
+        suffix = nil
+      end
     else
-      TmpdirPackage.Dir_mktmpdir(prefix)
+      prefix = prefix_suffix.is_a?(String) ? prefix_suffix :
+               (String.try_convert(prefix_suffix) or
+                raise ArgumentError, "unexpected prefix: #{prefix_suffix.inspect}")
+      suffix = nil
     end
-    if block_given?
+    # CRuby: strip unusable characters from prefix and suffix.
+    prefix = prefix.delete(UNUSABLE_CHARS)
+    suffix = suffix.delete(UNUSABLE_CHARS) if suffix
+
+    # parent_dir: explicit, or Dir.tmpdir. CRuby's Tmpname.create also
+    # accepts a positional tmpdir arg, but the public API only documents
+    # the 2-arg form.
+    parent = parent_dir ? File.path(parent_dir) : Dir.tmpdir
+    raise ArgumentError, "empty parent path" if parent.empty?
+
+    max_try = options[:max_try] || 10000
+
+    path = TmpdirPackage.Dir_mktmpdir_pps(prefix, parent, suffix || "")
+
+    if block
       begin
-        yield path
+        yield path.dup
       ensure
         # Best-effort cleanup. Only handles empty directories; callers
         # with files inside should clean up themselves.
@@ -45,4 +70,3 @@ class Dir
     end
   end
 end
-

--- a/packages/tmpdir/tmpdir.rb
+++ b/packages/tmpdir/tmpdir.rb
@@ -61,8 +61,17 @@ class Dir
       begin
         yield path.dup
       ensure
-        # Best-effort cleanup. Only handles empty directories; callers
-        # with files inside should clean up themselves.
+        # CRuby raises ArgumentError if the parent directory is
+        # world-writable without the sticky bit: a symlink there could
+        # redirect our cleanup to an arbitrary location. Check the
+        # parent first, before touching path, so we never delete
+        # through a hostile parent.
+        base = File.dirname(path)
+        stat = File.stat(base) rescue nil
+        if stat && (stat.mode & 0o1002) == 0o1002 && (stat.mode & 0o1000) == 0
+          # world-writable (o+w) and NOT sticky (no t-bit) -> reject.
+          raise ArgumentError, "parent directory is world writable but not sticky: #{base}"
+        end
         Dir.delete(path) if Dir.exist?(path) && Dir.empty?(path)
       end
     else


### PR DESCRIPTION
my agent constantly writes ruby code using this module, then when i need to run it under spinel i need to refactor the code again. adding this as a built-in module finally closes this gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bundled temporary-directory support through `Dir.tmpdir` and `Dir.mktmpdir`.
  * Supports custom prefixes, suffixes, parent directories, retry limits, and block-based cleanup.
  * Creates temporary directories with unique names and restricted permissions.

* **Tests**
  * Added coverage for temporary-directory creation, customization, parent paths, block usage, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->