### PR TITLE
codegen: read_nonblock with exception: false returns nil at EOF

### DIFF
--- a/lib/sp_io.c
+++ b/lib/sp_io.c
@@ -851,7 +851,8 @@ const char *sp_File_readpartial(sp_File *f, sp_int n) {SP_GC_ROOT(f);
   return r;
 }
 
-const char *sp_sock_read_nb(sp_File *f, sp_int len, sp_bool exc, sp_bool is_recv) {SP_GC_ROOT(f);
+const char *sp_sock_read_nb(sp_File *f, sp_int len, sp_bool exc, sp_bool is_recv, sp_bool *eof) {SP_GC_ROOT(f);
+  if (eof) *eof = 0;
   if (is_recv) sp_sock_nb_prepare(f, "recv_nonblock");
   else if (!f || !f->fp) sp_raise_cls("IOError", "closed stream");
   if (len <= 0) return sp_str_from_bytes("", 0);
@@ -873,6 +874,7 @@ const char *sp_sock_read_nb(sp_File *f, sp_int len, sp_bool exc, sp_bool is_recv
   if (n > 0) { const char *s = sp_str_from_bytes(buf, (size_t)n); free(buf); return s; }
   if (n == 0) {
     free(buf);
+    if (eof) *eof = 1;
     if (!exc) return NULL;                     /* CRuby: nil at EOF */
     sp_raise_cls("EOFError", "end of file reached");
   }

--- a/lib/sp_io.h
+++ b/lib/sp_io.h
@@ -76,7 +76,7 @@ const char *sp_File_inspect(sp_File *f);
 const char *sp_io_kind_name(sp_File *f);
 sp_File *sp_sock_accept(sp_File *f);
 sp_File *sp_sock_accept_nb(sp_File *f, sp_bool exc);
-const char *sp_sock_read_nb(sp_File *f, sp_int len, sp_bool exc, sp_bool is_recv);
+const char *sp_sock_read_nb(sp_File *f, sp_int len, sp_bool exc, sp_bool is_recv, sp_bool *eof);
 sp_int sp_sock_write_nb(sp_File *f, const char *data, sp_bool exc);
 sp_int sp_sock_write_nb_bin(sp_File *f, const char *data, sp_bool exc);
 sp_int sp_sock_connect_nb(sp_File *f, const char *host, sp_int port, sp_bool exc);

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -6126,17 +6126,17 @@ else {
           int e7 = kwh_lookup(nt, kwh, "exception");
           no_exc7 = e7 >= 0 && nt_type(nt, e7) && sp_streq(nt_type(nt, e7), "FalseNode");
         }
-        int trd7 = ++g_tmp;
-        buf_printf(b, " case SP_BUILTIN_IO: { const char *_t%d = sp_sock_read_nb("
-                      "(sp_File *)_t%d.v.p, ", trd7, tv);
+        int trd7 = ++g_tmp, te7 = ++g_tmp;
+        buf_printf(b, " case SP_BUILTIN_IO: { sp_bool _e%d; const char *_t%d = sp_sock_read_nb("
+                      "(sp_File *)_t%d.v.p, ", te7, trd7, tv);
         if (atmp_ty[0] == TY_POLY) buf_printf(b, "sp_poly_to_i(_t%d)", atmp[0]);
         else buf_printf(b, "(sp_int)_t%d", atmp[0]);
-        buf_printf(b, ", %d, 0); ", no_exc7 ? 0 : 1);
+        buf_printf(b, ", %d, 0, &_e%d); ", no_exc7 ? 0 : 1, te7);
         buf_printf(b, "_t%d = ", tr);
         if (ret == TY_POLY) {
           if (no_exc7)
-            buf_printf(b, "_t%d ? sp_box_str(_t%d) : sp_box_sym(sp_sym_intern(\"wait_readable\"))",
-                       trd7, trd7);
+            buf_printf(b, "_t%d ? sp_box_str(_t%d) : (_e%d ? sp_box_nil() : sp_box_sym(sp_sym_intern(\"wait_readable\")))",
+                       trd7, trd7, te7);
           else buf_printf(b, "sp_box_str(_t%d)", trd7);
         }
         else buf_printf(b, "_t%d", trd7);
@@ -18219,15 +18219,17 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
       }
       if (sp_streq(name, "recv_nonblock") && pos9 == 1) {
         if (no_exc) {
-          int tw = ++g_tmp;
-          buf_printf(b, "({ const char *_t%d = sp_sock_read_nb(%s, ", tw, r);
+          int tw = ++g_tmp, te = ++g_tmp;
+          buf_printf(b, "sp_bool _e%d; const char *_t%d = sp_sock_read_nb(%s, ", te, tw, r);
           emit_int_expr(c, argv[0], b);
-          buf_printf(b, ", 0, 1); _t%d ? sp_box_str(_t%d)"
-                        " : sp_box_sym(sp_sym_intern(\"wait_readable\")); })", tw, tw);
+          buf_printf(b, ", 0, 1, &_e%d); _t%d ? sp_box_str(_t%d)"
+                        " : (_e%d ? sp_box_nil() : sp_box_sym(sp_sym_intern(\"wait_readable\"))); })",
+                     te, tw, tw, te);
         }
         else {
-          buf_printf(b, "sp_sock_read_nb(%s, ", r); emit_int_expr(c, argv[0], b);
-          buf_puts(b, ", 1, 1)");
+          int te = ++g_tmp;
+          buf_printf(b, "sp_bool _e%d; sp_sock_read_nb(%s, ", te, r); emit_int_expr(c, argv[0], b);
+          buf_printf(b, ", 1, 1, &_e%d); })", te);
         }
         free(rb.p); return;
       }
@@ -18490,15 +18492,17 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
       int no_exc8 = exc8 >= 0 && nt_type(nt, exc8) && sp_streq(nt_type(nt, exc8), "FalseNode");
       if (sp_streq(name, "read_nonblock")) {
         if (no_exc8) {
-          int tw = ++g_tmp;
-          buf_printf(b, "({ const char *_t%d = sp_sock_read_nb(%s, ", tw, r);
+          int tw = ++g_tmp, te = ++g_tmp;
+          buf_printf(b, "sp_bool _e%d; const char *_t%d = sp_sock_read_nb(%s, ", te, tw, r);
           emit_int_expr(c, argv[0], b);
-          buf_printf(b, ", 0, 0); _t%d ? sp_box_str(_t%d)"
-                        " : sp_box_sym(sp_sym_intern(\"wait_readable\")); })", tw, tw);
+          buf_printf(b, ", 0, 0, &_e%d); _t%d ? sp_box_str(_t%d)"
+                        " : (_e%d ? sp_box_nil() : sp_box_sym(sp_sym_intern(\"wait_readable\"))); })",
+                     te, tw, tw, te);
         }
         else {
-          buf_printf(b, "sp_sock_read_nb(%s, ", r); emit_int_expr(c, argv[0], b);
-          buf_puts(b, ", 1, 0)");
+          int te = ++g_tmp;
+          buf_printf(b, "sp_bool _e%d; sp_sock_read_nb(%s, ", te, r); emit_int_expr(c, argv[0], b);
+          buf_printf(b, ", 1, 0, &_e%d); })", te);
         }
       }
       else {
@@ -18959,16 +18963,18 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
                       sp_streq(nt_type(nt, exc9), "FalseNode");
         if (sp_streq(name, "read_nonblock")) {
           if (no_exc9) {
-            int tw9 = ++g_tmp;
-            buf_printf(b, "const char *_t%d = sp_sock_read_nb(_t%d, ", tw9, tio2);
+            int tw9 = ++g_tmp, te9 = ++g_tmp;
+            buf_printf(b, "sp_bool _e%d; const char *_t%d = sp_sock_read_nb(_t%d, ", te9, tw9, tio2);
             emit_int_expr(c, argv[0], b);
-            buf_printf(b, ", 0, 0); _t%d ? sp_box_str(_t%d)"
-                          " : sp_box_sym(sp_sym_intern(\"wait_readable\")); })", tw9, tw9);
+            buf_printf(b, ", 0, 0, &_e%d); _t%d ? sp_box_str(_t%d)"
+                          " : (_e%d ? sp_box_nil() : sp_box_sym(sp_sym_intern(\"wait_readable\"))); })",
+                         te9, tw9, tw9, te9);
           }
           else {
-            buf_printf(b, "sp_sock_read_nb(_t%d, ", tio2);
+            int te9 = ++g_tmp;
+            buf_printf(b, "sp_bool _e%d; sp_sock_read_nb(_t%d, ", te9, tio2);
             emit_int_expr(c, argv[0], b);
-            buf_puts(b, ", 1, 0); })");
+            buf_printf(b, ", 1, 0, &_e%d); })", te9);
           }
         }
         else {

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -18227,9 +18227,8 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
                      te, tw, tw, te);
         }
         else {
-          int te = ++g_tmp;
-          buf_printf(b, "sp_bool _e%d; sp_sock_read_nb(%s, ", te, r); emit_int_expr(c, argv[0], b);
-          buf_printf(b, ", 1, 1, &_e%d); })", te);
+          buf_printf(b, "sp_sock_read_nb(%s, ", r); emit_int_expr(c, argv[0], b);
+          buf_puts(b, ", 1, 1, NULL)");
         }
         free(rb.p); return;
       }
@@ -18493,16 +18492,15 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
       if (sp_streq(name, "read_nonblock")) {
         if (no_exc8) {
           int tw = ++g_tmp, te = ++g_tmp;
-          buf_printf(b, "sp_bool _e%d; const char *_t%d = sp_sock_read_nb(%s, ", te, tw, r);
+          buf_printf(b, "({ sp_bool _e%d; const char *_t%d = sp_sock_read_nb(%s, ", te, tw, r);
           emit_int_expr(c, argv[0], b);
           buf_printf(b, ", 0, 0, &_e%d); _t%d ? sp_box_str(_t%d)"
                         " : (_e%d ? sp_box_nil() : sp_box_sym(sp_sym_intern(\"wait_readable\"))); })",
                      te, tw, tw, te);
         }
         else {
-          int te = ++g_tmp;
-          buf_printf(b, "sp_bool _e%d; sp_sock_read_nb(%s, ", te, r); emit_int_expr(c, argv[0], b);
-          buf_printf(b, ", 1, 0, &_e%d); })", te);
+          buf_printf(b, "sp_sock_read_nb(%s, ", r); emit_int_expr(c, argv[0], b);
+          buf_puts(b, ", 1, 0, NULL)");
         }
       }
       else {
@@ -18971,10 +18969,9 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
                          te9, tw9, tw9, te9);
           }
           else {
-            int te9 = ++g_tmp;
-            buf_printf(b, "sp_bool _e%d; sp_sock_read_nb(_t%d, ", te9, tio2);
+            buf_printf(b, "sp_sock_read_nb(_t%d, ", tio2);
             emit_int_expr(c, argv[0], b);
-            buf_printf(b, ", 1, 0, &_e%d); })", te9);
+            buf_puts(b, ", 1, 0, NULL); })");
           }
         }
         else {

--- a/test/read_nonblock_eof_nil.rb
+++ b/test/read_nonblock_eof_nil.rb
@@ -1,0 +1,41 @@
+# read_nonblock with `exception: false` distinguishes EOF from would-block.
+# At EOF, the call returns nil (CRuby's nil, not :wait_readable). When the
+# fd is not readable yet, the call returns :wait_readable. Without the
+# keyword, EOF raises EOFError as before.
+#
+# Spinel's sp_sock_read_nb used to fold both EOF and would-block into the
+# same NULL return; the codegen then mapped NULL to :wait_readable, which
+# turned every IO.select + read_nonblock loop into a busy spin because
+# select said readable and read said would block. The fix adds an
+# out-parameter so the codegen can tell EOF from would-block.
+
+require "socket"
+
+a, b = Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM, 0)
+
+# 1. exception: false at EOF -> nil
+b.write "x"
+b.close
+p a.read_nonblock(64, exception: false)      #=> "x"
+p a.read_nonblock(64, exception: false)      #=> nil
+
+# 2. exception: false when would block -> :wait_readable
+c, d = Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM, 0)
+p c.read_nonblock(64, exception: false)      #=> :wait_readable
+
+# 3. raising form at EOF -> EOFError
+a2, b2 = Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM, 0)
+b2.close
+begin
+  a2.read_nonblock(64)
+  p "no error"                                # NOT this
+rescue EOFError
+  p "EOFError"
+end
+
+c.close
+d.close
+a.close
+a2.close
+
+puts "done"

--- a/test/read_nonblock_eof_nil.rb.expected
+++ b/test/read_nonblock_eof_nil.rb.expected
@@ -1,0 +1,5 @@
+"x"
+nil
+:wait_readable
+"EOFError"
+done


### PR DESCRIPTION
sp_sock_read_nb folded EOF and would-block into the same NULL return. The codegen for exception: false then mapped NULL to :wait_readable, so the call could not tell the peer closed from the fd simply not ready yet. Every IO.select + read_nonblock loop turned into a busy spin: select said readable, read said would block, forever.

The fix adds an out-parameter so sp_sock_read_nb can signal EOF to the codegen. The exception: false path returns nil at EOF and :wait_readable when the fd is not ready. The raising form still raises EOFError at EOF. recv_nonblock shares the same runtime function and gets the same fix.

closes #4336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Non-blocking reads now distinguish end-of-file from temporarily unavailable data.
  - `read_nonblock` returns `nil` at end-of-file instead of incorrectly reporting `:wait_readable`, preventing unnecessary busy-waiting.
  - When exceptions are enabled, reaching end-of-file raises `EOFError` as expected.
  - Reads that would block continue to report `:wait_readable` when exceptions are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->