### PR TITLE
common.mk: detect busybox timeout variant, not just GNU

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,6 +284,13 @@ $(SPINEL): $(SPINEL_OBJ) build/csrc/sp_parse_lib.o build/csrc/re_lit_check.o $(R
 	@# (the installed command is `spinel` too). Best-effort; gitignored.
 	@ln -sf $@ spinel 2>/dev/null || cp $@ spinel 2>/dev/null || true
 
+# Wrapper around the system `timeout` that always returns GNU coreutils'
+# exit code (124 on timeout), regardless of which `timeout` is on PATH.
+# The bench target keys on 124 to mark a run as SKIP; busybox uses 143
+# and BSDs use 399, which would be misclassified. Built once from C.
+$(SPINEL_TIMEOUT): scripts/spinel-timeout.c
+	$(CC) $(CFLAGS) $< -o $@
+
 # ---- RBS extractor ----
 # Reads sig/**/*.rbs, emits the seed-file format spinel_analyze consumes
 # when invoked with `spinel --rbs DIR`.
@@ -652,7 +659,7 @@ re-lit-test: $(SPINEL)
 # `make test` always runs fresh: it wipes the prior `.ok` stamps first,
 # then runs the suite. (The old incremental `test` + `retest` split is
 # gone — a stale `.ok` reading PASS was a recurring foot-gun.)
-test:
+test: $(SPINEL_TIMEOUT)
 	@if [ -z "$(TIMEOUT_BIN)" ]; then \
 	  echo "WARNING: no 'timeout'/'gtimeout' on PATH -- tests run with NO time limit."; \
 	  echo "         A hanging test will hang this run until the CI job's own limit."; \

--- a/common.mk
+++ b/common.mk
@@ -54,19 +54,16 @@ else
   GC_FLAGS = -Wl,--gc-sections
 endif
 
-# `timeout` is GNU coreutils on Linux, `gtimeout` on macOS (brew coreutils).
-# Busybox also ships a `timeout` applet with a different syntax
-# (`-t SECS PROG ARGS` instead of `SECS PROG ARGS`). Pick the form that
-# works: probe with `timeout 1 sh -c true`; if it succeeds, the GNU form
-# is available; if it fails with "can't execute", busybox is the only
-# `timeout` on PATH and we need `-t SECS`. If no `timeout` is found, run
-# without limits. The result is the full prefix including the duration
-# argument (e.g. `timeout 10`), so callers can append the command directly.
-TIMEOUT_BIN := $(shell { timeout 1 sh -c true; } 2>/dev/null >/dev/null && echo 'timeout 1' || \
-           { command -v timeout >/dev/null && echo 'timeout -t 1'; } || \
-           { command -v gtimeout >/dev/null && gtimeout 1 sh -c true && echo 'gtimeout 1'; } || echo '')
-TIMEOUT10 := $(if $(TIMEOUT_BIN),$(subst 1,10,$(TIMEOUT_BIN)),)
-TIMEOUT60 := $(if $(TIMEOUT_BIN),$(subst 1,60,$(TIMEOUT_BIN)),)
+# Wrapper around the system `timeout` that always returns GNU coreutils'
+# exit code (124 on timeout), regardless of which `timeout` is on PATH.
+# The bench target keys on 124 to mark a run as SKIP; busybox uses 143
+# and BSDs use 399, which would be misclassified. Built once from C.
+# `TIMEOUT_BIN` is the wrapper path, so the existing `$(TIMEOUT_BIN)`
+# emptiness checks (which print a "no time limit" warning) still work.
+SPINEL_TIMEOUT := scripts/spinel-timeout
+TIMEOUT_BIN := $(SPINEL_TIMEOUT)
+TIMEOUT10 := $(SPINEL_TIMEOUT) 10
+TIMEOUT60 := $(SPINEL_TIMEOUT) 60
 
 # Default to a parallel build at the logical CPU count, unless the
 # invocation already asked for a job count. Applied ONLY at the top level

--- a/common.mk
+++ b/common.mk
@@ -54,11 +54,19 @@ else
   GC_FLAGS = -Wl,--gc-sections
 endif
 
-# `timeout` is GNU coreutils — present on Linux, named `gtimeout` on macOS
-# (brew coreutils). Detect both; if neither is found run without limits.
-TIMEOUT_BIN := $(shell command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null)
-TIMEOUT10 := $(if $(TIMEOUT_BIN),$(TIMEOUT_BIN) 10,)
-TIMEOUT60 := $(if $(TIMEOUT_BIN),$(TIMEOUT_BIN) 60,)
+# `timeout` is GNU coreutils on Linux, `gtimeout` on macOS (brew coreutils).
+# Busybox also ships a `timeout` applet with a different syntax
+# (`-t SECS PROG ARGS` instead of `SECS PROG ARGS`). Pick the form that
+# works: probe with `timeout 1 sh -c true`; if it succeeds, the GNU form
+# is available; if it fails with "can't execute", busybox is the only
+# `timeout` on PATH and we need `-t SECS`. If no `timeout` is found, run
+# without limits. The result is the full prefix including the duration
+# argument (e.g. `timeout 10`), so callers can append the command directly.
+TIMEOUT_BIN := $(shell { timeout 1 sh -c true; } 2>/dev/null >/dev/null && echo 'timeout 1' || \
+           { command -v timeout >/dev/null && echo 'timeout -t 1'; } || \
+           { command -v gtimeout >/dev/null && gtimeout 1 sh -c true && echo 'gtimeout 1'; } || echo '')
+TIMEOUT10 := $(if $(TIMEOUT_BIN),$(subst 1,10,$(TIMEOUT_BIN)),)
+TIMEOUT60 := $(if $(TIMEOUT_BIN),$(subst 1,60,$(TIMEOUT_BIN)),)
 
 # Default to a parallel build at the logical CPU count, unless the
 # invocation already asked for a job count. Applied ONLY at the top level

--- a/scripts/spinel-timeout.c
+++ b/scripts/spinel-timeout.c
@@ -1,0 +1,78 @@
+/* spinel-timeout: a minimal timeout wrapper.
+ *
+ * GNU coreutils' `timeout` returns 124 when the command runs past the
+ * duration. Busybox's applet and other implementations return different
+ * values (143 = 128+SIGTERM, or 399 on some BSDs). The Makefile's bench
+ * target keys on 124 to mark a benchmark as SKIP, so it needs a uniform
+ * exit code regardless of which `timeout` is on PATH.
+ *
+ * Usage: spinel-timeout SECONDS COMMAND [ARG...]
+ *
+ * Implementation: fork, exec the child, arm SIGALRM for SECONDS. If the
+ * child is still running when the alarm fires, send SIGTERM and wait
+ * for it to exit (or SIGKILL after a grace period). The wrapper returns
+ * 124 on timeout, otherwise the child's exit status.
+ *
+ * No dependencies beyond POSIX.1-2001 (fork, exec, kill, sigaction,
+ * alarm, waitpid). */
+
+#include <signal.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+#include <time.h>
+
+static volatile sig_atomic_t timed_out;
+
+static void on_alarm(int sig) {
+  (void)sig;
+  timed_out = 1;
+}
+
+int main(int argc, char **argv) {
+  if (argc < 3) {
+    const char *u = "usage: spinel-timeout SECONDS COMMAND [ARG...]\n";
+    write(2, u, strlen(u));
+    return 2;
+  }
+  long secs = atol(argv[1]);
+  if (secs <= 0) secs = 1;
+
+  struct sigaction sa = {0};
+  sa.sa_handler = on_alarm;
+  sigaction(SIGALRM, &sa, NULL);
+  alarm((unsigned)secs);
+
+  pid_t pid = fork();
+  if (pid < 0) { perror("fork"); return 1; }
+  if (pid == 0) {
+    /* child: reset alarm disposition, exec the command */
+    alarm(0);
+    struct sigaction dfl = {0};
+    dfl.sa_handler = SIG_DFL;
+    sigaction(SIGALRM, &dfl, NULL);
+    execvp(argv[2], argv + 2);
+    perror("execvp");
+    _exit(127);
+  }
+
+  int status;
+  while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {}
+
+  if (timed_out) {
+    /* give the child a moment to exit on SIGTERM, then force it */
+    kill(pid, SIGTERM);
+    struct timespec grace = {0, 100 * 1000 * 1000};  /* 100ms */
+    nanosleep(&grace, NULL);
+    kill(pid, SIGKILL);
+    while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {}
+    return 124;
+  }
+
+  if (WIFEXITED(status)) return WEXITSTATUS(status);
+  if (WIFSIGNALED(status)) return 128 + WTERMSIG(status);
+  return 1;
+}


### PR DESCRIPTION
the reason i never ran make test, but instead let the CI run it, was that make test never worked on my machine.
it just printed a never-ending sequence of "F"s which i killed after ~30 mins, assuming that there was UB in form of an infinite loop in the test runner. after a several-hours long bug hunt i finally found the culprit. GNU coreutils specific behaviour was hardcoded, which let every single test fail with "timeout: can't execute '10': No such file or directory".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout detection across supported environments.
  * Added compatibility for GNU, BusyBox, and macOS timeout implementations.
  * Gracefully falls back to running without a timeout when no compatible utility is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->