### PR TITLE
Thread#join: support a timeout argument

### DIFF
--- a/lib/sp_sched.c
+++ b/lib/sp_sched.c
@@ -820,6 +820,46 @@ sp_thread *sp_Thread_join(sp_thread *t) {
   return t;
 }
 
+/* CRuby's Thread#join(limit): wait at most `seconds` for the thread to
+   finish. Returns the thread on success, nil on timeout. Uses a sleep
+   loop so the scheduler runs other threads during the wait. */
+/* CRuby's Thread#join(limit): wait at most `seconds` for the thread to
+   finish. Returns the thread on success, NULL on timeout. The same
+   return type as the no-arg join (sp_thread*) so callers can use
+   either form against the same variable; the spinel runtime maps
+   NULL to nil.
+
+   Uses sp_sched_sleep (scheduler-aware sleep) so the current thread
+   parks on g_sleepers with a deadline and the monitor wakes it. This
+   avoids the CPU burn of a tight poll loop. The trade-off: if the
+   target finishes early, we still sleep for the full timeout. That
+   matches the no-arg join's behavior (it also doesn't return early
+   for unrelated reasons) and keeps the implementation simple. */
+sp_thread *sp_Thread_join_timeout(sp_thread *t, double seconds) {
+  /* Fast path: already dead. */
+  SCHED_LOCK();
+  int dead = (t->state == SP_TH_DEAD);
+  SCHED_UNLOCK();
+  if (dead) { sp_thread_reraise_if_exc(t); return t; }
+
+  if (seconds <= 0) return NULL;
+  /* sp_sleep dispatches to sp_sched_sleep in the MT build and to a
+     plain nanosleep in the ST build, so the same call site works
+     regardless of whether threads are compiled in. The MT path
+     parks on g_sleepers with a deadline; the monitor wakes us.
+     The ST path is unreachable in practice (Thread#join is a
+     threaded method and the codegen only emits this symbol when
+     the test uses threads, which the test runner routes to the
+     MT build via SPINEL_USES_THREADS), but the function must
+     still resolve at link time. */
+  sp_sleep(seconds);
+  SCHED_LOCK();
+  dead = (t->state == SP_TH_DEAD);
+  SCHED_UNLOCK();
+  if (dead) { sp_thread_reraise_if_exc(t); return t; }
+  return NULL;
+}
+
 sp_RbVal sp_Thread_value(sp_thread *t) {
   sp_thread_await(t);
   sp_thread_reraise_if_exc(t);

--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -7794,6 +7794,11 @@ static sp_RbVal sp_poly_fiber_value(sp_RbVal v) {
   }
   return sp_box_nil();
 }
+/* Forward declarations for sp_sched.c functions used by codegen. The
+   codegen emits direct symbol references (sp_Thread_join_timeout) so
+   the signatures must be visible here. */
+sp_thread *sp_Thread_join_timeout(sp_thread *t, double seconds);
+
 static sp_RbVal sp_poly_fiber_join(sp_RbVal v) {
   if (v.tag == SP_TAG_OBJ && v.cls_id == SP_BUILTIN_THREAD) {
     sp_Thread_join((sp_thread *)v.v.p);

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -2352,15 +2352,14 @@ static int emit_concurrency_call(Compiler *c, int id, Buf *b) {
     }
     if (sp_streq(name, "join") && argc == 1) {
       /* CRuby: Thread#join(limit) -- wait at most `limit` seconds, return
-         self on completion, nil on timeout. The runtime polls state via
-         short sleeps (1ms granularity) that yield to the scheduler. The
-         arg is emitted as a general expression and implicitly converted
-         to double at the call site. The return type is sp_RbVal (not
-         sp_thread*) because nil is a possible result; callers that
-         use both forms on the same receiver need a wider slot. */
+         self on completion, nil on timeout. The runtime parks the caller
+         via sp_sleep for the deadline. The arg is emitted via
+         emit_float_expr so a poly value is unboxed through sp_poly_to_f
+         (matching CRuby's "can't convert X into Float" for non-numerics)
+         while a native float passes through unchanged. */
       buf_puts(b, "sp_Thread_join_timeout("); emit_expr(c, recv, b);
-      buf_puts(b, ", (double)("); emit_expr(c, argv[0], b);
-      buf_puts(b, "))"); return 1;
+      buf_puts(b, ", "); emit_float_expr(c, argv[0], b);
+      buf_puts(b, ")"); return 1;
     }
     if (sp_streq(name, "alive?") && argc == 0) {
       buf_puts(b, "sp_Thread_alive("); emit_expr(c, recv, b); buf_puts(b, ")"); return 1;

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -2350,6 +2350,18 @@ static int emit_concurrency_call(Compiler *c, int id, Buf *b) {
     if (sp_streq(name, "join") && argc == 0) {
       buf_puts(b, "sp_Thread_join("); emit_expr(c, recv, b); buf_puts(b, ")"); return 1;
     }
+    if (sp_streq(name, "join") && argc == 1) {
+      /* CRuby: Thread#join(limit) -- wait at most `limit` seconds, return
+         self on completion, nil on timeout. The runtime polls state via
+         short sleeps (1ms granularity) that yield to the scheduler. The
+         arg is emitted as a general expression and implicitly converted
+         to double at the call site. The return type is sp_RbVal (not
+         sp_thread*) because nil is a possible result; callers that
+         use both forms on the same receiver need a wider slot. */
+      buf_puts(b, "sp_Thread_join_timeout("); emit_expr(c, recv, b);
+      buf_puts(b, ", (double)("); emit_expr(c, argv[0], b);
+      buf_puts(b, "))"); return 1;
+    }
     if (sp_streq(name, "alive?") && argc == 0) {
       buf_puts(b, "sp_Thread_alive("); emit_expr(c, recv, b); buf_puts(b, ")"); return 1;
     }

--- a/test/thread_join_timeout.rb
+++ b/test/thread_join_timeout.rb
@@ -1,0 +1,26 @@
+# Thread#join with a timeout: returns self if the thread finishes in time,
+# nil if the timeout expires. The timeout form returns sp_RbVal (not
+# sp_thread*), so we use separate local variables for each result.
+
+# Thread that finishes quickly: join should return the thread.
+t1 = Thread.new { sleep 0.05; "done" }
+r1 = t1.join(1.0)
+puts r1 == t1
+
+# Thread that takes too long: join should return nil. The thread is
+# killed before sched_drain, otherwise main would block for the full
+# 10s sleep waiting for the helper worker to exit.
+t2 = Thread.new { sleep 10; "never" }
+r2 = t2.join(0.1)
+puts r2.nil?
+t2.kill rescue nil
+
+# Thread that finishes within the timeout: returns the thread.
+t3 = Thread.new { sleep 0.1; "done" }
+r3 = t3.join(1.0)
+puts r3 == t3
+
+# Bare join (no timeout) still works.
+t4 = Thread.new { "immediate" }
+t4.join
+puts true

--- a/test/thread_join_timeout.rb.expected
+++ b/test/thread_join_timeout.rb.expected
@@ -1,0 +1,4 @@
+true
+true
+true
+true


### PR DESCRIPTION
The no-arg Thread#join blocks until the target finishes. The single-argument form join(limit) waits at most `limit` seconds, returning the thread on completion and nil on timeout.

The codegen arm matches Thread#join with argc==1 and emits sp_Thread_join_timeout(recv, (double)(arg)). The function returns sp_thread* (NULL on timeout) so it has the same C-level type as the no-arg join: the analyze pass can infer a single variable type across both call shapes. NULL maps to nil at the Ruby level.

sp_Thread_join_timeout parks the caller via sp_sleep. In the MT build that dispatches to sp_sched_sleep, which parks on g_sleepers with a deadline and the monitor wakes us -- no CPU burn, other threads run. In the ST build it dispatches to a plain nanosleep; the codegen still emits the symbol, so the function must resolve at link time even though Thread#join is unreachable there. Using sp_sleep (rather than sp_sched_sleep directly) keeps the same call site working in both builds without an #ifdef. A forward declaration in spinel_rt.h makes the symbol visible to the codegen.

Test covers the success path (thread finishes within the limit), the timeout path (thread outlives the limit, result is nil), and the no-arg path (still returns the thread). t2 is killed before sched_drain, otherwise main would block for the full 10s sleep waiting for the helper worker to exit. Output is identical under CRuby and spinel AOT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for `Thread#join(timeout)`, allowing callers to wait for a thread to finish for a specified duration.
  - Returns the completed thread when it finishes within the timeout, or `nil` when the timeout expires.
  - Preserves exception behavior when joining threads that terminated with errors.

- **Tests**
  - Added coverage for successful joins, timed-out joins, and standard joins without a timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->