### PR TITLE
An application can name the allocator it wants

### DIFF
--- a/docs/spin.md
+++ b/docs/spin.md
@@ -221,6 +221,46 @@ compiles it unless something requires it, and an excluded `.h` is still on the
 include path for the C that is compiled. An application scaffolded by
 `spin new` has no `[package]` table; add one to use the field.
 
+## Choosing an allocator
+
+A program that runs for a second and exits spends no meaningful time in
+`malloc`. A server does: it allocates for every request for as long as it is
+up, and on that shape the allocator is a measurable fraction of the whole
+profile. `allocator` names the one this program wants:
+
+```toml
+[package]
+allocator = "jemalloc"
+```
+
+Anything `-l<name>` can link is accepted, and it becomes an ordinary link
+input. `"system"` and the absent key both mean the platform's own allocator,
+which is the default and stays the default: spinel compiles batch programs and
+benchmarks as readily as servers, and the right allocator is a property of the
+program rather than of the language. Only the manifest knows which kind of
+program this is. An application scaffolded by `spin new` has no `[package]`
+table; add one to use the field.
+
+The library has to be linkable at build time, which on Debian and Ubuntu means
+the development package (`libjemalloc-dev`) and not just the runtime one
+(`libjemalloc2`). Asking for an allocator that is not installed fails the
+build:
+
+```console
+$ spin build
+/usr/bin/ld: cannot find -ljemalloc: No such file or directory
+```
+
+That is deliberate. The manifest states what the program needs, and an unmet
+statement should fail the way an unresolvable dependency does — quietly
+building something slower than what was asked for is how one machine's binary
+comes to differ from another's without anyone noticing.
+
+On two Rails-derived applications compiled by spinel, `"jemalloc"` was worth
++58% on one OS worker and +25% on twelve for a 420 KB page, and +22% and +59%
+for a 6 KB one. It is the same reason Rails ships jemalloc in its production
+image.
+
 ## Building outside spin
 
 `spin build` owns the tree it sits in. When the build is driven from somewhere

--- a/tools/spin.rb
+++ b/tools/spin.rb
@@ -939,7 +939,7 @@ end
 # --- manifest ----------------------------------------------------------------
 
 class Project
-  attr_reader :root, :name, :dep_paths
+  attr_reader :root, :name, :dep_paths, :allocator
 
   def initialize(root)
     @root = root
@@ -951,6 +951,12 @@ class Project
       nm = base
     end
     @name = nm
+    # `[package] allocator`. A malloc replacement is a property of the
+    # PROGRAM, not of the compiler: a server allocates for its whole life
+    # where a batch job barely allocates at all, and only the manifest knows
+    # which this is. "" (the default) and "system" both mean the platform's
+    # own allocator.
+    @allocator = toml.get("package", "allocator")
     # per-dependency feature enablement from THIS manifest's [dependencies]
     # inline specs (dep = { ..., features = ["cuda"] }); root-level only --
     # transitive feature unification is out of scope
@@ -1089,6 +1095,13 @@ def spin_flags(prj)
   # that is not already cached, which is what makes the --link paths real.
   prj.native_objs.each { |o| f += " --link #{o}" }
   prj.native_build_libs.split("\n").each { |l| f += " --link #{l}" if l != "" }
+  # The allocator the manifest asked for, as an ordinary link input. Declared
+  # and missing is a hard link error, deliberately: the manifest states what
+  # the program needs, and an unmet statement should fail the way an
+  # unresolvable dependency does rather than quietly building something
+  # slower than what was asked for. Ordering is free -- this is a whole -l,
+  # not an object the earlier ones resolve symbols against.
+  f += " --link -l" + prj.allocator if prj.allocator != "" && prj.allocator != "system"
   f
 end
 


### PR DESCRIPTION
Follows #4334. You closed that with "allocation is no longer what limits
that... open a fresh issue if you hit a specific shape" — this is a shape,
and it turned out to be small enough to be a patch instead.

## What the profile says

`6fb02909` did what it claimed: on the campfire binary under load,
`try_to_wake_up` is now **0.21%** of the profile where the contended path
used to be 23.6%. What is left in its place is the allocator itself. A
60-second `perf record` at 12 OS workers, 66,690 samples:

| bucket | share |
|---|--:|
| glibc `_int_malloc`, `cfree`, `_int_free`, `malloc_consolidate`, `malloc`, `_int_free_merge_chunk`, `free@plt`, `__libc_calloc`, `unlink_chunk` | **~35%** |
| `sp_gc_collect`, `sp_gc_mark`, `sp_gc_sweep_slot`, `sp_gc_mark_drain`, `sp_str_sweep_young` | ~13% |

Your tcmalloc probe in #4334 found nothing, and I think that reading was
correct at the time: the ask storm dominated, so the allocator underneath
it could not show. With the storm gone it does.

## The measurement

`LD_PRELOAD=libjemalloc.so.2` against an otherwise identical build, two
applications with very different shapes, median of repeats:

| | glibc | jemalloc |
|---|--:|--:|
| 420 KB page, 1 worker | 23.8 req/s | **37.5** (+58%) |
| 420 KB page, 12 workers | 44.8 | **54.6** (+25%) |
| 6 KB page, 1 worker | 7435 | **9041** (+22%) |
| 6 KB page, 12 workers | 4613 | **7336** (+59%) |

CPU per request on the 420 KB page falls 42.5 ms -> 27.1 ms at one worker.
Note the 6 KB row: glibc *regresses* from 1 worker to 12 (7435 -> 4613)
where jemalloc largely holds.

A binary **linked** this way rather than preloaded lands in the same place
— 9297 req/s on the 6 KB page at one worker, against the preload arm's
9041 — so the manifest field buys what the preload measured.

## The change

```toml
[package]
allocator = "jemalloc"
```

Two lines of behaviour: `Project` reads the key, `spin_flags` appends
`--link -l<name>` unless it is `""` or `"system"`. It goes in `spin_flags`
because that is the one place `spin build` and `spin flags` both read, so
the two cannot disagree about which allocator a build got.

**Deliberately not a default.** spinel compiles optcarrot and batch
programs as readily as servers, and a program that runs for a second and
exits spends no meaningful time in `malloc`. The right allocator is a
property of the program, not of the language, and only the manifest knows
which kind of program this is. The absent key and `"system"` both keep the
platform allocator, so nothing changes for anyone who does not ask.

**Declared and missing is a hard link error**, not a fallback:

```console
$ spin build
/usr/bin/ld: cannot find -ljemalloc: No such file or directory
```

I first wrote this with a probe and a warn-and-continue fallback, and it
was worse. A compiled program already fails this way when `-lsqlite3` has
no `libsqlite3-dev` behind it; special-casing one library would be the
inconsistency. And quietly building something slower than what was asked
for is how one machine's binary comes to differ from another's without
anyone noticing. Note this needs the development package
(`libjemalloc-dev`) — the runtime `libjemalloc2` that `LD_PRELOAD` uses is
not enough to link against.

## Verified

`spin.rb` is itself spinel-compiled, so the patch stays in the subset;
`make bin/spin` builds it. Then, on Ubuntu 24.04 / gcc 13.3:

- absent key -> no `-l` in `spin flags`; `"system"` -> no `-l`
- `"jemalloc"` -> `--link -ljemalloc`, and a real `spin build` produces a
  binary whose `ldd` shows `libjemalloc.so.2`
- a name that does not exist -> the link error above

Unrelated, but you may want to know: `make bin/spin` fails at `b80f6302`
on macOS/arm64 with `_sp_io_raise_closed` undefined, referenced from
`sp_File_gets`. It reproduces with this patch stashed, so it is not from
here. The symbol is defined at `lib/sp_io.c:246` and is present in
`libspinel_rt.a`, so it looks like a link-path issue rather than a missing
definition. Linux is fine. Happy to file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GntgyveNAjNS98MjuchFJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects can now select a custom memory allocator through the package manifest.
  * Allocator libraries are linked automatically during builds when configured.
  * The platform’s default allocator remains available when no custom allocator is specified.

* **Documentation**
  * Added guidance on configuring allocators, build requirements, failure behavior, and benchmark results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->