### PR TITLE
The at_exit table is locked in the threaded build

### DIFF
--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -9359,6 +9359,28 @@ sp_IntArray *sp_file_binread_bytes(const char *path);
 struct sp_Proc;
 static struct sp_Proc *sp_at_exit_hooks[SP_AT_EXIT_MAX];
 static sp_int sp_at_exit_count = 0;
+/* Threaded build: the table is shared by every worker, and on the exit, abort
+   and uncaught-raise paths the drain runs on main while the helper workers are
+   still executing green threads (CRuby keeps them alive across the hooks too),
+   so a thread registering a hook at that moment pushes while main pops. One
+   mutex around the push and the pop; the hook itself is called outside it,
+   since it may register another. No-op in the single-threaded build, the way
+   SP_HEAP_LOCK is, so that build compiles the code it did. */
+#ifdef SP_THREADS
+static pthread_mutex_t sp_at_exit_lock = PTHREAD_MUTEX_INITIALIZER;
+#define SP_AT_EXIT_LOCK()   pthread_mutex_lock(&sp_at_exit_lock)
+#define SP_AT_EXIT_UNLOCK() pthread_mutex_unlock(&sp_at_exit_lock)
+#else
+#define SP_AT_EXIT_LOCK()   ((void)0)
+#define SP_AT_EXIT_UNLOCK() ((void)0)
+#endif
+/* `at_exit { }`: the registering expression evaluates to the proc. */
+static inline struct sp_Proc *sp_at_exit_push(struct sp_Proc *p) {
+  SP_AT_EXIT_LOCK();
+  sp_at_exit_hooks[sp_at_exit_count++] = p;
+  SP_AT_EXIT_UNLOCK();
+  return p;
+}
 static void sp_mark_at_exit_hooks(void) {
   for (sp_int i = 0; i < sp_at_exit_count; i++)
     if (sp_at_exit_hooks[i]) sp_gc_mark(sp_at_exit_hooks[i]);
@@ -10292,8 +10314,12 @@ static int sp_at_exit_run(int status) {
   /* setjmp: `st` is written on the landing path and read after it. */
   volatile int st = status;
   sp_int args[16] = {0};   /* sp_proc_call's fixed slot convention */
-  while (sp_at_exit_count > 0) {
-    sp_Proc *h = sp_at_exit_hooks[--sp_at_exit_count];
+  for (;;) {
+    SP_AT_EXIT_LOCK();
+    sp_int n = sp_at_exit_count;
+    sp_Proc *h = n > 0 ? sp_at_exit_hooks[--sp_at_exit_count] : NULL;
+    SP_AT_EXIT_UNLOCK();
+    if (n <= 0) break;
     SP_GC_ROOT(h);
     if (!h) continue;
     /* Every hook starts from an empty proc-return / break / catch state, the
@@ -10307,6 +10333,10 @@ static int sp_at_exit_run(int status) {
        as the block's own return and never reaches these stacks.) Only the
        exception stack is left alone: this loop's own frame is on it. */
     sp_proc_ret_head = NULL; sp_brk_top = 0; sp_catch_top = 0;
+    /* The check every other arm of this stack has. It cannot fire here --
+       every path into the drain arrives with the exception stack empty -- but
+       an arm without it is the one a reader has to reason about. */
+    sp_exc_check_depth();
     sp_exc_rootmark[sp_exc_top] = sp_gc_nroots; sp_rescue_mark[sp_exc_top] = sp_rescue_sp;
     sp_exc_msg[sp_exc_top] = 0; sp_exc_obj[sp_exc_top] = 0; sp_exc_top++;
     if (setjmp(sp_exc_stack[sp_exc_top - 1]) == 0) {

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -18964,10 +18964,11 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
 
   /* at_exit { ... } -> register the block as a Proc; sp_at_exit_run runs
      the hooks in reverse order, from main()'s tail and from every other path
-     that ends the program. The registration expression evaluates to the proc. */
+     that ends the program. The registration expression evaluates to the proc;
+     sp_at_exit_push locks the table in the threaded build. */
   if (recv < 0 && sp_streq(name, "at_exit") && nt_ref(nt, id, "block") >= 0 && !bare_call_class_owned(c, id)) {
     g_needs_at_exit = 1;
-    buf_puts(b, "(sp_at_exit_hooks[sp_at_exit_count++] = ");
+    buf_puts(b, "sp_at_exit_push(");
     emit_proc_literal(c, id, b);
     buf_puts(b, ")");
     return;

--- a/test/at_exit_registered_from_thread_during_drain.rb
+++ b/test/at_exit_registered_from_thread_during_drain.rb
@@ -1,0 +1,21 @@
+# A hook that a non-main thread registers WHILE the hooks are already running
+# still runs. On the exit paths the drain runs on the main thread with the
+# program's other threads alive -- CRuby keeps them alive across the hooks
+# too -- so a thread can call at_exit in the middle of it, and in the threaded
+# build that is a push onto the table from one OS thread while main pops from
+# it. The two queues make the interleaving deterministic: the thread registers
+# only once the first hook has started, and that hook finishes only once the
+# registration is in.
+started = Queue.new
+registered = Queue.new
+Thread.new do
+  started.pop
+  at_exit { puts "hook registered from the thread during the drain" }
+  registered.push(true)
+end
+at_exit do
+  started.push(true)
+  registered.pop
+  puts "main hook"
+end
+exit

--- a/test/at_exit_registered_from_thread_during_drain.rb.expected
+++ b/test/at_exit_registered_from_thread_during_drain.rb.expected
@@ -1,0 +1,2 @@
+main hook
+hook registered from the thread during the drain


### PR DESCRIPTION
## Why

Since #4282 the `at_exit` hooks run on every path that ends the program, and on three of them — `exit`, `abort` and an uncaught raise — they run while the program's other threads are still alive. That is the right time to run them: CRuby keeps its threads alive across the end procs too, and a thread that calls `at_exit` while the hooks are already running gets its hook run, on both. But in Spinel's threaded build those threads execute on helper OS threads in parallel with main, and the hook table is one static array shared by all of them. A thread registering a hook at that moment pushed onto the table while main popped from it, with nothing between the two.

CodeRabbit raised the table on #4282, though with the wrong mechanism: it read the drain as reachable from a helper worker through `sp_exit_raise`, `sp_abort_raise` or an uncaught `sp_raise_cls`. It is not. Every green thread body runs under the handler frame the fiber trampoline arms (`sp_exc_arm`, lib/sp_fiber.c), so on a worker `sp_exc_top` is never 0, and `exit`, `abort` or an uncaught `raise` inside a thread take the raise branch, end that thread, and resurface at `join` on main, which is where the hooks then run. What was real is the other direction: main draining with workers alive.

## What

Registration goes through a runtime helper, and the drain's pop and that helper share one mutex in the threaded build. The single-threaded build compiles the code it did. A program that uses `Thread`, `Mutex` or `Queue` links the `-DSP_THREADS` runtime (src/main.c); nothing else is affected.

## How

`sp_at_exit_push(p)` (lib/spinel_rt.h) stores the proc under `SP_AT_EXIT_LOCK` and returns it, so the registering expression still evaluates to the proc, as `at_exit` does in Ruby. `sp_at_exit_run` takes the same lock around its pop and releases it before calling the hook: a hook may register another hook, and it may block — the new test's first hook waits on a `Queue`. Nothing allocates or polls a safepoint under the lock, so a worker can never be parked at a stop-the-world barrier while holding it.

The lock is built the way `SP_HEAP_LOCK` is (lib/sp_alloc.h): a `pthread_mutex_t` under `SP_THREADS` and `((void)0)` otherwise. The helper is `static inline`, so in the single-threaded build the generated C differs only in the text of the registering expression, `sp_at_exit_push(...)` in place of the inline store.

The normal-end path did not need any of this: codegen already emits `sp_sched_drain()`, which joins every worker, before the tail's `sp_at_exit_run(0)` (src/codegen.c).

The codegen change is the one registering expression (src/codegen_call.c). The helper keeps the table's `sp_at_exit_` prefix for the reason #4282 gave for `sp_at_exit_run`: `mc_top` reserves the first underscore segment of every runtime symbol against top-level `def`s, and `at` is reserved already.

## Validation

- Tests 3425 pass, 0 fail, 0 error. Benchmarks 61 pass. Optcarrot OK 59662, and optcarrot's generated C is byte-identical. ext-cruby, rbs-seed and the rubyspec gate pass; the macOS-only spin-e2e leg is red on this machine for the pre-existing reason it has been on the last several PRs, progress output leaking onto stdout, independent of this change.
- On the differential corpus of 2,131 minimized programs that behave differently under CRuby 4.0.6 and Spinel: 806 matched at the merge-base (c3a16a43) and 806 match on this branch. Nothing lost, nothing gained.
- Generated C is byte-identical for 3428 of the 3440 test and benchmark programs, plus optcarrot. The twelve that differ are exactly the programs that register an `at_exit` hook — test/at_exit_hook_nonlocal_jump.rb, test/at_exit_hook_raises_and_exits.rb, test/at_exit_hook_survives_collection.rb, test/at_exit_lifo.rb, test/at_exit_returns_proc.rb, test/at_exit_runs_on_abort.rb, test/at_exit_runs_on_exit.rb, test/at_exit_runs_on_uncaught.rb, test/at_exit_skipped_by_exit_bang.rb, test/signal_module_surface.rb, test/warn_kernel.rb and the new test — and each differs only in its registering expressions, the inline store becoming `sp_at_exit_push(...)`. All twelve still match their expected output.
- No suite program fails to reach its inference fixpoint that reached one before: over 3378 programs there are 0 new non-convergences, no round count differs from the merge-base's, and the two that hit the round cap hit it there too.
- ThreadSanitizer, with `make tsan-archive` and scripts/tsan-run.sh, is what shows the race. On master (c3a16a43) this program reports one data race, the thread body's write of `sp_at_exit_count` in its `at_exit` registration against the decrement in `sp_at_exit_run`, reached from `sp_exit_raise`:

```ruby
at_exit { puts "main hook" }
Thread.new { sleep 0.2; at_exit { puts "late" } }
exit 2
```

  On this branch that program, the new test, a sleep-based shape where the thread registers while main's first hook is running, and `Thread.new { exit 3 }.join` with a hook all run under it with no report, and print what CRuby prints.
- test/at_exit_registered_from_thread_during_drain.rb passes plain, under `SPINEL_GC_STRESS=1`, and under ASAN+UBSAN both plain and stressed, in about 40 ms. It produced its expected output on 180 of 180 runs across `SPINEL_WORKERS` set to 1, 2, 3, 4, 8 and 16. CRuby 4.0.6 prints the same two lines and exits 0, so the harness regenerates its expected file rather than skipping it.
- The single-threaded build compiles to the same machine code. The header before and after the change was compiled at `-O2`, the default, for a non-threaded program with a hook: the assembly is identical apart from two reordered `.zerofill` directives, and `sp_at_exit_push` does not appear in it, since it is inlined. At `-O0` and `-O1`, which only a `--debug` build uses, an out-of-line call to the helper remains.
- `exit`, `abort` and `raise` inside a thread that is then joined, each with a hook registered, print the same lines and exit with the same status on master and on this branch, and match CRuby apart from the pre-existing `terminated with exception` line. This is the claim that a thread never reaches the drain on its own, checked at the three termination paths.
- The Makefile's reserved-prefix pipeline, the one `mc_top` consumes, was run over master and this branch: identical sets. The new identifiers add no reserved segment.

## Left alone, on purpose

- **The registration bound.** `SP_AT_EXIT_MAX` is 256 and the push does not check the count, exactly as the inline store did not. #4282 left it for its own change, which needs a decision about what to do where CRuby has no limit; this one does not take that decision.
- **The `terminated with exception` line Spinel prints when a non-main thread exits.** Pre-existing and unchanged; #4282 listed it too.
- **Concurrent registration from two threads at once.** It goes through the same lock now, so it is covered, but it was not the reason for the change and there is no test for it: two `at_exit` calls racing each other have no observable order to pin.
- **`exit` inside a thread that nobody joins.** Here it ends only that thread and the program goes on to its normal end, status 0. CRuby ends the whole process with that status. Pre-existing on master, unrelated to the table, and its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread safety for exit-hook registration and execution.
  * Exit hooks registered by another thread while hooks are running are now executed reliably.
  * Improved exception handling during exit-hook processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->