### PR TITLE
A tool that uses Thread depends on the threaded runtime archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -483,14 +483,14 @@ tools: $(TOOL_BINS) bin/spin
 # extractor beside the compiler when vendor/rbs is fetched: a spin-driven
 # build resolves --rbs via <dir-of-spinel>/spinel_rbs_extract, and without
 # the copy it silently lost every .rbs seed (#1845 bounce 6).
-bin/spin: tools/spin.rb tools/spin/toml.rb $(SPINEL) $(SP_RT_LIB) $(RBS_EXTRACT_TARGET)
+bin/spin: tools/spin.rb tools/spin/toml.rb $(SPINEL) $(SP_RT_LIB) $(SP_RT_MT_LIB) $(RBS_EXTRACT_TARGET)
 	$(SPINEL) tools/spin.rb -o bin/spin
 	@if [ -n "$(RBS_EXTRACT_TARGET)" ]; then \
 	  cp -f $(RBS_EXTRACT_BIN) bin/spinel_rbs_extract; \
 	  echo "$(RBS_EXTRACT_BIN) -> bin/spinel_rbs_extract"; \
 	fi
 
-bin/spinel-%: tools/%.rb tools/tool_common.rb $(SPINEL) $(SP_RT_LIB)
+bin/spinel-%: tools/%.rb tools/tool_common.rb $(SPINEL) $(SP_RT_LIB) $(SP_RT_MT_LIB)
 	@mkdir -p bin
 	$(SPINEL) $< -o $@
 


### PR DESCRIPTION
`bin/spin` and `bin/spinel-%` list `$(SP_RT_LIB)` as a prerequisite but not
`$(SP_RT_MT_LIB)`. A program that uses `Thread` links the threaded archive
instead, and three tools do — `tools/spin.rb`,
`tools/gen_builtin_arity_spec.rb`, `tools/gen_conv_slot_probe.rb`.

So an incremental build after any runtime `.c` change rebuilds
`libspinel_rt.a`, leaves `libspinel_rt_mt.a` alone, and links the tool
against the stale one.

## Repro

Visible with no symbol change at all:

```console
$ touch lib/sp_io.c && make bin/spin
libspinel_rt.a    rebuilt
libspinel_rt_mt.a NOT rebuilt
```

When the changed file added a symbol the tool reaches, the link fails
outright. On `b80f6302`, `make bin/spin`:

```
Undefined symbols for architecture arm64:
  "_sp_io_raise_closed", referenced from:
      _sp_File_gets in spinel_out_91457_0-4fc2ba.o
ld: symbol(s) not found for architecture arm64
```

`70210fa3` is where this starts, since it added `sp_io_raise_closed` and
`sp_File_gets` calls it. Five lines are enough to show the same thing
directly, once `libspinel_rt_mt.a` is stale — threaded and single-threaded
differ only in which archive they link:

```ruby
f = File.open("/etc/hosts")
t = Thread.new { 1 + 1 }   # drop this line and it compiles
t.join
puts f.gets
f.close
```

Not platform-specific — the rule is the same everywhere; a machine that has
done a full build since `70210fa3` just has a current archive and never
sees it.

## Fix

Add `$(SP_RT_MT_LIB)` to both rules. Every other target that links threaded
code — `gc-minor-test`, the `build/test-results/%` rules — already names
both archives, so these two are the omission rather than the convention.

Verified: with the patch, `touch lib/sp_io.c && make bin/spin` rebuilds the
mt archive, and the five-line program above compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GntgyveNAjNS98MjuchFJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Threaded tool builds now ensure the required threaded runtime archive is available during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->