### PR TITLE
The seed of sum / inject / reduce keeps its own class

### DIFF
--- a/lib/sp_array.c
+++ b/lib/sp_array.c
@@ -367,9 +367,10 @@ sp_float sp_FloatArray_min(sp_FloatArray*a){if(!a||a->len==0)return sp_float_nil
 sp_float sp_FloatArray_max(sp_FloatArray*a){if(!a||a->len==0)return sp_float_nil();  /* CRuby: nil on empty (#4288) */ sp_float m=a->data[0];for(sp_int i=1;i<a->len;i++)if(a->data[i]>m)m=a->data[i];return m;}
 /* Array#sum for floats: Kahan-Babuska-Neumaier compensated summation,
    matching CRuby (float addition isn't associative, so a naive fold of
-   [0.1,0.2,0.3] yields 0.6000000000000001 instead of 0.6). `c` accumulates
-   the low-order bits dropped at each add and is folded back at the end. */
-sp_float sp_FloatArray_sum(sp_FloatArray*a,sp_float init){sp_float s=init,c=0.0;for(sp_int i=0;i<a->len;i++){sp_float x=a->data[i],t=s+x;if(fabs(s)>=fabs(x))c+=(s-t)+x;else c+=(x-t)+s;s=t;}return s+c;}
+   [0.1,0.2,0.3] yields 0.6000000000000001 instead of 0.6). The step, with
+   CRuby's NaN/Infinity arms, is sp_float_sum_step in sp_array.h -- shared with
+   the boxed fold so the two cannot drift. */
+sp_float sp_FloatArray_sum(sp_FloatArray*a,sp_float init){sp_float s=init,c=0.0;for(sp_int i=0;i<a->len;i++)sp_float_sum_step(&s,&c,a->data[i]);return s+c;}
 void sp_FloatArray_replace(sp_FloatArray*dst,sp_FloatArray*src){dst->len=0;if(src->len>dst->cap){sp_gc_hdr*h=(sp_gc_hdr*)((char*)dst-sizeof(sp_gc_hdr));sp_gc_bytes_sub(sizeof(sp_float)*dst->cap);h->size-=sizeof(sp_float)*dst->cap;void*nd=realloc(dst->data,sizeof(sp_float)*src->len);if(!nd){perror("realloc");exit(1);}dst->data=(sp_float*)nd;dst->cap=src->len;h->size+=sizeof(sp_float)*dst->cap;sp_gc_bytes_add(sizeof(sp_float)*dst->cap);}memcpy(dst->data,src->data,sizeof(sp_float)*src->len);dst->len=src->len;}
 /* a[start, len] / a[start..end] for FloatArray. Same negative-start and
    length-clamping semantics as sp_IntArray_slice. */

--- a/lib/sp_array.h
+++ b/lib/sp_array.h
@@ -14,6 +14,7 @@
  * generated TU and resolved at the final link, the same way lib/sp_core.c
  * calls them -- so lib/sp_array.c can use them without a runtime include.
  */
+#include <math.h>      /* isnan / isinf / signbit / NAN / fabs for sp_float_sum_step */
 #include "sp_gc.h"      /* sp_gc_hdr, sp_gc_bytes, SP_GC_ROOT, sp_oom_die */
 #include "sp_alloc.h"   /* sp_gc_alloc, sp_str_alloc, sp_raise_cls, sp_raise_frozen_array */
 
@@ -107,6 +108,32 @@ static inline sp_float sp_FloatArray_first_opt(sp_FloatArray*a){return (!a||a->l
 static inline sp_float sp_FloatArray_last_opt(sp_FloatArray*a){return (!a||a->len<=0)?sp_float_nil():sp_FloatArray_get(a,a->len-1);}
 /* Issue #769: no-op for negative index after adjustment. */
 static inline void sp_FloatArray_set(sp_FloatArray*a,sp_int i,sp_float v){if(!a)return;if(a->frozen){sp_raise_frozen_array_at(a, SP_BUILTIN_FLT_ARRAY);return;}sp_int orig=i;if(i<0)i+=a->len;if(i<0)sp_raise_cls("IndexError",sp_sprintf("index %lld too small for array; minimum: %lld",(long long)orig,(long long)-a->len));while(i>=a->cap){a->cap=((((((a->cap*2))))))+1;a->data=(sp_float*)realloc(a->data,sizeof(sp_float)*a->cap);}while(i>=a->len){a->data[a->len]=sp_float_nil();a->len++;}a->data[i]=v;}  /* the gap is nil, not 0.0 (#3836) */
+
+/* One step of CRuby's compensated summation (array.c ary_sum): Kahan-Babuska-
+   Neumaier, where `comp` collects the low-order bits each add drops and is
+   folded back once the run ends. The special-value arms are CRuby's own: a
+   total that is already NaN stays NaN, a NaN element makes it NaN, and an
+   Infinity element takes the total over unless it meets an Infinity of the
+   other sign, which is NaN. Without them the compensation computed
+   (inf - inf) and `[Float::INFINITY, 1.0].sum` answered NaN where Ruby
+   answers Infinity. Shared so the typed float sum and the boxed fold in
+   spinel_rt.h cannot drift apart. */
+static inline void sp_float_sum_step(sp_float *sum, sp_float *comp, sp_float x) {
+  sp_float f = *sum;
+  if (isnan(f)) return;
+  if (isnan(x)) { *sum = x; return; }
+  if (isinf(x)) {
+    *sum = (isinf(f) && signbit(x) != signbit(f)) ? (sp_float)NAN : x;
+    return;
+  }
+  if (isinf(f)) return;
+  {
+    sp_float t = f + x;
+    if (fabs(f) >= fabs(x)) *comp += (f - t) + x;
+    else *comp += (x - t) + f;
+    *sum = t;
+  }
+}
 
 /* ---- sp_FloatArray cold ops (compiled in lib/sp_array.c) ---- */
 void sp_FloatArray_unshift(sp_FloatArray *a, sp_float v);

--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -1723,6 +1723,26 @@ static sp_RbVal sp_poly_bitop(sp_RbVal a, sp_RbVal b, int op) {  /* 0:& 1:| 2:^ 
     sp_bool av = sp_poly_truthy(a), bv = sp_poly_truthy(b);
     return sp_box_bool(op == 0 ? (av && bv) : op == 1 ? (av || bv) : (av != bv));
   }
+  /* Two ARRAYS: `&` and `|` are Array's set operations, as `+` and `-` already
+     are on this path. Read as integer arithmetic they answered 0, so a fold
+     over an array of arrays lost its result silently (#3966). */
+  if (a.tag == SP_TAG_OBJ && sp_poly_is_array_kind(a.cls_id) &&
+      b.tag == SP_TAG_OBJ && sp_poly_is_array_kind(b.cls_id) && op != 2) {
+    SP_GC_ROOT_RBVAL(a); SP_GC_ROOT_RBVAL(b);
+    sp_PolyArray *pa = sp_poly_to_poly_array(a); SP_GC_ROOT(pa);
+    sp_PolyArray *pb = sp_poly_to_poly_array(b); SP_GC_ROOT(pb);
+    return sp_box_poly_array(op == 0 ? sp_PolyArray_intersect(pa, pb)
+                                     : sp_PolyArray_union(pa, pb));
+  }
+  /* Integer's own reading of the operator, and Integer's alone: a Float,
+     Rational or Complex receiver has no `&`, `|` or `^` in Ruby at all, and
+     reading it as an integer answered a bitwise result for the truncated
+     value. This has to come BEFORE the bignum arm below, which converts BOTH
+     sides with sp_poly_as_bigint -- a Bignum on either side otherwise carried
+     a Float or a String receiver into it as a zero. Everything with a meaning
+     of its own for the operator was answered above. */
+  if (a.tag != SP_TAG_INT && a.tag != SP_TAG_BIGINT)
+    return sp_poly_binop_bad(op == 0 ? "&" : op == 1 ? "|" : "^", a, b);
   /* A bignum operand keeps its width: truncating both sides to int64 first
      turned `x ^ (x << 17)` into a negative int once the shift had promoted,
      which is how a masked xorshift diverged from CRuby for good (#3371). `&`
@@ -1736,17 +1756,6 @@ static sp_RbVal sp_poly_bitop(sp_RbVal a, sp_RbVal b, int op) {  /* 0:& 1:| 2:^ 
                    : op == 1 ? sp_bigint_or(ba, bb) : sp_bigint_xor(ba, bb);
       return sp_box_bigint(r);
     }
-  }
-  /* Two ARRAYS: `&` and `|` are Array's set operations, as `+` and `-` already
-     are on this path. Read as integer arithmetic they answered 0, so a fold
-     over an array of arrays lost its result silently (#3966). */
-  if (a.tag == SP_TAG_OBJ && sp_poly_is_array_kind(a.cls_id) &&
-      b.tag == SP_TAG_OBJ && sp_poly_is_array_kind(b.cls_id) && op != 2) {
-    SP_GC_ROOT_RBVAL(a); SP_GC_ROOT_RBVAL(b);
-    sp_PolyArray *pa = sp_poly_to_poly_array(a); SP_GC_ROOT(pa);
-    sp_PolyArray *pb = sp_poly_to_poly_array(b); SP_GC_ROOT(pb);
-    return sp_box_poly_array(op == 0 ? sp_PolyArray_intersect(pa, pb)
-                                     : sp_PolyArray_union(pa, pb));
   }
   sp_int ai = sp_poly_to_i(a), bi = sp_poly_to_i(b);
   return sp_box_int(op == 0 ? (ai & bi) : op == 1 ? (ai | bi) : (ai ^ bi));
@@ -2142,18 +2151,41 @@ static sp_bool sp_complex_coerce_op_p(const char *op) {
   }
   return FALSE;
 }
+/* `& | ^ << >>` are Integer's alone: CRuby answers NoMethodError for a Float,
+   Rational or Complex receiver, not the coercion TypeError the arithmetic four
+   report. Array and String keep the ones they define. */
+static sp_bool sp_poly_bitop_name_p(const char *op) {
+  if (op[0] && !op[1]) return op[0] == '&' || op[0] == '|' || op[0] == '^';
+  return strcmp(op, "<<") == 0 || strcmp(op, ">>") == 0;
+}
 static sp_bool sp_poly_has_binop(sp_RbVal recv, const char *op) {
+  if (sp_poly_bitop_name_p(op)) {
+    if (recv.tag == SP_TAG_INT || recv.tag == SP_TAG_BIGINT) return TRUE;
+    if (recv.tag == SP_TAG_STR) return strcmp(op, "<<") == 0;   /* String#<< appends */
+    /* Array has `&`, `|` and `<<`, and none of `^ >> `. */
+    return recv.tag == SP_TAG_OBJ && recv.v.p &&
+           sp_poly_is_array_kind(recv.cls_id) &&
+           (op[0] == '&' || op[0] == '|' || strcmp(op, "<<") == 0);
+  }
   if (recv.tag == SP_TAG_INT || recv.tag == SP_TAG_FLT || recv.tag == SP_TAG_BIGINT)
     return TRUE;
   if (recv.tag == SP_TAG_STR)
     return strcmp(op, "+") == 0 || strcmp(op, "*") == 0;
   if (recv.tag == SP_TAG_OBJ && recv.v.p) {
+    /* Time has `+` and `-`; whatever it still refuses is a coercion failure,
+       not a missing method. */
+    if (recv.cls_id == SP_BUILTIN_TIME)
+      return strcmp(op, "+") == 0 || strcmp(op, "-") == 0;
     if (sp_poly_is_rational(recv) || sp_poly_is_brat(recv)) return TRUE;
     /* the same admitted set: saying no to the rest turns the failure into
        CRuby's NoMethodError, saying yes to these turns an operand Complex
        cannot coerce into CRuby's TypeError. */
     if (recv.cls_id == SP_BUILTIN_COMPLEX) return sp_complex_coerce_op_p(op);
-    if (sp_poly_is_array_kind(recv.cls_id)) return TRUE;
+    /* Array's arithmetic is `+`, `-` and `*` and stops there: `/`, `%` and
+       `**` are NoMethodError, which is what FALSE here reports. A Range has
+       none of these at all and reaches the same answer by having no arm. */
+    if (sp_poly_is_array_kind(recv.cls_id))
+      return strcmp(op, "+") == 0 || strcmp(op, "-") == 0 || strcmp(op, "*") == 0;
   }
   return FALSE;
 }
@@ -2200,6 +2232,38 @@ static sp_user_binop_fn sp_user_binop_hook = NULL;
 typedef sp_RbVal (*sp_user_coerce_fn)(const char *op, sp_RbVal recv, sp_RbVal obj, sp_bool *handled);
 static sp_user_coerce_fn sp_user_coerce_hook = NULL;
 static sp_bool sp_poly_numeric_p(sp_RbVal v);  /* fwd: the coerce guard below is numeric-only */
+SP_COLD static const char *sp_nomethod_msg(const char *m, sp_RbVal v);  /* fwd: spells nil/true/false as themselves */
+/* The numeric tower: the kinds an arithmetic arm below may convert. NOT
+   sp_poly_numeric_p, which guards the coerce protocol and has to stay
+   int/float/bigint. */
+static inline sp_bool sp_poly_tower_p(sp_RbVal v) {
+  if (v.tag == SP_TAG_INT || v.tag == SP_TAG_FLT || v.tag == SP_TAG_BIGINT) return TRUE;
+  return v.tag == SP_TAG_OBJ && v.v.p &&
+         (v.cls_id == SP_BUILTIN_RATIONAL || v.cls_id == SP_BUILTIN_BIG_RATIONAL ||
+          v.cls_id == SP_BUILTIN_COMPLEX);
+}
+/* The tower kinds that OWN an arm: a Bignum, Rational, BigRational or Complex
+   on EITHER side sends the pair to that arm, which converts the other side
+   with sp_poly_as_bigint / as_rational / as_complex -- and those read a
+   String, Array, Hash, nil or Symbol as ZERO. So `10**30 + "x"` answered the
+   Bignum where Ruby raises. An int or a float owns no such arm (every int and
+   float branch tests both tags), so a plain number beside a String already
+   falls through to the operator's own failure. */
+static inline sp_bool sp_poly_tower_arm_p(sp_RbVal v) {
+  if (v.tag == SP_TAG_BIGINT) return TRUE;
+  return v.tag == SP_TAG_OBJ && v.v.p &&
+         (v.cls_id == SP_BUILTIN_RATIONAL || v.cls_id == SP_BUILTIN_BIG_RATIONAL ||
+          v.cls_id == SP_BUILTIN_COMPLEX);
+}
+/* An arm-owning operand beside something that is no number at all: there is no
+   arm to reach, and the failure belongs to the operator. sp_poly_binop_bad
+   words it as Ruby does -- "String can't be coerced into Integer" from the
+   Bignum's side, "no implicit conversion of Integer into String" from the
+   String's. Asked once at the head of each of the six arithmetic ops. */
+static inline sp_bool sp_poly_tower_mismatch(sp_RbVal a, sp_RbVal b) {
+  return (sp_poly_tower_arm_p(a) || sp_poly_tower_arm_p(b)) &&
+         (!sp_poly_tower_p(a) || !sp_poly_tower_p(b));
+}
 static sp_RbVal sp_poly_binop_bad(const char *op, sp_RbVal recv, sp_RbVal arg) {
   if (recv.tag == SP_TAG_OBJ && recv.cls_id >= 0 && sp_user_binop_hook) {
     sp_bool _h = FALSE;
@@ -2220,8 +2284,11 @@ static sp_RbVal sp_poly_binop_bad(const char *op, sp_RbVal recv, sp_RbVal arg) {
     if (_h) return _r;
   }
   const char *rc = sp_poly_class_name(recv);
+  /* CRuby names nil, true and false as THEMSELVES here, not as instances of
+     their classes -- `[1, 2].reduce(nil, :+)` reads "undefined method '+' for
+     nil". sp_nomethod_msg is where that wording already lives. */
   if (!sp_poly_has_binop(recv, op))
-    sp_raise_cls("NoMethodError", sp_sprintf("undefined method '%s' for an instance of %s", op, rc));
+    sp_raise_cls("NoMethodError", sp_nomethod_msg(op, recv));
   /* CRuby names the offending value by its class, EXCEPT nil/true/false, which
      it spells as themselves -- and the two messages disagree about Symbol:
      "no implicit conversion" says Symbol, "can't be coerced" says :sym. */
@@ -2241,14 +2308,14 @@ static inline int sp_poly_is_user_obj(sp_RbVal v) {
   return v.tag == SP_TAG_OBJ && v.cls_id >= 0;
 }
 static int sp_poly_user_cmp(const char *op, sp_RbVal a, sp_RbVal b, sp_RbVal *out);  /* fwd */
-static sp_RbVal sp_poly_add(sp_RbVal a, sp_RbVal b) { /* Two plain numbers are what a boxed arithmetic loop actually holds, and the tower checks below cannot match either tag: answer them first rather than after eight of them (#3984). */ if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f + b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(add, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f + (sp_float)b.v.i); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i + b.v.f); /* a user object on either side belongs to the binop hook and the coerce protocol, not to the tower branches below -- those match on the RECEIVER kind and would convert the object to a number of that kind */ if (SP_UNLIKELY(sp_poly_is_user_obj(a) || sp_poly_is_user_obj(b))) return sp_poly_binop_bad("+", a, b); if ((a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_COMPLEX) || (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_COMPLEX)) return sp_box_complex(sp_complex_add(sp_poly_as_complex(a), sp_poly_as_complex(b))); if ((sp_poly_is_brat(a) || sp_poly_is_brat(b))) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) + sp_poly_to_f(b)); return sp_brat_add_poly(a, b); } if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && a.tag != SP_TAG_FLT && b.tag != SP_TAG_FLT) return sp_box_rational(sp_rational_add(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT)) return sp_box_float(sp_poly_to_f_with_rational(a) + sp_poly_to_f_with_rational(b)); if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) + sp_poly_to_f(b)); return sp_box_bigint(sp_bigint_add(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); } if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(add, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f + b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i + b.v.f); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f + (sp_float)b.v.i); if (a.tag == SP_TAG_STR && b.tag == SP_TAG_STR) return sp_box_str(sp_str_concat(a.v.s, b.v.s)); if (a.tag == SP_TAG_OBJ && sp_poly_is_array_kind(a.cls_id) && b.tag == SP_TAG_OBJ && sp_poly_is_array_kind(b.cls_id)) { SP_GC_ROOT_RBVAL(a); SP_GC_ROOT_RBVAL(b); sp_PolyArray *pa = sp_poly_to_poly_array(a); SP_GC_ROOT(pa); sp_PolyArray *pb = sp_poly_to_poly_array(b); SP_GC_ROOT(pb); return sp_box_poly_array(sp_PolyArray_concat(pa, pb)); } if (a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_TIME) { if (b.tag == SP_TAG_INT) return sp_box_time(sp_time_add_i(*(sp_Time *)a.v.p, b.v.i)); if (b.tag == SP_TAG_FLT) return sp_box_time(sp_time_add_f(*(sp_Time *)a.v.p, b.v.f)); } if (sp_poly_is_strbuf(a) || sp_poly_is_strbuf(b)) return sp_poly_add(sp_poly_strbuf_deref(a), sp_poly_strbuf_deref(b)); return sp_poly_binop_bad("+", a, b); }
-static sp_RbVal sp_poly_sub(sp_RbVal a, sp_RbVal b) { /* Two plain numbers are what a boxed arithmetic loop actually holds, and the tower checks below cannot match either tag: answer them first rather than after eight of them (#3984). */ if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f - b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(sub, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f - (sp_float)b.v.i); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i - b.v.f); /* a user object on either side belongs to the binop hook and the coerce protocol, not to the tower branches below -- those match on the RECEIVER kind and would convert the object to a number of that kind */ if (SP_UNLIKELY(sp_poly_is_user_obj(a) || sp_poly_is_user_obj(b))) return sp_poly_binop_bad("-", a, b); if ((a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_COMPLEX) || (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_COMPLEX)) return sp_box_complex(sp_complex_sub(sp_poly_as_complex(a), sp_poly_as_complex(b))); if ((sp_poly_is_brat(a) || sp_poly_is_brat(b))) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) - sp_poly_to_f(b)); return sp_brat_sub_poly(a, b); } if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && a.tag != SP_TAG_FLT && b.tag != SP_TAG_FLT) return sp_box_rational(sp_rational_sub(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT)) return sp_box_float(sp_poly_to_f_with_rational(a) - sp_poly_to_f_with_rational(b)); if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) - sp_poly_to_f(b)); return sp_box_bigint(sp_bigint_sub(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); } if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(sub, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f - b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i - b.v.f); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f - (sp_float)b.v.i); if (a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_TIME) { if (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_TIME) return sp_box_float(sp_time_sub_t(*(sp_Time *)a.v.p, *(sp_Time *)b.v.p)); if (b.tag == SP_TAG_INT) return sp_box_time(sp_time_sub_i(*(sp_Time *)a.v.p, b.v.i)); if (b.tag == SP_TAG_FLT) return sp_box_time(sp_time_add_f(*(sp_Time *)a.v.p, -b.v.f)); }
+static sp_RbVal sp_poly_add(sp_RbVal a, sp_RbVal b) { /* Two plain numbers are what a boxed arithmetic loop actually holds, and the tower checks below cannot match either tag: answer them first rather than after eight of them (#3984). */ if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f + b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(add, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f + (sp_float)b.v.i); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i + b.v.f); /* a user object on either side belongs to the binop hook and the coerce protocol, not to the tower branches below -- those match on the RECEIVER kind and would convert the object to a number of that kind */ if (SP_UNLIKELY(sp_poly_is_user_obj(a) || sp_poly_is_user_obj(b))) return sp_poly_binop_bad("+", a, b); /* A shared-mutable string handle behaves as its live string VALUE for every non-mutating operator, so it has to become one BEFORE the rules below read its kind -- reached as a handle it is neither a String nor a number, and the guard reported a missing method for an operator String has. */ if (SP_UNLIKELY(sp_poly_is_strbuf(a) || sp_poly_is_strbuf(b))) return sp_poly_add(sp_poly_strbuf_deref(a), sp_poly_strbuf_deref(b)); /* Time arithmetic takes any real number of the tower -- an offset may be a Rational or a Bignum -- so it answers before the guard below, which would otherwise call the pair a coercion failure. */ if (SP_UNLIKELY(a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_TIME && a.v.p)) { if (b.tag == SP_TAG_INT) return sp_box_time(sp_time_add_i(*(sp_Time *)a.v.p, b.v.i)); if (sp_poly_tower_p(b) && !(b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_COMPLEX)) return sp_box_time(sp_time_add_f(*(sp_Time *)a.v.p, sp_poly_to_f_with_rational(b))); } if (SP_UNLIKELY(sp_poly_tower_mismatch(a, b))) return sp_poly_binop_bad("+", a, b); if ((a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_COMPLEX) || (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_COMPLEX)) return sp_box_complex(sp_complex_add(sp_poly_as_complex(a), sp_poly_as_complex(b))); if ((sp_poly_is_brat(a) || sp_poly_is_brat(b))) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) + sp_poly_to_f(b)); return sp_brat_add_poly(a, b); } if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && a.tag != SP_TAG_FLT && b.tag != SP_TAG_FLT) return sp_box_rational(sp_rational_add(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT)) return sp_box_float(sp_poly_to_f_with_rational(a) + sp_poly_to_f_with_rational(b)); if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) + sp_poly_to_f(b)); return sp_box_bigint(sp_bigint_add(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); } if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(add, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f + b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i + b.v.f); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f + (sp_float)b.v.i); if (a.tag == SP_TAG_STR && b.tag == SP_TAG_STR) return sp_box_str(sp_str_concat(a.v.s, b.v.s)); if (a.tag == SP_TAG_OBJ && sp_poly_is_array_kind(a.cls_id) && b.tag == SP_TAG_OBJ && sp_poly_is_array_kind(b.cls_id)) { SP_GC_ROOT_RBVAL(a); SP_GC_ROOT_RBVAL(b); sp_PolyArray *pa = sp_poly_to_poly_array(a); SP_GC_ROOT(pa); sp_PolyArray *pb = sp_poly_to_poly_array(b); SP_GC_ROOT(pb); return sp_box_poly_array(sp_PolyArray_concat(pa, pb)); } return sp_poly_binop_bad("+", a, b); }
+static sp_RbVal sp_poly_sub(sp_RbVal a, sp_RbVal b) { /* Two plain numbers are what a boxed arithmetic loop actually holds, and the tower checks below cannot match either tag: answer them first rather than after eight of them (#3984). */ if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f - b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(sub, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f - (sp_float)b.v.i); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i - b.v.f); /* a user object on either side belongs to the binop hook and the coerce protocol, not to the tower branches below -- those match on the RECEIVER kind and would convert the object to a number of that kind */ if (SP_UNLIKELY(sp_poly_is_user_obj(a) || sp_poly_is_user_obj(b))) return sp_poly_binop_bad("-", a, b); /* A shared-mutable string handle behaves as its live string VALUE for every non-mutating operator, so it has to become one BEFORE the rules below read its kind -- reached as a handle it is neither a String nor a number, and the guard reported a missing method for an operator String has. */ if (SP_UNLIKELY(sp_poly_is_strbuf(a) || sp_poly_is_strbuf(b))) return sp_poly_sub(sp_poly_strbuf_deref(a), sp_poly_strbuf_deref(b)); /* see sp_poly_add: Time answers before the guard, and Time - Time is a Float count of seconds. */ if (SP_UNLIKELY(a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_TIME && a.v.p)) { if (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_TIME && b.v.p) return sp_box_float(sp_time_sub_t(*(sp_Time *)a.v.p, *(sp_Time *)b.v.p)); if (b.tag == SP_TAG_INT) return sp_box_time(sp_time_sub_i(*(sp_Time *)a.v.p, b.v.i)); if (sp_poly_tower_p(b) && !(b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_COMPLEX)) return sp_box_time(sp_time_add_f(*(sp_Time *)a.v.p, -sp_poly_to_f_with_rational(b))); } if (SP_UNLIKELY(sp_poly_tower_mismatch(a, b))) return sp_poly_binop_bad("-", a, b); if ((a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_COMPLEX) || (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_COMPLEX)) return sp_box_complex(sp_complex_sub(sp_poly_as_complex(a), sp_poly_as_complex(b))); if ((sp_poly_is_brat(a) || sp_poly_is_brat(b))) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) - sp_poly_to_f(b)); return sp_brat_sub_poly(a, b); } if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && a.tag != SP_TAG_FLT && b.tag != SP_TAG_FLT) return sp_box_rational(sp_rational_sub(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT)) return sp_box_float(sp_poly_to_f_with_rational(a) - sp_poly_to_f_with_rational(b)); if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) - sp_poly_to_f(b)); return sp_box_bigint(sp_bigint_sub(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); } if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(sub, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f - b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i - b.v.f); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f - (sp_float)b.v.i);
   /* two Arrays: the set difference, mirroring the concat branch sp_poly_add
      has. Without it a poly-carried Array pair reached the failure message,
      which then read "no implicit conversion of Array into Array" (#3475). */
   if (a.tag == SP_TAG_OBJ && sp_poly_is_array_kind(a.cls_id) && b.tag == SP_TAG_OBJ && sp_poly_is_array_kind(b.cls_id)) { SP_GC_ROOT_RBVAL(a); SP_GC_ROOT_RBVAL(b); sp_PolyArray *pa = sp_poly_to_poly_array(a); SP_GC_ROOT(pa); sp_PolyArray *pb = sp_poly_to_poly_array(b); SP_GC_ROOT(pb); return sp_box_poly_array(sp_PolyArray_difference(pa, pb)); }
   return sp_poly_binop_bad("-", a, b); }
-static sp_RbVal sp_poly_mul(sp_RbVal a, sp_RbVal b) { /* Two plain numbers are what a boxed arithmetic loop actually holds, and the tower checks below cannot match either tag: answer them first rather than after eight of them (#3984). */ if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f * b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(mul, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f * (sp_float)b.v.i); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i * b.v.f); /* a user object on either side belongs to the binop hook and the coerce protocol, not to the tower branches below -- those match on the RECEIVER kind and would convert the object to a number of that kind */ if (SP_UNLIKELY(sp_poly_is_user_obj(a) || sp_poly_is_user_obj(b))) return sp_poly_binop_bad("*", a, b); if ((a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_COMPLEX) || (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_COMPLEX)) return sp_box_complex(sp_complex_mul(sp_poly_as_complex(a), sp_poly_as_complex(b))); if ((sp_poly_is_brat(a) || sp_poly_is_brat(b))) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) * sp_poly_to_f(b)); return sp_brat_mul_poly(a, b); } if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && a.tag != SP_TAG_FLT && b.tag != SP_TAG_FLT) return sp_box_rational(sp_rational_mul(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT)) return sp_box_float(sp_poly_to_f_with_rational(a) * sp_poly_to_f_with_rational(b)); if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) * sp_poly_to_f(b)); return sp_box_bigint(sp_bigint_mul(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); } if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(mul, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f * b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i * b.v.f); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f * (sp_float)b.v.i); if (a.tag == SP_TAG_STR && b.tag == SP_TAG_INT) return a.v.s ? sp_box_str(sp_str_repeat(a.v.s, b.v.i)) : a; /* String#*; NULL is the empty string */ if (sp_poly_is_strbuf(a) || sp_poly_is_strbuf(b)) return sp_poly_mul(sp_poly_strbuf_deref(a), sp_poly_strbuf_deref(b)); return sp_poly_binop_bad("*", a, b); }
+static sp_RbVal sp_poly_mul(sp_RbVal a, sp_RbVal b) { /* Two plain numbers are what a boxed arithmetic loop actually holds, and the tower checks below cannot match either tag: answer them first rather than after eight of them (#3984). */ if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f * b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(mul, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f * (sp_float)b.v.i); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i * b.v.f); /* a user object on either side belongs to the binop hook and the coerce protocol, not to the tower branches below -- those match on the RECEIVER kind and would convert the object to a number of that kind */ if (SP_UNLIKELY(sp_poly_is_user_obj(a) || sp_poly_is_user_obj(b))) return sp_poly_binop_bad("*", a, b); /* A shared-mutable string handle behaves as its live string VALUE for every non-mutating operator, so it has to become one BEFORE the rules below read its kind -- reached as a handle it is neither a String nor a number, and the guard reported a missing method for an operator String has. */ if (SP_UNLIKELY(sp_poly_is_strbuf(a) || sp_poly_is_strbuf(b))) return sp_poly_mul(sp_poly_strbuf_deref(a), sp_poly_strbuf_deref(b)); if (SP_UNLIKELY(sp_poly_tower_mismatch(a, b))) return sp_poly_binop_bad("*", a, b); if ((a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_COMPLEX) || (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_COMPLEX)) return sp_box_complex(sp_complex_mul(sp_poly_as_complex(a), sp_poly_as_complex(b))); if ((sp_poly_is_brat(a) || sp_poly_is_brat(b))) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) * sp_poly_to_f(b)); return sp_brat_mul_poly(a, b); } if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && a.tag != SP_TAG_FLT && b.tag != SP_TAG_FLT) return sp_box_rational(sp_rational_mul(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT)) return sp_box_float(sp_poly_to_f_with_rational(a) * sp_poly_to_f_with_rational(b)); if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) * sp_poly_to_f(b)); return sp_box_bigint(sp_bigint_mul(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); } if (a.tag == SP_TAG_INT && b.tag == SP_TAG_INT) return SP_POLY_INT_OP(mul, a.v.i, b.v.i); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_FLT) return sp_box_float(a.v.f * b.v.f); if (a.tag == SP_TAG_INT && b.tag == SP_TAG_FLT) return sp_box_float((sp_float)a.v.i * b.v.f); if (a.tag == SP_TAG_FLT && b.tag == SP_TAG_INT) return sp_box_float(a.v.f * (sp_float)b.v.i); if (a.tag == SP_TAG_STR && b.tag == SP_TAG_INT) return a.v.s ? sp_box_str(sp_str_repeat(a.v.s, b.v.i)) : a; /* String#*; NULL is the empty string */ return sp_poly_binop_bad("*", a, b); }
 static SP_NOINLINE sp_int sp_poly_to_i_cold(sp_RbVal v);
 /* Int and float are what an unboxed integer slot is fed in a hot loop; every
    other kind -- bigint, a numeric string, a Rational, a Time -- goes out of
@@ -2581,7 +2648,6 @@ static sp_bool sp_poly_hash_subset(sp_RbVal a, sp_RbVal b, int strict) {
    String slot and never rescues a receiver (CRuby raises for `Pathname#upcase`
    even though Pathname defines #to_str). A shared-mutable string is a builtin
    OBJ box, not SP_TAG_STR, and is a string. */
-SP_COLD static const char *sp_nomethod_msg(const char *m, sp_RbVal v);   /* below */
 static const char *sp_poly_recv_s(sp_RbVal v, const char *meth) {
   if (v.tag == SP_TAG_STR) return v.v.s ? v.v.s : sp_str_empty;
   if (sp_poly_is_strbuf(v)) return sp_poly_to_s(v);
@@ -2622,6 +2688,9 @@ static sp_float sp_poly_Float(sp_RbVal v) {
   if (v.tag == SP_TAG_FLT) return v.v.f;
   if (v.tag == SP_TAG_INT) return (sp_float)v.v.i;
   if (v.tag == SP_TAG_BIGINT) return sp_poly_to_f(v);
+  /* a Rational is a real number Kernel#Float converts (Float(1/2r) is 0.5);
+     without an arm it reached the raise below as "can't convert Rational" */
+  if (sp_poly_is_rational(v) || sp_poly_is_brat(v)) return sp_poly_to_f(v);
   if (v.tag == SP_TAG_STR) return sp_str_to_f_strict(v.v.s ? v.v.s : sp_str_empty);
   sp_raise_cls("TypeError", sp_sprintf("can't convert %s into Float", sp_convert_src_name(v)));
   return 0.0;
@@ -3159,9 +3228,9 @@ static void sp_sort_idx_by_poly(sp_int *idx, const sp_RbVal *keys, sp_int n) {
   if (src != idx) for (sp_int x = 0; x < n; x++) idx[x] = src[x];   /* odd #levels: result is in tmp */
   free(tmp);
 }
-static sp_RbVal sp_poly_div(sp_RbVal a, sp_RbVal b) { /* before the tower branches, which match on the receiver kind and would convert a user object to a number of that kind */ if (SP_UNLIKELY(sp_poly_is_user_obj(a) || sp_poly_is_user_obj(b))) return sp_poly_binop_bad("/", a, b); if ((sp_poly_is_brat(a) || sp_poly_is_brat(b))) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) / sp_poly_to_f(b)); return sp_brat_div_poly(a, b); } if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && a.tag != SP_TAG_FLT && b.tag != SP_TAG_FLT) return sp_box_rational(sp_rational_div(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_COMPLEX) || (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_COMPLEX)) return sp_box_complex(sp_complex_div(sp_poly_as_complex(a), sp_poly_as_complex(b))); if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f_with_rational(a) / sp_poly_to_f_with_rational(b)); if ((a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT)) return sp_box_bigint(sp_bigint_div(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); return sp_box_int(sp_idiv(sp_poly_to_i(a), sp_poly_to_i(b))); }
+static sp_RbVal sp_poly_div(sp_RbVal a, sp_RbVal b) { /* before the tower branches, which match on the receiver kind and would convert a user object to a number of that kind */ if (SP_UNLIKELY(sp_poly_is_user_obj(a) || sp_poly_is_user_obj(b))) return sp_poly_binop_bad("/", a, b); if (SP_UNLIKELY(sp_poly_is_strbuf(a) || sp_poly_is_strbuf(b))) return sp_poly_div(sp_poly_strbuf_deref(a), sp_poly_strbuf_deref(b)); if (SP_UNLIKELY(sp_poly_tower_mismatch(a, b))) return sp_poly_binop_bad("/", a, b); if ((sp_poly_is_brat(a) || sp_poly_is_brat(b))) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f(a) / sp_poly_to_f(b)); return sp_brat_div_poly(a, b); } if ((sp_poly_is_rational(a) || sp_poly_is_rational(b)) && a.tag != SP_TAG_FLT && b.tag != SP_TAG_FLT) return sp_box_rational(sp_rational_div(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((a.tag == SP_TAG_OBJ && a.cls_id == SP_BUILTIN_COMPLEX) || (b.tag == SP_TAG_OBJ && b.cls_id == SP_BUILTIN_COMPLEX)) return sp_box_complex(sp_complex_div(sp_poly_as_complex(a), sp_poly_as_complex(b))); if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_poly_to_f_with_rational(a) / sp_poly_to_f_with_rational(b)); if ((a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT)) return sp_box_bigint(sp_bigint_div(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); return sp_box_int(sp_idiv(sp_poly_to_i(a), sp_poly_to_i(b))); }
 static sp_RbVal sp_poly_str_mod(sp_RbVal a, sp_RbVal b);  /* fwd: defined beside the format helper */
-static sp_RbVal sp_poly_mod(sp_RbVal a, sp_RbVal b) { if (a.tag == SP_TAG_STR || sp_poly_is_strbuf(a)) return sp_poly_str_mod(sp_poly_strbuf_deref(a), b); /* the user-object arm has to come before the float one: a Float on either side otherwise converted the object to a number (0.0) and answered a division by zero where CRuby coerces. */ if (sp_poly_is_user_obj(a) || sp_poly_is_user_obj(b)) return sp_poly_binop_bad("%", a, b); if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_fmod(sp_poly_to_f(a), sp_poly_to_f(b))); if (sp_poly_is_rational(a) || sp_poly_is_rational(b)) return sp_box_rational(sp_rational_mod(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT)) return sp_box_bigint(sp_bigint_mod(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); return sp_box_int(sp_imod(sp_poly_to_i(a), sp_poly_to_i(b))); }  /* sp_fmod: CRuby divisor-sign result + zero-divisor raise */
+static sp_RbVal sp_poly_mod(sp_RbVal a, sp_RbVal b) { if (a.tag == SP_TAG_STR || sp_poly_is_strbuf(a)) return sp_poly_str_mod(sp_poly_strbuf_deref(a), b); /* the user-object arm has to come before the float one: a Float on either side otherwise converted the object to a number (0.0) and answered a division by zero where CRuby coerces. */ if (sp_poly_is_user_obj(a) || sp_poly_is_user_obj(b)) return sp_poly_binop_bad("%", a, b); /* a strbuf RECEIVER already returned through sp_poly_str_mod above */ if (SP_UNLIKELY(sp_poly_is_strbuf(b))) return sp_poly_mod(a, sp_poly_strbuf_deref(b)); if (SP_UNLIKELY(sp_poly_tower_mismatch(a, b))) return sp_poly_binop_bad("%", a, b); if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_box_float(sp_fmod(sp_poly_to_f(a), sp_poly_to_f(b))); if (sp_poly_is_rational(a) || sp_poly_is_rational(b)) return sp_box_rational(sp_rational_mod(sp_poly_as_rational(a), sp_poly_as_rational(b))); if ((a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT)) return sp_box_bigint(sp_bigint_mod(sp_poly_as_bigint(a), sp_poly_as_bigint(b))); return sp_box_int(sp_imod(sp_poly_to_i(a), sp_poly_to_i(b))); }  /* sp_fmod: CRuby divisor-sign result + zero-divisor raise */
 /* divmod / quo on a boxed receiver. The typed paths build these inline per
    receiver kind; the poly path had neither, so an exact Rational reaching them
    through a block parameter raised NoMethodError on a method it answers (#3512).
@@ -3370,6 +3439,9 @@ static sp_RbVal sp_poly_pow(sp_RbVal a, sp_RbVal b) {
     return sp_box_bigint(sp_bigint_pow((sp_Bigint *)a.v.p, e));
   }
   if (sp_poly_is_user_obj(a) || sp_poly_is_user_obj(b)) return sp_poly_binop_bad("**", a, b);
+  if (SP_UNLIKELY(sp_poly_is_strbuf(a) || sp_poly_is_strbuf(b)))
+    return sp_poly_pow(sp_poly_strbuf_deref(a), sp_poly_strbuf_deref(b));
+  if (SP_UNLIKELY(sp_poly_tower_mismatch(a, b))) return sp_poly_binop_bad("**", a, b);
   /* An exact receiver keeps its class through `**`, as it does on the typed
      path: a Rational raised to an integer is a Rational, and a Complex is a
      Complex. Falling to pow(double, double) evaluated them in floats, which is
@@ -3412,6 +3484,8 @@ static sp_RbVal sp_poly_shr(sp_RbVal a, sp_RbVal b) {
   if (a.tag == SP_TAG_BIGINT)
     return sp_box_bigint(sp_bigint_shr((sp_Bigint *)a.v.p, (int64_t)sp_poly_to_i(b)));
   if (sp_poly_is_user_obj(a)) return sp_poly_binop_bad(">>", a, b);
+  /* Integer#>> is Integer's alone (see sp_poly_bitop) */
+  if (a.tag != SP_TAG_INT) return sp_poly_binop_bad(">>", a, b);
   return sp_box_int(sp_poly_to_i(a) >> sp_poly_to_i(b));
 }
 /* & | ^ are boolean operators on a nil/boolean receiver (NilClass#& is
@@ -3434,6 +3508,8 @@ static sp_RbVal sp_poly_band(sp_RbVal a, sp_RbVal b) {
     return sp_box_poly_array(sp_PolyArray_intersect(pa, pb));
   }
   if (sp_poly_is_user_obj(a)) return sp_poly_binop_bad("&", a, b);
+  /* Integer#& is Integer's alone (see sp_poly_bitop) */
+  if (a.tag != SP_TAG_INT && a.tag != SP_TAG_BIGINT) return sp_poly_binop_bad("&", a, b);
   return sp_box_int(sp_poly_to_i(a) & sp_poly_to_i(b));
 }
 static sp_RbVal sp_poly_bor(sp_RbVal a, sp_RbVal b) {
@@ -3446,12 +3522,16 @@ static sp_RbVal sp_poly_bor(sp_RbVal a, sp_RbVal b) {
     return sp_box_poly_array(sp_PolyArray_union(pa, pb));
   }
   if (sp_poly_is_user_obj(a)) return sp_poly_binop_bad("|", a, b);
+  /* Integer#| is Integer's alone (see sp_poly_bitop) */
+  if (a.tag != SP_TAG_INT && a.tag != SP_TAG_BIGINT) return sp_poly_binop_bad("|", a, b);
   return sp_box_int(sp_poly_to_i(a) | sp_poly_to_i(b));
 }
 static sp_RbVal sp_poly_bxor(sp_RbVal a, sp_RbVal b) {
   if (a.tag == SP_TAG_NIL) return sp_box_bool(sp_poly_truthy(b));
   if (a.tag == SP_TAG_BOOL) return sp_box_bool(a.v.b != sp_poly_truthy(b));
   if (sp_poly_is_user_obj(a)) return sp_poly_binop_bad("^", a, b);
+  /* Integer#^ is Integer's alone (see sp_poly_bitop) */
+  if (a.tag != SP_TAG_INT && a.tag != SP_TAG_BIGINT) return sp_poly_binop_bad("^", a, b);
   return sp_box_int(sp_poly_to_i(a) ^ sp_poly_to_i(b));
 }
 /* Unary minus on a boxed value. Only Float and Integer were handled, and
@@ -3611,6 +3691,9 @@ static sp_RbVal sp_poly_shl(sp_RbVal a, sp_RbVal b) {
      gave 0 where CRuby raises RangeError (#4015). */
   if (a.tag == SP_TAG_STR && (b.tag == SP_TAG_INT || b.tag == SP_TAG_BIGINT))
     return sp_box_str(sp_str_concat(a.v.s, sp_int_codepoint_to_str(sp_poly_to_i(b))));
+  /* Integer#<< is Integer's alone (see sp_poly_bitop); Array, String, IO,
+     Queue, Proc and a user class were all answered above. */
+  if (a.tag != SP_TAG_INT && a.tag != SP_TAG_BIGINT) return sp_poly_binop_bad("<<", a, b);
   /* Integer#<<. A Bignum receiver shifts as a Bignum; an int receiver whose
      result escapes the word promotes under --int-overflow=promote and
      raises/wraps per mode otherwise (sp_int_shl carries those semantics). */
@@ -7635,20 +7718,111 @@ static sp_RbVal sp_poly_sum(sp_RbVal v) {
     }
   }
 }
-/* sum(seed) over a container-read row: accumulate through sp_poly_add from
-   the boxed seed, so Rational/Float/Bignum seeds and elements combine with
-   full numeric-tower semantics (#3234). */
+static sp_PolyArray *sp_poly_to_a_arr(sp_RbVal v);  /* defined below; hash -> pairs */
+/* Range#sum(seed). CRuby's range_sum adds the closed form to an INTEGER seed
+   and, for a seed of any other class, converts it with Kernel#Float and
+   answers a Float -- so a Rational seed makes the whole sum a Float and a
+   String seed raises ArgumentError from the conversion, not from the addition.
+   An EMPTY range never touches the seed and answers it unchanged. */
+static sp_RbVal sp_range_sum_seed(sp_Range r, sp_RbVal seed) {
+  if (sp_range_count(r) <= 0) return seed;
+  SP_GC_ROOT_RBVAL(seed);
+  sp_IntArray *ia = sp_range_to_ia(r);
+  SP_GC_ROOT(ia);
+  sp_int total = sp_IntArray_sum(ia, 0);
+  /* through sp_poly_add so a Bignum seed keeps its digits instead of wrapping
+     into the sp_int the typed emitter used to hand this path */
+  if (seed.tag == SP_TAG_INT || seed.tag == SP_TAG_BIGINT)
+    return sp_poly_add(sp_box_int(total), seed);
+  return sp_box_float(sp_poly_Float(seed) + (sp_float)total);
+}
+/* Is this a value CRuby's Array#sum keeps in its EXACT accumulation phase --
+   the Integer/Rational family, which adds without dropping a digit? A Float is
+   not one: it opens the compensated phase below instead. */
+static sp_bool sp_poly_sum_exact_p(sp_RbVal v) {
+  return v.tag == SP_TAG_INT || v.tag == SP_TAG_BIGINT ||
+         sp_poly_is_rational(v) || sp_poly_is_brat(v);
+}
+/* One element of the summed collection: an array reads its own storage, every
+   other receiver had its elements materialized once by the caller. */
+static sp_RbVal sp_poly_sum_item(sp_RbVal v, sp_PolyArray *items, sp_int i) {
+  return items ? sp_PolyArray_get(items, i) : sp_poly_arr_get(v, i);
+}
+/* sum(seed): CRuby's Array#sum, which is also the code Enumerable#sum runs for
+   a Hash's pairs and for a String-bounded Range. Three phases, in order: an
+   EXACT one while the seed and the elements are Integers or Rationals, so a
+   Bignum seed keeps its digits and a Rational one stays a Rational; from the
+   first Float onward the compensated summation sp_FloatArray_sum uses, started
+   at the exact total; and plain `+` for the rest -- which is where the raise
+   CRuby answers for a nil, String or Array seed comes from. A seed of no
+   numeric class has no exact phase at all and takes that last one from the
+   first element (#3234). */
 static sp_RbVal sp_poly_sum_seed(sp_RbVal v, sp_RbVal seed) {
-  sp_RbVal acc = seed;
   /* On a String the argument is the bit width of the checksum, not a seed. */
   if (v.tag == SP_TAG_STR || sp_poly_is_strbuf(v))
     return sp_box_int(sp_str_sum_bits(sp_poly_strbuf_deref(v).v.s, sp_poly_to_i(seed)));
-  if (v.tag != SP_TAG_OBJ || !sp_poly_is_array_kind(v.cls_id)) return acc;
-  sp_int n = sp_poly_length(v);
-  for (sp_int i = 0; i < n; i++) acc = sp_poly_add(acc, sp_poly_arr_get(v, i));
+  /* An Integer Range sums by its own rule, which the element walk below cannot
+     express -- and with no arm at all it simply handed the seed back. */
+  if (v.tag == SP_TAG_OBJ && v.cls_id == SP_BUILTIN_RANGE && v.v.p)
+    return sp_range_sum_seed(*(sp_Range *)v.v.p, seed);
+  SP_GC_ROOT_RBVAL(v);
+  SP_GC_ROOT_RBVAL(seed);
+  /* The elements Enumerable#sum folds: an array's own, a Hash's [k, v] pairs,
+     a String range's members, an Enumerator's or a user Enumerable's. A
+     receiver that is no collection at all adds nothing and answers the seed. */
+  sp_PolyArray *items = NULL;
+  SP_GC_ROOT(items);
+  sp_int n = 0;
+  if (v.tag == SP_TAG_OBJ && sp_poly_is_array_kind(v.cls_id)) n = sp_poly_length(v);
+  else if (v.tag == SP_TAG_OBJ &&
+           (sp_poly_is_hash_kind(v.cls_id) || v.cls_id == SP_BUILTIN_STR_RANGE ||
+            v.cls_id == SP_BUILTIN_ENUMERATOR)) {
+    items = sp_poly_to_a_arr(v);
+    n = items ? items->len : 0;
+  }
+  else if (v.tag == SP_TAG_OBJ && v.cls_id >= 0) {
+    items = sp_poly_user_elems(v);
+    if (!items) return seed;
+    n = items->len;
+  }
+  else return seed;
+  sp_RbVal acc = seed;
+  SP_GC_ROOT_RBVAL(acc);
+  sp_int i = 0;
+  /* Only a seed of the numeric tower has an exact or a compensated phase at
+     all: nil, a String, an Array start at plain `+` from the first element,
+     which is the whole point -- that is the operator whose failure CRuby
+     reports. */
+  sp_bool numeric_seed = sp_poly_sum_exact_p(acc) || acc.tag == SP_TAG_FLT;
+  if (sp_poly_sum_exact_p(acc)) {
+    for (; i < n; i++) {
+      sp_RbVal e = sp_poly_sum_item(v, items, i);
+      if (!sp_poly_sum_exact_p(e)) break;
+      acc = sp_poly_add(acc, e);
+    }
+  }
+  /* The compensated phase, entered from a Float seed or from the first Float
+     element -- and running the very step sp_FloatArray_sum runs, NaN and
+     Infinity arms included. `e` is carried across the turn boundary so the
+     element that decided the entry is not read a second time. */
+  if (numeric_seed && i < n) {
+    sp_RbVal e = sp_poly_sum_item(v, items, i);
+    if (acc.tag == SP_TAG_FLT || e.tag == SP_TAG_FLT) {
+      sp_float f = sp_poly_to_f(acc), c = 0.0;
+      while (i < n && (e.tag == SP_TAG_FLT || sp_poly_sum_exact_p(e))) {
+        sp_float_sum_step(&f, &c, sp_poly_to_f(e));
+        if (++i < n) e = sp_poly_sum_item(v, items, i);
+      }
+      /* CRuby folds the compensation back only when the run reaches the END of
+         the elements: its `not_float:` label takes DBL2NUM(f) alone, so
+         `[0.1, 0.2, 0.3, Complex(0, 1)].sum(0.0)` keeps the uncompensated
+         0.6000000000000001 before the Complex is added. */
+      acc = sp_box_float(i < n ? f : f + c);
+    }
+  }
+  for (; i < n; i++) acc = sp_poly_add(acc, sp_poly_sum_item(v, items, i));
   return acc;
 }
-static sp_PolyArray *sp_poly_to_a_arr(sp_RbVal v);  /* defined below; hash -> pairs */
 static sp_PolyArray *sp_enum_to_a_boxed(sp_RbVal v);  /* defined below, after sp_enum.h */
 /* The count-taking reads of Array's surface, for a receiver carried in a poly
    slot -- an array read out of a nested Array or Hash answers Array to #class

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -142,6 +142,40 @@ static int method_name_implicitly_invoked(const char *nm) {
   return 0;
 }
 
+/* Can this fold seed only ever be a BUILTIN? A literal, or an expression whose
+   value a literal decides, can never reach a user class's `+`, so a seeded
+   `sum` written with one must not keep every `+` in the program alive. Asked
+   of the Prism node because compute_reachable runs before inference. */
+static int an_seed_is_builtin(const NodeTable *nt, int id) {
+  if (id < 0) return 0;
+  switch (nt_kind(nt, id)) {
+    case NK_IntegerNode: case NK_FloatNode: case NK_StringNode:
+    case NK_InterpolatedStringNode: case NK_SymbolNode:
+    case NK_NilNode: case NK_TrueNode: case NK_FalseNode:
+    case NK_ArrayNode: case NK_HashNode: case NK_RangeNode:
+    case NK_RationalNode: case NK_ImaginaryNode:
+      return 1;
+    case NK_CallNode: {
+      const char *nm = nt_str(nt, id, "name");
+      int rcv = nt_ref(nt, id, "receiver");
+      if (!nm) return 0;
+      /* the Kernel constructors, which name a builtin class and answer one */
+      if (rcv < 0 &&
+          (sp_streq(nm, "Rational") || sp_streq(nm, "Complex") ||
+           sp_streq(nm, "Float") || sp_streq(nm, "Integer") ||
+           sp_streq(nm, "String") || sp_streq(nm, "Array")))
+        return 1;
+      /* arithmetic ON a literal is still a literal's class: `10**30`, `-1`.
+         An operator name is the one that does not start like an identifier. */
+      if (rcv >= 0 && nm[0] &&
+          !((nm[0] >= 'a' && nm[0] <= 'z') || (nm[0] >= 'A' && nm[0] <= 'Z') || nm[0] == '_'))
+        return an_seed_is_builtin(nt, rcv);
+      return 0;
+    }
+    default: return 0;
+  }
+}
+
 void compute_reachable(Compiler *c) {
   /* Build per-scope call sets (CallNode names, not entering nested DefNodes). */
   char ***scope_calls = calloc((size_t)c->nscopes, sizeof(char **));
@@ -282,6 +316,40 @@ void compute_reachable(Compiler *c) {
       for (int k = 0; k < an; k++)
         if (nt_kind(c->nt, av[k]) == NK_SymbolNode && nt_str(c->nt, av[k], "value"))
           MARK_NAME(nt_str(c->nt, av[k], "value"));
+      /* `reduce(seed, &:sym)` spells the same operator in the block, where the
+         argument walk above cannot see it. */
+      { int blk = nt_ref(c->nt, id, "block");
+        if (blk >= 0 && nt_type(c->nt, blk) && sp_streq(nt_type(c->nt, blk), "BlockArgumentNode")) {
+          int ex = nt_ref(c->nt, blk, "expression");
+          if (ex >= 0 && nt_kind(c->nt, ex) == NK_SymbolNode && nt_str(c->nt, ex, "value"))
+            MARK_NAME(nt_str(c->nt, ex, "value"));
+        } }
+    }
+    /* `sum(seed)` names no operator at all: the fold applies the SEED's `+`
+       once per element. A user class used as the seed therefore needs its `+`
+       kept, exactly as `reduce(seed, :+)` does -- without it the dispatch arm
+       was emitted empty and the fold raised NoMethodError for a method the
+       program defines. MARK_NAME is by name and global, so ask first whether
+       the seed could BE a user object: a literal, or an expression that can
+       only build a builtin, never reaches a user `+`, and marking for one
+       resurrects every `+` in the program -- including bodies the emitter
+       cannot compile, which turned a program that built into one that does
+       not. A local, an ivar, a constant or a call such as `Money.new(0)`
+       marks, which is the same reach `reduce(seed, :+)` already has. */
+    for (int id = 0; id < c->nt->count; id++) {
+      if (nt_kind(c->nt, id) != NK_CallNode) continue;
+      { const char *nm = nt_str(c->nt, id, "name");
+        if (!nm || !sp_streq(nm, "sum")) continue; }
+      if (nt_ref(c->nt, id, "block") >= 0) continue;   /* a block decides what is summed */
+      /* `"abc".sum(16)` is String's checksum width, not a fold seed */
+      { int rcv = nt_ref(c->nt, id, "receiver");
+        if (rcv >= 0 && nt_kind(c->nt, rcv) == NK_StringNode) continue; }
+      { int args = nt_ref(c->nt, id, "arguments");
+        int an = 0; const int *av = args >= 0 ? nt_arr(c->nt, args, "arguments", &an) : NULL;
+        if (an < 1 || !av) continue;
+        if (an_seed_is_builtin(c->nt, av[0])) continue;
+        MARK_NAME("+");
+        break; }
     }
     while (qhead < qtail) { int s = queue[qhead++]; for (int ni = 0; ni < sc_n[s]; ni++) MARK_NAME(scope_calls[s][ni]); }
   }

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -1646,8 +1646,14 @@ static TyKind infer_call_inner(Compiler *c, int id) {
         if (argc == 1 && (sp_streq(name, "is_a?") || sp_streq(name, "kind_of?") ||
                           sp_streq(name, "instance_of?"))) return TY_BOOL;
         if (argc == 0 && sp_streq(name, "to_h")) return TY_STR_POLY_HASH;   /* (#2410) */
-        if (argc <= 1 && sp_streq(name, "sum"))
-          return argc == 1 ? infer_type(c, argv[0]) : TY_INT;               /* (#2416) */
+        if (argc <= 1 && sp_streq(name, "sum")) {
+          /* the empty collection answers the SEED itself, so the call is the
+             seed's type -- except that nil and true/false have no scalar slot
+             to be answered in, and ride boxed (`{}.sum(nil)` is nil) */
+          TyKind st0 = argc == 1 ? infer_type(c, argv[0]) : TY_INT;         /* (#2416) */
+          if (st0 == TY_NIL || st0 == TY_BOOL || st0 == TY_VOID) st0 = TY_POLY;
+          return st0;
+        }
         if (argc == 0 && (sp_streq(name, "min") || sp_streq(name, "max"))) return TY_POLY;
         if (argc == 0 && sp_streq(name, "minmax")) return TY_POLY_ARRAY;    /* (#2406) */
         if (argc == 1 && (sp_streq(name, "<") || sp_streq(name, "<=") ||

--- a/src/analyze_infer_recv.c
+++ b/src/analyze_infer_recv.c
@@ -12,6 +12,29 @@
 #include <stdio.h>
 #include <string.h>
 
+/* infer_type through fold_seed_kind, which owns the rule (see types.c). */
+static TyKind fold_seed_infer_ty(Compiler *c, int node) {
+  return fold_seed_kind(infer_type(c, node), nt_type(c->nt, node));
+}
+
+/* The operator a seeded fold applies, whichever spelling was used.
+   `reduce(seed, :op)` carries the symbol as the trailing argument, with the
+   seed in front of it; `reduce(seed, &:op)` carries it in the block, which
+   leaves the seed as the only argument. Both are the same fold and take the
+   same accumulator rule -- reading only the argument list typed the &:op
+   spelling from the seed and then dropped it. */
+static const char *fold_seed_op_sym(Compiler *c, int id, int argc, const int *argv) {
+  const NodeTable *nt = c->nt;
+  if (argc >= 2 && argv) return sym_static_value(c, argv[argc - 1]);
+  if (argc != 1) return NULL;
+  { int blk = nt_ref(nt, id, "block");
+    if (blk < 0 || !nt_type(nt, blk) || !sp_streq(nt_type(nt, blk), "BlockArgumentNode")) return NULL;
+    { int ex = nt_ref(nt, blk, "expression");
+      if (ex >= 0 && nt_type(nt, ex) && sp_streq(nt_type(nt, ex), "SymbolNode"))
+        return nt_str(nt, ex, "value"); } }
+  return NULL;
+}
+
 /* True when `id` is the receiver of an enclosing call that carries a block:
    the chain emitters own that shape (arr.map.with_index { }), so the inner
    blockless call must keep its legacy typing. */
@@ -199,9 +222,18 @@ int infer_range_call(Compiler *c, int id, TyKind rt, TyKind *out) {
   if (rt == TY_RANGE && recv >= 0 && argc == 1 && nt_ref(nt, id, "block") < 0 &&
       (sp_streq(name, "min") || sp_streq(name, "max")))
     { *out = TY_INT_ARRAY; return 1; }
+  /* Range#sum(seed): CRuby adds the closed form to an INTEGER seed and answers
+     a Float for a seed of any other class (it runs the seed through
+     Kernel#Float first), so only an Integer or Float seed lands in a scalar
+     slot -- a Bignum seed wrapped in one, and a Rational one did not compile
+     at all. */
   if (rt == TY_RANGE && sp_streq(name, "sum") && argc == 1 &&
-      nt_ref(nt, id, "block") < 0)
-    { *out = infer_type(c, argv[0]) == TY_FLOAT ? TY_FLOAT : TY_INT; return 1; }
+      nt_ref(nt, id, "block") < 0) {
+    TyKind st = fold_seed_infer_ty(c, argv[0]);
+    if (st == TY_FLOAT) { *out = TY_FLOAT; return 1; }
+    *out = fold_seed_typed(st, TY_INT) ? TY_INT : TY_POLY;
+    return 1;
+  }
   /* each_slice(n) { } / each_cons(n) { } answer the receiver, which the value
      emitter yields; the materializing redispatch below would otherwise type
      them as the int array it walks, and an assigned result then printed the
@@ -558,7 +590,13 @@ int infer_hash_call(Compiler *c, int id, TyKind rt, TyKind *out) {
         (ty_is_array(infer_type(c, argv[0])) ||
          (nt_type(nt, argv[0]) && sp_streq(nt_type(nt, argv[0]), "ArrayNode"))))
       { *out = TY_POLY_ARRAY; return 1; }   /* an Array init concatenates the pairs (#3571) */
-    if (nt_ref(nt, id, "block") < 0 && sp_streq(name, "sum") && argc <= 1)
+    /* Every other blockless seed keeps its own class: Enumerable#sum adds the
+       first [k, v] pair to it with Ruby's `+`, so an Integer seed raises and
+       a nil / false one raises from nil itself -- neither is an Integer, and
+       an EMPTY hash answers the seed unchanged (`{}.sum(nil)` is nil). */
+    if (nt_ref(nt, id, "block") < 0 && sp_streq(name, "sum") && argc == 1)
+      { *out = fold_seed_typed(fold_seed_infer_ty(c, argv[0]), TY_INT) ? TY_INT : TY_POLY; return 1; }
+    if (nt_ref(nt, id, "block") < 0 && sp_streq(name, "sum") && argc == 0)
       { *out = TY_INT; return 1; }
     if (nt_ref(nt, id, "block") >= 0 &&
         (sp_streq(name, "flat_map") || sp_streq(name, "collect_concat") ||
@@ -879,6 +917,25 @@ int infer_array_call(Compiler *c, int id, TyKind rt, TyKind *out) {
       if (rt == TY_STR_ARRAY && blk < 0 &&
           !(argc == 1 && infer_type(c, argv[0]) == TY_STRING))
         { *out = TY_POLY; return 1; }
+      /* A blockless seed keeps its OWN class through the whole fold: CRuby's
+         accumulator is the seed object and every step is Ruby's `+` on it. Only
+         a seed of the element's own class can live in the element's C slot --
+         plus an Integer seed over Floats, and a Float seed over Integers, both
+         of which CRuby answers as a Float too. Everything else folds boxed and
+         the call IS that boxed value: a Rational total, a Bignum that no longer
+         wraps, or the raise the generic `+` produces. Only the three
+         concretely-typed kinds are decided here; a poly array keeps the
+         sp_PolyArray_sum_* typings its own emitter arms expect. */
+      if (argc == 1 && blk < 0 &&
+          (rt == TY_INT_ARRAY || rt == TY_FLOAT_ARRAY || rt == TY_STR_ARRAY)) {
+        TyKind st = fold_seed_infer_ty(c, argv[0]);
+        TyKind et = ty_array_elem(rt);
+        /* the String-seed concatenation; the rule above took every other seed */
+        if (rt == TY_STR_ARRAY) { *out = TY_STRING; return 1; }
+        if (et == TY_INT && st == TY_FLOAT) { *out = TY_FLOAT; return 1; }
+        *out = fold_seed_typed(st, et) ? et : TY_POLY;
+        return 1;
+      }
       /* a float initial value promotes the whole sum to Float (e.g.
          ints.sum(0.0) or ints.sum(0.0) { |x| x }), regardless of the block. */
       if (argc == 1 && infer_type(c, argv[0]) == TY_FLOAT) { *out = TY_FLOAT; return 1; }
@@ -944,8 +1001,13 @@ int infer_array_call(Compiler *c, int id, TyKind rt, TyKind *out) {
               infer_type(c, argv[0]) == TY_PROC) { *out = TY_POLY; return 1; }
         }
         const char *a0ty = nt_type(nt, argv[0]);
-        /* a symbol literal, or a local statically holding one (s = :+) */
-        int is_sym_op = argc == 1 && sym_static_value(c, argv[0]) != NULL;
+        /* a symbol literal, or a local statically holding one (s = :+) -- and
+           only when there is no block: `inject(:s, &:+)` gives the operator in
+           the block, which makes the lone Symbol the SEED, not the operator
+           (Enumerable#inject's own rule). Read as an operator it typed the
+           call from the elements while the emitter folded from the seed. */
+        int is_sym_op = argc == 1 && nt_ref(nt, id, "block") < 0 &&
+                        sym_static_value(c, argv[0]) != NULL;
         (void)a0ty;
         /* `reduce(nil) { |acc, t| acc.nil? ? t : acc + t }` -- the idiom for a
            fold with no natural identity. The seed says nothing about the
@@ -1010,11 +1072,18 @@ int infer_array_call(Compiler *c, int id, TyKind rt, TyKind *out) {
                `:+` still came out Integer. Promote a numeric seed by the element
                type when the operator is arithmetic (#3181). */
             else if (rbn == 0 && ty_is_numeric(it)) {
-              const char *sop = argc >= 2 ? sym_static_value(c, argv[argc - 1]) : NULL;
+              const char *sop = fold_seed_op_sym(c, id, argc, argv);
               TyKind et = ty_array_elem(rt);
               int arith = sop && (sp_streq(sop, "+") || sp_streq(sop, "-") || sp_streq(sop, "*") ||
                                   sp_streq(sop, "/") || sp_streq(sop, "%") || sp_streq(sop, "**"));
-              if (arith && ty_is_numeric(et))
+              /* A seed of another class is not an accumulator this element type
+                 can hold at all: `[1, 2, 3].reduce(0.5, :+)` accumulates Float
+                 and a Bignum seed does not fit an sp_int. Those fold boxed, and
+                 the promotion below then only ever widens Integer to Float. An
+                 ERASED element type says nothing about the seed's class, so it
+                 is left to the two rules below, which have their own answer. */
+              if (sop && et != TY_POLY && !fold_seed_typed(it, et)) it = TY_POLY;
+              else if (arith && ty_is_numeric(et))
                 it = ty_promote_numeric(it, et);
               /* fold over a literal array of boxed Rationals/Complex with an
                  arithmetic operator: the accumulator promotes to the boxed
@@ -1036,6 +1105,15 @@ int infer_array_call(Compiler *c, int id, TyKind rt, TyKind *out) {
                  the bits. Keep the result boxed (#3238). */
               else if (arith && et == TY_POLY) it = TY_POLY;
             }
+            /* The same rule for a seed that is not a number at all -- a String,
+               nil, true/false, a Rational. `[1, 2].reduce("x", :*)` accumulates
+               a String ("xx"), and `[1, 2].reduce(nil, :+)` raises from nil's
+               own missing `+`; both were read out of an sp_int slot, so nil
+               came back as the sum and a String stopped the C build. */
+            else if (rbn == 0 && fold_seed_op_sym(c, id, argc, argv) &&
+                     ty_array_elem(rt) != TY_POLY &&
+                     !fold_seed_typed(it, ty_array_elem(rt)))
+              it = TY_POLY;
             /* A hash/array/object seed whose block body reassigns the
                accumulator to a boxed poly value (e.g. a method that returns
                poly because it is also used in a poly context elsewhere) widens

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -12728,17 +12728,17 @@ int emit_arg_type_guards(Compiler *c, int id, Buf *b) {
     TyKind art = ar >= 0 ? comp_ntype(c, ar) : TY_UNKNOWN;
     if (ar >= 0 && an2 && ac2 >= 1 && av2 && ty_is_array(art) &&
         !user_defines_or_reads(c, an2)) {
-      /* which argument has to be an Integer, and which an Array */
+      /* Which argument has to be an Integer, and which an Array. `sum` is
+         deliberately absent: its seed is not an Integer slot at all -- CRuby's
+         accumulator IS the seed, and a seed of any class folds from it with
+         that class's own `+`. The blanket "X can't be coerced into Integer"
+         this used to raise for a literal String/Symbol/Array/Hash seed was the
+         Integer wording for what is really String#+ or Symbol's missing `+`;
+         sp_poly_sum_seed reaches the operator, which words each one CRuby's
+         way. */
       int want_int = -1, want_arr = -1;
       if (sp_streq(an2, "rotate")) want_int = 0;
       else if (sp_streq(an2, "fill") && ac2 >= 2) want_int = 1;
-      /* Array#sum over a String or Array element list folds by concatenation,
-         and its seed is legitimately one of those: only a NUMERIC element list
-         wants an Integer seed. */
-      /* ... and a BLOCK decides what is summed (`a.sum("") { |x| x.to_s }`),
-         so only the blockless numeric form wants an Integer seed. */
-      else if (sp_streq(an2, "sum") && ty_is_numeric(ty_array_elem(art)) &&
-               nt_ref(nt, id, "block") < 0) want_int = 0;
       else if (sp_streq(an2, "product")) want_arr = 0;
       const char *badcls = NULL;
       int check = want_int >= 0 ? want_int : want_arr;
@@ -12760,11 +12760,8 @@ int emit_arg_type_guards(Compiler *c, int id, Buf *b) {
         TyKind rty3 = comp_ntype(c, id);
         const char *dv3 = default_value(rty3);
         buf_puts(b, "({ (void)("); emit_expr(c, ar, b); buf_puts(b, "); ");
-        if (want_int >= 0 && sp_streq(an2, "sum"))
-          buf_printf(b, "sp_raise_cls(\"TypeError\", \"%s can't be coerced into Integer\"); ", badcls);
-        else
-          buf_printf(b, "sp_raise_cls(\"TypeError\", \"no implicit conversion of %s into %s\"); ",
-                     badcls, want_int >= 0 ? "Integer" : "Array");
+        buf_printf(b, "sp_raise_cls(\"TypeError\", \"no implicit conversion of %s into %s\"); ",
+                   badcls, want_int >= 0 ? "Integer" : "Array");
         buf_printf(b, "%s; })", dv3 ? dv3 : "0");
         return 1;
       }
@@ -27667,8 +27664,13 @@ else {
       buf_puts(b, "sp_StrPolyHash_new()"); return;   /* {}.to_h == {} (#2410) */
     }
     if (argc <= 1 && sp_streq(name, "sum") && nt_ref(nt, id, "block") < 0) {
-      /* {}.sum == the init (or 0) (#2416) */
-      if (argc == 1) emit_expr(c, argv[0], b); else buf_puts(b, "0");
+      /* {}.sum == the init (or 0) (#2416). A nil or Boolean init has no scalar
+         slot to be answered in and the call is typed poly for it, so the init
+         has to be boxed there -- emitted raw, `{}.sum(nil)` answered 0. */
+      TyKind hst = comp_ntype(c, id);
+      if (argc == 0) buf_puts(b, hst == TY_POLY ? "sp_box_int(0)" : "0");
+      else if (hst == TY_POLY) emit_boxed(c, argv[0], b);
+      else emit_expr(c, argv[0], b);
       return;
     }
     if (argc == 0 && (sp_streq(name, "min") || sp_streq(name, "max"))) {
@@ -27765,8 +27767,7 @@ else {
     for (int k = 0; k < c->nclasses; k++)
       if (comp_method_in_chain(c, k, name, NULL) >= 0) ncand9++;
     if (ncand9 == 0) {
-      buf_puts(b, "sp_poly_sum_seed("); emit_expr(c, recv, b); buf_puts(b, ", ");
-      emit_boxed(c, argv[0], b); buf_puts(b, ")");
+      emit_poly_sum_seed(c, recv, argv[0], b);
       return;
     }
   }

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -3624,21 +3624,21 @@ else {
         buf_printf(b, "(sp_%sArray_length(", k); emit_expr(c, recv, b); buf_puts(b, ") == 0)");
         return 1;
       }
-      /* A blockless sum over Strings adds each element to an Integer seed,
-         which CRuby rejects with "String can't be coerced into Integer". There
-         is no sp_StrArray_sum, so the generic arms emitted a call to a function
-         that does not exist and the C compiler stopped on its implicit
-         declaration (#4327). An EMPTY receiver adds nothing and answers the
-         seed, which is why the test is at run time. */
-      if (sp_streq(name, "sum") && rt == TY_STR_ARRAY && argc <= 1 &&
-          nt_ref(nt, id, "block") < 0 &&
-          !(argc == 1 && comp_ntype(c, argv[0]) == TY_STRING)) {
+      /* A blockless SEEDLESS sum over Strings adds each element to the implied
+         Integer 0, which CRuby rejects with "String can't be coerced into
+         Integer". There is no sp_StrArray_sum, so the generic arms emitted a
+         call to a function that does not exist and the C compiler stopped on
+         its implicit declaration (#4327). An EMPTY receiver adds nothing and
+         answers the 0, which is why the test is at run time. A seed of any
+         class takes the boxed fold below, which reaches the same raise through
+         the operator itself. */
+      if (sp_streq(name, "sum") && rt == TY_STR_ARRAY && argc == 0 &&
+          nt_ref(nt, id, "block") < 0) {
         int ts = ++g_tmp;
         buf_printf(b, "({ sp_StrArray *_t%d = ", ts); emit_expr(c, recv, b);
         buf_printf(b, "; SP_GC_ROOT(_t%d); if (sp_StrArray_length(_t%d) != 0)"
                       " sp_raise_cls(\"TypeError\", \"String can't be coerced into Integer\"); ", ts, ts);
-        if (argc == 1) emit_boxed(c, argv[0], b); else buf_puts(b, "sp_box_int(0)");
-        buf_puts(b, "; })");
+        buf_puts(b, "sp_box_int(0); })");
         return 1;
       }
       if (sp_streq(name, "sum") && argc == 0 && nt_ref(nt, id, "block") < 0) {
@@ -3646,15 +3646,7 @@ else {
         return 1;
       }
       if (sp_streq(name, "sum") && argc == 1 && nt_ref(nt, id, "block") < 0) {
-        TyKind init_t = comp_ntype(c, argv[0]);
-        /* a String initial value over numeric elements is a TypeError (String#+
-           rejects an Integer), matching CRuby (#2504). */
-        if ((rt == TY_INT_ARRAY || rt == TY_FLOAT_ARRAY) && init_t == TY_STRING) {
-          buf_puts(b, "((void)("); emit_expr(c, recv, b); buf_puts(b, "), (void)(");
-          emit_expr(c, argv[0], b);
-          buf_puts(b, "), sp_raise_cls(\"TypeError\", \"no implicit conversion of Integer into String\"), (sp_int)0)");
-          return 1;
-        }
+        TyKind init_t = fold_seed_ntype(c, argv[0]);
         /* a String initial value concatenates (["a","b"].sum("") == "ab") */
         if (rt == TY_STR_ARRAY && init_t == TY_STRING) {
           buf_puts(b, "sp_StrArray_sum_str("); emit_expr(c, recv, b); buf_puts(b, ", ");
@@ -3669,15 +3661,20 @@ else {
           buf_puts(b, ") + (sp_float)sp_IntArray_sum("); emit_expr(c, recv, b); buf_puts(b, ", 0))");
           return 1;
         }
+        /* Any other seed keeps its OWN class for the whole fold: CRuby's
+           accumulator is the seed object and every step is Ruby's `+` on it. A
+           Rational seed therefore answers a Rational total, a Bignum one stops
+           wrapping into an sp_int, and nil / a String / an Array reach the raise
+           that operator itself produces -- worded for the ELEMENT's class, which
+           the hard-coded String-seed raise that used to stand here could only
+           get right over Integers. sp_poly_sum_seed runs CRuby's own phases. */
+        if (rt == TY_STR_ARRAY || !fold_seed_typed(init_t, ty_array_elem(rt))) {
+          emit_poly_sum_seed(c, recv, argv[0], b);
+          return 1;
+        }
         buf_printf(b, "sp_%sArray_sum(", k); emit_expr(c, recv, b); buf_puts(b, ", ");
         if (rt == TY_FLOAT_ARRAY && init_t == TY_INT) {
           buf_puts(b, "(sp_float)("); emit_expr(c, argv[0], b); buf_puts(b, ")");
-        }
-        else if (rt == TY_FLOAT_ARRAY && init_t == TY_POLY) {
-          buf_puts(b, "sp_poly_to_f("); emit_expr(c, argv[0], b); buf_puts(b, ")");
-        }
-        else if (rt == TY_INT_ARRAY && init_t == TY_POLY) {
-          buf_puts(b, "sp_poly_to_i("); emit_expr(c, argv[0], b); buf_puts(b, ")");
         }
         else {
           emit_expr(c, argv[0], b);
@@ -5426,6 +5423,15 @@ else {
         }
         else { buf_puts(b, "((void)("); emit_expr(c, argv[0], b); buf_puts(b, "), sp_PolyArray_new())"); }
         buf_puts(b, ")");
+        return 1;
+      }
+      /* A seed of any other class folds the pairs into IT: `nil + [k, v]` is
+         nil's own missing `+` (NoMethodError), not the Integer coercion the
+         int arm below reports -- and an empty hash adds nothing and answers
+         the seed itself, so `{}.sum(nil)` is nil. */
+      if (sp_streq(name, "sum") && argc == 1 && nt_ref(nt, id, "block") < 0 &&
+          !fold_seed_typed(fold_seed_ntype(c, argv[0]), TY_INT)) {
+        emit_poly_sum_seed(c, recv, argv[0], b);
         return 1;
       }
       if (sp_streq(name, "sum") && argc <= 1 && nt_ref(nt, id, "block") < 0) {
@@ -11232,6 +11238,17 @@ int emit_range_call(Compiler *c, int id, Buf *b) {
       else if (sp_streq(name, "sum") && argc == 1 && comp_ntype(c, argv[0]) == TY_FLOAT) {
         buf_puts(b, "(("); emit_expr(c, argv[0], b);
         buf_printf(b, ") + (double)sp_IntArray_sum(sp_range_to_ia(_t%d), 0))", t);
+      }
+      /* Range#sum takes an INTEGER seed exactly and runs every other class
+         through Kernel#Float, answering a Float -- so a Bignum seed wrapped
+         into the sp_int slot here, a Rational one did not compile, and nil and
+         a String reported the wrong conversion. An empty range answers the
+         seed untouched, which is why the helper decides at run time. */
+      else if (sp_streq(name, "sum") && argc == 1 &&
+               !fold_seed_typed(fold_seed_ntype(c, argv[0]), TY_INT)) {
+        buf_printf(b, "sp_range_sum_seed(_t%d, ", t);
+        emit_boxed(c, argv[0], b);
+        buf_puts(b, ")");
       }
       else if (sp_streq(name, "sum") && argc == 1) {
         buf_printf(b, "sp_IntArray_sum(sp_range_to_ia(_t%d), ", t);

--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -3117,22 +3117,29 @@ int emit_inject_expr(Compiler *c, int id, Buf *b) {
   if (!k) return 0;
   TyKind et = ty_array_elem(rt);
 
-  /* find the operator symbol (from a &:op block or a trailing :op arg) and
-     any explicit initial value */
-  const char *op = NULL; int init = -1;
+  /* Find the operator symbol (from a &:op block or a trailing :op arg), its
+     NODE, and any explicit initial value. The two spellings put the seed in
+     different places: `reduce(seed, :op)` in front of the symbol argument,
+     `reduce(seed, &:op)` as the only argument, the symbol being in the block.
+     Only the first was read for a seed, so the &:op spelling folded from the
+     first ELEMENT and dropped the seed entirely. */
+  const char *op = NULL; int init = -1, sym_node = -1;
   int block = resolve_forwarded_block(c, nt_ref(nt, id, "block"));
   if (block >= 0 && nt_type(nt, block) && sp_streq(nt_type(nt, block), "BlockArgumentNode")) {
     int ex = nt_ref(nt, block, "expression");
-    if (ex >= 0 && nt_type(nt, ex) && sp_streq(nt_type(nt, ex), "SymbolNode")) op = nt_str(nt, ex, "value");
+    if (ex >= 0 && nt_type(nt, ex) && sp_streq(nt_type(nt, ex), "SymbolNode"))
+      { op = nt_str(nt, ex, "value"); sym_node = ex; }
   }
   int args = nt_ref(nt, id, "arguments");
   int argc = 0; const int *argv = args >= 0 ? nt_arr(nt, args, "arguments", &argc) : NULL;
-  if (!op && argc >= 1) {
+  if (op && sym_node >= 0 && argc == 1) init = argv[0];
+  else if (!op && argc >= 1) {
     int last = argv[argc - 1];
     /* a symbol literal, or a local that statically holds one (s = :+) */
     const char *sv = sym_static_value(c, last);
     if (sv) {
       op = sv;
+      sym_node = last;
       if (argc == 2) init = argv[0];
     }
   }
@@ -3143,17 +3150,37 @@ int emit_inject_expr(Compiler *c, int id, Buf *b) {
      operator folds through sp_poly_binop_sym -- the static arms below only
      serve the concretely-typed element kinds. This is what lets an array of
      lambdas fold with reduce(:>>) (#2880). */
+  int runtime_sym = (!op && block < 0 && argc >= 1 &&
+                     (comp_ntype(c, argv[argc - 1]) == TY_SYMBOL ||
+                      comp_ntype(c, argv[argc - 1]) == TY_POLY));
   int poly_sym_fold = (k && sp_streq(k, "Poly") && block < 0 && argc >= 1 &&
                        comp_ntype(c, argv[argc - 1]) == TY_SYMBOL);
-  if ((!op || poly_sym_fold) && block < 0 && argc >= 1 &&
-      (comp_ntype(c, argv[argc - 1]) == TY_SYMBOL || comp_ntype(c, argv[argc - 1]) == TY_POLY)) {
-    int symarg = argv[argc - 1];
-    int rinit = (argc == 2) ? argv[0] : -1;
+  /* A seed of a class other than the elements' folds boxed as well. Ruby's
+     accumulator IS the seed object and every step is the seed's own operator,
+     so `[1, 2, 3].reduce(0.5, :+)` accumulates Float (6.5) where the typed arm
+     below truncated 0.5 into its sp_int accumulator and answered 6.0 -- and a
+     Rational, Bignum or String seed has no sp_int spelling at all, so the
+     generated C did not compile. Either spelling of the operator gets here:
+     the symbol node is the one found above, not always a trailing argument. */
+  int seed_boxed_fold = (op && init >= 0 && sym_node >= 0 &&
+                         (comp_ntype(c, sym_node) == TY_SYMBOL ||
+                          comp_ntype(c, sym_node) == TY_POLY) &&
+                         !fold_seed_typed(fold_seed_ntype(c, init), et));
+  if (runtime_sym || poly_sym_fold || seed_boxed_fold) {
+    int symarg = (sym_node >= 0) ? sym_node : argv[argc - 1];
+    int rinit = (init >= 0) ? init : ((block < 0 && argc == 2) ? argv[0] : -1);
     int ta = ++g_tmp, tacc = ++g_tmp, ti = ++g_tmp, tn = ++g_tmp, tsy = ++g_tmp;
     const char *boxfn = et == TY_INT ? "sp_box_int" : et == TY_FLOAT ? "sp_box_float"
                       : et == TY_STRING ? "sp_box_str" : NULL;
     buf_printf(b, "({ sp_%sArray *_t%d = ", k, ta); emit_expr(c, recv, b);
-    buf_printf(b, "; sp_int _t%d = sp_%sArray_length(_t%d); sp_sym _t%d = ", tn, k, ta, tsy);
+    /* The receiver temp has to be a GC root for the whole fold: the boxed seed
+       allocates before the loop and every sp_poly_binop_sym allocates inside
+       it, so a receiver built by this same statement was collected out from
+       under the walk. The poly-array arm above roots its own for this reason;
+       this one never did, which the seeded fold now makes reachable from
+       `arr.reduce(Rational(1, 2), :+)`. */
+    buf_printf(b, "; SP_GC_ROOT(_t%d); sp_int _t%d = sp_%sArray_length(_t%d); sp_sym _t%d = ",
+               ta, tn, k, ta, tsy);
     /* a statically-poly operand (a `|sym|` block param over a poly array)
        carries the symbol in its .v.i slot */
     if (comp_ntype(c, symarg) == TY_SYMBOL) emit_expr(c, symarg, b);

--- a/src/codegen_internal.h
+++ b/src/codegen_internal.h
@@ -590,6 +590,12 @@ void emit_box_open(Compiler *c, TyKind t, Buf *b);
 void emit_box_close(Compiler *c, TyKind t, Buf *b);
 /* "Int" / "Str" / "Float" for the sp_<K>Array_* runtime family. */
 const char *array_kind(TyKind t);
+/* comp_ntype for a fold seed, with an empty `[]` / `{}` literal resolved to
+   its container kind rather than left TY_UNKNOWN (see types.c). */
+TyKind fold_seed_ntype(Compiler *c, int node);
+/* `sum(seed)` through sp_poly_sum_seed, with both operands boxed into rooted
+   temporaries in receiver-then-seed order (see codegen_util.c). */
+void emit_poly_sum_seed(Compiler *c, int recv, int seed, Buf *b);
 void emit_c_escaped_n(Buf *b, const char *s, size_t len);
 void emit_c_escaped(Buf *b, const char *s);
 /* A poly RHS assigned into a scalar slot needs an unbox. The statement form

--- a/src/codegen_util.c
+++ b/src/codegen_util.c
@@ -1372,6 +1372,22 @@ void emit_box_close(Compiler *c, TyKind t, Buf *b) {
   if (t == TY_POLY_ARRAY)  { buf_puts(b, "), SP_BUILTIN_POLY_ARRAY)"); return; }
   buf_puts(b, ")");
 }
+/* comp_ntype through fold_seed_kind, which owns the rule (see types.c). */
+TyKind fold_seed_ntype(Compiler *c, int node) {
+  return fold_seed_kind(comp_ntype(c, node), nt_type(c->nt, node));
+}
+/* sum(seed) through the boxed fold. The receiver is boxed into a ROOTED temp
+   before the seed runs: a seed that allocates -- a Rational, a Bignum -- can
+   collect a receiver array the same statement just built, and the fold then
+   walked an empty one. Rooting also fixes the order, which is Ruby's: the
+   receiver first, then the seed, each evaluated exactly once. Shared by the
+   typed-array, Hash and poly-receiver call sites, which each had the hazard. */
+void emit_poly_sum_seed(Compiler *c, int recv, int seed, Buf *b) {
+  int tr = ++g_tmp, ts = ++g_tmp;
+  buf_printf(b, "({ sp_RbVal _t%d = ", tr); emit_boxed(c, recv, b);
+  buf_printf(b, "; SP_GC_ROOT_RBVAL(_t%d); sp_RbVal _t%d = ", tr, ts); emit_boxed(c, seed, b);
+  buf_printf(b, "; SP_GC_ROOT_RBVAL(_t%d); sp_poly_sum_seed(_t%d, _t%d); })", ts, tr, ts);
+}
 const char *array_kind(TyKind t) {
   switch (t) {
     case TY_INT_ARRAY:   return "Int";

--- a/src/types.c
+++ b/src/types.c
@@ -313,6 +313,22 @@ TyKind ty_promote_numeric(TyKind a, TyKind b) {
   return ty_unify(a, b);
 }
 
+TyKind fold_seed_kind(TyKind resolved, const char *node_type) {
+  if (resolved != TY_UNKNOWN) return resolved;
+  if (node_type && sp_streq(node_type, "ArrayNode")) return TY_POLY_ARRAY;
+  if (node_type && sp_streq(node_type, "HashNode")) return TY_POLY_POLY_HASH;
+  return resolved;
+}
+
+int fold_seed_typed(TyKind seed, TyKind elem) {
+  /* A seed whose class is not settled yet says nothing about the accumulator,
+     and the boxed fold would be no more right than the typed one: keep what
+     the typed emitters already do for it. */
+  if (seed == TY_UNKNOWN) return 1;
+  if (seed == elem) return 1;
+  return elem == TY_FLOAT && seed == TY_INT;
+}
+
 /* The single-element-arg array iterators: a block bound to one of these
    receives exactly one param = the array element. Enumerated once here so the
    knowledge is not re-encoded as scattered method-name lists. */

--- a/src/types.h
+++ b/src/types.h
@@ -161,6 +161,21 @@ const char *ty_name(TyKind t);         /* legacy string tag, for diagnostics */
 int ty_is_numeric(TyKind t);           /* INT or FLOAT */
 int ty_never_callable(TyKind t);       /* kind can never answer #call */
 TyKind ty_promote_numeric(TyKind a, TyKind b); /* fold-accumulator numeric promotion */
+/* Can a seeded fold (sum(seed), inject(seed, :op)) keep the element's C type?
+   Ruby's accumulator is the SEED's object and every step is the seed's own
+   operator, so only a seed of the element's own class stays in that slot --
+   plus an Integer seed over Floats, which widens exactly and answers a Float
+   in Ruby too. Every other seed folds boxed. Read by the inference and by the
+   emitters, so the two can never disagree about which fold is emitted. */
+int fold_seed_typed(TyKind seed, TyKind elem);
+/* The seed kind a fold decides by, from the kind already resolved for the node
+   and the node's own type name. An empty `[]` or `{}` literal resolves to
+   TY_UNKNOWN so that a later push can narrow it, and TY_UNKNOWN is the one
+   kind fold_seed_typed lets through to the typed accumulator -- but as a fold
+   SEED the literal is already an Array or a Hash and belongs in the boxed
+   fold. The inference and the emitter each pass the kind they resolved, so the
+   rule itself is written once and they cannot answer differently. */
+TyKind fold_seed_kind(TyKind resolved, const char *node_type);
 int ty_is_array(TyKind t);
 /* Set while the type fixpoint iterates; defined in analyze.c. Declared here
    because ty_array_of consults it -- see the TY_UNKNOWN case. */

--- a/test/bundle_array_e.rb
+++ b/test/bundle_array_e.rb
@@ -217,22 +217,22 @@ def t_array_sum_init
   puts [1.5, 2.5].sum(1)            # 5.0 (int init implicitly widens)
   puts [1.5, 2.5].sum(-0.5)         # 3.5 (negative float init)
   
-  # Poly init: a heterogeneous-array element resolves to a poly local.
-  # compile_arg0_as_int / compile_arg0_as_float unbox via `.v.i` / `.v.f`;
-  # without them gcc rejects passing sp_RbVal to sp_int / sp_float.
+  # Poly init: a heterogeneous-array element resolves to a poly local,
+  # whose CLASS is only known at run time -- so the fold runs boxed and
+  # answers whatever that value's own `+` answers.
   poly_arr = [10, "x"]
   init_p = poly_arr[0]
-  puts [1, 2].sum(init_p)           # 13 (poly init unboxed as sp_int)
+  puts [1, 2].sum(init_p)           # 13 (poly init: the boxed fold)
   
   fpoly_arr = [1.5, "x"]
   finit_p = fpoly_arr[0]
-  puts [1.0, 2.0].sum(finit_p)      # 4.5 (poly init unboxed as sp_float)
+  puts [1.0, 2.0].sum(finit_p)      # 4.5 (poly init: the boxed fold)
   
-  # Tag-mixed: poly is INT-tagged but the FloatArray expects sp_float.
-  # sp_poly_to_f dispatches on the tag so the int value is coerced to
-  # float rather than reinterpreted bit-for-bit from `.v.f`.
+  # Tag-mixed: the poly value is INT-tagged and the elements are Floats.
+  # The boxed fold adds through the numeric tower, so the Integer widens
+  # to Float rather than being reinterpreted bit-for-bit from `.v.f`.
   ipoly_for_float = [1, "x"][0]
-  puts [1.0, 2.0].sum(ipoly_for_float)   # 4.0 (poly INT->float via sp_poly_to_f)
+  puts [1.0, 2.0].sum(ipoly_for_float)   # 4.0 (an Integer seed over Floats)
   
   # FloatArray + block + float init: compile_array_sum_block now picks
   # an sp_float accumulator and compile_arg0_as_float when recv_type is

--- a/test/inject_seed_keeps_its_class.rb
+++ b/test/inject_seed_keeps_its_class.rb
@@ -1,0 +1,55 @@
+# inject/reduce(seed, :op) makes the SEED the accumulator and applies :op to
+# it once per element -- nothing numeric-special. A seed of another class than
+# the elements therefore decides the arithmetic, and a seed with no `+` at all
+# raises from its own missing method.
+def t
+  p yield
+rescue => e
+  p [e.class, e.message]
+end
+
+t { [1, 2, 3].reduce(0.5, :+) }
+t { [2, 3].reduce(1.5, :*) }
+t { [1, 2, 3].reduce(Rational(1, 2), :+) }
+t { [1, 2, 3].reduce(10**30, :+) }
+t { [1, 2, 3].reduce("x", :+) }
+t { [1, 2].reduce("x", :*) }
+t { [1, 2].reduce(nil, :+) }
+t { [1, 2].reduce(true, :+) }
+t { [1, 2].reduce(false, :+) }
+t { ["a"].reduce(1, :+) }
+t { [1.0, 2.0].reduce(10**30, :+) }
+t { [1.0, 2.0].reduce("x", :+) }
+t { (1..3).inject(0.5, :+) }
+t { (1..3).inject(10**30, :+) }
+t { (1..3).inject("x", :+) }
+t { (1..3).reduce(false, :+) }
+t { ("a".."c").inject(0, :+) }
+t { s = :+; [1, 2].reduce(0.5, s) }   # the operator through a local
+
+# the &:op spelling is the same fold: the seed is then the only argument,
+# which is how it came to be dropped altogether
+t { [1, 2, 3].inject(10, &:+) }
+t { [1, 2, 3].inject(0.5, &:+) }
+t { [1.5].inject(1, &:+) }
+t { [2, 3].inject(1.5, &:*) }
+# with a block the lone argument is the SEED, not the operator
+t { [1, 2, 3].inject(:s, &:+) }
+
+# nil has no `*` either, and a Float has none of the bit operators
+t { [1, 2].reduce(nil, :*) }
+t { [2, 3].reduce(7.5, :<<) }
+
+# a user class as the seed, through both spellings of the operator
+class Money
+  def initialize(cents); @cents = cents; end
+  def +(other); Money.new(@cents + other); end
+  def inspect; "$#{@cents}"; end
+end
+t { [1, 2, 3].inject(Money.new(0), :+) }
+t { [1, 2, 3].inject(Money.new(0), &:+) }
+
+# the same-class seeds keep the typed fold they always had
+t { [1, 2, 3].reduce(10, :+) }
+t { [1.0, 2.0].reduce(1, :+) }
+t { [].reduce(0.5, :+) }

--- a/test/inject_seed_keeps_its_class.rb.expected
+++ b/test/inject_seed_keeps_its_class.rb.expected
@@ -1,0 +1,30 @@
+6.5
+9.0
+(13/2)
+1000000000000000000000000000006
+[TypeError, "no implicit conversion of Integer into String"]
+"xx"
+[NoMethodError, "undefined method '+' for nil"]
+[NoMethodError, "undefined method '+' for true"]
+[NoMethodError, "undefined method '+' for false"]
+[TypeError, "String can't be coerced into Integer"]
+1.0e+30
+[TypeError, "no implicit conversion of Float into String"]
+6.5
+1000000000000000000000000000006
+[TypeError, "no implicit conversion of Integer into String"]
+[NoMethodError, "undefined method '+' for false"]
+[TypeError, "String can't be coerced into Integer"]
+3.5
+16
+6.5
+2.5
+9.0
+[NoMethodError, "undefined method '+' for an instance of Symbol"]
+[NoMethodError, "undefined method '*' for nil"]
+[NoMethodError, "undefined method '<<' for an instance of Float"]
+$6
+$6
+16
+4.0
+0.5

--- a/test/sum_seed_keeps_its_class.rb
+++ b/test/sum_seed_keeps_its_class.rb
@@ -1,0 +1,106 @@
+# sum(seed) accumulates in the SEED's class, with Ruby's `+` at every step:
+# a Rational or Bignum seed keeps its own arithmetic, a Float one widens the
+# whole sum, and nil / a String / an Array reach the raise that operator
+# produces -- worded for the element's class, not for Integer.
+def t
+  p yield
+rescue => e
+  p [e.class, e.message]
+end
+
+# an integer array, one seed class per line
+t { [1, 2, 3].sum(Rational(1, 2)) }
+t { [1, 2, 3].sum(10**30) }
+t { [1, 2, 3].sum("x") }
+t { [1, 2, 3].sum(nil) }
+t { [1, 2, 3].sum(false) }
+t { [1, 2, 3].sum(1.0i) }
+t { [1, 2, 3].sum([]) }
+t { [1, 2, 3].sum(0.5) }              # a Float seed already widened: 6.5
+t { [3, 4].sum(10**30) - 10**30 }
+
+# a float array
+t { [1.0, 2.0].sum(Rational(1, 2)) }
+t { [1.0, 2.0].sum(10**30) }
+t { [1.0, 2.0].sum("x") }
+t { [1.0, 2.0].sum(nil) }
+# the exact phase gives way to compensated summation at the first Float
+t { ([0.1] * 10).sum(0r) }
+
+# an integer Range adds the closed form to an Integer seed and runs every
+# other class through Kernel#Float
+t { (1..3).sum(Rational(1, 2)) }
+t { (1..3).sum(1.5r) }
+t { (1..3).sum(10**30) }
+t { (1..3).sum("x") }
+t { (1..3).sum(nil) }
+t { (1..3).sum(false) }
+t { (1..3).sum([]) }
+t { (1...1).sum(Rational(1, 2)) }     # empty: the seed, unconverted
+t { (1..3).sum(0.5) }                 # a Float seed already answered 6.5
+t { ("a".."c").sum(0.5) }
+t { ("a".."c").sum(0) }               # unchanged wording, from the generic `+`
+
+# a Hash folds its [key, value] pairs into the seed
+t { { a: 1, b: 2 }.sum(nil) }
+t { { a: 1, b: 2 }.sum(false) }
+t { {}.sum(nil) }
+t { { a: 1, b: 2 }.sum(0) }           # already the Integer coercion failure
+t { { a: 1, b: 2 }.sum([]) }          # already the concatenation
+
+# a seed of the numeric tower beside an element that is no number at all: the
+# arithmetic reaches no tower arm, so the operator itself reports the failure
+t { ["x"].sum(Rational(1, 2)) }
+t { ["x"].sum(10**30) }               # pin: already the Integer coercion failure
+t { { 1 => 2 }.sum(10**30) }          # pin: likewise, over the [k, v] pairs
+t { ["a"].reduce(Rational(1, 2), :+) }
+t { [10**30, "x"].inject(:+) }
+
+# the compensated phase carries CRuby's NaN and Infinity arms
+t { [Float::INFINITY, 1.0].sum }
+t { [1.0, 2.0].sum(Float::INFINITY) }
+t { [1.0, Float::NAN].sum }                   # pin
+t { [Float::INFINITY, -Float::INFINITY].sum } # pin
+t { [Float::INFINITY, 1].sum(0.5) }           # pin
+t { a = [[Float::INFINITY, 1.0], 0][0]; a.sum(0) }   # pin, through the boxed fold
+# a run BROKEN by a non-number keeps the uncompensated total, as CRuby's
+# not_float label does; only an exhausted run folds the compensation back
+t { a = [[0.1, 0.2, 0.3, Complex(0, 1)], 0][0]; a.sum(0.0) }   # pin
+
+# receivers read out of a container, so their class is only known at run time
+t { r = [(1..3), 0][0]; r.sum(10) }
+t { a = [[1, 2], 0][0]; a.sum(Rational(1, 2)) }     # pin: already (7/2)
+t { a = [[1, 2.5], 0][0]; a.sum(Rational(1, 2)) }   # pin: the exact phase gives way mid-fold
+
+# a user class as the seed: the fold applies ITS `+`, which the seeded sum
+# names nowhere, so the operator has to be kept reachable for it
+class Money
+  def initialize(cents); @cents = cents; end
+  def +(other); Money.new(@cents + other); end
+  def inspect; "$#{@cents}"; end
+end
+class Tally
+  attr_reader :n
+  def initialize(n); @n = n; end
+  def coerce(other); [Tally.new(other), self]; end
+  def +(other); Tally.new(@n + (other.is_a?(Tally) ? other.n : other)); end
+  def inspect; "T(#{@n})"; end
+end
+t { [1, 2, 3].sum(Money.new(0)) }
+t { [1, 2, 3].sum(Tally.new(0)) }
+
+# the seed expression, and the receiver expression, run exactly once
+$n = 0
+def seed
+  $n += 1
+  Rational(1, 2)
+end
+p [1, 2].sum(seed)
+p $n
+$m = 0
+def nums
+  $m += 1
+  [1, 2]
+end
+p nums.sum(Rational(1, 2))
+p $m

--- a/test/sum_seed_keeps_its_class.rb.expected
+++ b/test/sum_seed_keeps_its_class.rb.expected
@@ -1,0 +1,51 @@
+(13/2)
+1000000000000000000000000000006
+[TypeError, "no implicit conversion of Integer into String"]
+[NoMethodError, "undefined method '+' for nil"]
+[NoMethodError, "undefined method '+' for false"]
+(6+1.0i)
+[TypeError, "no implicit conversion of Integer into Array"]
+6.5
+7
+3.5
+1.0e+30
+[TypeError, "no implicit conversion of Float into String"]
+[NoMethodError, "undefined method '+' for nil"]
+1.0
+6.5
+7.5
+1000000000000000000000000000006
+[ArgumentError, "invalid value for Float(): \"x\""]
+[TypeError, "can't convert nil into Float"]
+[TypeError, "can't convert false into Float"]
+[TypeError, "can't convert Array into Float"]
+(1/2)
+6.5
+[TypeError, "String can't be coerced into Float"]
+[TypeError, "String can't be coerced into Integer"]
+[NoMethodError, "undefined method '+' for nil"]
+[NoMethodError, "undefined method '+' for false"]
+nil
+[TypeError, "Array can't be coerced into Integer"]
+[:a, 1, :b, 2]
+[TypeError, "String can't be coerced into Rational"]
+[TypeError, "String can't be coerced into Integer"]
+[TypeError, "Array can't be coerced into Integer"]
+[TypeError, "String can't be coerced into Rational"]
+[TypeError, "String can't be coerced into Integer"]
+Infinity
+Infinity
+NaN
+NaN
+Infinity
+Infinity
+(0.6000000000000001+1i)
+16
+(7/2)
+4.0
+$6
+T(6)
+(7/2)
+1
+(7/2)
+1


### PR DESCRIPTION
## Why

When you hand `sum`, `inject` or `reduce` a starting value, Ruby makes that value the accumulator and applies the operator to it once per element. So the starting value decides the arithmetic: a Rational start keeps the sum exact, a Bignum start keeps its digits, a Float start widens everything, and a start with no `+` at all raises from its own missing method. Spinel gave the accumulator the type of the *elements* instead, which is right only when the two happen to be the same class.

Concretely:

```ruby
p [1, 2, 3].sum(Rational(1, 2))   # CRuby (13/2); spinel: the generated C did not compile
p [1, 2, 3].sum(10**30)           # CRuby 1000000000000000000000000000006; spinel: did not compile
p (1..3).sum(10**30)              # CRuby 1000000000000000000000000000006; spinel 5076944270305263622
p [1, 2, 3].reduce(0.5, :+)       # CRuby 6.5; spinel 6.0
p [1, 2].sum(nil)                 # CRuby NoMethodError "undefined method '+' for nil"; spinel 3
p [1.0, 2.0].sum("x")             # CRuby "no implicit conversion of Float into String";
                                  #   spinel "String can't be coerced into Integer"
r = [(1..3), 0][0]; p r.sum(10)   # CRuby 16; spinel 10
p [1, 2, 3].inject(10, &:+)       # CRuby 16; spinel 6 (the seed dropped entirely)
```

A seed of another class was truncated (a Float into an `sp_int`), read as zero (nil, false), given a message written for Integer elements, or refused outright by the C compiler: a Rational, Bignum, String or Array seed simply stopped the build.

## What

- `sum(seed)` on an Integer, Float or String array, `inject/reduce(seed, :op)` on those arrays, `Range#sum(seed)`, `Hash#sum(seed)`, and each of those reached through a value whose class is only known at run time, now accumulate in the seed's class.
- The `&:op` spelling takes the same rule. It read the seed only when the operator came from the argument list, so `[1, 2, 3].inject(10, &:+)` folded from the first element and answered 6 where Ruby answers 16, whatever the seed's class. And with a block, `inject`'s lone argument is the seed, not the operator: `[1, 2, 3].inject(:s, &:+)` starts from `:s` and raises from Symbol's missing `+`, where it used to read `:s` as the operator and answer 6.
- The messages come from the operator that actually fails, so they name the element's class: `[1, 2].sum("x")` is "no implicit conversion of Integer into String" and `[1.0, 2.0].sum("x")` is "no implicit conversion of Float into String", where one hard-coded raise used to answer both. A `NoMethodError` from a boxed operator spells nil, true and false as themselves ("for nil", not "for an instance of NilClass").
- The dynamic arithmetic's numeric-tower arms fire only for two numbers. A Bignum, Rational or Complex on one side used to convert the other side with a helper that reads a String, Array, Hash, nil or Symbol as zero, so `[10**30, "x"].inject(:+)` answered the Bignum and `["x"].sum(Rational(1, 2))` named the wrong class; the pair now reaches the operator, which raises as Ruby does. Two kinds answer ahead of that rule because they have their own meaning for the operator: a mutable String behaves as the String it holds, and `Time + Rational(1, 2)` is a Time half a second later rather than a failure.
- `& | ^ << >>` are Integer's alone, and the check runs before the Bignum arm that used to read the other side as a number: `[2, 3].reduce(7.5, :<<)` and `[7.5, 0][0] & [10**30, 0][0]` are NoMethodError now, where a Float, Rational, Complex, String, Array or Proc receiver used to be masked or shifted as an integer.
- The table that words a failing operator now says what each builtin has, so `[[1, 2], 0][0] >> 1` and `[[1], 0][0] / [10**30, 0][0]` read as CRuby's NoMethodError rather than a coercion TypeError.
- The compensated float summation carries CRuby's NaN and Infinity arms, so `[Float::INFINITY, 1.0].sum` is Infinity rather than NaN. That step is written once and shared by the typed float sum and the boxed fold.
- `Kernel#Float` accepts a Rational, which is what `Range#sum` needs to convert a Rational seed.

## How

One predicate, `fold_seed_typed(seed, elem)` in `src/types.c`, decides which fold is emitted: the seed keeps the element's C slot when it is of the element's own class, or an Integer over Floats (which widens exactly, and Ruby answers a Float too). The inference (`src/analyze_infer_recv.c`) and the emitters (`src/codegen_call_recv.c`, `src/codegen_fold.c`) read the same predicate, so they decide alike. An empty `[]` or `{}` literal seed infers as no type at all, so both sides resolve it to its container kind first.

Every other seed folds boxed. `sp_poly_sum_seed` in `lib/spinel_rt.h` follows CRuby's `ary_sum`: an exact phase while the seed and the elements are Integers or Rationals; from the first Float onward the Kahan-Babuska compensated summation the typed float sum already used, started at the exact total; then plain `+`, which is where the raise comes from. A seed that is not a number has no exact phase and starts at that last one. The compensated step moved into `sp_float_sum_step` in `lib/sp_array.h`, called by both the typed sum and the boxed fold, and gained CRuby's NaN and Infinity arms; without them the compensation computed (inf - inf) and `[Float::INFINITY, 1.0].sum` answered NaN on both paths. A run broken by a value that is no number keeps the uncompensated total, which is what CRuby's `not_float:` label does, so `[[0.1, 0.2, 0.3, Complex(0, 1)], 0][0].sum(0.0)` still reads 0.6000000000000001 before the Complex is added.

Everything that folds boxed boxes its receiver and its seed into rooted temporaries, receiver first. A seed that allocates (a Rational, a Bignum) could otherwise collect a receiver array the same statement had just built. The three `sum(seed)` call sites share one emitter helper for this, and `emit_inject_expr`'s boxed arm roots its receiver temp the way the poly-array arm beside it always did. That arm's other entry, the runtime operator symbol, had the same hole on master, so one line fixes both.

The numeric tower gets one rule of its own, since the seeded fold is what sends unusual pairs through it: an arm fires only when both operands are numbers of the tower. A Bignum, Rational, BigRational or Complex on either side used to send the pair to that arm, which converted the other side with `sp_poly_as_bigint` / `as_rational` / `as_complex`, and those read a String, Array, Hash, nil or Symbol as zero. `sp_poly_tower_mismatch` says when there is no arm to reach, and the pair goes to `sp_poly_binop_bad`, which already words the failure Ruby's way from either side. Two kinds answer before that question is asked: a shared mutable string handle becomes its live String, so it is judged as a String; and a Time takes any real number of the tower as an offset, Rational and Bignum included. The five bit operators get the neighbouring rule: they belong to Integer, so `sp_poly_bitop` sends any other receiver to the same place, and asks before the Bignum arm that converts both sides. `sp_poly_has_binop`, which decides whether a failure reads as a missing method or as a coercion, now lists what each builtin has: `+ - * & | <<` for an Array, `<<` for a String, `+ -` for a Time, nothing for a Range.

`Range#sum(seed)` gets `sp_range_sum_seed`: an empty range answers the seed untouched, an Integer or Bignum seed is added to the range's total through the numeric tower, and any other class goes through `Kernel#Float` and answers a Float. That is `range.c`'s rule, which is why `(1..3).sum("x")` is an ArgumentError from the conversion rather than a TypeError from an addition. The seed keeps its digits; the total itself is still an `sp_int` sum of the members, as on master.

`inject/reduce` reaches the boxed arm that was already there for a runtime operator symbol and folds through `sp_poly_binop_sym` from the boxed seed. `emit_inject_expr` records the operator's symbol node alongside its name, which is what lets both spellings, the trailing `:op` argument and the `&:op` block, find their seed and reach that arm. The inference reads the operator from either place too, and stops reading a lone Symbol as the operator when a block is present, because then it is the seed.

A user class used as a seed needs its `+`: `sum(seed)` names that operator nowhere, so the dead-code pass pruned a `+` with no other call site and the dispatch arm came out empty. The pass that keeps `reduce(seed, :+)`'s operator now keeps a seeded `sum`'s `+` when the seed could be a user object (a literal or a builtin constructor cannot be one, so `[1, 2].sum(0)` marks nothing), and reads an `&:op` block for its symbol. An erased element type says nothing about the seed's class and keeps the typings it had, though a user class used as its seed reaches its own `+` there too: `[[1, 2, 3], 0][0].sum(Money.new(0))` answers $6 where master raised NoMethodError.

## Validation

`make test`: 3472 pass, 0 fail, 0 error. Benchmarks 61 pass. optcarrot OK, checksum 59662, and its generated C is byte-identical. ext-cruby pass, rbs-seed pass, rubyspec 6/6.

Against a differential corpus of ~2,100 minimized programs that behave differently under CRuby 4.0.6 and Spinel (the same corpus behind #3999/#4003/#4029): 27 flipped to matching, 0 regressed (812/2131 before, 839/2131 after). The corpus holds no seeded `&:op` fold and no user-class seed, so those parts are pinned by the new tests rather than by a corpus program.

Generated-C sweep over the 3487 test and benchmark programs the sweep compiles: 3473 identical, 14 changed, 0 failures. Every one of the fourteen contains a fold; the numeric-tower rule, the bit operators and the compensated step are runtime-only and change no generated C:

- `test/sum_seed_keeps_its_class.rb`, `test/inject_seed_keeps_its_class.rb`: new.
- `test/array_bad_literal_argument.rb`, `test/enumerable_methods.rb`, `test/sum_non_numeric_raises.rb` hold `[1, 2].sum("x")`, `[1, 2].sum("")` and `["a"].sum(0)`, which lose their hard-coded raise and reach the operator instead: the same TypeError, worded by the operator.
- `test/bundle_array_e.rb` folds from a seed read out of a heterogeneous array, whose class is only known at run time, so it folds boxed; three of its comments named the old unboxing helpers and now describe the boxed fold.
- `test/container_read_builtin_methods.rb` and `test/poly_string_surface.rb` sum from a seed on a receiver read out of a container: that call site now goes through the same rooted helper as the others.
- `test/issue_2880.rb`, `test/issue_2939.rb`, `test/issue_3167.rb`, `test/method_compose_container.rb` fold through a runtime operator symbol, whose arm now roots its receiver temp. Same answers, one added `SP_GC_ROOT`.
- `test/symbol_to_proc_after_positional.rb` holds `[10, 20, 30].inject(0, &:+)`, whose seed is now actually read. Its answer was already 60, because that seed is 0.
- `test/issue_2903.rb` is `"01".chars.reduce(:a) { |s, c| ... }`, a lone Symbol with a block, so it is the seed, which the inference now agrees with. The file's own comment calls `:a` the accumulator; the answers are unchanged.

No program without a seeded fold changes its generated C. A `sum(x)` whose seed is not a literal keeps user `+` methods alive, which is the reach `reduce(x, :+)` already had: `[1, 2].sum(0)` beside a `def +` emits exactly master's C, and `sum(k)` over a local marks, as `reduce(k, :+)` does on master too.

Inference fixpoint: no program that converged on master fails to converge here.

New tests `test/sum_seed_keeps_its_class.rb` (51 lines of output) and `test/inject_seed_keeps_its_class.rb` (30), both with expectations generated by CRuby 4.0.6, both clean under `SPINEL_GC_STRESS=1` and under ASAN/UBSAN in plain and stress modes. They cover one seed class per line, both spellings of the operator, a user class as the seed (one with `+`, one with `coerce`), the NaN and Infinity arms, the uncompensated total a broken run keeps, and the pins that must not move: a Float seed over Integers, the coercion failures a Hash and a String range already reported, an empty receiver answering its seed, the same-class folds that keep the typed fast path, and the boxed-receiver folds whose answers the rewritten runtime must not move. Two lines count side effects, and hold the seed expression and the receiver expression to one evaluation each.

## Left alone, on purpose

- Seedless folds have no seed to keep a class and are untouched. A block form can take a seed, and there the accumulator is still typed from the block's value, so `[1, 2].sum(Rational(1, 2)) { |x| x * 2 }` still does not compile. That accumulator belongs to the block emitters and is their own follow-up.
- `sum(seed)` over an array whose element types are erased still totals the elements from an implied 0 and adds the seed afterwards. So it has no compensated phase, `[].sum(nil)` adds instead of answering the seed, and `[1, "q"].sum(Rational(1, 2))` says "String can't be coerced into Integer" where CRuby, folding from the seed, says "into Rational". That is `sp_PolyArray_sum_poly`'s own arm and it reads the same before and after.
- `Range#sum` adds an exact seed to an `sp_int` total of the members, so a range whose members total past 2^63 still wraps: `((2**62)..(2**62 + 3)).sum(10**30)` answers 1000000000000000000000000000006 where CRuby answers 1000000000018446744073709551622. The seed no longer wraps; the closed form is the range emitter's own rule, and master wraps there too.
- An Array receiver of `/`, `%` or `**` with a plain number still reads the array as 0 (`[[1, 2], 0][0] / 2` is 0 on master and here; CRuby raises NoMethodError): those operators convert the receiver before any table is consulted. Only the Bignum operand shape reaches the table and raises.
- `String#*` and `Array#*` convert their count through `to_int`, which the dynamic arithmetic does not do: `["ab", 0][0] * Rational(2, 1)` and `[[1, 2], 0][0] * Rational(2, 1)` raise "no implicit conversion of Rational into String/Array" where CRuby answers "abab" and [1, 2, 1, 2]. Master answered a Rational zero for both, so the raise is closer, but a to_int count is its own rule. An Integer count is no better on either tree: `[[1, 2], 0][0] * 2` is a TypeError before and after, where CRuby answers [1, 2, 1, 2].
- The messages Time raises for an operand it cannot use are its own conversion rule: `[Time.at(0).utc, 0][0] + Complex(1, 1)` reads "Complex can't be coerced into Time" where CRuby says RangeError "can't convert 1+1i into Rational"; a String or nil operand reads "... can't be coerced into Time" where CRuby says "can't convert String into an exact number"; `Time + Time` reads "Time can't be coerced into Time" where CRuby says "time + time?". All are TypeErrors from the operator now, where master answered the operand itself for a Rational and NoMethodError for a String.
- Spinel's Time is 64-bit nanoseconds, so an offset it cannot hold saturates: `[Time.at(0).utc, 0][0] + [10**30, 0][0]` is 2262-04-11 23:47:16.854775807 UTC. Master saturates `Time + 1e30` the same way; the new arm routes a Bignum and a Rational there instead of answering the offset itself, as master did. A non-Integer offset goes through a double, so `Time.at(5) + Rational(2**53 + 1, 1)` is one second off; every value inside 2^53 is exact.
- `[proc, 0][0] << 3` is NoMethodError where CRuby raises TypeError "callable object is expected". Proc composition itself works both ways on both trees.
- `Integer#+` redefinition: CRuby's `sum` checks whether the operator is still the built-in one and Spinel does not model that.
- A typed Integer fold does not promote to Bignum on overflow: `[2**62, 2**62].sum(1)` wraps and `[2**62, 2**62].reduce(1, :+)` raises RangeError "integer overflow in +", where CRuby answers 9223372036854775809. That is typed arithmetic's own rule, unchanged here.
- `Kernel#Float` on a Complex: on the Range path `sp_poly_Float` raises TypeError "can't convert Complex into Float", so `(1..3).sum(1.0i)` names the class where CRuby says RangeError "can't convert 0+1.0i into Float"; a bare `Float(Complex(0, 1))` raises RangeError with no value named. Master could not compile `(1..3).sum(1.0i)` at all, so this is newly reachable rather than unchanged; the wording is `Kernel#Float`'s own rule.
- A Complex read through the dynamic arithmetic loses its components' Float-ness: `c = [Complex(0, 1), 0][0]; p c + 1.0` answers (1+1i) on master and here, where CRuby answers (1.0+1i), so `[1.0, 2.0].sum(Complex(0, 1))` is (3+1i) rather than (3.0+1i). The typed spelling `Complex(0, 1) + 1.0` is right on both trees.
- In the boxed fold, a Float seed over integers past 2^53 adds them one at a time in floating point where CRuby totals them exactly first, so `[[1, 2**53], 0][0].sum(0.5)` lands one ulp away. Every value a double represents exactly agrees, and the typed path (`[1, 2**53].sum(0.5)`) matches CRuby as it did before.
- `{}.sum(-0.0)` is 0.0 in CRuby, because Enumerable#sum's accumulator adds a +0.0 even to an empty receiver; Spinel answers the seed, -0.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `sum`, `reduce`, `inject`, and related folds now preserve the seed’s type and support broader combinations of numeric, string, collection, and user-defined values.
  - Added support for seeded folds involving Rational, Complex, large Integer, Float, `nil`, booleans, and custom objects.
  - Array set and bitwise operations now follow receiver-appropriate behavior.
  - Improved handling of range and hash summation, including special numeric values and compensated floating-point accuracy.

- **Bug Fixes**
  - Fold operations now produce more accurate errors for unsupported operand combinations and missing methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->