### PR TITLE
A container walk that meets an object already on its path stops there

### DIFF
--- a/lib/sp_exc.c
+++ b/lib/sp_exc.c
@@ -333,6 +333,10 @@ const char *sp_exc_parent_of_name(const char *cls) {
     {"LoadError",             "StandardError"},
     {"RegexpError",           "StandardError"},
     {"StringScanner_Error",   "StandardError"},
+    /* the json package raises these by name; NestingError is what a document
+       too deep to serialize raises, and `rescue JSON::ParserError` catches it
+       in CRuby because it is a ParserError */
+    {"JSON::NestingError",    "JSON::ParserError"},
     {"FiberError",            "StandardError"},
     {"UncaughtThrowError",    "ArgumentError"},
     {"SyntaxError",           "ScriptError"},

--- a/lib/sp_inspect.c
+++ b/lib/sp_inspect.c
@@ -8,6 +8,145 @@
 #include "sp_inspect.h"
 #include "sp_string.h"   /* sp_String, sp_alloc.h, SP_GC_ROOT via sp_gc.h */
 #include "sp_str.h"      /* sp_sym_inspect_key for the symbol hash-key short form */
+#include <stdlib.h>   /* realloc for the growing path below */
+
+/* The walk guard's per-worker path (see sp_inspect.h). It lives here because
+   this archive unit is the one every side of the runtime already links for
+   #inspect, and the guard has to be one set of frames shared by the generated
+   translation unit, the archive and the carried packages -- a per-TU copy would
+   let a walk that crosses the boundary forget where it had been. */
+SP_TLS sp_poly_recur_frame *sp_poly_recur_stack = NULL;
+SP_TLS int sp_poly_recur_top = 0;
+SP_TLS int sp_poly_recur_cap = 0;
+/* Make room for at least `want` frames, doubling from 64. Off the hot path:
+   a walk deep enough to reach the end of the buffer has already paid far more
+   in its own recursion than this call costs. */
+#define SP_POLY_RECUR_FIRST_CAP 64   /* frames; 1.5 KB, more than any real walk */
+SP_COLD void sp_poly_recur_grow(int want) {
+  int cap = sp_poly_recur_cap ? sp_poly_recur_cap : SP_POLY_RECUR_FIRST_CAP;
+  while (cap < want) cap *= 2;
+  sp_poly_recur_frame *f = (sp_poly_recur_frame *)
+      realloc(sp_poly_recur_stack, sizeof(sp_poly_recur_frame) * (size_t)cap);
+  if (!f) sp_oom_die();
+  sp_poly_recur_stack = f;
+  sp_poly_recur_cap = cap;
+}
+
+/* ---- the deep-walk index (SP_POLY_RECUR_SCAN, sp_inspect.h) ----
+   Open addressing over the frames themselves: a slot names a frame by index
+   and repeats its key, and is live only while that frame is still on the path
+   with that key. A pop lowers sp_poly_recur_top and sp_poly_recur_ixtop and
+   leaves the slots to go stale on their own; a lookup checks the frame, an
+   insert may take a stale slot, and once the slots in use (live or stale) pass
+   half the table it is rebuilt from the live frames at a quarter load. Nothing
+   here runs until a walk is deeper than the scan budget. */
+typedef struct { const void *a, *b; int kind, frame; } sp_poly_recur_slot;
+static SP_TLS sp_poly_recur_slot *sp_poly_recur_ix = NULL;
+static SP_TLS int sp_poly_recur_ixcap = 0;    /* a power of two, or 0 before first use */
+static SP_TLS int sp_poly_recur_ixused = 0;   /* slots holding a frame, live or stale */
+SP_TLS int sp_poly_recur_ixtop = 0;
+
+/* Multipliers for the slot hash: 2^64 / phi and two more odd constants of the
+   same shape (xxHash's), so a pointer's bits spread across the word before the
+   fold and the mask. Any odd multipliers would do; these are the usual ones. */
+#define SP_POLY_RECUR_HASH_M1 0x9E3779B97F4A7C15ull
+#define SP_POLY_RECUR_HASH_M2 0xC2B2AE3D27D4EB4Full
+#define SP_POLY_RECUR_HASH_M3 0x165667B19E3779F9ull
+#define SP_POLY_RECUR_IX_MIN  256   /* slots; an eighth full at the scan budget */
+/* Callers guarantee a built table: sp_poly_recur_index rebuilds before any probe. */
+static inline int sp_poly_recur_slot_of(int kind, const void *a, const void *b) {
+  uint64_t h = ((uint64_t)(uintptr_t)a >> 4) * SP_POLY_RECUR_HASH_M1
+             ^ ((uint64_t)(uintptr_t)b >> 4) * SP_POLY_RECUR_HASH_M2
+             ^ (uint64_t)kind * SP_POLY_RECUR_HASH_M3;
+  h ^= h >> 32;
+  return (int)(h & (uint64_t)(sp_poly_recur_ixcap - 1));
+}
+static inline int sp_poly_recur_slot_live(const sp_poly_recur_slot *s) {
+  if (s->frame >= sp_poly_recur_top) return 0;
+  const sp_poly_recur_frame *f = &sp_poly_recur_stack[s->frame];
+  return f->a == s->a && f->b == s->b && f->kind == s->kind;
+}
+static void sp_poly_recur_ix_insert(int frame) {
+  const sp_poly_recur_frame *f = &sp_poly_recur_stack[frame];
+  int mask = sp_poly_recur_ixcap - 1;
+  int i = sp_poly_recur_slot_of(f->kind, f->a, f->b);
+  for (;;) {
+    sp_poly_recur_slot *s = &sp_poly_recur_ix[i];
+    if (s->frame < 0) { sp_poly_recur_ixused++; break; }
+    if (!sp_poly_recur_slot_live(s)) break;   /* a stale slot is free */
+    i = (i + 1) & mask;
+  }
+  sp_poly_recur_ix[i].a = f->a;
+  sp_poly_recur_ix[i].b = f->b;
+  sp_poly_recur_ix[i].kind = f->kind;
+  sp_poly_recur_ix[i].frame = frame;
+}
+SP_COLD static void sp_poly_recur_ix_rebuild(int frames) {
+  int cap = SP_POLY_RECUR_IX_MIN;
+  while (cap < frames * 4) cap *= 2;
+  if (cap != sp_poly_recur_ixcap) {
+    free(sp_poly_recur_ix);
+    sp_poly_recur_ix = (sp_poly_recur_slot *)malloc(sizeof(sp_poly_recur_slot) * (size_t)cap);
+    if (!sp_poly_recur_ix) sp_oom_die();
+    sp_poly_recur_ixcap = cap;
+  }
+  for (int i = 0; i < cap; i++) sp_poly_recur_ix[i].frame = -1;
+  sp_poly_recur_ixused = 0;
+  sp_poly_recur_ixtop = 0;
+}
+void sp_poly_recur_index(void) {
+  int top = sp_poly_recur_top;
+  if (sp_poly_recur_ixused + (top - sp_poly_recur_ixtop) > sp_poly_recur_ixcap / 2)
+    sp_poly_recur_ix_rebuild(top);
+  for (int i = sp_poly_recur_ixtop; i < top; i++) sp_poly_recur_ix_insert(i);
+  sp_poly_recur_ixtop = top;
+}
+int sp_poly_recur_seen_deep(int kind, const void *a, const void *b) {
+  /* a fiber switch (sp_exc_ctx_load) puts other frames under the index, and
+     the first deep lookup of a worker finds no table at all */
+  if (sp_poly_recur_ixcap == 0 || sp_poly_recur_ixtop < sp_poly_recur_top) sp_poly_recur_index();
+  int mask = sp_poly_recur_ixcap - 1;
+  int i = sp_poly_recur_slot_of(kind, a, b);
+  for (;;) {
+    const sp_poly_recur_slot *s = &sp_poly_recur_ix[i];
+    if (s->frame < 0) return 0;
+    if (s->a == a && s->b == b && s->kind == kind && sp_poly_recur_slot_live(s)) return 1;
+    i = (i + 1) & mask;
+  }
+}
+
+/* ---- the Set package's walks (prototypes and kinds in sp_inspect.h) ---- */
+static sp_int sp_poly_recur_enter(int kind, const void *a, const void *b) {
+  if (sp_poly_recur_seen(kind, a, b)) return -1;
+  return sp_poly_recur_push(kind, a, b);
+}
+sp_int sp_poly_recur_enter_inspect(sp_RbVal set) {
+  return sp_poly_recur_enter(SP_POLY_RECUR_SET_INSPECT, set.v.p, NULL);
+}
+sp_int sp_poly_recur_enter_eq(sp_RbVal set, sp_RbVal other) {
+  return sp_poly_recur_enter(SP_POLY_RECUR_SET_EQ, set.v.p, other.v.p);
+}
+sp_int sp_poly_recur_enter_flatten(sp_RbVal set) {
+  /* the Ruby raises on -1; as in the runtime's flatten, the walk's own frames
+     go before the raise (sp_poly_recur_drop_kind) */
+  if (sp_poly_recur_seen(SP_POLY_RECUR_SET_FLATTEN, set.v.p, NULL)) {
+    sp_poly_recur_drop_kind(SP_POLY_RECUR_SET_FLATTEN);
+    return -1;
+  }
+  return sp_poly_recur_push(SP_POLY_RECUR_SET_FLATTEN, set.v.p, NULL);
+}
+/* The mark comes back from Ruby, where anyone can spell the module's name. One
+   this path never handed out to a Set walk -- outside the frames, or naming a
+   frame of the runtime's own -- is ignored rather than moving the depth under
+   a walk that is still running. A Set walk's own mark whose frame a handler
+   has already dropped is beyond top, and ignored the same way. */
+void sp_poly_recur_leave(sp_int mark) {
+  if (mark < 0 || mark >= sp_poly_recur_top) return;
+  int kind = sp_poly_recur_stack[mark].kind;
+  if (kind != SP_POLY_RECUR_SET_INSPECT && kind != SP_POLY_RECUR_SET_EQ &&
+      kind != SP_POLY_RECUR_SET_FLATTEN) return;
+  sp_poly_recur_pop((int)mark);
+}
 
 const char *sp_inspect_container(sp_RbVal v) {
   /* The container is live across the sp_String allocations below; root it so a
@@ -17,6 +156,13 @@ const char *sp_inspect_container(sp_RbVal v) {
   SP_GC_ROOT_RBVAL(v);
   int kind = sp_json_kind_fn ? sp_json_kind_fn(v) : 0;
   sp_int n = sp_json_len_fn ? sp_json_len_fn(v) : 0;
+  /* A container reached from inside itself renders as the ellipsis and stops:
+     CRuby prints [[...]] for `a << a` and {h: {...}} for `h[:h] = h`. The mark
+     covers the loop below, so a SIBLING copy of the same object still renders
+     in full -- only the one the walk is standing inside is elided. */
+  if (sp_poly_recur_seen(SP_POLY_RECUR_INSPECT, v.v.p, NULL))
+    return kind == 1 ? SPL("[...]") : SPL("{...}");
+  int rmark = sp_poly_recur_push(SP_POLY_RECUR_INSPECT, v.v.p, NULL);
   if (kind == 1) {  /* array: [e0, e1, ...] */
     sp_String *s = sp_String_new("[");
     SP_GC_ROOT(s);
@@ -25,6 +171,7 @@ const char *sp_inspect_container(sp_RbVal v) {
       sp_String_append(s, sp_poly_inspect_fn(sp_json_aref_fn(v, i)));
     }
     sp_String_append(s, "]");
+    sp_poly_recur_pop(rmark);
     return sp_str_dup(s->data);
   }
   /* hash: {k => v, ...}, with the `sym: v` shorthand for a Symbol key. */
@@ -45,5 +192,6 @@ const char *sp_inspect_container(sp_RbVal v) {
     sp_String_append(s, sp_poly_inspect_fn(val));
   }
   sp_String_append(s, "}");
+  sp_poly_recur_pop(rmark);
   return sp_str_dup(s->data);
 }

--- a/lib/sp_inspect.h
+++ b/lib/sp_inspect.h
@@ -11,4 +11,114 @@
 #include "sp_gc.h"   /* sp_RbVal */
 
 const char *sp_inspect_container(sp_RbVal v);
+
+/* ---- the walk guard: an object already on the path stops the walk ----
+ *
+ * `a = []; a << a` is legal Ruby, and so is a Struct that holds itself. Every
+ * walk that descends into a container -- #inspect, ==, eql?, <=>, #hash,
+ * #flatten, #join, puts -- would follow such a cycle until the C stack ran
+ * out. CRuby's rb_exec_recursive keeps, per thread, the set of objects (or
+ * object PAIRS) the current walk is already inside and answers a fixed result
+ * for one it meets again; this is that set, as a small stack.
+ *
+ * Frames hold raw pointers that are only ever COMPARED, never dereferenced:
+ * the collector does not move objects, and pushing a frame allocates nothing,
+ * so a walk cannot collect the very object it is remembering. Per-worker
+ * (SP_TLS) like the exception stack, and carried across a green thread's
+ * suspension by sp_exc_ctx_save/load, so two fibers walking at once each keep
+ * their own path. */
+#define SP_POLY_RECUR_INSPECT 1
+#define SP_POLY_RECUR_EQ      2   /* shared by ==, eql? and <=>: all three answer
+                                     "equal" for a pair they are already inside */
+#define SP_POLY_RECUR_HASH    3
+#define SP_POLY_RECUR_FLATTEN 4
+#define SP_POLY_RECUR_JOIN    5
+#define SP_POLY_RECUR_PUTS    6   /* `puts a` walks an array without inspecting it */
+/* What a repeated object contributes to a #hash: a fixed ODD constant, because
+   nil, false and 0 all hash to 0 and a Struct holding itself must not hash like
+   one holding nil. */
+#define SP_POLY_RECUR_HASH_VALUE ((sp_int)0x3f5b9d7e2c1a4d05LL)
+typedef struct { const void *a, *b; int kind; } sp_poly_recur_frame;
+/* The frames grow on demand rather than sitting in a fixed TLS array: a fixed
+   cap would leave a cycle whose repeated object is deeper than the cap running
+   off the C stack, and kilobytes of TLS shift the layout (and the cost) of
+   every hot per-worker variable -- the break stack's own comment records
+   measuring 8% of optcarrot on exactly that. Only the pointer and the two
+   counts live in TLS; the frames are malloc'd on the first push, doubled when
+   full, and never shrunk, per worker. */
+extern SP_TLS sp_poly_recur_frame *sp_poly_recur_stack;
+extern SP_TLS int sp_poly_recur_top;
+extern SP_TLS int sp_poly_recur_cap;
+void sp_poly_recur_grow(int want);   /* first allocation and every doubling */
+/* A lookup scans the path: a real program's path is under ten frames, and a
+   scan of that beats any table. But a scan at every level of a deep walk is
+   quadratic -- a 2000-deep nest would compare 2000 frames at each of its 2000
+   levels, where CRuby's rb_exec_recursive, a hash, stays linear. So past
+   SP_POLY_RECUR_SCAN frames the path is also indexed (sp_inspect.c) and a
+   lookup is one probe. Frames [0, sp_poly_recur_ixtop) are in the index; a pop
+   below that simply lowers it, and the next deep push indexes what is missing. */
+#define SP_POLY_RECUR_SCAN 32
+extern SP_TLS int sp_poly_recur_ixtop;
+int  sp_poly_recur_seen_deep(int kind, const void *a, const void *b);
+void sp_poly_recur_index(void);      /* bring the index up to sp_poly_recur_top */
+/* Is (kind, a, b) already on the path? `b` is NULL for the single-object kinds
+   (inspect, hash, flatten, join, puts) and the other side of the pair for
+   equality. An empty path (the common case) reads one int and returns. */
+static inline int sp_poly_recur_seen(int kind, const void *a, const void *b) {
+  int top = sp_poly_recur_top;
+  /* the scan covers SCAN frames; the push of the frame at index SCAN is the
+     one that indexes (below), and from then on top is SCAN + 1 or more */
+  if (SP_UNLIKELY(top > SP_POLY_RECUR_SCAN)) return sp_poly_recur_seen_deep(kind, a, b);
+  for (int i = top - 1; i >= 0; i--) {
+    if (sp_poly_recur_stack[i].a == a && sp_poly_recur_stack[i].b == b &&
+        sp_poly_recur_stack[i].kind == kind) return 1;
+  }
+  return 0;
+}
+/* Push a frame and answer the mark to hand back to sp_poly_recur_pop. */
+static inline int sp_poly_recur_push(int kind, const void *a, const void *b) {
+  int mark = sp_poly_recur_top;
+  if (SP_UNLIKELY(mark == sp_poly_recur_cap)) sp_poly_recur_grow(mark + 1);
+  sp_poly_recur_stack[mark].a = a;
+  sp_poly_recur_stack[mark].b = b;
+  sp_poly_recur_stack[mark].kind = kind;
+  sp_poly_recur_top = mark + 1;
+  if (SP_UNLIKELY(mark >= SP_POLY_RECUR_SCAN)) sp_poly_recur_index();
+  return mark;
+}
+static inline void sp_poly_recur_pop(int mark) {
+  sp_poly_recur_top = mark;
+  if (SP_UNLIKELY(sp_poly_recur_ixtop > mark)) sp_poly_recur_ixtop = mark;
+}
+/* The current depth as a mark, for a walk that took a branch where it did not
+   push: the pop that pairs with it then leaves the path exactly as it was. */
+static inline int sp_poly_recur_save(void) { return sp_poly_recur_top; }
+/* Drop every frame of `kind` from the top of the path. A walk about to raise
+   with no answer to give -- an unlimited flatten or a join that met itself --
+   takes its own frames with it, so nothing is left on the path for a later
+   walk to trip over even where no handler restores the depth (an at_exit
+   block still walks). A handler further out that does restore re-exposes the
+   frames of walks that are still running, which is what it should do. */
+static inline void sp_poly_recur_drop_kind(int kind) {
+  int top = sp_poly_recur_top;
+  while (top > 0 && sp_poly_recur_stack[top - 1].kind == kind) top--;
+  sp_poly_recur_pop(top);
+}
+/* The Set package (packages/set/set.rb) walks its elements in Ruby, so its
+   #inspect, #== and #flatten bind these through native_func and keep their
+   frames on this same path: per fiber, restored by every longjmp, and with no
+   `ensure` in the Ruby. `enter` answers the mark for sp_poly_recur_leave, or
+   -1 when the walk is already inside that Set (or pair), which is the caller's
+   cue to stop. The module is reachable by name from Ruby, so `leave` ignores a
+   mark this path never handed out to a Set walk. The kinds are Set's own so a
+   frame the runtime pushed for the same object or pair -- sp_poly_eql on two
+   Sets reaches Set#== through the user hook -- is not mistaken for the Set
+   walk's. */
+#define SP_POLY_RECUR_SET_INSPECT 7
+#define SP_POLY_RECUR_SET_EQ      8
+#define SP_POLY_RECUR_SET_FLATTEN 9
+sp_int sp_poly_recur_enter_inspect(sp_RbVal set);
+sp_int sp_poly_recur_enter_eq(sp_RbVal set, sp_RbVal other);
+sp_int sp_poly_recur_enter_flatten(sp_RbVal set);
+void   sp_poly_recur_leave(sp_int mark);
 #endif /* SP_INSPECT_H */

--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -1648,9 +1648,14 @@ static inline void sp_poly_puts(sp_RbVal v) {
         case SP_BUILTIN_BIG_RATIONAL: puts(sp_brat_to_s((sp_BigRational *)v.v.p)); break;
         case SP_BUILTIN_REGEX: puts(sp_re_to_s_str(v.v.p)); break;
         case SP_BUILTIN_POLY_ARRAY: {
-          /* puts flattens arrays recursively, one element per line */
+          /* puts flattens arrays recursively, one element per line -- and one
+             that holds itself gets CRuby's single `[...]` line instead of an
+             endless flattening. */
           sp_PolyArray *_a = (sp_PolyArray *)v.v.p;
+          if (sp_poly_recur_seen(SP_POLY_RECUR_PUTS, _a, NULL)) { puts("[...]"); break; }
+          int _pm = sp_poly_recur_push(SP_POLY_RECUR_PUTS, _a, NULL);
           for (sp_int _i = 0; _i < _a->len; _i++) sp_poly_puts(_a->data[_i]);
+          sp_poly_recur_pop(_pm);
           break;
         }
         /* A user object (or any non-array OBJ) prints via to_s: delegate to
@@ -3010,6 +3015,8 @@ static sp_bool sp_poly_hash_eq_cross(sp_RbVal a, sp_RbVal b);
    for two same-class user objects that no builtin arm handles. */
 typedef sp_bool (*sp_obj_eq_fn)(sp_RbVal a, sp_RbVal b);
 static sp_obj_eq_fn sp_obj_eq_hook = NULL;
+/* The == arms that can walk back into the pair they started from (below). */
+static sp_bool sp_poly_eq_deep(sp_RbVal a, sp_RbVal b);
 static sp_bool sp_poly_eq(sp_RbVal a, sp_RbVal b) {
   /* a user class's own == answers before any builtin reading, the way its
      other operators now do; the field-wise hook below stays the default for
@@ -3023,9 +3030,48 @@ static sp_bool sp_poly_eq(sp_RbVal a, sp_RbVal b) {
       if (!_sa) { if (a.tag != SP_TAG_STR) return FALSE; _sa = a.v.s; }
       if (!_sb) { if (b.tag != SP_TAG_STR) return FALSE; _sb = b.v.s; }
       return sp_str_eq(_sa, _sb);
-    } } if (sp_poly_is_brat(a) || sp_poly_is_brat(b)) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_poly_to_f(a) == sp_poly_to_f(b); int _oka = sp_poly_is_brat(a) || sp_poly_is_rational(a) || a.tag == SP_TAG_INT || a.tag == SP_TAG_BIGINT; int _okb = sp_poly_is_brat(b) || sp_poly_is_rational(b) || b.tag == SP_TAG_INT || b.tag == SP_TAG_BIGINT; return (_oka && _okb) ? (sp_brat_cmp_poly(a, b) == 0) : FALSE; } /* A boxed Rational against a number: sp_poly_numeric_p covers only int/float/bigint, so without this a Rational operand fell through to the tag-equality test below and `Rational(1,1) == 1` answered false (#3382). The BigRational clause above already covers the mixed big cases. */ if (sp_poly_is_rational(a) || sp_poly_is_rational(b)) { int _qa = sp_poly_is_rational(a) || sp_poly_numeric_p(a); int _qb = sp_poly_is_rational(b) || sp_poly_numeric_p(b); if (!(_qa && _qb)) return FALSE; if (sp_poly_is_rational(a) && sp_poly_is_rational(b) && a.v.p && b.v.p) return sp_rational_eq(*(sp_Rational *)a.v.p, *(sp_Rational *)b.v.p); return sp_poly_to_f(a) == sp_poly_to_f(b); } if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { sp_Bigint *ba = sp_poly_as_bigint(a), *bb = sp_poly_as_bigint(b); if (ba && bb) return sp_bigint_cmp(ba, bb) == 0; if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) return sp_poly_to_f(a) == sp_poly_to_f(b); return FALSE; } if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) return sp_poly_to_f(a) == sp_poly_to_f(b); if (a.tag != b.tag) return FALSE; switch (a.tag) { case SP_TAG_INT: return a.v.i == b.v.i; case SP_TAG_STR: return (a.v.s == NULL || b.v.s == NULL) ? (a.v.s == b.v.s) : (sp_str_cmp_bytes(a.v.s, b.v.s) == 0); case SP_TAG_FLT: return a.v.f == b.v.f; case SP_TAG_BOOL: return a.v.b == b.v.b; case SP_TAG_NIL: return TRUE; case SP_TAG_SYM: return a.v.i == b.v.i; case SP_TAG_ENCODING: return (a.v.s == NULL || b.v.s == NULL) ? (a.v.s == b.v.s) : (strcmp(a.v.s, b.v.s) == 0); case SP_TAG_OBJ: /* Arrays compare by VALUE across storage kinds: [1,2] boxed as an IntArray equals the same numbers rebuilt as a PolyArray (a splat-rest, a mapped run). Ruby has one Array; the kinds are a storage optimization and must not leak into ==. */ if (sp_poly_is_array_kind(a.cls_id) && sp_poly_is_array_kind(b.cls_id)) { if (a.cls_id == b.cls_id && a.v.p == b.v.p) return TRUE; { sp_int __n = sp_poly_length(a); if (__n != sp_poly_length(b)) return FALSE; for (sp_int __i = 0; __i < __n; __i++) if (!sp_poly_eq(sp_poly_arr_get(a, __i), sp_poly_arr_get(b, __i))) return FALSE; return TRUE; } } if (sp_poly_is_hash_kind(a.cls_id) && sp_poly_is_hash_kind(b.cls_id) && a.cls_id != b.cls_id) return sp_poly_hash_eq_cross(a, b); if (a.cls_id != b.cls_id) return FALSE; if (a.v.p == b.v.p) return TRUE; switch (a.cls_id) { case SP_BUILTIN_INT_ARRAY: return sp_IntArray_eq((sp_IntArray*)a.v.p,(sp_IntArray*)b.v.p); case SP_BUILTIN_STR_ARRAY: return sp_StrArray_eq((sp_StrArray*)a.v.p,(sp_StrArray*)b.v.p); case SP_BUILTIN_FLT_ARRAY: return sp_FloatArray_eq((sp_FloatArray*)a.v.p,(sp_FloatArray*)b.v.p); case SP_BUILTIN_POLY_ARRAY: return sp_PolyArray_eq((sp_PolyArray*)a.v.p,(sp_PolyArray*)b.v.p); case SP_BUILTIN_TIME: { sp_Time *ta = (sp_Time*)a.v.p, *tb = (sp_Time*)b.v.p; /* two Times read out of containers compare by instant, not by box (#3699) */ return (ta && tb) ? (ta->tv_sec == tb->tv_sec && ta->tv_nsec == tb->tv_nsec) : (ta == tb); } case SP_BUILTIN_RATIONAL: { sp_Rational *ra = (sp_Rational*)a.v.p, *rb = (sp_Rational*)b.v.p; return (ra && rb) ? sp_rational_eq(*ra, *rb) : (ra == rb); } case SP_BUILTIN_TMS: { sp_Tms *ta = (sp_Tms*)a.v.p, *tb = (sp_Tms*)b.v.p; /* Process::Tms is a Struct: field-wise, like its other by-value siblings here */ return (ta && tb) ? (ta->utime == tb->utime && ta->stime == tb->stime && ta->cutime == tb->cutime && ta->cstime == tb->cstime) : (ta == tb); } /* the structural heap handles (Object's identity arm routes a poly operand here: emit_native_object_protocol) */ case SP_BUILTIN_OPENSTRUCT: return sp_OpenStruct_eq((sp_OpenStruct*)a.v.p, (sp_OpenStruct*)b.v.p); case SP_BUILTIN_EXCEPTION: return sp_exc_eq((sp_Exception*)a.v.p, (sp_Exception*)b.v.p); case SP_BUILTIN_IO: return sp_io_eq((sp_File*)a.v.p, (sp_File*)b.v.p); case SP_BUILTIN_COMPLEX: { sp_Complex *ca = (sp_Complex*)a.v.p, *cb = (sp_Complex*)b.v.p; return (ca && cb) ? (ca->re == cb->re && ca->im == cb->im) : (ca == cb); } case SP_BUILTIN_BIG_RATIONAL: { sp_BigRational *ra = (sp_BigRational*)a.v.p, *rb = (sp_BigRational*)b.v.p; return (ra && rb) ? (sp_bigint_cmp(ra->num, rb->num) == 0 && sp_bigint_cmp(ra->den, rb->den) == 0) : (ra == rb); } /* boxed hashes of the same variant compare by value like every other
+    } } if (sp_poly_is_brat(a) || sp_poly_is_brat(b)) { if (a.tag == SP_TAG_FLT || b.tag == SP_TAG_FLT) return sp_poly_to_f(a) == sp_poly_to_f(b); int _oka = sp_poly_is_brat(a) || sp_poly_is_rational(a) || a.tag == SP_TAG_INT || a.tag == SP_TAG_BIGINT; int _okb = sp_poly_is_brat(b) || sp_poly_is_rational(b) || b.tag == SP_TAG_INT || b.tag == SP_TAG_BIGINT; return (_oka && _okb) ? (sp_brat_cmp_poly(a, b) == 0) : FALSE; } /* A boxed Rational against a number: sp_poly_numeric_p covers only int/float/bigint, so without this a Rational operand fell through to the tag-equality test below and `Rational(1,1) == 1` answered false (#3382). The BigRational clause above already covers the mixed big cases. */ if (sp_poly_is_rational(a) || sp_poly_is_rational(b)) { int _qa = sp_poly_is_rational(a) || sp_poly_numeric_p(a); int _qb = sp_poly_is_rational(b) || sp_poly_numeric_p(b); if (!(_qa && _qb)) return FALSE; if (sp_poly_is_rational(a) && sp_poly_is_rational(b) && a.v.p && b.v.p) return sp_rational_eq(*(sp_Rational *)a.v.p, *(sp_Rational *)b.v.p); return sp_poly_to_f(a) == sp_poly_to_f(b); } if (a.tag == SP_TAG_BIGINT || b.tag == SP_TAG_BIGINT) { sp_Bigint *ba = sp_poly_as_bigint(a), *bb = sp_poly_as_bigint(b); if (ba && bb) return sp_bigint_cmp(ba, bb) == 0; if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) return sp_poly_to_f(a) == sp_poly_to_f(b); return FALSE; } if (sp_poly_numeric_p(a) && sp_poly_numeric_p(b)) return sp_poly_to_f(a) == sp_poly_to_f(b); if (a.tag != b.tag) return FALSE; switch (a.tag) { case SP_TAG_INT: return a.v.i == b.v.i; case SP_TAG_STR: return (a.v.s == NULL || b.v.s == NULL) ? (a.v.s == b.v.s) : (sp_str_cmp_bytes(a.v.s, b.v.s) == 0); case SP_TAG_FLT: return a.v.f == b.v.f; case SP_TAG_BOOL: return a.v.b == b.v.b; case SP_TAG_NIL: return TRUE; case SP_TAG_SYM: return a.v.i == b.v.i; case SP_TAG_ENCODING: return (a.v.s == NULL || b.v.s == NULL) ? (a.v.s == b.v.s) : (strcmp(a.v.s, b.v.s) == 0); case SP_TAG_OBJ: /* Arrays compare by VALUE across storage kinds: [1,2] boxed as an IntArray equals the same numbers rebuilt as a PolyArray (a splat-rest, a mapped run). Ruby has one Array; the kinds are a storage optimization and must not leak into ==. */ if (sp_poly_is_array_kind(a.cls_id) && sp_poly_is_array_kind(b.cls_id)) { if (a.cls_id == b.cls_id && a.v.p == b.v.p) return TRUE; return sp_poly_eq_deep(a, b); } if (sp_poly_is_hash_kind(a.cls_id) && sp_poly_is_hash_kind(b.cls_id) && a.cls_id != b.cls_id) return sp_poly_eq_deep(a, b); if (a.cls_id != b.cls_id) return FALSE; if (a.v.p == b.v.p) return TRUE; switch (a.cls_id) { case SP_BUILTIN_INT_ARRAY: return sp_IntArray_eq((sp_IntArray*)a.v.p,(sp_IntArray*)b.v.p); case SP_BUILTIN_STR_ARRAY: return sp_StrArray_eq((sp_StrArray*)a.v.p,(sp_StrArray*)b.v.p); case SP_BUILTIN_FLT_ARRAY: return sp_FloatArray_eq((sp_FloatArray*)a.v.p,(sp_FloatArray*)b.v.p); case SP_BUILTIN_POLY_ARRAY: return sp_PolyArray_eq((sp_PolyArray*)a.v.p,(sp_PolyArray*)b.v.p); case SP_BUILTIN_TIME: { sp_Time *ta = (sp_Time*)a.v.p, *tb = (sp_Time*)b.v.p; /* two Times read out of containers compare by instant, not by box (#3699) */ return (ta && tb) ? (ta->tv_sec == tb->tv_sec && ta->tv_nsec == tb->tv_nsec) : (ta == tb); } case SP_BUILTIN_RATIONAL: { sp_Rational *ra = (sp_Rational*)a.v.p, *rb = (sp_Rational*)b.v.p; return (ra && rb) ? sp_rational_eq(*ra, *rb) : (ra == rb); } case SP_BUILTIN_TMS: { sp_Tms *ta = (sp_Tms*)a.v.p, *tb = (sp_Tms*)b.v.p; /* Process::Tms is a Struct: field-wise, like its other by-value siblings here */ return (ta && tb) ? (ta->utime == tb->utime && ta->stime == tb->stime && ta->cutime == tb->cutime && ta->cstime == tb->cstime) : (ta == tb); } /* the structural heap handles (Object's identity arm routes a poly operand here: emit_native_object_protocol) */ case SP_BUILTIN_OPENSTRUCT: return sp_OpenStruct_eq((sp_OpenStruct*)a.v.p, (sp_OpenStruct*)b.v.p); case SP_BUILTIN_EXCEPTION: return sp_exc_eq((sp_Exception*)a.v.p, (sp_Exception*)b.v.p); case SP_BUILTIN_IO: return sp_io_eq((sp_File*)a.v.p, (sp_File*)b.v.p); case SP_BUILTIN_COMPLEX: { sp_Complex *ca = (sp_Complex*)a.v.p, *cb = (sp_Complex*)b.v.p; return (ca && cb) ? (ca->re == cb->re && ca->im == cb->im) : (ca == cb); } case SP_BUILTIN_BIG_RATIONAL: { sp_BigRational *ra = (sp_BigRational*)a.v.p, *rb = (sp_BigRational*)b.v.p; return (ra && rb) ? (sp_bigint_cmp(ra->num, rb->num) == 0 && sp_bigint_cmp(ra->den, rb->den) == 0) : (ra == rb); } /* boxed hashes of the same variant compare by value like every other
      container -- the arm was simply missing, so [h] == [h-literal] was
-     pointer identity and always false. */ case SP_BUILTIN_STR_INT_HASH: return sp_StrIntHash_eq((sp_StrIntHash*)a.v.p,(sp_StrIntHash*)b.v.p); case SP_BUILTIN_STR_STR_HASH: return sp_StrStrHash_eq((sp_StrStrHash*)a.v.p,(sp_StrStrHash*)b.v.p); case SP_BUILTIN_INT_STR_HASH: return sp_IntStrHash_eq((sp_IntStrHash*)a.v.p,(sp_IntStrHash*)b.v.p); case SP_BUILTIN_INT_INT_HASH: return sp_IntIntHash_eq((sp_IntIntHash*)a.v.p,(sp_IntIntHash*)b.v.p); case SP_BUILTIN_STR_POLY_HASH: return sp_StrPolyHash_eq((sp_StrPolyHash*)a.v.p,(sp_StrPolyHash*)b.v.p); case SP_BUILTIN_SYM_POLY_HASH: return sp_SymPolyHash_eq((sp_SymPolyHash*)a.v.p,(sp_SymPolyHash*)b.v.p); case SP_BUILTIN_POLY_POLY_HASH: return sp_PolyPolyHash_eq((sp_PolyPolyHash*)a.v.p,(sp_PolyPolyHash*)b.v.p); case SP_BUILTIN_RANGE: return sp_range_eq(*(sp_Range*)a.v.p,*(sp_Range*)b.v.p); case SP_BUILTIN_FLOAT_RANGE: { sp_FloatRange *fa=(sp_FloatRange*)a.v.p,*fb=(sp_FloatRange*)b.v.p; return (fa&&fb)?(fa->first==fb->first&&fa->last==fb->last&&fa->excl==fb->excl):(fa==fb); } case SP_BUILTIN_STR_RANGE: { sp_StrRange *sa=(sp_StrRange*)a.v.p,*sb=(sp_StrRange*)b.v.p; if(!sa||!sb)return sa==sb; return sa->excl==sb->excl&&sp_str_eq(sa->first,sb->first)&&sp_str_eq(sa->last,sb->last); } default: return sp_obj_eq_hook ? sp_obj_eq_hook(a, b) : FALSE; } case SP_TAG_CLASS: { const char *an = sp_class_val_name(a), *bn = sp_class_val_name(b); return (an && bn) ? strcmp(an, bn) == 0 : an == bn; } default: return FALSE; } }
+     pointer identity and always false. */ case SP_BUILTIN_STR_INT_HASH: return sp_StrIntHash_eq((sp_StrIntHash*)a.v.p,(sp_StrIntHash*)b.v.p); case SP_BUILTIN_STR_STR_HASH: return sp_StrStrHash_eq((sp_StrStrHash*)a.v.p,(sp_StrStrHash*)b.v.p); case SP_BUILTIN_INT_STR_HASH: return sp_IntStrHash_eq((sp_IntStrHash*)a.v.p,(sp_IntStrHash*)b.v.p); case SP_BUILTIN_INT_INT_HASH: return sp_IntIntHash_eq((sp_IntIntHash*)a.v.p,(sp_IntIntHash*)b.v.p); case SP_BUILTIN_STR_POLY_HASH: case SP_BUILTIN_SYM_POLY_HASH: case SP_BUILTIN_POLY_POLY_HASH: return sp_poly_eq_deep(a, b); case SP_BUILTIN_RANGE: return sp_range_eq(*(sp_Range*)a.v.p,*(sp_Range*)b.v.p); case SP_BUILTIN_FLOAT_RANGE: { sp_FloatRange *fa=(sp_FloatRange*)a.v.p,*fb=(sp_FloatRange*)b.v.p; return (fa&&fb)?(fa->first==fb->first&&fa->last==fb->last&&fa->excl==fb->excl):(fa==fb); } case SP_BUILTIN_STR_RANGE: { sp_StrRange *sa=(sp_StrRange*)a.v.p,*sb=(sp_StrRange*)b.v.p; if(!sa||!sb)return sa==sb; return sa->excl==sb->excl&&sp_str_eq(sa->first,sb->first)&&sp_str_eq(sa->last,sb->last); } default: return sp_obj_eq_hook ? sp_poly_eq_deep(a, b) : FALSE; } case SP_TAG_CLASS: { const char *an = sp_class_val_name(a), *bn = sp_class_val_name(b); return (an && bn) ? strcmp(an, bn) == 0 : an == bn; } default: return FALSE; } }
+/* The == arms that can walk back into the pair they started from: two arrays
+   of any storage kinds, two hashes with poly values, and two user objects
+   compared field-wise through the generated hook. A pair the comparison is
+   already inside answers "equal", which is what lets `a << a; b << b; a == b`
+   finish and is the answer CRuby's rb_exec_recursive_paired gives.
+
+   Split out rather than guarded at the top of sp_poly_eq so the value types --
+   Time, Rational, Range, Complex, IO, the primitive-keyed hashes -- never push
+   a frame: none of them can contain a Ruby object, so none of them can meet
+   itself, and sp_poly_eq is hot enough that an unconditional push would be
+   felt by every comparison in a program that has no cycles at all. */
+static sp_bool sp_poly_eq_deep(sp_RbVal a, sp_RbVal b) {
+  if (sp_poly_recur_seen(SP_POLY_RECUR_EQ, a.v.p, b.v.p)) return TRUE;
+  int mark = sp_poly_recur_push(SP_POLY_RECUR_EQ, a.v.p, b.v.p);
+  sp_bool r;
+  if (sp_poly_is_array_kind(a.cls_id)) {
+    sp_int n = sp_poly_length(a);
+    r = (n == sp_poly_length(b));
+    for (sp_int i = 0; r && i < n; i++)
+      r = sp_poly_eq(sp_poly_arr_get(a, i), sp_poly_arr_get(b, i));
+  }
+  else if (sp_poly_is_hash_kind(a.cls_id)) {
+    /* The same dispatch the caller had, only guarded. Two hashes of DIFFERENT
+       variants are compared by the generic cross-variant walk whatever their
+       key types are; two of the same variant only reach here when that variant
+       has poly values, since the primitive-keyed ones keep their own cases in
+       sp_poly_eq and cannot hold a container at all. Each variant is named;
+       one added later and not listed here takes the cross-variant walk, which
+       is right for any two variants, only slower. */
+    if (a.cls_id != b.cls_id)                      r = sp_poly_hash_eq_cross(a, b);
+    else if (a.cls_id == SP_BUILTIN_STR_POLY_HASH) r = sp_StrPolyHash_eq((sp_StrPolyHash *)a.v.p, (sp_StrPolyHash *)b.v.p);
+    else if (a.cls_id == SP_BUILTIN_SYM_POLY_HASH) r = sp_SymPolyHash_eq((sp_SymPolyHash *)a.v.p, (sp_SymPolyHash *)b.v.p);
+    else if (a.cls_id == SP_BUILTIN_POLY_POLY_HASH) r = sp_PolyPolyHash_eq((sp_PolyPolyHash *)a.v.p, (sp_PolyPolyHash *)b.v.p);
+    else                                           r = sp_poly_hash_eq_cross(a, b);
+  }
+  else r = sp_obj_eq_hook(a, b);   /* non-NULL: sp_poly_eq's object arm checks it first */
+  sp_poly_recur_pop(mark);
+  return r;
+}
 /* sp_sym_name_fn is now an extern hook (sp_gc.h / sp_gc.c) so cold lib readers
    like sp_json.c can resolve symbol names too; the generated TU still sets it. */
 static sp_int sp_poly_arr_cmp(sp_RbVal a, sp_RbVal b, sp_bool *comparable);
@@ -4095,10 +4141,18 @@ static sp_int sp_poly_arr_cmp(sp_RbVal a, sp_RbVal b, sp_bool *comparable) {
   if (a.v.p == b.v.p) { *comparable = TRUE; return 0; }
   sp_int la = sp_poly_arr_len(a), lb = sp_poly_arr_len(b);
   sp_int n = la < lb ? la : lb;
-  for (sp_int i = 0; i < n; i++) {
-    sp_bool ec; sp_int r = sp_poly_cmp(sp_poly_arr_get(a, i), sp_poly_arr_get(b, i), &ec);
-    if (!ec) { *comparable = FALSE; return 0; }
-    if (r != 0) { *comparable = TRUE; return r < 0 ? -1 : 1; }
+  /* Two DISTINCT arrays that each contain themselves meet the same pair again
+     one level down. CRuby counts a repeated pair as equal and lets the lengths
+     decide -- `a <=> [a, 1]` is -1 -- so skipping the element loop is exactly
+     that answer, not a shortcut around it. */
+  if (!sp_poly_recur_seen(SP_POLY_RECUR_EQ, a.v.p, b.v.p)) {
+    int mark = sp_poly_recur_push(SP_POLY_RECUR_EQ, a.v.p, b.v.p);
+    for (sp_int i = 0; i < n; i++) {
+      sp_bool ec; sp_int r = sp_poly_cmp(sp_poly_arr_get(a, i), sp_poly_arr_get(b, i), &ec);
+      if (!ec) { sp_poly_recur_pop(mark); *comparable = FALSE; return 0; }
+      if (r != 0) { sp_poly_recur_pop(mark); *comparable = TRUE; return r < 0 ? -1 : 1; }
+    }
+    sp_poly_recur_pop(mark);
   }
   *comparable = TRUE;
   return (la > lb) - (la < lb);
@@ -4453,6 +4507,14 @@ static sp_PolyArray *sp_PolyArray_difference(sp_PolyArray *a, sp_PolyArray *b) {
 /* Array#compact for poly_array: keep elements whose tag is not SP_TAG_NIL. */
 static sp_PolyArray *sp_PolyArray_compact(sp_PolyArray *a) { SP_GC_ROOT(a); sp_PolyArray *b = sp_PolyArray_new(); SP_GC_ROOT(b); if (!a) return b; for (sp_int i = 0; i < a->len; i++) { if (a->data[i].tag != SP_TAG_NIL) sp_PolyArray_push(b, a->data[i]); } return b; }
 static sp_PolyArray *sp_PolyArray_compact_bang(sp_PolyArray *a) {sp_gc_wb((void*)a);  if (!a) return a; sp_int w = 0; for (sp_int i = 0; i < a->len; i++) { if (a->data[i].tag != SP_TAG_NIL) a->data[w++] = a->data[i]; } a->len = w; return a; }
+/* An unlimited flatten (or a join) that meets an array it is already inside
+   has no answer to give: the flat run would be infinite, so CRuby raises. The
+   walk's own frames go first (sp_poly_recur_drop_kind). Off the hot path by
+   construction -- they never return. */
+SP_NORETURN SP_COLD static __attribute__((noinline)) void sp_poly_recur_raise(int kind, const char *msg) {
+  sp_poly_recur_drop_kind(kind);
+  sp_raise_cls("ArgumentError", msg);
+}
 /* Array#flatten -- walk into nested array values recursively. Each
    array-tagged element (IntArray / StrArray / SymArray / FloatArray /
    PolyArray) is expanded inline; scalars are appended as-is. Issue
@@ -4463,21 +4525,47 @@ static void sp_PolyArray_flatten_into(sp_PolyArray *dst, sp_RbVal v) {
   if (v.cls_id == SP_BUILTIN_STR_ARRAY) { sp_StrArray *sa = (sp_StrArray *)v.v.p; for (sp_int i = 0; i < sa->len; i++) sp_PolyArray_push(dst, sp_box_str(sa->data[i])); return; }
   if (v.cls_id == SP_BUILTIN_SYM_ARRAY) { sp_IntArray *ya = (sp_IntArray *)v.v.p; for (sp_int i = 0; i < ya->len; i++) sp_PolyArray_push(dst, sp_box_sym((sp_sym)ya->data[ya->start + i])); return; }
   if (v.cls_id == SP_BUILTIN_FLT_ARRAY) { sp_FloatArray *fa = (sp_FloatArray *)v.v.p; for (sp_int i = 0; i < fa->len; i++) sp_PolyArray_push(dst, sp_box_float(fa->data[i])); return; }
-  if (v.cls_id == SP_BUILTIN_POLY_ARRAY) { sp_PolyArray *pa = (sp_PolyArray *)v.v.p; for (sp_int i = 0; i < pa->len; i++) sp_PolyArray_flatten_into(dst, pa->data[i]); return; }
+  if (v.cls_id == SP_BUILTIN_POLY_ARRAY) {
+    sp_PolyArray *pa = (sp_PolyArray *)v.v.p;
+    if (sp_poly_recur_seen(SP_POLY_RECUR_FLATTEN, pa, NULL))
+      sp_poly_recur_raise(SP_POLY_RECUR_FLATTEN, "tried to flatten recursive array");
+    int mark = sp_poly_recur_push(SP_POLY_RECUR_FLATTEN, pa, NULL);
+    for (sp_int i = 0; i < pa->len; i++) sp_PolyArray_flatten_into(dst, pa->data[i]);
+    sp_poly_recur_pop(mark);
+    return;
+  }
   /* Other array variants fall through as opaque elements; rare for
      deep-flatten use cases. */
   sp_PolyArray_push(dst, v);
 }
 static sp_PolyArray *sp_PolyArray_flatten_bang(sp_PolyArray *a);  /* below */
-static sp_PolyArray *sp_PolyArray_flatten(sp_PolyArray *a) { SP_GC_ROOT(a); sp_PolyArray *b = sp_PolyArray_new(); SP_GC_ROOT(b); if (!a) return b; for (sp_int i = 0; i < a->len; i++) sp_PolyArray_flatten_into(b, a->data[i]); return b; }
+static sp_PolyArray *sp_PolyArray_flatten(sp_PolyArray *a) {
+  SP_GC_ROOT(a);
+  sp_PolyArray *b = sp_PolyArray_new(); SP_GC_ROOT(b);
+  if (!a) return b;
+  /* the receiver is on the path as much as any nested array is: `a << a;
+     a.flatten` has to raise, and only this frame can catch that */
+  int mark = sp_poly_recur_push(SP_POLY_RECUR_FLATTEN, a, NULL);
+  for (sp_int i = 0; i < a->len; i++) sp_PolyArray_flatten_into(b, a->data[i]);
+  sp_poly_recur_pop(mark);
+  return b;
+}
 /* depth-limited flatten: depth counts how many nesting levels unwrap
    (CRuby's flatten(1)); a negative depth flattens fully. */
 static void sp_PolyArray_flatten_into_d(sp_PolyArray *out, sp_RbVal v, sp_int depth);
 static void sp_PolyArray_flatten_into_d(sp_PolyArray *out, sp_RbVal v, sp_int depth) {
   if (depth != 0 && v.tag == SP_TAG_OBJ && sp_poly_is_array_kind(v.cls_id)) {
+    /* Only the unlimited walk (a negative depth) can be trapped by a cycle. A
+       counted one ends by counting down, and CRuby prints [[[...]]] for it
+       rather than raising, so it carries no path. */
+    if (depth < 0 && sp_poly_recur_seen(SP_POLY_RECUR_FLATTEN, v.v.p, NULL))
+      sp_poly_recur_raise(SP_POLY_RECUR_FLATTEN, "tried to flatten recursive array");
     sp_PolyArray *in = sp_poly_to_poly_array(v); SP_GC_ROOT(in);
+    int mark = depth < 0 ? sp_poly_recur_push(SP_POLY_RECUR_FLATTEN, v.v.p, NULL)
+                         : sp_poly_recur_save();
     for (sp_int i = 0; i < in->len; i++)
       sp_PolyArray_flatten_into_d(out, in->data[i], depth - 1);
+    sp_poly_recur_pop(mark);
     return;
   }
   sp_PolyArray_push(out, v);
@@ -4486,7 +4574,9 @@ static sp_PolyArray *sp_PolyArray_flatten_depth(sp_PolyArray *a, sp_int d) {
   SP_GC_ROOT(a);
   sp_PolyArray *b = sp_PolyArray_new(); SP_GC_ROOT(b);
   if (!a) return b;
+  int mark = d < 0 ? sp_poly_recur_push(SP_POLY_RECUR_FLATTEN, a, NULL) : sp_poly_recur_save();
   for (sp_int i = 0; i < a->len; i++) sp_PolyArray_flatten_into_d(b, a->data[i], d);
+  sp_poly_recur_pop(mark);
   return b;
 }
 /* Array#flatten!: replace the receiver's contents with the flattened run
@@ -4526,6 +4616,8 @@ static sp_RbVal sp_fmt_named_ref(sp_PolyArray *a, const char *nm, char nclose, c
 /* puts over an argument list: arrays flatten, an empty one writes nothing */
 static void sp_puts_elems(sp_RbVal a) {
   sp_int n = sp_poly_arr_len(a);
+  if (sp_poly_recur_seen(SP_POLY_RECUR_PUTS, a.v.p, NULL)) { puts("[...]"); return; }
+  int pmark = sp_poly_recur_push(SP_POLY_RECUR_PUTS, a.v.p, NULL);
   for (sp_int i = 0; i < n; i++) {
     sp_RbVal e = sp_poly_arr_get(a, i);
     if (e.tag == SP_TAG_OBJ && sp_poly_is_array_kind(e.cls_id)) { sp_puts_elems(e); continue; }
@@ -4533,6 +4625,7 @@ static void sp_puts_elems(sp_RbVal a) {
     if (s) fputs(s, stdout);
     if (!s || !*s || s[strlen(s) - 1] != 10) putchar(10);
   }
+  sp_poly_recur_pop(pmark);
 }
 /* `puts *arr`: an empty array is a bare `puts` */
 static void sp_splat_puts(sp_RbVal a) {
@@ -4865,7 +4958,22 @@ static void sp_PolyArray_flatten_into_n(sp_PolyArray *dst, sp_RbVal v, sp_int de
   if (v.cls_id == SP_BUILTIN_STR_ARRAY) { sp_StrArray *sa = (sp_StrArray *)v.v.p; for (sp_int i = 0; i < sa->len; i++) sp_PolyArray_push(dst, sp_box_str(sa->data[i])); return; }
   if (v.cls_id == SP_BUILTIN_SYM_ARRAY) { sp_IntArray *ya = (sp_IntArray *)v.v.p; for (sp_int i = 0; i < ya->len; i++) sp_PolyArray_push(dst, sp_box_sym((sp_sym)ya->data[ya->start + i])); return; }
   if (v.cls_id == SP_BUILTIN_FLT_ARRAY) { sp_FloatArray *fa = (sp_FloatArray *)v.v.p; for (sp_int i = 0; i < fa->len; i++) sp_PolyArray_push(dst, sp_box_float(fa->data[i])); return; }
-  if (v.cls_id == SP_BUILTIN_POLY_ARRAY) { sp_PolyArray *pa = (sp_PolyArray *)v.v.p; for (sp_int i = 0; i < pa->len; i++) sp_PolyArray_flatten_into_n(dst, pa->data[i], depth - 1); return; }
+  if (v.cls_id == SP_BUILTIN_POLY_ARRAY) {
+    sp_PolyArray *pa = (sp_PolyArray *)v.v.p;
+    /* A negative depth is the "no limit" form, and the only one a cycle can
+       trap; it stays negative rather than counting down from INT64_MAX, so the
+       walk that carries the path is the one the code says it is. */
+    if (depth < 0) {
+      if (sp_poly_recur_seen(SP_POLY_RECUR_FLATTEN, pa, NULL))
+        sp_poly_recur_raise(SP_POLY_RECUR_FLATTEN, "tried to flatten recursive array");
+      int mark = sp_poly_recur_push(SP_POLY_RECUR_FLATTEN, pa, NULL);
+      for (sp_int i = 0; i < pa->len; i++) sp_PolyArray_flatten_into_n(dst, pa->data[i], depth);
+      sp_poly_recur_pop(mark);
+      return;
+    }
+    for (sp_int i = 0; i < pa->len; i++) sp_PolyArray_flatten_into_n(dst, pa->data[i], depth - 1);
+    return;
+  }
   sp_PolyArray_push(dst, v);
 }
 static sp_PolyArray *sp_PolyArray_flatten_n(sp_PolyArray *a, sp_int depth) {
@@ -4873,8 +4981,9 @@ static sp_PolyArray *sp_PolyArray_flatten_n(sp_PolyArray *a, sp_int depth) {
   sp_PolyArray *b = sp_PolyArray_new();
   SP_GC_ROOT(b);
   if (!a) return b;
-  if (depth < 0) depth = INT64_MAX;
+  int mark = depth < 0 ? sp_poly_recur_push(SP_POLY_RECUR_FLATTEN, a, NULL) : sp_poly_recur_save();
   for (sp_int i = 0; i < a->len; i++) sp_PolyArray_flatten_into_n(b, a->data[i], depth);
+  sp_poly_recur_pop(mark);
   return b;
 }
 /* Transpose a poly-array of typed arrays (each row becomes a column).
@@ -5354,6 +5463,12 @@ static const char *sp_poly_join(sp_RbVal a, const char *sep);  /* mutual recursi
 static const char *sp_PolyArray_join(sp_PolyArray *a, const char *sep) {
   if (!a) return sp_str_empty;
   SP_GC_ROOT(a); SP_GC_ROOT(sep);
+  /* A run that contains itself has no finite text, so CRuby raises here rather
+     than printing an ellipsis the way #inspect does. Nested arrays come back
+     through sp_poly_join into this same function, so one check covers them. */
+  if (sp_poly_recur_seen(SP_POLY_RECUR_JOIN, a, NULL))
+    sp_poly_recur_raise(SP_POLY_RECUR_JOIN, "recursive array join");
+  int rmark = sp_poly_recur_push(SP_POLY_RECUR_JOIN, a, NULL);
   sp_String *s = sp_String_new("");
   SP_GC_ROOT(s);
   for (sp_int i = 0; i < a->len; i++) {
@@ -5371,6 +5486,7 @@ static const char *sp_PolyArray_join(sp_PolyArray *a, const char *sep) {
      dangling pointer. The fd-buffer's 0xfd marker also makes sp_mark_string a
      no-op, so the buffer cannot be kept alive by marking it. Return a standalone
      heap string instead (#3151). */
+  sp_poly_recur_pop(rmark);
   return sp_str_from_bytes(s->data, (size_t)s->len);
 }
 /* join on a boxed array (poly value holding any array kind) */
@@ -5399,11 +5515,19 @@ static const char *sp_poly_join(sp_RbVal a, const char *sep) {
 }
 static sp_bool sp_PolyArray_eq(sp_PolyArray *a, sp_PolyArray *b) {
   if (!a || !b) return a == b;
+  /* An array is == to itself in O(1), which also ends `x == x` for one that
+     holds itself -- CRuby's rb_ary_equal starts the same way. */
+  if (a == b) return TRUE;
   if (a->len != b->len) return FALSE;
-  for (sp_int i = 0; i < a->len; i++) {
-    if (!sp_poly_eq(a->data[i], b->data[i])) return FALSE;
-  }
-  return TRUE;
+  /* Reached directly from generated code as well as through sp_poly_eq, so it
+     carries the pair guard itself: two distinct self-containing arrays walk
+     into the same pair one level down, and a repeated pair is equal. */
+  if (sp_poly_recur_seen(SP_POLY_RECUR_EQ, a, b)) return TRUE;
+  int mark = sp_poly_recur_push(SP_POLY_RECUR_EQ, a, b);
+  sp_bool r = TRUE;
+  for (sp_int i = 0; r && i < a->len; i++) r = sp_poly_eq(a->data[i], b->data[i]);
+  sp_poly_recur_pop(mark);
+  return r;
 }
 /* Box a typed (int/str/float) array into a fresh poly array element-wise.
    `kind` is the typed array's SP_BUILTIN_* tag. */
@@ -5741,10 +5865,6 @@ typedef sp_int  (*sp_obj_hash_fn)(int cls_id, void *p);
 typedef sp_bool (*sp_obj_eql_fn)(int cls_id, void *a, void *b);
 static sp_obj_hash_fn sp_obj_hash_hook = NULL;
 static sp_obj_eql_fn  sp_obj_eql_hook  = NULL;
-/* Depth guard for the container branches below: `h[:a] = h` and `a << a` are
-   legal, and hashing them by content would otherwise not terminate. CRuby
-   answers a fixed value for the recursive reference; so does this, once the
-   walk is deeper than any real key nesting. */
 /* The bucket index takes the LOW bits of a key's hash, and several key kinds
    leave their information out of those: a Float's mantissa bits are zero for
    every whole number, an array of small coordinates folds to h*31+x, a Struct
@@ -5752,6 +5872,12 @@ static sp_obj_eql_fn  sp_obj_eql_hook  = NULL;
    large the table grows and the probe sequences collapse into linear scans (a
    40k-bucket group_by ran for minutes, #3984). Mixing at the INDEX, not in the
    key hash, keeps every #hash value as it was. */
+/* CRuby's rb_hash_start mixes a per-TYPE seed into every container hash, which
+   is what keeps `{}.hash` away from `[].hash` -- both are empty and both would
+   otherwise fold to their length, 0. Odd, so a container never folds a member's
+   hash back onto the seed itself. */
+#define SP_HASH_SEED_ARRAY ((uint64_t)0x5d2a3f1b9c4e7a61ULL)
+#define SP_HASH_SEED_HASH  ((uint64_t)0x2c1b8f3d6e5a9047ULL)
 static sp_int sp_hash_slot(sp_int hk) {
   uint64_t h = (uint64_t)hk;
   h ^= h >> 33; h *= 0xff51afd7ed558ccdULL;
@@ -5759,8 +5885,6 @@ static sp_int sp_hash_slot(sp_int hk) {
   h ^= h >> 33;
   return (sp_int)h;
 }
-static int sp_rbval_hash_depth = 0;
-#define SP_RBVAL_HASH_MAX_DEPTH 24
 static sp_int sp_rbval_hash_key(sp_RbVal v) {
   switch (v.tag) {
     case SP_TAG_INT: case SP_TAG_BOOL: case SP_TAG_NIL: case SP_TAG_SYM:
@@ -5793,9 +5917,6 @@ static sp_int sp_rbval_hash_key(sp_RbVal v) {
          PolyArray [0, 0] (e.g. one built by Array#product) are `==` and must
          hash alike to collide in a Hash, so hash each element through
          sp_rbval_hash_key rather than the raw IntArray words (#2911). */
-      if (sp_poly_is_array_kind(v.cls_id) || sp_poly_is_hash_kind(v.cls_id)) {
-        if (sp_rbval_hash_depth >= SP_RBVAL_HASH_MAX_DEPTH) return 0;
-      }
       if (sp_poly_is_array_kind(v.cls_id)) {
         /* unsigned accumulator: the rolling h*31+x is meant to wrap, but on a
            signed type that is UB rather than wraparound -- and this is a
@@ -5803,11 +5924,23 @@ static sp_int sp_rbval_hash_key(sp_RbVal v) {
            two copies compiled under different flags could disagree and a Hash
            lookup would silently miss. Same rule as the Rational key below. */
         sp_int n = sp_poly_length(v);
-        uint64_t h = 0;
-        sp_rbval_hash_depth++;
+        /* A container reached from inside itself contributes a fixed value and
+           stops, the way CRuby's rb_exec_recursive_outer answers. It replaces a
+           depth counter that gave up on the WHOLE walk once it was 24 deep, so
+           `a << a` hashed like [] at every level. */
+        if (sp_poly_recur_seen(SP_POLY_RECUR_HASH, v.v.p, NULL)) return SP_POLY_RECUR_HASH_VALUE;
+        /* Seeded with the length (CRuby's rb_hash_start(len)) rather than 0:
+           from 0 the rolling h*31+x gave [], [0] and [nil] one hash, and it is
+           the length that keeps `a << a` apart from []. The salt is CRuby's
+           per-type seed: without one an empty Array and an empty Hash both
+           start (and end) at 0 and hash alike. Both array kinds take the SAME
+           salt, so an IntArray [0, 0] still collides with the PolyArray the
+           same numbers were rebuilt as. */
+        uint64_t h = (uint64_t)n ^ SP_HASH_SEED_ARRAY;
+        int mark = sp_poly_recur_push(SP_POLY_RECUR_HASH, v.v.p, NULL);
         for (sp_int i = 0; i < n; i++)
           h = (h * 31) + (uint64_t)sp_rbval_hash_key(sp_poly_arr_get(v, i));
-        sp_rbval_hash_depth--;
+        sp_poly_recur_pop(mark);
         return (sp_int)h;
       }
       if (sp_poly_is_hash_kind(v.cls_id)) {
@@ -5816,8 +5949,9 @@ static sp_int sp_rbval_hash_key(sp_RbVal v) {
            operation: two `==` hashes must agree, whatever order they were
            built in. Unsigned for the same reason the array accumulator is. */
         sp_int n = sp_poly_length(v);
-        uint64_t h = 0;
-        sp_rbval_hash_depth++;
+        if (sp_poly_recur_seen(SP_POLY_RECUR_HASH, v.v.p, NULL)) return SP_POLY_RECUR_HASH_VALUE;
+        uint64_t h = (uint64_t)n ^ SP_HASH_SEED_HASH;  /* length + salt, as the array above */
+        int mark = sp_poly_recur_push(SP_POLY_RECUR_HASH, v.v.p, NULL);
         for (sp_int i = 0; i < n; i++) {
           sp_RbVal k, val;
           sp_poly_hash_pair(v, i, &k, &val);
@@ -5829,7 +5963,7 @@ static sp_int sp_rbval_hash_key(sp_RbVal v) {
           t ^= t >> 33; t *= 0xff51afd7ed558ccdULL; t ^= t >> 33;
           h += t;
         }
-        sp_rbval_hash_depth--;
+        sp_poly_recur_pop(mark);
         return (sp_int)h;
       }
       /* two patterns with the same source are one Hash key, whichever way each
@@ -5893,7 +6027,15 @@ static sp_int sp_rbval_hash_key(sp_RbVal v) {
         memcpy(&bi, &cx->im, sizeof bi);
         return (sp_int)((uintptr_t)(br * 31u) ^ (uintptr_t)bi);
       }
-      if (sp_obj_hash_hook) return sp_obj_hash_hook(v.cls_id, v.v.p);
+      if (sp_obj_hash_hook) {
+        /* A Struct that holds itself hashes its own members through here; the
+           generated hook has no path of its own, so this is where it stops. */
+        if (sp_poly_recur_seen(SP_POLY_RECUR_HASH, v.v.p, NULL)) return SP_POLY_RECUR_HASH_VALUE;
+        int mark = sp_poly_recur_push(SP_POLY_RECUR_HASH, v.v.p, NULL);
+        sp_int oh = sp_obj_hash_hook(v.cls_id, v.v.p);
+        sp_poly_recur_pop(mark);
+        return oh;
+      }
       return (sp_int)((uintptr_t)v.v.p);
   }
   return 0;
@@ -5934,9 +6076,18 @@ static sp_bool sp_rbval_eql_key(sp_RbVal a, sp_RbVal b) {
         if (a.v.p == b.v.p && a.cls_id == b.cls_id) return TRUE;
         sp_int n = sp_poly_length(a);
         if (n != sp_poly_length(b)) return FALSE;
-        for (sp_int i = 0; i < n; i++)
-          if (!sp_rbval_eql_key(sp_poly_arr_get(a, i), sp_poly_arr_get(b, i))) return FALSE;
-        return TRUE;
+        /* The same pair guard sp_poly_eql carries: this is the eql? a Hash
+           LOOKUP runs, so `h = {a => 1}; h[b]` with two distinct arrays that
+           each hold themselves walks into the same pair for ever without it. */
+        if (sp_poly_recur_seen(SP_POLY_RECUR_EQ, a.v.p, b.v.p)) return TRUE;
+        {
+          int mark = sp_poly_recur_push(SP_POLY_RECUR_EQ, a.v.p, b.v.p);
+          sp_bool r = TRUE;
+          for (sp_int i = 0; r && i < n; i++)
+            r = sp_rbval_eql_key(sp_poly_arr_get(a, i), sp_poly_arr_get(b, i));
+          sp_poly_recur_pop(mark);
+          return r;
+        }
       }
       if (a.cls_id != b.cls_id) return FALSE;
       if (a.v.p == b.v.p) return TRUE;
@@ -5983,7 +6134,16 @@ static sp_bool sp_rbval_eql_key(sp_RbVal a, sp_RbVal b) {
         sp_Complex *ca = (sp_Complex *)a.v.p, *cb = (sp_Complex *)b.v.p;
         return (ca && cb) ? (ca->re == cb->re && ca->im == cb->im) : (ca == cb);
       }
-      if (sp_obj_eql_hook) return sp_obj_eql_hook(a.cls_id, a.v.p, b.v.p);
+      if (sp_obj_eql_hook) {
+        /* a Struct key that holds itself reaches its own eql? through the hook */
+        if (sp_poly_recur_seen(SP_POLY_RECUR_EQ, a.v.p, b.v.p)) return TRUE;
+        {
+          int mark = sp_poly_recur_push(SP_POLY_RECUR_EQ, a.v.p, b.v.p);
+          sp_bool r = sp_obj_eql_hook(a.cls_id, a.v.p, b.v.p);
+          sp_poly_recur_pop(mark);
+          return r;
+        }
+      }
       return FALSE;
   }
   return FALSE;
@@ -7110,9 +7270,15 @@ static sp_bool sp_poly_eql(sp_RbVal a, sp_RbVal b) {
     if (a.v.p == b.v.p) return TRUE;  /* same object: eql? to itself (O(1)) */
     sp_int n = sp_poly_length(a);
     if (n != sp_poly_length(b)) return FALSE;
-    for (sp_int i = 0; i < n; i++)
-      if (!sp_poly_eql(sp_poly_arr_get(a, i), sp_poly_arr_get(b, i))) return FALSE;
-    return TRUE;
+    /* Same pair guard as ==, and the same kind of frame: both answer TRUE for a
+       pair they are already inside, so a nest that mixes the two still ends. */
+    if (sp_poly_recur_seen(SP_POLY_RECUR_EQ, a.v.p, b.v.p)) return TRUE;
+    int mark = sp_poly_recur_push(SP_POLY_RECUR_EQ, a.v.p, b.v.p);
+    sp_bool r = TRUE;
+    for (sp_int i = 0; r && i < n; i++)
+      r = sp_poly_eql(sp_poly_arr_get(a, i), sp_poly_arr_get(b, i));
+    sp_poly_recur_pop(mark);
+    return r;
   }
   /* Two user objects of the same class: eql? (used by uniq / Set / Hash keys,
      unlike ==) honors a user-defined eql? via the cls_id hook. Identity is the
@@ -7122,7 +7288,14 @@ static sp_bool sp_poly_eql(sp_RbVal a, sp_RbVal b) {
   if (a.tag == SP_TAG_OBJ && b.tag == SP_TAG_OBJ && a.cls_id == b.cls_id &&
       a.cls_id >= 0) {
     if (a.v.p == b.v.p) return TRUE;
-    if (sp_obj_eql_hook) return sp_obj_eql_hook(a.cls_id, a.v.p, b.v.p);
+    if (sp_obj_eql_hook) {
+      /* a Struct that holds itself reaches its own eql? through the hook */
+      if (sp_poly_recur_seen(SP_POLY_RECUR_EQ, a.v.p, b.v.p)) return TRUE;
+      int mark = sp_poly_recur_push(SP_POLY_RECUR_EQ, a.v.p, b.v.p);
+      sp_bool r = sp_obj_eql_hook(a.cls_id, a.v.p, b.v.p);
+      sp_poly_recur_pop(mark);
+      return r;
+    }
     /* No eql? hook (so no Struct/Data value key exists to need field-wise eql?):
        a user object's eql? is identity, NOT its `==`. Falling through to
        sp_poly_eq would pick up a class's user-defined `==` (which uniq / Set /
@@ -8407,6 +8580,26 @@ static SP_TLS int sp_rescue_sp = 0;
    exception landing so a rescue body that exits by raising doesn't leak its push
    (a side array beside the handler stack, mirroring sp_exc_rootmark). */
 static SP_TLS int sp_rescue_mark[SP_EXC_STACK_MAX];
+/* The container-walk path's depth (sp_inspect.h) at each handler's arm. Any
+   non-local exit out of a guarded walk -- a raise, a throw, a break out of a
+   block, a proc's non-local return -- longjmps past the sp_poly_recur_pop calls,
+   and the frames left behind would make the NEXT walk over the same objects
+   print "[...]", call two different arrays equal, or raise "recursive array
+   join" for a structure that never repeated. So EVERY stack that can be landed
+   on records the depth where its arm was armed, and every longjmp into one
+   restores it: this array beside sp_exc_stack, sp_catch_recur_mark beside the
+   catch stack, sp_brk_recur_mark beside the break scopes, and a field on the
+   proc-return home node. The exception, catch and break arms are all opened by
+   a runtime call (sp_exc_check_depth, sp_catch_check_depth, sp_brk_push), so
+   only the proc-return home -- a struct the method builds on its own C stack --
+   needs a line in generated code. */
+static SP_TLS int sp_poly_recur_mark[SP_EXC_STACK_MAX];
+/* Called immediately before every longjmp into sp_exc_stack: the landing frame
+   is the one on top, and the walk frames pushed since it armed are about to be
+   jumped over, so give the path back the depth that frame recorded. */
+static inline void sp_poly_recur_unwind(void) {
+  if (sp_exc_top > 0) sp_poly_recur_pop(sp_poly_recur_mark[sp_exc_top - 1]);
+}
 #define sp_cur_handled() (sp_rescue_sp > 0 ? sp_exc_handling[sp_rescue_sp-1] : NULL)
 /* Push a handled exception. sp_rescue_sp grows with recursion *through* rescue
    bodies (the handler stays pushed across the recursive call it makes, unlike a
@@ -8440,6 +8633,7 @@ SP_NORETURN SP_COLD static void sp_stack_too_deep(void) {
    (sp_exc_arm below), so 63 of the body's own is the last that fits. */
 static inline void sp_exc_check_depth(void) {
   if (SP_UNLIKELY(sp_exc_top >= SP_EXC_STACK_MAX)) sp_stack_too_deep();
+  sp_poly_recur_mark[sp_exc_top] = sp_poly_recur_top;
 }
 /* ---- Native backtrace formatting (spinel --debug) ---------------------- */
 /* True for sp_<name> symbols that are runtime helpers, not user Ruby methods.
@@ -8609,7 +8803,7 @@ SP_NORETURN SP_COLD void sp_raise_cls(const char *cls, const char *msg) {
      live (a --debug build). Without it there is no location to print, and an
      uncaught raise in a multi-file program said only what went wrong, never
      where (#3974). Frames are method-granularity, so there is no `:line:`. */
-  if (sp_exc_top > 0) { sp_exc_msg[sp_exc_top-1] = msg; sp_exc_cls[sp_exc_top-1] = cls; sp_exc_obj[sp_exc_top-1] = sp_pending_exc_obj; sp_pending_exc_obj = NULL; sp_pending_cause = sp_explicit_cause_set ? sp_explicit_cause : (sp_cur_handled() ? sp_cur_handled() : sp_inflight_cause); sp_inflight_cause = NULL; sp_explicit_cause = NULL; sp_explicit_cause_set = 0; sp_last_exc_cls = cls; sp_handler_stacks_unwind(); longjmp(sp_exc_stack[sp_exc_top-1], 1); }
+  if (sp_exc_top > 0) { sp_exc_msg[sp_exc_top-1] = msg; sp_exc_cls[sp_exc_top-1] = cls; sp_exc_obj[sp_exc_top-1] = sp_pending_exc_obj; sp_pending_exc_obj = NULL; sp_pending_cause = sp_explicit_cause_set ? sp_explicit_cause : (sp_cur_handled() ? sp_cur_handled() : sp_inflight_cause); sp_inflight_cause = NULL; sp_explicit_cause = NULL; sp_explicit_cause_set = 0; sp_last_exc_cls = cls; sp_handler_stacks_unwind(); sp_poly_recur_unwind(); longjmp(sp_exc_stack[sp_exc_top-1], 1); }
   /* Uncaught SystemExit terminates silently with its status (Kernel#exit).
      Read the status BEFORE the hooks run: it lives in the pending exception
      object, which nothing roots once the hooks start allocating. */
@@ -9023,11 +9217,15 @@ static SP_TLS unsigned char sp_catch_tag_kind[SP_CATCH_STACK_MAX];
 static SP_TLS sp_RbVal sp_catch_val[SP_CATCH_STACK_MAX];
 static SP_TLS int sp_catch_exc_top[SP_CATCH_STACK_MAX];  /* exception depth at each catch's entry */
 static SP_TLS int sp_catch_rootmark[SP_CATCH_STACK_MAX]; /* GC-root watermark at entry (see sp_exc_rootmark) */
+static SP_TLS int sp_catch_recur_mark[SP_CATCH_STACK_MAX]; /* walk-path depth at entry (see sp_poly_recur_mark) */
 static SP_TLS volatile int sp_catch_top = 0;
 /* Guard a catch push, like sp_exc_check_depth: the arm's first store is
-   sp_catch_tag[sp_catch_top], so this runs in front of it. */
+   sp_catch_tag[sp_catch_top], so this runs in front of it -- which also makes
+   it the one place every catch arm passes through, so the walk path's depth is
+   recorded here rather than in the emitted arm. */
 static inline void sp_catch_check_depth(void) {
   if (SP_UNLIKELY(sp_catch_top >= SP_CATCH_STACK_MAX)) sp_stack_too_deep();
+  sp_catch_recur_mark[sp_catch_top] = sp_poly_recur_top;
 }
 /* shared counter (not SP_TLS) so `catch { |tag| }` autotags are globally
    unique; see sp_brk_seq for the same shape */
@@ -9040,8 +9238,10 @@ static void sp_throw(const char *tag, int kind, sp_RbVal val) {
       sp_catch_val[i] = val; sp_catch_top = i + 1;
       if (sp_exc_top > sp_catch_exc_top[i]) {       /* run intervening ensures first */
         sp_unwind_kind = SP_UNWIND_THROW; sp_unwind_target = i; sp_unwind_exc_top = sp_catch_exc_top[i];
+        sp_poly_recur_unwind();
         longjmp(sp_exc_stack[sp_exc_top - 1], 1);
       }
+      sp_poly_recur_pop(sp_catch_recur_mark[i]);
       longjmp(sp_catch_stack[i], 1);
     }
     i--;
@@ -9077,6 +9277,7 @@ static SP_TLS jmp_buf *sp_brk_stack;              /* lazily allocated */
 static SP_TLS sp_RbVal *sp_brk_val;
 static SP_TLS sp_int *sp_brk_serial;
 static SP_TLS int *sp_brk_exc_top;                /* sp_exc_top at scope entry */
+static SP_TLS int *sp_brk_recur_mark;            /* walk-path depth at scope entry (see sp_poly_recur_mark) */
 static SP_TLS volatile int sp_brk_top = 0;
 /* shared counter (not SP_TLS) so serials are globally unique; see
    sp_proc_home_seq for the same shape */
@@ -9091,7 +9292,9 @@ static sp_int sp_brk_push(void) {
     sp_brk_val = (sp_RbVal *)malloc(sizeof(sp_RbVal) * SP_BRK_STACK_MAX);
     sp_brk_serial = (sp_int *)malloc(sizeof(sp_int) * SP_BRK_STACK_MAX);
     sp_brk_exc_top = (int *)malloc(sizeof(int) * SP_BRK_STACK_MAX);
-    if (!sp_brk_stack || !sp_brk_val || !sp_brk_serial || !sp_brk_exc_top)
+    sp_brk_recur_mark = (int *)malloc(sizeof(int) * SP_BRK_STACK_MAX);
+    if (!sp_brk_stack || !sp_brk_val || !sp_brk_serial || !sp_brk_exc_top ||
+        !sp_brk_recur_mark)
       sp_oom_die();
   }
 #ifdef SP_THREADS
@@ -9101,6 +9304,7 @@ static sp_int sp_brk_push(void) {
 #endif
   sp_brk_serial[sp_brk_top] = s;
   sp_brk_exc_top[sp_brk_top] = sp_exc_top;
+  sp_brk_recur_mark[sp_brk_top] = sp_poly_recur_top;
   sp_brk_val[sp_brk_top] = sp_box_nil();
   sp_brk_top++;
   return s;
@@ -9113,8 +9317,10 @@ static void __attribute__((noreturn)) sp_brk_throw(sp_int serial, sp_RbVal v) {
     if (sp_exc_top > sp_brk_exc_top[i]) {  /* run intervening ensures first */
       sp_unwind_kind = SP_UNWIND_BREAK; sp_unwind_target = i;
       sp_unwind_exc_top = sp_brk_exc_top[i];
+      sp_poly_recur_unwind();
       longjmp(sp_exc_stack[sp_exc_top - 1], 1);
     }
+    sp_poly_recur_pop(sp_brk_recur_mark[i]);
     longjmp(sp_brk_stack[i], 1);
   }
   /* no live scope carries the serial: an escaped/foreign proc's break. An
@@ -9167,6 +9373,7 @@ typedef struct sp_proc_home {
   sp_RbVal val;               /* the in-flight return value (nil until delivered) */
   int exc_top;                /* sp_exc_top at the method's entry */
   int catch_top;              /* sp_catch_top at the method's entry */
+  int recur_mark;             /* walk-path depth at the method's entry (see sp_poly_recur_mark) */
   sp_int id;                 /* fresh id captured by the home's returning procs */
   struct sp_proc_home *prev;  /* enclosing home, forming the per-fiber chain */
 } sp_proc_home;
@@ -9190,8 +9397,10 @@ static void sp_proc_return(sp_int id, sp_RbVal v) {
       h->val = v;
       if (sp_exc_top > h->exc_top) {   /* run intervening ensures first */
         sp_unwind_kind = SP_UNWIND_PROCRET; sp_unwind_home = h; sp_unwind_exc_top = h->exc_top;
+        sp_poly_recur_unwind();
         longjmp(sp_exc_stack[sp_exc_top - 1], 1);
       }
+      sp_poly_recur_pop(h->recur_mark);
       longjmp(h->jb, 1);
     }
   }
@@ -9278,11 +9487,21 @@ __attribute__((constructor)) static void sp_install_safepoint_publish(void) {
    handlers lie between here and the target, longjmp to the next; otherwise
    deliver to the target (the proc-return home node, or the matched catch slot). */
 static void sp_unwind_resume(void) {
-  if (sp_exc_top > sp_unwind_exc_top) longjmp(sp_exc_stack[sp_exc_top - 1], 1);
+  if (sp_exc_top > sp_unwind_exc_top) { sp_poly_recur_unwind(); longjmp(sp_exc_stack[sp_exc_top - 1], 1); }
   int kind = sp_unwind_kind;
   sp_unwind_kind = SP_UNWIND_NONE;
-  if (kind == SP_UNWIND_PROCRET) longjmp(sp_unwind_home->jb, 1);
-  if (kind == SP_UNWIND_BREAK) longjmp(sp_brk_stack[sp_unwind_target], 1);
+  /* the ensures are done; deliver, giving the walk path back the depth the
+     target arm recorded (the intervening exception frames restored their own on
+     the way here) */
+  if (kind == SP_UNWIND_PROCRET) {
+    sp_poly_recur_pop(sp_unwind_home->recur_mark);
+    longjmp(sp_unwind_home->jb, 1);
+  }
+  if (kind == SP_UNWIND_BREAK) {
+    sp_poly_recur_pop(sp_brk_recur_mark[sp_unwind_target]);
+    longjmp(sp_brk_stack[sp_unwind_target], 1);
+  }
+  sp_poly_recur_pop(sp_catch_recur_mark[sp_unwind_target]);
   longjmp(sp_catch_stack[sp_unwind_target], 1);
 }
 
@@ -9303,6 +9522,8 @@ typedef struct {
   int uk, ut, ue; sp_proc_home *uh;  /* transient unwind state (in flight only while running ensures) */
   void **shand; int rn, rcap;        /* sp_exc_handling prefix [0..sp_rescue_sp) */
   void *pcause;                      /* sp_pending_cause */
+  sp_poly_recur_frame *rrf; int rrn, rrcap;  /* sp_poly_recur_stack prefix [0..sp_poly_recur_top) */
+  int *rrem, *rrcm, *rrbm;           /* the walk-path marks of the exception, catch and break arms */
 } sp_exc_ctx_t;
 
 #ifdef SPINEL_EXT_HOST
@@ -9318,7 +9539,8 @@ void sp_exc_ctx_free(void *p) {
   if (!x) return;
   free(x->es); free(x->em); free(x->ec); free(x->eo);
   free(x->cs); free(x->ct); free(x->ctk); free(x->cv); free(x->cet);
-  free(x->bs); free(x->bv); free(x->bser); free(x->bet); free(x->shand); free(x);
+  free(x->bs); free(x->bv); free(x->bser); free(x->bet); free(x->shand);
+  free(x->rrf); free(x->rrem); free(x->rrcm); free(x->rrbm); free(x);
 }
 #endif
 #ifdef SPINEL_EXT_HOST
@@ -9331,9 +9553,15 @@ void sp_exc_ctx_save(void *p) {            /* current globals -> ctx */
     x->es = (jmp_buf *)realloc(x->es, sizeof(jmp_buf) * n);
     x->em = (const char **)realloc(x->em, sizeof(char *) * n);
     x->ec = (const char **)realloc(x->ec, sizeof(char *) * n);
-    x->eo = (void **)realloc(x->eo, sizeof(void *) * n); }
+    x->eo = (void **)realloc(x->eo, sizeof(void *) * n);
+    x->rrem = (int *)realloc(x->rrem, sizeof(int) * n); }
   for (int i = 0; i < n; i++) { memcpy(x->es[i], sp_exc_stack[i], sizeof(jmp_buf));
-    x->em[i] = sp_exc_msg[i]; x->ec[i] = sp_exc_cls[i]; x->eo[i] = sp_exc_obj[i]; }
+    x->em[i] = sp_exc_msg[i]; x->ec[i] = sp_exc_cls[i]; x->eo[i] = sp_exc_obj[i];
+    /* the arm's walk-path depth travels with the arm: two green threads whose
+       handlers sit at the same index would otherwise share one slot, and a
+       raise in one would restore the other's depth -- a HIGHER one resurrects
+       frames that belong to the other context (see sp_poly_recur_mark) */
+    x->rrem[i] = sp_poly_recur_mark[i]; }
   x->en = n;
   int m = sp_catch_top;
   if (m > x->ccap) { x->ccap = m;
@@ -9341,10 +9569,12 @@ void sp_exc_ctx_save(void *p) {            /* current globals -> ctx */
     x->ct = (const char **)realloc(x->ct, sizeof(char *) * m);
     x->ctk = (unsigned char *)realloc(x->ctk, sizeof(unsigned char) * m);
     x->cv = (sp_RbVal *)realloc(x->cv, sizeof(sp_RbVal) * m);
-    x->cet = (int *)realloc(x->cet, sizeof(int) * m); }
+    x->cet = (int *)realloc(x->cet, sizeof(int) * m);
+    x->rrcm = (int *)realloc(x->rrcm, sizeof(int) * m); }
   for (int i = 0; i < m; i++) { memcpy(x->cs[i], sp_catch_stack[i], sizeof(jmp_buf));
     x->ct[i] = sp_catch_tag[i]; x->ctk[i] = sp_catch_tag_kind[i];
-    x->cv[i] = sp_catch_val[i]; x->cet[i] = sp_catch_exc_top[i]; }
+    x->cv[i] = sp_catch_val[i]; x->cet[i] = sp_catch_exc_top[i];
+    x->rrcm[i] = sp_catch_recur_mark[i]; }
   x->cn = m;
   int bn = sp_brk_top;
   if (bn > x->bcap) { x->bcap = bn;
@@ -9352,9 +9582,11 @@ void sp_exc_ctx_save(void *p) {            /* current globals -> ctx */
     x->bv = (sp_RbVal *)realloc(x->bv, sizeof(sp_RbVal) * bn);
     x->bser = (sp_int *)realloc(x->bser, sizeof(sp_int) * bn);
     x->bet = (int *)realloc(x->bet, sizeof(int) * bn);
-    if (!x->bs || !x->bv || !x->bser || !x->bet) sp_oom_die(); }
+    x->rrbm = (int *)realloc(x->rrbm, sizeof(int) * bn);
+    if (!x->bs || !x->bv || !x->bser || !x->bet || !x->rrbm) sp_oom_die(); }
   for (int i = 0; i < bn; i++) { memcpy(x->bs[i], sp_brk_stack[i], sizeof(jmp_buf));
-    x->bv[i] = sp_brk_val[i]; x->bser[i] = sp_brk_serial[i]; x->bet[i] = sp_brk_exc_top[i]; }
+    x->bv[i] = sp_brk_val[i]; x->bser[i] = sp_brk_serial[i]; x->bet[i] = sp_brk_exc_top[i];
+    x->rrbm[i] = sp_brk_recur_mark[i]; }
   x->bn = bn;
   x->prhead = sp_proc_ret_head;
   x->uk = sp_unwind_kind; x->ut = sp_unwind_target; x->ue = sp_unwind_exc_top; x->uh = sp_unwind_home;
@@ -9364,6 +9596,17 @@ void sp_exc_ctx_save(void *p) {            /* current globals -> ctx */
     if (!x->shand) sp_oom_die(); }
   for (int i = 0; i < rn; i++) x->shand[i] = sp_exc_handling[i];
   x->rn = rn; x->pcause = sp_pending_cause;
+  /* The container-walk path travels with the green thread, like the handler
+     stack above it: a fiber suspended in the middle of an #inspect resumes
+     still knowing what it was inside, and the fiber that runs meanwhile starts
+     from an empty path rather than reading this one's frames. Almost always
+     nothing to copy -- a yield lands between walks, not inside one. */
+  int rrn = sp_poly_recur_top;
+  if (rrn > x->rrcap) { x->rrcap = rrn;
+    x->rrf = (sp_poly_recur_frame *)realloc(x->rrf, sizeof(sp_poly_recur_frame) * rrn);
+    if (!x->rrf) sp_oom_die(); }
+  for (int i = 0; i < rrn; i++) x->rrf[i] = sp_poly_recur_stack[i];
+  x->rrn = rrn;
 }
 #endif
 #ifdef SPINEL_EXT_HOST
@@ -9372,22 +9615,29 @@ void sp_exc_ctx_load(void *p);
 void sp_exc_ctx_load(void *p) {            /* ctx -> current globals */
   sp_exc_ctx_t *x = (sp_exc_ctx_t *)p;
   for (int i = 0; i < x->en; i++) { memcpy(sp_exc_stack[i], x->es[i], sizeof(jmp_buf));
-    sp_exc_msg[i] = x->em[i]; sp_exc_cls[i] = x->ec[i]; sp_exc_obj[i] = x->eo[i]; }
+    sp_exc_msg[i] = x->em[i]; sp_exc_cls[i] = x->ec[i]; sp_exc_obj[i] = x->eo[i];
+    sp_poly_recur_mark[i] = x->rrem[i]; }
   sp_exc_top = x->en;
   /* the marker covers one slot past top (handler consumption window); zero
      it so a stale entry from another fiber's context is never chased */
   if (x->en < SP_EXC_STACK_MAX) { sp_exc_msg[x->en] = 0; sp_exc_obj[x->en] = 0; }
   for (int i = 0; i < x->cn; i++) { memcpy(sp_catch_stack[i], x->cs[i], sizeof(jmp_buf));
     sp_catch_tag[i] = x->ct[i]; sp_catch_tag_kind[i] = x->ctk[i];
-    sp_catch_val[i] = x->cv[i]; sp_catch_exc_top[i] = x->cet[i]; }
+    sp_catch_val[i] = x->cv[i]; sp_catch_exc_top[i] = x->cet[i];
+    sp_catch_recur_mark[i] = x->rrcm[i]; }
   sp_catch_top = x->cn;
   for (int i = 0; i < x->bn; i++) { memcpy(sp_brk_stack[i], x->bs[i], sizeof(jmp_buf));
-    sp_brk_val[i] = x->bv[i]; sp_brk_serial[i] = x->bser[i]; sp_brk_exc_top[i] = x->bet[i]; }
+    sp_brk_val[i] = x->bv[i]; sp_brk_serial[i] = x->bser[i]; sp_brk_exc_top[i] = x->bet[i];
+    sp_brk_recur_mark[i] = x->rrbm[i]; }
   sp_brk_top = x->bn;
   sp_proc_ret_head = x->prhead;
   sp_unwind_kind = x->uk; sp_unwind_target = x->ut; sp_unwind_exc_top = x->ue; sp_unwind_home = x->uh;
   for (int i = 0; i < x->rn; i++) sp_exc_handling[i] = x->shand[i];
   sp_rescue_sp = x->rn; sp_pending_cause = x->pcause;
+  if (x->rrn > sp_poly_recur_cap) sp_poly_recur_grow(x->rrn);
+  for (int i = 0; i < x->rrn; i++) sp_poly_recur_stack[i] = x->rrf[i];
+  sp_poly_recur_top = x->rrn;
+  sp_poly_recur_ixtop = 0;   /* the index described the other context's frames */
 }
 #endif
 #ifdef SPINEL_EXT_HOST
@@ -10641,6 +10891,11 @@ sp_int sp_proc_call(sp_Proc *p, sp_int argc, sp_int *args) { if (!p || !p->fn) r
    the table is the collector's only handle on it, and the pop takes that handle
    away. */
 static int sp_at_exit_run(int status) {
+  /* The hooks run at top level. A raise that reached here unhandled, or an exit
+     from inside a walk, abandoned whatever walk it was inside; drop the frames
+     it left, or the first hook to inspect or compare that same object is told
+     it is already inside it. */
+  sp_poly_recur_pop(0);
   /* The hooks run at termination, where the path that got here has left its own
      raise in the pending slots. Clear them, or the first `raise` inside a hook
      binds the TERMINATING exception instead of its own: sp_raise_cls' recovery

--- a/packages/json/sp_json.c
+++ b/packages/json/sp_json.c
@@ -68,7 +68,21 @@ static const char *sp_json_key(sp_RbVal k) {
   return sp_json_str("");
 }
 
-const char *sp_json_val(sp_RbVal v) {
+/* CRuby's json refuses to serialize past 100 levels of nesting, which is how
+   it answers a structure that contains itself: `a << a; JSON.generate(a)` is a
+   JSON::NestingError, not an endless document. The limit is on DEPTH, not on
+   identity -- 100 levels of distinct arrays serialize and the 101st raises,
+   whether or not anything repeats. */
+#define SP_JSON_MAX_NESTING 100
+SP_COLD static __attribute__((noinline, noreturn)) void sp_json_too_deep(void) {
+  sp_raise_cls("JSON::NestingError",
+               "nesting of 100 is too deep. Did you try to serialize objects with circular references?");
+}
+static const char *sp_json_val_d(sp_RbVal v, int depth);
+const char *sp_json_val(sp_RbVal v) { return sp_json_val_d(v, 0); }
+/* `depth` counts the containers already entered, so a container reached at
+   depth 100 would be the 101st level. */
+static const char *sp_json_val_d(sp_RbVal v, int depth) {
   switch (v.tag) {
     case SP_TAG_INT:  return sp_int_to_s(v.v.i);
     case SP_TAG_FLT:  return sp_float_to_s(v.v.f);
@@ -79,17 +93,19 @@ const char *sp_json_val(sp_RbVal v) {
     case SP_TAG_OBJ: {
       int kind = sp_json_kind_fn ? sp_json_kind_fn(v) : 0;
       if (kind == 1) {  /* array */
+        if (depth >= SP_JSON_MAX_NESTING) sp_json_too_deep();
         sp_int n = sp_json_len_fn(v);
         jbuf b; memset(&b, 0, sizeof b); jb_c(&b, '[');
         for (sp_int i = 0; i < n; i++) {
           if (i) jb_c(&b, ',');
-          const char *e = sp_json_val(sp_json_aref_fn(v, i));
+          const char *e = sp_json_val_d(sp_json_aref_fn(v, i), depth + 1);
           jb_add(&b, e, strlen(e));
         }
         jb_c(&b, ']');
         return jb_finish(&b);
       }
       if (kind == 2) {  /* hash */
+        if (depth >= SP_JSON_MAX_NESTING) sp_json_too_deep();
         sp_int n = sp_json_len_fn(v);
         jbuf b; memset(&b, 0, sizeof b); jb_c(&b, '{');
         for (sp_int i = 0; i < n; i++) {
@@ -99,7 +115,7 @@ const char *sp_json_val(sp_RbVal v) {
           const char *ks = sp_json_key(k);
           jb_add(&b, ks, strlen(ks));
           jb_c(&b, ':');
-          const char *vs = sp_json_val(val);
+          const char *vs = sp_json_val_d(val, depth + 1);
           jb_add(&b, vs, strlen(vs));
         }
         jb_c(&b, '}');
@@ -111,7 +127,7 @@ const char *sp_json_val(sp_RbVal v) {
          knowledge lives here or in the compiler; only the generic reflection. */
       /* a user class's own #to_json wins, as it does in CRuby's json */
       if (sp_obj_to_json_fn) { const char *uj = sp_obj_to_json_fn(v); if (uj) return uj; }
-      if (sp_obj_to_hash_fn) return sp_json_val(sp_obj_to_hash_fn(v));
+      if (sp_obj_to_hash_fn) return sp_json_val_d(sp_obj_to_hash_fn(v), depth);
       return JSPL("null");
     }
     default: return JSPL("null");
@@ -131,6 +147,7 @@ static void sp_json_pretty_val(jbuf *b, sp_RbVal v, int depth) {
   if (v.tag == SP_TAG_OBJ) {
     int kind = sp_json_kind_fn ? sp_json_kind_fn(v) : 0;
     if (kind == 1) {  /* array */
+      if (depth >= SP_JSON_MAX_NESTING) sp_json_too_deep();
       sp_int n = sp_json_len_fn(v);
       if (n == 0) { jb_add(b, "[]", 2); return; }
       jb_c(b, '[');
@@ -146,6 +163,7 @@ static void sp_json_pretty_val(jbuf *b, sp_RbVal v, int depth) {
       return;
     }
     if (kind == 2) {  /* hash */
+      if (depth >= SP_JSON_MAX_NESTING) sp_json_too_deep();
       sp_int n = sp_json_len_fn(v);
       if (n == 0) { jb_add(b, "{}", 2); return; }
       jb_c(b, '{');

--- a/packages/set/set.rb
+++ b/packages/set/set.rb
@@ -11,6 +11,24 @@
 class Set
   include Enumerable
 
+  # A Set may hold itself (`s.add(s)`), directly or through an Array, a Hash or
+  # any object that leads back to it, and #==, #inspect and #flatten all walk
+  # their elements. Without a memory of what they are already inside, each of
+  # them follows the cycle until the C stack runs out. The runtime keeps that
+  # memory for Array and Hash -- a per-fiber path of the objects (or object
+  # pairs) the current walk is inside, restored by every non-local exit -- and
+  # a Set's walks, which are written in Ruby, join it through these bindings.
+  # Each `enter` answers the mark that `leave` takes back, or -1 when the walk
+  # is already inside this Set, which is the cue to stop. No `ensure` is
+  # needed: a raise, throw or break out of a walk lands on a handler that
+  # restores the path to the depth it had when that handler was armed.
+  module RecursionGuard
+    native_func :enter_inspect, [:any], :int, "sp_poly_recur_enter_inspect"
+    native_func :enter_eq, [:any, :any], :int, "sp_poly_recur_enter_eq"
+    native_func :enter_flatten, [:any], :int, "sp_poly_recur_enter_flatten"
+    native_func :leave, [:int], :nil, "sp_poly_recur_leave"
+  end
+
   # Set[1, 2, 3] builds a Set from the given elements (CRuby's Set.[]).
   def self.[](*args)
     new(args)
@@ -271,8 +289,19 @@ class Set
   end
 
   def ==(other)
+    return true if self.equal?(other)
     return false unless other.is_a?(Set)
-    size == other.size && subset?(other)
+    return false unless size == other.size
+    mark = RecursionGuard.enter_eq(self, other)
+    # A pair already being compared answers "equal", which is what lets two
+    # distinct self-containing Sets finish. CRuby answers false here, for a
+    # reason Spinel's array-backed Set cannot reproduce: its Set is a hash
+    # table, and the element's hash was stored while the Set was still empty,
+    # so the membership probe misses.
+    return true if mark < 0
+    r = subset?(other)
+    RecursionGuard.leave(mark)
+    r
   end
   alias eql? ==
 
@@ -414,8 +443,11 @@ class Set
     end
   end
 
-  # flatten recursively merges nested Set elements into a flat Set.
+  # flatten recursively merges nested Set elements into a flat Set. A Set that
+  # holds itself has no flat form, so CRuby raises rather than looping.
   def flatten
+    mark = RecursionGuard.enter_flatten(self)
+    raise ArgumentError, "tried to flatten recursive Set" if mark < 0
     r = Set.new
     @data.each do |x|
       if x.is_a?(Set)
@@ -424,6 +456,7 @@ class Set
         r.add(x)
       end
     end
+    RecursionGuard.leave(mark)
     r
   end
 
@@ -444,7 +477,11 @@ class Set
   end
 
   def inspect
-    "Set[" + @data.map { |x| x.inspect }.join(", ") + "]"
+    mark = RecursionGuard.enter_inspect(self)
+    return "Set[...]" if mark < 0
+    r = "Set[" + @data.map { |x| x.inspect }.join(", ") + "]"
+    RecursionGuard.leave(mark)
+    r
   end
   alias to_s inspect
 end

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -3152,7 +3152,12 @@ void emit_method(Compiler *c, Scope *s, Buf *b) {
        unlinks it. val starts nil so a GC before any return marks nothing. */
     buf_puts(b, "    sp_proc_home _h;\n");
     buf_puts(b, "    _h.val = sp_box_nil(); _h.id = sp_proc_home_next();\n");
+    /* ...and the walk path's depth, so a non-local return out of a container
+       walk (a user #inspect that returns through a proc) drops the frames the
+       longjmp jumps over; the exception and catch stacks record theirs inside
+       the runtime calls that open their arms, but this node is built here. */
     buf_puts(b, "    _h.exc_top = sp_exc_top; _h.catch_top = sp_catch_top;\n");
+    buf_puts(b, "    _h.recur_mark = sp_poly_recur_save();\n");
     buf_puts(b, "    _h.prev = sp_proc_ret_head; sp_proc_ret_head = &_h;\n");
     if (!is_void) {
       buf_puts(b, "    "); emit_ctype(c, s->ret, b); buf_puts(b, " _prret = ");
@@ -5808,6 +5813,15 @@ void emit_class_new(Compiler *c, ClassInfo *ci, Buf *b) {
       const char *rn = class_ruby_name(c, cid); if (!rn) rn = ci->name;
       buf_printf(b, "static const char *sp_%s_inspect(sp_%s *self) {\n", ci->c_name, ci->c_name);
       buf_puts(b, "  if (!self) return \"nil\";\n");
+      /* A member can hold the struct itself (`s.a = s`), and this function
+         renders a member of its own class by calling straight back into
+         itself. Stop at the object the render is already inside, as CRuby's
+         #<struct S a=#<struct S:...>> does. Only a struct with members can be
+         reached from inside itself, so a memberless one keeps its old body. */
+      if (ci->nivars > 0)
+        buf_printf(b, "  if (sp_poly_recur_seen(SP_POLY_RECUR_INSPECT, self, NULL)) return \"#<%s %s:...>\";\n"
+                      "  int _rcm = sp_poly_recur_push(SP_POLY_RECUR_INSPECT, self, NULL);\n",
+                   ci->is_data ? "data" : "struct", ci->is_anon_struct ? "" : rn);
       /* an anonymous struct class has no name to show: #<struct a=1, b=2> */
       if (ci->is_anon_struct)
         /* the space that would precede the first member is CRuby's even when
@@ -5840,7 +5854,9 @@ void emit_class_new(Compiler *c, ClassInfo *ci, Buf *b) {
           free(bx.p); free(ivb.p);
         }
       }
-      buf_puts(b, "  sp_String_append(s, \">\");\n  return s->data;\n}\n");
+      buf_puts(b, "  sp_String_append(s, \">\");\n");
+      if (ci->nivars > 0) buf_puts(b, "  sp_poly_recur_pop(_rcm);\n");
+      buf_puts(b, "  return s->data;\n}\n");
       }
     }
     if (comp_method_in_chain(c, cid, "to_s", NULL) < 0) {
@@ -6595,8 +6611,25 @@ static void emit_obj_inspect_dispatch(Compiler *c, Buf *b) {
     }
     buf_printf(b, "    case %d: {\n", i);
     buf_printf(b, "      sp_%s *o = (sp_%s *)p; (void)o;\n", ci->c_name, ci->c_name);
+    /* An ivar can point back at the object (a tree node's @parent), and the
+       walk below renders each ivar through the inspects that come back here.
+       CRuby shows the repeated object as #<N:0x... ...>; an object with no
+       ivars cannot be reached from inside itself and keeps its old body. */
+    if (ci->nivars > 0)
+      buf_printf(b, "      if (sp_poly_recur_seen(SP_POLY_RECUR_INSPECT, p, NULL))\n"
+                    "        return sp_sprintf(\"#<%s:0x%%016llx ...>\", (unsigned long long)(uintptr_t)p);\n"
+                    "      int _rcm = sp_poly_recur_push(SP_POLY_RECUR_INSPECT, p, NULL);\n",
+                 class_ruby_name(c, i) ? class_ruby_name(c, i) : ci->name);
     buf_printf(b, "      sp_String *_s = sp_String_new(sp_sprintf(\"#<%s:0x%%016llx\", (unsigned long long)(uintptr_t)p));\n",
                class_ruby_name(c, i) ? class_ruby_name(c, i) : ci->name);
+    /* The builder is live across every allocation the ivar walk below makes --
+       each element's own inspect, and the sp_sprintf that renders an ivar
+       pointing back at this object. Unrooted, a collection mid-walk swept it
+       and the appends wrote into a freed buffer (the Struct/Data inspect above
+       has always rooted its builder for the same reason). A class with no
+       ivars has no such walk: it appends one byte, which reallocs off the GC
+       heap and cannot collect, so its arm is left as it was. */
+    if (ci->nivars > 0) buf_puts(b, "      SP_GC_ROOT(_s);\n");
     for (int j = 0; j < ci->nivars; j++) {
       char expr[160]; snprintf(expr, sizeof expr, "o->iv_%s", ci->ivars[j] + 1);
       buf_printf(b, "      sp_String_append(_s, \"%s%s=\"); sp_String_append(_s, ",
@@ -6627,6 +6660,7 @@ static void emit_obj_inspect_dispatch(Compiler *c, Buf *b) {
       buf_puts(b, ");\n");
     }
     buf_puts(b, "      sp_String_append(_s, \">\");\n");
+    if (ci->nivars > 0) buf_puts(b, "      sp_poly_recur_pop(_rcm);\n");
     buf_puts(b, "      return _s->data;\n    }\n");
   }
   buf_puts(b, "    default: return \"#<Object>\";\n  }\n}\n");
@@ -7458,15 +7492,21 @@ static void emit_obj_hashkey_dispatch(Compiler *c, Buf *b) {
   for (int k = 0; k < c->nclasses; k++) {
     if (!class_is_valuekey(c, k)) continue;
     ClassInfo *ci = &c->classes[k];
-    buf_printf(b, "    case %d: { sp_%s *o = (sp_%s *)p; sp_int _h = %d;\n",
+    /* Unsigned accumulator, like the runtime's array and hash ones and the
+       inline Struct#hash at a call site: the rolling h*31+x is meant to wrap,
+       and on a signed type that is undefined behavior rather than wraparound.
+       A member that holds the struct itself now contributes a large fixed
+       constant, so a two-member struct whose self-reference is not last
+       overflows on the very next multiply (UBSan caught it). */
+    buf_printf(b, "    case %d: { sp_%s *o = (sp_%s *)p; uint64_t _h = %d;\n",
                comp_class_index(c, ci->name), ci->c_name, ci->c_name, ci->nivars + 1);
     for (int i = 0; i < ci->nivars; i++) {
       char fe[128]; snprintf(fe, sizeof fe, "o->iv_%s", iv_c(ci->ivars[i] + 1));
       Buf bx; memset(&bx, 0, sizeof bx); emit_boxed_text(c, ci->ivar_types[i], fe, &bx);
-      buf_printf(b, "      _h = _h * 31 + sp_rbval_hash_key(%s);\n", bx.p ? bx.p : fe);
+      buf_printf(b, "      _h = _h * 31 + (uint64_t)sp_rbval_hash_key(%s);\n", bx.p ? bx.p : fe);
       free(bx.p);
     }
-    buf_puts(b, "      return _h; }\n");
+    buf_puts(b, "      return (sp_int)_h; }\n");
   }
   buf_puts(b, "    default: break;\n  }\n  return (sp_int)(uintptr_t)p;\n}\n");
 

--- a/test/recursive_containers.rb
+++ b/test/recursive_containers.rb
@@ -1,0 +1,310 @@
+# A container walk that meets an object already on its path stops there, the
+# way CRuby's rb_exec_recursive does: #inspect prints an ellipsis, == and <=>
+# call the repeated pair equal, #hash contributes a fixed value, and #flatten
+# and #join raise rather than following the cycle for ever.
+
+a = []
+a << a
+p a
+p [a]
+p a.uniq
+p a.to_s
+p "#{a}"
+puts a
+print a
+puts ""
+
+c = [1]
+c << c
+p c
+
+x = []
+y = [x]
+x << y
+p x
+p y
+
+f = []
+f << f
+f.freeze
+p f
+
+h = {}
+h[:h] = h
+p h
+p h.to_s
+p h.to_a
+p h.flatten
+p({a: h})
+k = {}
+k[k] = 1
+p k
+p({a: a}.flatten)
+
+# == / eql? / <=>: a repeated PAIR is equal, and the lengths break the tie
+b = []
+b << b
+p [a == b, a.eql?(b), [a] == [b], a == [a], a == [[a]]]
+p [a <=> b, a <=> [a, 1], a <=> a]
+p [a, b].uniq.size
+
+g = {}
+g[:h] = g
+p h == g
+n1 = {}
+n2 = {}
+n1[:x] = { y: n1 }
+n2[:x] = { y: n2 }
+p n1 == n2
+
+# #hash: the repeated object contributes a fixed value, and the container
+# mixes its own length in, so a self-containing array is not [] and not [nil]
+p [a.hash == b.hash, a.hash == [].hash, a.hash == [nil].hash, h.hash == {}.hash]
+
+# flatten: only the UNLIMITED walk raises; a counted one prints the ellipsis
+begin
+  a.flatten
+rescue ArgumentError => e
+  p e.message
+end
+d = a.dup
+begin
+  d.flatten!
+rescue ArgumentError => e
+  p e.message
+end
+p [d.size, d[0].equal?(a)]
+begin
+  [[a]].flatten
+rescue ArgumentError => e
+  p e.message
+end
+p a.flatten(1)
+p [a].flatten(2)
+p a.dup.flatten!(1)
+
+# join has no finite text either
+begin
+  a.join(",")
+rescue ArgumentError => e
+  p e.message
+end
+begin
+  [1, [2, a]].join("-")
+rescue ArgumentError => e
+  p e.message
+end
+begin
+  a * ","
+rescue ArgumentError => e
+  p e.message
+end
+
+# Struct, Data, and a plain object all render the object they are inside
+S = Struct.new(:a)
+S2 = Struct.new(:a, :b)
+s = S.new
+s.a = s
+p s
+p [s]
+p({ a: s })
+p({ s => 1 })
+p s.to_h
+p s.to_a
+t = S.new
+t.a = t
+p [s == t, s.eql?(t), s == s]
+p [s.hash == S.new(nil).hash, s.hash == t.hash, s.hash == s.hash]
+u = S2.new
+u.a = u
+p u
+v = S2.new
+w = S2.new
+w.a = w
+w.b = 3
+v.a = w
+v.b = 2
+p v
+
+D = Data.define(:x)
+dd = D.new(x: [])
+dd.x << dd
+p dd
+
+class Node
+  attr_accessor :kids, :parent
+  def initialize
+    @kids = []
+    @parent = nil
+  end
+end
+root = Node.new
+kid = Node.new
+kid.parent = root
+root.kids << kid
+p root.inspect.gsub(/0x[0-9a-f]+/, "0xX")
+
+# a raise from inside a walk must not leave the path behind
+$armed = false
+class Boom
+  def inspect
+    raise "boom" if $armed
+    "B"
+  end
+end
+p [Boom.new, a].inspect
+$armed = true
+begin
+  p [Boom.new, a].inspect
+rescue RuntimeError => e
+  p e.message
+end
+$armed = false
+p [1, [2]].inspect
+p a.inspect
+p h.inspect
+begin
+  a.flatten
+rescue ArgumentError
+  nil
+end
+p a.inspect
+begin
+  a.join(",")
+rescue ArgumentError
+  nil
+end
+p a.inspect
+
+# a user #inspect on an element of a recursive container runs once per render
+$calls = 0
+class Counted
+  def inspect
+    $calls += 1
+    "C"
+  end
+end
+r = [Counted.new]
+r << r
+p r.inspect
+p $calls
+
+# deep but NOT recursive: the guard must not fire
+deep1 = []
+cur = deep1
+1999.times do
+  n = []
+  cur << n
+  cur = n
+end
+text = deep1.inspect
+p [text.size, text.include?("...")]
+deep2 = []
+cur = deep2
+1999.times do
+  n = []
+  cur << n
+  cur = n
+end
+p [deep1 == deep2, deep1.hash == deep2.hash]
+
+# a non-local exit out of a walk leaves nothing on the path: a raise, a throw,
+# a break out of a block and a proc's return all jump over the pops
+$exit_kind = nil
+$pr = proc { return 11 }
+class Jump
+  def inspect
+    k = $exit_kind
+    $exit_kind = nil
+    throw(:out, 7) if k == :throw
+    if k == :break
+      [1].each { break }
+      return "J"
+    end
+    if k == :procret
+      $pr.call
+      return "J"
+    end
+    "J"
+  end
+end
+def run_procret
+  $pr = proc { return 11 }
+  [1, Jump.new].inspect
+  99
+end
+jj = [1, Jump.new]
+p jj.inspect
+$exit_kind = :throw
+p catch(:out) { jj.inspect }
+p jj.inspect
+p a.inspect
+$exit_kind = :break
+p jj.inspect
+p jj.inspect
+p a == b
+$exit_kind = :procret
+p run_procret
+p jj.inspect
+p a.inspect
+p a.join(",") rescue p $!.message
+p [1, [2]] == [1, [2]]
+
+# the eql? a Hash LOOKUP runs takes the same pair guard, so a key that holds
+# itself is found by an equal-but-distinct one
+p({ a => 1 }[b])
+p({ a => 1 }.key?(b))
+p({ s => 5 }[t])
+
+# an empty Array and an empty Hash no longer hash alike
+p [{}.hash == [].hash, [].hash == [].hash, {}.hash == {}.hash]
+# two members with the self-reference first still hash as a number
+U2 = Struct.new(:a, :b)
+u2 = U2.new(nil, 1)
+u2.a = u2
+p [u2.hash.class, u2.hash == U2.new(nil, 1).hash]
+
+# a cycle whose repeated element sits deeper than any fixed frame budget
+levels = []
+inner = []
+levels << inner
+600.times do
+  outer = [inner]
+  levels << outer
+  inner = outer
+end
+levels[0] << levels[50]
+deep_cycle = inner.inspect
+p [deep_cycle.length, deep_cycle.include?("...")]
+
+# past the scan budget the path is indexed: a 2000-deep nest compares, hashes
+# and renders in a straight line, a cycle whose repeated element sits far down
+# is still found, and a wide array of nests crosses the budget once per element
+def nest(n)
+  root = []
+  cur = root
+  n.times do
+    m = []
+    cur << m
+    cur = m
+  end
+  root
+end
+d1 = nest(2000)
+d2 = nest(2000)
+p [d1 == d2, d1.eql?(d2), d1.hash == d2.hash, d1 <=> d2]
+leaf = d2
+2000.times { leaf = leaf[0] }
+leaf << 1
+p [d1 == d2, d1.hash == d2.hash, d1 <=> d2]
+leaf << d2[0][0][0]
+r = d2.inspect
+p [r.count("["), r.include?("[...]")]
+p d2.hash == d2.hash
+begin
+  d2.flatten
+rescue ArgumentError => e
+  p e.message
+end
+wide = Array.new(50) { nest(40) }
+p [wide == Array.new(50) { nest(40) }, wide.hash == Array.new(50) { nest(40) }.hash, wide.inspect.length]

--- a/test/recursive_containers.rb.expected
+++ b/test/recursive_containers.rb.expected
@@ -1,0 +1,81 @@
+[[...]]
+[[[...]]]
+[[[...]]]
+"[[...]]"
+"[[...]]"
+[...]
+[[...]]
+[1, [...]]
+[[[...]]]
+[[[...]]]
+[[...]]
+{h: {...}}
+"{h: {...}}"
+[[:h, {h: {...}}]]
+[:h, {h: {...}}]
+{a: {h: {...}}}
+{{...} => 1}
+[:a, [[...]]]
+[true, true, true, true, true]
+[0, -1, 0]
+1
+true
+true
+[true, false, false, false]
+"tried to flatten recursive array"
+"tried to flatten recursive array"
+[1, true]
+"tried to flatten recursive array"
+[[[...]]]
+[[[...]]]
+[[[...]]]
+"recursive array join"
+"recursive array join"
+"recursive array join"
+#<struct S a=#<struct S:...>>
+[#<struct S a=#<struct S:...>>]
+{a: #<struct S a=#<struct S:...>>}
+{#<struct S a=#<struct S:...>> => 1}
+{a: #<struct S a=#<struct S:...>>}
+[#<struct S a=#<struct S:...>>]
+[true, true, true]
+[false, true, true]
+#<struct S2 a=#<struct S2:...>, b=nil>
+#<struct S2 a=#<struct S2 a=#<struct S2:...>, b=3>, b=2>
+#<data D x=[#<data D:...>]>
+"#<Node:0xX @kids=[#<Node:0xX @kids=[], @parent=#<Node:0xX ...>>], @parent=nil>"
+"[B, [[...]]]"
+"boom"
+"[1, [2]]"
+"[[...]]"
+"{h: {...}}"
+"[[...]]"
+"[[...]]"
+"[C, [...]]"
+1
+[4000, false]
+[true, true]
+"[1, J]"
+7
+"[1, J]"
+"[[...]]"
+"[1, J]"
+"[1, J]"
+true
+11
+"[1, J]"
+"[[...]]"
+"recursive array join"
+true
+1
+true
+5
+[false, true, true]
+[Integer, false]
+[1207, true]
+[true, true, true, 0]
+[false, false, -1]
+[2002, true]
+true
+"tried to flatten recursive array"
+[true, true, 4200]

--- a/test/recursive_set_json.rb
+++ b/test/recursive_set_json.rb
@@ -1,0 +1,223 @@
+# The same rule, in the two bundled packages that walk containers of their own:
+# Set does its walking in Ruby, and JSON answers a cycle the way CRuby's json
+# does -- with the nesting limit, not with an identity check.
+require "set"
+require "json"
+
+st = Set.new
+st.add(st)
+p st
+p st.inspect
+p [st].inspect
+p st.to_s
+begin
+  st.flatten
+rescue ArgumentError => e
+  p e.message
+end
+p [st.hash == Set.new.hash, st.hash == st.hash, st == st]
+p Set[1, 2].inspect
+p Set[1, Set[2]].flatten.inspect
+s12 = Set[1, 2]
+t12 = Set[1, 2]
+p s12 == t12
+
+a = []
+a << a
+begin
+  JSON.generate(a)
+rescue JSON::NestingError => e
+  p [e.class, e.message]
+end
+begin
+  a.to_json
+rescue JSON::NestingError => e
+  p e.message
+end
+begin
+  JSON.pretty_generate(a)
+rescue JSON::NestingError => e
+  p e.message
+end
+h = {}
+h[:h] = h
+begin
+  JSON.generate(h)
+rescue JSON::NestingError => e
+  p e.message
+end
+begin
+  JSON.pretty_generate(h)
+rescue JSON::NestingError => e
+  p e.message
+end
+
+# the limit is on depth, not on identity: 100 levels serialize, the 101st does not
+deep = []
+cur = deep
+99.times do
+  n = []
+  cur << n
+  cur = n
+end
+p JSON.generate(deep).size
+deeper = []
+cur = deeper
+100.times do
+  n = []
+  cur << n
+  cur = n
+end
+begin
+  JSON.generate(deeper)
+rescue JSON::NestingError => e
+  p e.message
+end
+p JSON.generate([1, { a: 2 }])
+
+
+# The Set walks keep their frames on the runtime's path, so a raise handled
+# inside an outer walk, a retry, or a fiber parked mid-walk leaves nothing
+# behind for the next walk
+$n = 0
+class R
+  def inspect
+    $n += 1
+    raise "x" if $n < 3
+    "R"
+  end
+end
+$inner = Set[R.new]
+class Mid
+  def inspect
+    begin
+      $inner.inspect
+    rescue RuntimeError
+      retry
+    end
+  end
+end
+p Set[Mid.new].inspect
+p $inner.inspect
+$fire = true
+class B
+  def inspect
+    if $fire
+      $fire = false
+      raise "boom"
+    end
+    "B"
+  end
+end
+$bset = Set[B.new]
+class Mid2
+  def inspect
+    r = nil
+    begin
+      r = $bset.inspect
+    rescue RuntimeError
+      r = "rescued"
+    end
+    r + "/" + $bset.inspect
+  end
+end
+p Set[Mid2.new].inspect
+$fire2 = true
+class K
+  attr_reader :v
+  def initialize(v)
+    @v = v
+  end
+  def eql?(o)
+    if $fire2
+      $fire2 = false
+      raise "boom"
+    end
+    o.is_a?(K) && o.v == @v
+  end
+  def ==(o)
+    eql?(o)
+  end
+  def hash
+    1
+  end
+end
+$x = Set[K.new(1)]
+$y = Set[K.new(2)]
+$res = []
+class Mid3
+  def eql?(o)
+    begin
+      $res << ($x == $y)
+    rescue RuntimeError
+      $res << :raised
+    end
+    $res << ($x == $y)
+    true
+  end
+  def ==(o)
+    eql?(o)
+  end
+  def hash
+    2
+  end
+end
+m1 = Set[Mid3.new]
+m2 = Set[Mid3.new]
+p(m1 == m2)
+p $res
+p($x == $y)
+class Y
+  def inspect
+    Fiber.yield "yielded"
+    "Y"
+  end
+end
+f = Fiber.new { Set[Y.new].inspect }
+p f.resume
+p Set[1, Set[2]].inspect
+n1 = Set[Set[3]]
+n2 = Set[Set[3]]
+p n1 == n2
+p Set[Set[3]].flatten.inspect
+# a cycle through an Array and a Set
+a2 = []
+s2 = Set[a2]
+a2 << s2
+p a2
+p s2
+p a2 == [s2]
+p s2.hash == s2.hash
+# a flatten that raised leaves the next one alone
+st2 = Set[Set[1]]
+st2.add(st2)
+begin
+  st2.flatten
+rescue ArgumentError => e
+  p e.message
+end
+p Set[Set[4], 5].flatten.inspect
+
+# an exit from inside a nested walk abandons it; the at_exit hooks start from
+# an empty path and render the very objects the walk was inside. Last in the
+# file on purpose: the exit ends the program.
+$once = true
+class Q
+  def inspect
+    if $once
+      $once = false
+      exit
+    end
+    "Q"
+  end
+end
+Ex = Struct.new(:a)
+$ex = Ex.new(Q.new)
+$qs = Set[$ex]
+$outer = [$qs, { k: 1 }]
+at_exit do
+  p $outer
+  p $qs == Set[$ex]
+  p({ k: $ex }.inspect)
+end
+p $outer

--- a/test/recursive_set_json.rb.expected
+++ b/test/recursive_set_json.rb.expected
@@ -1,0 +1,36 @@
+Set[Set[...]]
+"Set[Set[...]]"
+"[Set[Set[...]]]"
+"Set[Set[...]]"
+"tried to flatten recursive Set"
+[false, true, true]
+"Set[1, 2]"
+"Set[1, 2]"
+true
+[JSON::NestingError, "nesting of 100 is too deep. Did you try to serialize objects with circular references?"]
+"nesting of 100 is too deep. Did you try to serialize objects with circular references?"
+"nesting of 100 is too deep. Did you try to serialize objects with circular references?"
+"nesting of 100 is too deep. Did you try to serialize objects with circular references?"
+"nesting of 100 is too deep. Did you try to serialize objects with circular references?"
+200
+"nesting of 100 is too deep. Did you try to serialize objects with circular references?"
+"[1,{\"a\":2}]"
+"Set[Set[R]]"
+"Set[R]"
+"Set[rescued/Set[B]]"
+true
+[:raised, false]
+false
+"yielded"
+"Set[1, Set[2]]"
+true
+"Set[3]"
+[Set[[...]]]
+Set[[Set[...]]]
+true
+true
+"tried to flatten recursive Set"
+"Set[4, 5]"
+[Set[#<struct Ex a=Q>], {k: 1}]
+true
+"{k: #<struct Ex a=Q>}"


### PR DESCRIPTION
## Why

`a = []; a << a` is legal Ruby, and so is a Struct that holds itself or a Hash that is its own value. Every walk that descends into a container followed such a cycle until the C stack ran out:

```ruby
a = []; a << a
p a                              # CRuby: [[...]]                                      Spinel: SIGSEGV
p a == [a]                       # CRuby: true                                         Spinel: SIGSEGV
p a.flatten                      # CRuby: ArgumentError "tried to flatten recursive array"   Spinel: SIGSEGV
p a.join(",")                    # CRuby: ArgumentError "recursive array join"         Spinel: SIGSEGV
h = {}; h[:h] = h; p h           # CRuby: {h: {...}}                                   Spinel: SIGSEGV
S = Struct.new(:a); s = S.new; s.a = s
p s                              # CRuby: #<struct S a=#<struct S:...>>                Spinel: SIGSEGV
t = S.new; t.a = t; p s == t     # CRuby: true                                         Spinel: never returns
b = []; b << b; p({ a => 1 }[b]) # CRuby: 1                                            Spinel: SIGSEGV
require "set"; st = Set.new; st.add(st); p st       # CRuby: Set[Set[...]]              Spinel: SIGSEGV
require "json"; JSON.generate(a)                    # CRuby: JSON::NestingError         Spinel: SIGSEGV
```

`#hash` did terminate, but only by giving up: a global depth counter answered 0 for the whole container once the walk was 24 deep, so `a.hash == [].hash` was true where CRuby says false.

A second crash sits in the same code and is fixed here because the first fix walks into it. The default `#inspect` for an object with instance variables builds its text in an `sp_String` that nothing roots, so a collection during the walk sweeps the half-built string and the appends write into freed memory:

```ruby
class N
  def initialize(k); @a = "x" * 200; @b = [1, 2, 3]; @c = k; end
end
200.times { |i| N.new(i).inspect }    # CRuby: fine    Spinel: aborts, rc 134
```

That is three runs out of three, with no GC stress and no recursion; fifty iterations still pass. The Struct and Data `#inspect` beside it has always rooted its builder.

## What

Each of those now answers what CRuby answers. `a.inspect` is `[[...]]` and `h.inspect` is `{h: {...}}`; the object the walk is standing inside is the only one elided, so `[a].inspect` is `[[[...]]]` and a sibling copy of the same object still renders in full. `==`, `eql?` and `<=>` call a repeated pair equal, so `a == b` is true and `a <=> [a, 1]` is -1 (the pair counts as equal and the lengths decide). The `eql?` a Hash lookup runs takes the same guard, so `{ a => 1 }[b]` is 1 and `{ a => 1 }.key?(b)` is true. `#hash` gives a repeated object a fixed value and mixes in the container's length and a per-type seed, so `a.hash == b.hash` is true while `a.hash == [].hash`, `a.hash == [nil].hash` and `{}.hash == [].hash` are false. Unlimited `#flatten` and `#join` raise CRuby's ArgumentError; a counted `flatten(1)` still prints `[[[...]]]`, because it terminates by counting down and CRuby does not raise there. `puts a` prints the single line `[...]`.

A Struct, a Data and a plain object render the same way: `#<struct S a=#<struct S:...>>`, `#<data D x=[#<data D:...>]>`, and `#<Node:0x... @kids=[#<Node:0x... @kids=[], @parent=#<Node:0x... ...>>], @parent=nil>`. Set gets `Set[Set[...]]`, `ArgumentError "tried to flatten recursive Set"`, and a hash that differs from `Set.new.hash`. `JSON.generate` raises `JSON::NestingError` with CRuby's message.

## How

One rule, one facility. `lib/sp_inspect.h` adds a per-fiber stack of frames `{a, b, kind}` holding the objects, or object pairs, the current walk is already inside, with `sp_poly_recur_seen` / `sp_poly_recur_push` / `sp_poly_recur_pop`. That is CRuby's `rb_exec_recursive` and `rb_exec_recursive_paired`. Frames hold raw pointers that are only ever compared, never dereferenced; the collector does not move objects, and pushing a frame cannot trigger a collection (the frames live in malloc'd storage, not on the GC heap), so a walk cannot collect the object it is remembering. The state lives in the archive (`lib/sp_inspect.c`) so the generated translation unit, the runtime and a carried package all share one path. The frames are malloc'd on the first push and doubled from 64 as a walk descends, so a cycle whose repeated object sits deeper than any fixed budget still answers; only a pointer and two counts live in thread-local storage.

A lookup scans the path. A real program's path is under ten frames, and a scan of that beats any table; but a scan at every level of a deep walk is quadratic, a 2000-deep nest would compare 2000 frames at each of its 2000 levels, where CRuby's hash stays linear. So past 32 frames the path is also indexed by an open-addressing table in `sp_inspect.c`. A slot names a frame by index and repeats its key, and is live only while that frame is still on the path with that key, so a pop lowers the count and leaves the slots to go stale on their own; a lookup checks the frame, an insert may take a stale slot, and the table is rebuilt from the live frames once half of it is in use. Nothing in it runs until a walk is deeper than the scan budget; on the hot path, push and pop each gain one compare.

Only the walks that can meet themselves carry it. In `sp_poly_eq` the recursion-capable arms (two arrays of any storage kinds, two hashes of different variants or of a poly-valued one, and two user objects compared field-wise through the generated hook) move into `sp_poly_eq_deep`; the value types above them, Time, Rational, Range, Complex and IO, and two hashes of the same primitive-keyed variant, push nothing, because none of them can contain a Ruby object. `sp_poly_eql`, `sp_poly_arr_cmp` and `sp_rbval_eql_key` share the pair frames with `==`, since all of them answer "equal" for a pair they are already inside. `sp_PolyArray_eq` gains CRuby's identity fast path and carries the guard itself, because generated code reaches it directly. In `sp_rbval_hash_key` the depth counter is gone and the array, hash and user-object arms take the path instead; the array and hash accumulators start from the length mixed with a per-type seed, CRuby's `rb_hash_start`. Only the three unlimited `flatten` walks check, and `sp_PolyArray_flatten_n` now carries a negative depth as "no limit" rather than counting down from `INT64_MAX`, so the walk that carries the path is the one the code says it is.

Any non-local exit out of a guarded walk longjmps past the pops, so every stack that can be landed on records the path depth where its arm was armed, and every longjmp into one restores it: `sp_poly_recur_mark` beside the exception stack, `sp_catch_recur_mark` beside the catch stack, `sp_brk_recur_mark` beside the break scopes, and a field on the proc-return home node. The exception, catch and break arms are each opened by exactly one runtime call (`sp_exc_check_depth`, `sp_catch_check_depth`, `sp_brk_push`), so only the proc-return home, a struct the method builds on its own C stack, needs a line in generated code. The flatten and join raise sites additionally drop their own frames first, and the at_exit hooks start from an empty path, because a raise that reached the top unhandled, or an exit from inside a walk, abandoned whatever walk it was inside; so nothing is left behind even where no handler restores the depth. A green thread carries its path and those marks across a suspension in `sp_exc_ctx_save` / `sp_exc_ctx_load`, beside the handler stacks it already carries and sized the same way, from the live depth; there is normally nothing to copy, because a yield lands between walks rather than inside one. A fiber that does yield from inside a walk pays a copy of its frames each way and a re-index on its next deep lookup: about 3 percent of a switch with a 10-deep walk parked, 12 percent with a 300-deep one, nothing with an empty path.

Two generated inspects need the guard emitted, because they recurse in generated code rather than through the runtime: the Struct and Data `#inspect`, which renders a member of its own class by calling straight back into itself, and the plain-object ivar walk in `sp_obj_inspect_sw`. Both take it only when the class has members; one with none cannot be reached from inside itself. The guard sits in each arm rather than once at the head of the dispatcher because two kinds of arm must not take it, a class with a user-defined `#inspect` (CRuby does not guard those either) and a memberless class, and the arms already encode both exclusions. The plain-object arm also gains the `SP_GC_ROOT(_s)` the Why describes. The generated Struct and Data `#hash` accumulates in `uint64_t` rather than `sp_int`: the rolling `h * 31 + x` is meant to wrap, on a signed type that is undefined behavior rather than wraparound, and a member that now contributes a large fixed constant overflows it on the next multiply.

Set does its walking in Ruby (it is Array-backed, and `e.eql?(x)` on an element compiles to a direct call that never passes through the runtime), so `packages/set/set.rb` joins the same path through three `native_func` bindings in a nested `Set::RecursionGuard` module: `enter_inspect`, `enter_eq` and `enter_flatten` answer the mark for `leave`, or -1 when the walk is already inside that Set or pair, which is the walk's cue to stop. Their frames are kinds of Set's own, so a frame the runtime pushed for the same pair is not mistaken for the Set walk's. Nothing else changes in Set: no `ensure`, because a raise, throw or break out of a walk lands on a handler that restores the depth it was armed at; no thread-local state; no method added to Set; and `require "set"` still compiles to the single-threaded runtime. The module is reachable by name from Ruby like any constant, so `leave` ignores a mark that is not a Set walk's own rather than moving the depth under a walk that is still running. `Set#hash` needs no change: it hashes each element through `sp_rbval_hash_key`, which is guarded.

JSON answers a cycle the way CRuby's json does, by depth rather than by identity: `packages/json/sp_json.c` threads a depth through `sp_json_val` and raises `JSON::NestingError` on entering the 101st nested array or object, with CRuby's message. `JSON.pretty_generate` already threaded a depth and now checks it. `lib/sp_exc.c` gains one row, `JSON::NestingError` under `JSON::ParserError`, so `e.is_a?(JSON::ParserError)` answers true as it does in CRuby.

## Validation

`.compat/gate.sh` GREEN: 3491 tests, 61 benchmarks, optcarrot checksum 59662, ext-cruby, rbs-seed and rubyspec all as on master. The inference fixpoint leg reports no new non-convergence over 3444 programs, and no round count moved.

Compatibility corpus: 847 to 863 of 2131, 16 gained, 0 lost, out of the 17 programs in the corpus that build a self-containing container. The one that does not flip compares two distinct self-containing Sets and is in Left alone below.

New tests: `test/recursive_containers.rb` and `test/recursive_set_json.rb`, expectations generated by Ruby 4.0.6, each under 10 ms compiled. Compiled on master, both die before their first line of output. Both are clean under `SPINEL_GC_STRESS=1` and under ASAN and UBSAN, plain and stressed. Between them they pin the ellipsis and equality and hash and flatten and join shapes, the Struct and Data and plain-object renders, a raise and a throw and a break and a proc's return out of a walk, a Hash lookup by an equal-but-distinct recursive key, `{}.hash != [].hash`, a two-member recursive Struct's hash, a cycle 600 levels deep, a raise rescued inside an outer Set walk and a `retry` through a nested one, a fiber parked inside a Set walk and dropped, a cycle that runs through an Array and a Set, a 2000-deep nest compared, hashed and ordered, a cycle closed 2000 levels down onto an element near the top, and fifty 40-deep nests side by side, none of which may show an ellipsis.

The threaded shapes are checked by hand rather than pinned: four threads inspecting ordinary nested Sets, four comparing them, two flattening them, and the same over recursive Sets, at 1, 4 and 16 workers, twice each, all matching CRuby line for line.

The Set test's GC-stress run is what exposed the constructor root miss fixed in #4350; this branch sits on that merge.

Generated-C sweep against master over 3506 programs: 2648 SAME, 858 CHANGED, 0 FAIL. The 806 files outside the Set package were recompiled with both binaries and every added and removed line matched against the insertions below: zero unexplained lines. The 52 that load `set` were read rather than line-matched; what they gain is listed in their own bullet.

- 683 files: a class with instance variables and no user `#inspect` gets, in its arm of `sp_obj_inspect_sw` (which the compiler already marks cold and noinline), a two-line prologue that answers `#<Name:0x... ...>` for the object the render is inside, the `sp_poly_recur_push` that follows it, the `SP_GC_ROOT(_s)` on the builder, and one `sp_poly_recur_pop` before the return. Five lines per class.
- 160 files: a generated Struct or Data `#inspect` gets the same prologue in its `"#<struct Name:...>"` form and the same one-line epilogue. Three lines per struct.
- The same 160 files: the generated Struct and Data `#hash` changes its accumulator from `sp_int` to `uint64_t` and casts the result back. Three lines per struct, changed rather than added.
- 52 files: loading the Set package, by `require "set"` in 42 of them and through the compiler's automatic require of it in the rest, re-emits the Set class body with the three walks rewritten, adds the four `extern` prototypes of the bindings, and adds the scaffold the compiler emits for any module, here `Set::RecursionGuard`: its struct and pool, an allocator whose only job is to raise NoMethodError for `new`, its arm in the object inspect and to_s dispatchers, and a row in the class tables, about twenty lines of which only the pool's start-up and shutdown hooks ever run. The binding declarations intern seven names into the symbol table (`enter_inspect`, `enter_eq`, `enter_flatten`, `leave`, `any`, `int`, `nil`, as every binding package's declarations do), and the changed body renumbers the temporaries and symbol ids in the user's own functions, which the diff shows as deleted and re-added lines. The program still links the single-threaded runtime.
- 13 files: a method that owns a proc-return frame gains `_h.recur_mark = sp_poly_recur_save();` beside the `_h.exc_top` it already sets. One line per method.

optcarrot is one of the 683 and carries nothing else. The same source through both compilers with `-S`: 13676 to 13726 lines, 50 added, 0 removed, and every one of them lies between the opening and closing brace of `sp_obj_inspect_sw` (its ten classes that have ivars and no user `#inspect`, five lines each). Nothing outside that function moved, and the emulator never calls it. Frames per second, five alternating runs of each tree's optcarrot binary, twice: the medians land within four percent of each other with the branch nominally ahead both times, which is the run-to-run spread.

A walk's cost against master, per call, medians of three (both trees built at -O2): `==` on two eight-element arrays 6.4 to 6.3 ns; `==` on `[[1, 2], [3, 4], [5, 6], [7, 8]]` 118 to 125 ns; `#hash` on the flat array 28 to 29 ns and on the nested one 59 to 78 ns; `#inspect` on the nested one 880 to 894 ns; `==` on two three-key Hashes with array values 125 to 150 ns; `==` on a two-member Struct 11.2 to 10.7 ns and on one holding an array and another Struct 47 to 50 ns; a Hash lookup keyed by `[1, [2]]` 51 to 61 ns. That is the frame push and the scan at each level a walk descends. Deep walks, where the index takes over, compared with master (seconds per twenty walks, medians of three): `==` on a 1000 / 2000 / 4000 / 8000-deep nest 0.0009 / 0.0017 / 0.0028 / 0.0069 against 0.0003 / 0.0006 / 0.0013 / 0.0026, and `#hash` on the same 0.0007 / 0.0012 / 0.0028 / 0.0047 against master's constant time, which was the depth cap answering 0. Linear on both sides; a scan alone was quadratic, 0.207 s at 8000 deep.

Set, branch against master, medians of three: 300k comparisons of `Set[1, 2, 3, 4, 5, 6, 7, 8]` with an equal Set 0.18 s on both; 100k comparisons of `Set[Set[1], Set[2], Set[3]]` with an equal Set 0.024 to 0.027 s, the three bindings and a frame per nested comparison; 200k `inspect` of the eight-element Set 0.088 to 0.090 s.

Hash VALUES change for arrays, hashes and Structs, because the accumulator now starts from the length mixed with a per-type seed. Only bucket placement depends on those numbers; iteration is insertion-ordered, and the whole suite and corpus are unchanged by it. Three collisions end as a side effect: `[0].hash == [].hash`, `[nil].hash == [].hash` and `{}.hash == [].hash` were true on master and are now false as in CRuby. Both array storage kinds take the same seed, so an IntArray `[0, 0]` still collides with the same numbers rebuilt as a PolyArray, and a Hash keyed by one still finds the other.

## Left alone, on purpose

`Set#==` on two distinct recursive Sets answers true here and false in CRuby, and everything that reaches `==` or `eql?` follows: `include?`, `subset?`, `superset?` and `intersect?` answer true where CRuby answers false, `disjoint?` false where CRuby answers true, `<=>` 0 where CRuby answers nil (even against itself, since CRuby's `<=>` goes through `subset?`), and a Hash keyed by one recursive Set finds a distinct equal-shaped one, as do `Array#uniq`, `Array#-` and `Array#include?`. CRuby's Set is a hash table, and the element's hash was stored while the Set was still empty, so its membership probe misses; Spinel's Set is Array-backed with a linear `eql?` scan and cannot reproduce that without storing per-element hashes, which is a different rule. A pair guard answering true is what makes the walk terminate at all. This is the one corpus program of the seventeen that does not flip.

Set carries a nested `RecursionGuard` module for its three bindings, which CRuby's Set does not have: `Set.constants` lists it, and `Set::RecursionGuard.respond_to?(:enter_eq)` answers true here and NameError there. It is not an API: `leave` with a mark that is not a Set walk's is ignored, and an `enter` without its `leave` leaves that object on the path for the rest of the walk it was called from, or, with no walk around it, until the next thing that restores the depth, which at top level is the start of the at_exit hooks and inside a hook is nothing at all. Nothing else about Set's surface changes.

`JSON.generate(x, max_nesting: n)`: the package's `native_func` binding takes no options, so CRuby's default of 100 is what Spinel enforces.

`rescue JSON::ParserError` does not catch a `JSON::NestingError`. A rescue arm naming a class the compiler does not know compiles to a name comparison rather than a hierarchy walk, which is how `JSON::ParserError` itself already behaves; `rescue => e` and `rescue JSON::NestingError` both catch, and `e.is_a?(JSON::ParserError)` is true.

`JSON.dump` on a recursive array raises `JSON::NestingError` here; CRuby raises `SystemStackError` for that one entry point while `JSON.generate` on the same value raises `NestingError`.

JSON of a Struct reflects it into a hash (deliberate, `native_obj_reflect`) where CRuby serializes its `to_s` as a string. Not this rule.

An anonymous Struct that holds itself prints `#<struct a=#<struct :...>>`. CRuby prints the anonymous class's own inspect, which carries an address: `#<struct a=#<struct #<Class:0x...>:...>>`. One deterministic form is worth more here than an address.

A user `#inspect`, `#==` or `#hash` that recurses through itself still exhausts the C stack. CRuby raises SystemStackError there; Spinel has no SystemStackError for C recursion. CRuby does not guard those either, so this is the same shape of program, not a new gap. `Array#hash` on a nest hundreds of thousands deep now runs off the C stack the way `==` and `inspect` always did; master answered a constant there, which was the wrong number.

A user `#hash` on an element of a recursive array runs once here and twice in CRuby: CRuby's `rb_exec_recursive_outer` restarts the whole computation from the outer object when it detects the cycle. A user `#inspect` runs exactly once on both.

The inline `Struct#hash` at a call site does not push the outer struct; the first member that recurses does, one level down. The answer is deterministic and differs from `S.new(nil).hash`, which is what the rule asks for.

The memberless-class arm of the plain-object `#inspect` keeps its unrooted builder: it appends one byte, which reallocs off the GC heap and cannot collect, so the crash in Why cannot reach it.

Comparing two freshly constructed objects, `Set[Set[3]] == Set[Set[3]]`, leaves the receiver unrooted while the operand is built, and under `SPINEL_GC_STRESS=1` it answers false on master too. A different site and a different rule; the test holds both sides in locals. Seven of the suite's programs that load Set also fail under the stress switch, six of them the same way on master and here, and one that master cannot finish at all completes here with one wrong boolean; none of those sites is this rule's, and this PR claims stress-cleanliness for its own tests only.

`spinel -E` maps a child killed by a signal to exit 1 with no message, which is why the crashes above showed as a silent exit rather than a signal. Pre-existing and separate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recursive arrays, hashes, sets, structs, and objects now terminate safely during inspection, comparison, hashing, flattening, and joining.
  * Recursive containers display ellipses or raise the appropriate `ArgumentError` instead of overflowing the stack.
  * JSON serialization now enforces a 100-level nesting limit and raises `JSON::NestingError` when exceeded.
  * `JSON::NestingError` is now catchable with `JSON::ParserError`.

* **Tests**
  * Added comprehensive coverage for recursive container behavior, Set handling, JSON nesting, fibers, exceptions, and interrupted operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->