### PR TITLE
codegen: accept TY_UNKNOWN and TY_POLY in the user-to_io dispatch

### DIFF
--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -1591,6 +1591,7 @@ static inline sp_bool sp_class_eq(sp_Class a, sp_Class b) {
   return (an && bn) ? strcmp(an, bn) == 0 : an == bn;
 }
 static inline const char *sp_poly_to_s(sp_RbVal v);   /* defined below; used by the user-object arm */
+static inline sp_File *sp_poly_to_file(sp_RbVal v); /* defined below; IO.select's user-#to_io unwrap */
 static inline void sp_poly_puts(sp_RbVal v) {
   switch (v.tag) {
     case SP_TAG_INT: printf("%lld\n", (long long)v.v.i); break;
@@ -1818,6 +1819,20 @@ static inline const char *sp_poly_to_s(sp_RbVal v) {
       }
     default: return sp_str_empty;
   }
+}
+/* Unwrap a boxed IO value to its sp_File *. The user-#to_io dispatch
+   asks this for a poly return type, because the generated arm is forced
+   to box the answer through sp_RbVal (the codegen of a poly body has
+   no other channel). CRuby's IO.select only ever sees the IO itself;
+   the protocol is: a user class with #to_io is fine, anything else
+   is a TypeError raised by the caller of the hook (it never reaches
+   this function). A builtin IO is a sp_File directly; a boxed user
+   class is a pointer the user-defined #to_io just returned, and the
+   dispatch already vetted it. NULL is the "not an IO" answer the
+   dispatch turns into the caller's TypeError. */
+static inline sp_File *sp_poly_to_file(sp_RbVal v) {
+  if (v.tag == SP_TAG_OBJ && v.cls_id == SP_BUILTIN_IO) return (sp_File *)v.v.p;
+  return NULL;
 }
 /* Class name of a boxed value, for `x.class` where x is poly. Returns a
    .rodata or names-table string (never GC-managed). */

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -7305,21 +7305,26 @@ static void emit_user_to_io_dispatch(Compiler *c, Buf *b) {
     int mi = comp_method_in_chain(c, k, "to_io", &defcls);
     if (mi < 0 || defcls < 0) continue;
     Scope *m = &c->scopes[mi];
-    if (!m->reachable || m->nparams != 0) continue;
+    if (!m->reachable || m->yields || m->nparams != 0) continue;
     if (m->ret != TY_IO && m->ret != TY_UNKNOWN && m->ret != TY_POLY) continue;
     if (scope_is_shadowed(c, mi) || m->is_transplanted_source) continue;
     const char *dcn = c->classes[defcls].c_name;
+    /* Non-yielding &block: the prototype includes a sp_Proc * parameter
+       (see emit_method_signature), so the dispatch must pass NULL for it. */
+    int has_blk = m->blk_param && m->blk_param[0];
     if (m->ret == TY_IO) {
-      buf_printf(b, "    case %d: return sp_%s_to_io(%s(sp_%s *)v.v.p);\n",
+      buf_printf(b, "    case %d: return sp_%s_to_io(%s(sp_%s *)v.v.p%s);\n",
                  comp_class_index(c, c->classes[k].name),
-                 dcn, c->classes[defcls].is_value_type ? "*" : "", dcn);
+                 dcn, c->classes[defcls].is_value_type ? "*" : "", dcn,
+                 has_blk ? ", NULL" : "");
     } else {
       /* poly/unknown: the #to_io body boxes; unwrap via the poly->file path
          so a non-IO answer falls through to the caller's TypeError instead
          of a segfault. */
-      buf_printf(b, "    case %d: { sp_RbVal _r = sp_%s_to_io(%s(sp_%s *)v.v.p); return (sp_File *)sp_poly_to_file(_r); }\n",
+      buf_printf(b, "    case %d: { sp_RbVal _r = sp_%s_to_io(%s(sp_%s *)v.v.p%s); return (sp_File *)sp_poly_to_file(_r); }\n",
                  comp_class_index(c, c->classes[k].name),
-                 dcn, c->classes[defcls].is_value_type ? "*" : "", dcn);
+                 dcn, c->classes[defcls].is_value_type ? "*" : "", dcn,
+                 has_blk ? ", NULL" : "");
     }
   }
   buf_puts(b, "    default: break;\n  }\n  return NULL;\n}\n");
@@ -10100,7 +10105,7 @@ char *codegen_program(const NodeTable *nt) {
     int dc = -1, mi2 = comp_method_in_chain(c, k, "to_io", &dc);
     if (mi2 < 0 || dc < 0) continue;
     Scope *m2 = &c->scopes[mi2];
-    if (m2->reachable && m2->nparams == 0 &&
+    if (m2->reachable && !m2->yields && m2->nparams == 0 &&
         (m2->ret == TY_IO || m2->ret == TY_UNKNOWN || m2->ret == TY_POLY) &&
         !scope_is_shadowed(c, mi2) && !m2->is_transplanted_source) { g_has_user_to_io = 1; break; }
   }

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -7281,7 +7281,21 @@ static void emit_user_binop_dispatch(Compiler *c, Buf *b) {
    on; the runtime cannot dispatch a user method itself, so it calls this
    through sp_user_to_io_hook. A class whose #to_io does not answer an IO is
    left out rather than emitted wrong: it falls through to the TypeError the
-   element would have raised anyway. */
+   element would have raised anyway.
+
+   The return-type gate accepts TY_IO, TY_UNKNOWN, and TY_POLY: a
+   wrapper written as `def to_io; @sock; end` lets the compiler infer
+   the return type from `@sock`, which is poly (TY_POLY) because the
+   constructor takes a raw socket the user hands in. The runtime hook
+   checks the result is actually an IO before using it, so a wrong
+   return is still a TypeError -- just at the moment of select, not
+   at the moment of class discovery.
+
+   A poly return means the emitted body boxes the value into sp_RbVal
+   first, then asks the runtime to unwrap an sp_File from it; the
+   IO path's existing box machinery is what handles "answer is an IO"
+   already (sp_poly_to_file / tag SP_TAG_FILE). The TY_IO arm stays
+   the direct cast: that function still returns sp_File * directly. */
 static void emit_user_to_io_dispatch(Compiler *c, Buf *b) {
   buf_puts(b, "static sp_File *sp_user_to_io_dispatch(sp_RbVal v) {\n");
   buf_puts(b, "  switch (v.cls_id) {\n");
@@ -7291,12 +7305,22 @@ static void emit_user_to_io_dispatch(Compiler *c, Buf *b) {
     int mi = comp_method_in_chain(c, k, "to_io", &defcls);
     if (mi < 0 || defcls < 0) continue;
     Scope *m = &c->scopes[mi];
-    if (!m->reachable || m->nparams != 0 || m->ret != TY_IO) continue;
+    if (!m->reachable || m->nparams != 0) continue;
+    if (m->ret != TY_IO && m->ret != TY_UNKNOWN && m->ret != TY_POLY) continue;
     if (scope_is_shadowed(c, mi) || m->is_transplanted_source) continue;
     const char *dcn = c->classes[defcls].c_name;
-    buf_printf(b, "    case %d: return sp_%s_to_io(%s(sp_%s *)v.v.p);\n",
-               comp_class_index(c, c->classes[k].name),
-               dcn, c->classes[defcls].is_value_type ? "*" : "", dcn);
+    if (m->ret == TY_IO) {
+      buf_printf(b, "    case %d: return sp_%s_to_io(%s(sp_%s *)v.v.p);\n",
+                 comp_class_index(c, c->classes[k].name),
+                 dcn, c->classes[defcls].is_value_type ? "*" : "", dcn);
+    } else {
+      /* poly/unknown: the #to_io body boxes; unwrap via the poly->file path
+         so a non-IO answer falls through to the caller's TypeError instead
+         of a segfault. */
+      buf_printf(b, "    case %d: { sp_RbVal _r = sp_%s_to_io(%s(sp_%s *)v.v.p); return (sp_File *)sp_poly_to_file(_r); }\n",
+                 comp_class_index(c, c->classes[k].name),
+                 dcn, c->classes[defcls].is_value_type ? "*" : "", dcn);
+    }
   }
   buf_puts(b, "    default: break;\n  }\n  return NULL;\n}\n");
 }
@@ -10076,7 +10100,8 @@ char *codegen_program(const NodeTable *nt) {
     int dc = -1, mi2 = comp_method_in_chain(c, k, "to_io", &dc);
     if (mi2 < 0 || dc < 0) continue;
     Scope *m2 = &c->scopes[mi2];
-    if (m2->reachable && m2->nparams == 0 && m2->ret == TY_IO &&
+    if (m2->reachable && m2->nparams == 0 &&
+        (m2->ret == TY_IO || m2->ret == TY_UNKNOWN || m2->ret == TY_POLY) &&
         !scope_is_shadowed(c, mi2) && !m2->is_transplanted_source) { g_has_user_to_io = 1; break; }
   }
   g_gen_obj_hashkey = 0;

--- a/test/io_select_user_to_io.rb
+++ b/test/io_select_user_to_io.rb
@@ -1,0 +1,78 @@
+# IO.select on a user wrapper that holds a raw socket is the protocol
+# behind every TLS/passthrough/pipe class. The codegen gate for adding
+# the class to sp_user_to_io_dispatch used to require m->ret == TY_IO
+# and skip nothing about yield or &block; the prototype and definition
+# loops, however, do skip s->yields and do add an sp_Proc * parameter
+# for non-yielding &block. The mismatch produced two failures:
+#
+# 1. A poly body (`def to_io; @sock; end`) left the class out of the
+#    dispatch, so IO.select raised "no implicit conversion of X into IO".
+# 2. A yielding body left the class in the dispatch but the prototype
+#    and definition loops had skipped it, so the C compile failed with
+#    "undefined reference to sp_X_to_io" (or, for &block, "too few
+#    arguments" because the dispatch call missed the sp_Proc *).
+#
+# The fix accepts TY_UNKNOWN and TY_POLY in the gate, excludes scopes
+# with s->yields, and passes NULL for the block parameter when the
+# method has one. Cases 1 and 2 below match between CRuby and spinel;
+# case 3 (yielding) is included in the source so the spinel compile
+# exercises the gate exclusion -- a class the gate forgot to skip
+# would fail the C build with an undefined-symbol error.
+
+require "socket"
+
+def make_pair
+  a, b = Socket.pair(1, 1, 0)
+  Thread.new { b.write "x"; b.close }
+  [a, b]
+end
+
+# 1. poly return (the common wrapper shape: `def to_io; @sock; end`).
+#    The constructor takes the raw socket (poly), so @sock is poly,
+#    so to_io's return is TY_POLY. The class must be in the dispatch.
+class Wrap
+  def initialize(sock)
+    @sock = sock
+  end
+  def to_io
+    @sock
+  end
+end
+
+a, _ = make_pair
+w = Wrap.new(a)
+ready = IO.select([w], nil, nil, 5)
+p ready ? "poly" : "TIMEOUT"      #=> "poly"
+
+# 2. non-yielding &block. The prototype includes sp_Proc *lv_block;
+#    the dispatch must pass NULL so the C compile succeeds.
+class BlockWrap
+  def initialize(sock)
+    @sock = sock
+  end
+  def to_io(&block)
+    @sock
+  end
+end
+
+a, _ = make_pair
+w = BlockWrap.new(a)
+ready = IO.select([w], nil, nil, 5)
+p ready ? "block" : "TIMEOUT"     #=> "block"
+
+# 3. yielding #to_io -- the class is excluded from the dispatch to
+#    match the prototype/definition loops. A class the gate forgot
+#    to skip would make the spinel C build fail with an undefined
+#    reference to sp_YieldWrap_to_io; this case is here to exercise
+#    the exclusion at compile time, not to test runtime behavior.
+class YieldWrap
+  def initialize(sock)
+    @sock = sock
+  end
+  def to_io
+    yield if block_given?
+    @sock
+  end
+end
+
+puts "done"

--- a/test/io_select_user_to_io.rb.expected
+++ b/test/io_select_user_to_io.rb.expected
@@ -1,0 +1,3 @@
+"poly"
+"block"
+done


### PR DESCRIPTION
A user class that wraps an IO -- a TLS socket, a passthrough, a process pipe -- exposes the underlying handle through #to_io. The codegen gate for adding the class to sp_user_to_io_dispatch required m->ret == TY_IO, which a poly body fails: the common shape is 'def to_io; @sock; end', and the constructor's parameter is poly, so @sock is poly and the return is TY_POLY (or TY_UNKNOWN when the analysis could not narrow further). The class was left out of the dispatch, and IO.select reached the runtime helper for a class the dispatch did not know, which raised:

    no implicit conversion of Wrap into IO (TypeError)

The fix accepts TY_UNKNOWN and TY_POLY alongside TY_IO in both gates (emit_user_to_io_dispatch and the g_has_user_to_io check in codegen_program). The runtime gets a small sp_poly_to_file inline in spinel_rt.h that turns a boxed IO into an sp_File * and returns NULL for anything else, so a wrong return is still a TypeError -- just at the moment of select, not at class discovery. The poly arm in the dispatch boxes the #to_io answer and asks sp_poly_to_file to unwrap it; the TY_IO arm keeps its direct cast because that function still returns sp_File * directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `IO.select` compatibility with custom `#to_io` methods returning dynamically typed IO values.
  * Added support for wrapper objects that return raw sockets through `#to_io`.
  * Corrected handling of non-yielding `#to_io` methods that accept a block parameter.
  * Excluded yielding `#to_io` methods from unsupported dispatch paths.
  * Preserved direct handling for methods with explicitly typed IO returns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->