### PR TITLE
rbs-seed: align instantiate hash type with find_by caller

### DIFF
--- a/test/rbs-seed/sig/override_family_ret.rbs
+++ b/test/rbs-seed/sig/override_family_ret.rbs
@@ -1,4 +1,4 @@
 class OfrBase
-  def self.instantiate: (Hash[String, untyped] _row) -> OfrBase
+  def self.instantiate: (Hash[Symbol, untyped] _row) -> OfrBase
   def self.find_by: (Hash[Symbol, untyped] conditions) -> OfrBase?
 end


### PR DESCRIPTION
The override_family_ret fixture had Hash[String, untyped] for instantiate but Hash[Symbol, untyped] for find_by. find_by calls instantiate(conditions) so the receiver hash type never matched the parameter hash type. CRuby permits this (untyped hashes are duck-typed) and the test was originally written against a GCC that did not promote -Wincompatible-pointer-types to an error under RBS_SEED_STRICT (-Werror=incompatible-pointer-types). GCC 14 does promote it, so the parameter mismatch blocks the syntax-only check before the return-seed path (#3203) is ever reached.

Align the instantiate parameter to Hash[Symbol, untyped] so it matches the caller's hash type. The test still exercises the return seed scenario: sp_OfrBase_s_instantiate returns sp_RbVal (family/boxed) while sp_OfrBase_s_find_by returns sp_OfrBase * (concrete class pointer), which is the exact #3203 surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the `OfrBase.instantiate` method signature to accept hashes with symbol keys, aligning the declared interface with supported input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->