### PR TITLE
A closed IO or Dir handle raises IOError for every operation

### DIFF
--- a/lib/sp_cold.c
+++ b/lib/sp_cold.c
@@ -1572,8 +1572,9 @@ const char *sp_dir_home_user(const char *user);
 sp_StrArray *sp_dir_children(const char *path);
 
 const char *sp_File_gets_sep(sp_File *f, const char *sep, sp_int limit, sp_bool chomp) {SP_GC_ROOT(f);SP_GC_ROOT_STR(sep);
+  SP_IO_OPEN(f);
   sp_io_wait_readable(f);
-  if (!f || !f->fp) return NULL;
+  SP_IO_OPEN(f);   /* the park can return after another thread closed the handle */
   size_t sl = sep ? strlen(sep) : 0;
   /* fast path: the default "\n" separator with no limit reads via fgets
      (the byte-wise loop below costs a call per character) */
@@ -1630,7 +1631,7 @@ const char *sp_File_readline_sep(sp_File *f, const char *sep, sp_int limit, sp_b
   return r;
 }
 const char *sp_File_getc(sp_File *f) {SP_GC_ROOT(f);
-  if (!f || !f->fp) return NULL;
+  SP_IO_OPEN(f);
   int ch = fgetc(f->fp);
   if (ch == EOF) return NULL;
   int extra = ((ch & 0xE0) == 0xC0) ? 1 : ((ch & 0xF0) == 0xE0) ? 2 : ((ch & 0xF8) == 0xF0) ? 3 : 0;
@@ -1652,40 +1653,38 @@ const char *sp_File_readchar(sp_File *f) {SP_GC_ROOT(f);
   return r;
 }
 sp_int sp_File_getbyte(sp_File *f) {
-  if (!f || !f->fp) return SP_INT_NIL;
+  SP_IO_OPEN(f);
   int ch = fgetc(f->fp);
   return ch == EOF ? SP_INT_NIL : (sp_int)ch;
 }
 sp_RbVal sp_File_ungetc(sp_File *f, sp_RbVal v) {
-  if (f && f->fp) {
-    if (v.tag == SP_TAG_STR && v.v.s && v.v.s[0]) {
-      size_t n = sp_str_byte_len(v.v.s);
-      for (size_t i = n; i > 0; i--) ungetc((unsigned char)v.v.s[i - 1], f->fp);
-    }
-    else if (v.tag == SP_TAG_INT) ungetc((int)v.v.i, f->fp);
+  SP_IO_OPEN(f);
+  if (v.tag == SP_TAG_STR && v.v.s && v.v.s[0]) {
+    size_t n = sp_str_byte_len(v.v.s);
+    for (size_t i = n; i > 0; i--) ungetc((unsigned char)v.v.s[i - 1], f->fp);
   }
+  else if (v.tag == SP_TAG_INT) ungetc((int)v.v.i, f->fp);
   return sp_box_nil();
 }
 sp_int sp_File_sysseek(sp_File *f, sp_int off, sp_int whence) {
-  if (!f || !f->fp) return 0;
+  SP_IO_OPEN(f);
   fseek(f->fp, (long)off, whence == 1 ? SEEK_CUR : whence == 2 ? SEEK_END : SEEK_SET);
   return (sp_int)ftell(f->fp);
 }
 sp_int sp_File_flock(sp_File *f, sp_int op) {
-  if (!f || !f->fp) return 0;
+  SP_IO_OPEN(f);
   return flock(fileno(f->fp), (int)op) == 0 ? 0 : 1;
 }
 sp_int sp_File_fsync(sp_File *f) {
-  if (!f || !f->fp) return 0;
+  SP_IO_OPEN(f);
   fflush(f->fp);
   fsync(fileno(f->fp));
   return 0;
 }
 sp_RbVal sp_File_putc(sp_File *f, sp_RbVal v) {
-  if (f && f->fp) {
-    if (v.tag == SP_TAG_INT) fputc((int)(v.v.i & 0xff), f->fp);
-    else if (v.tag == SP_TAG_STR && v.v.s && v.v.s[0]) fputc(v.v.s[0], f->fp);
-  }
+  SP_IO_OPEN(f);
+  if (v.tag == SP_TAG_INT) fputc((int)(v.v.i & 0xff), f->fp);
+  else if (v.tag == SP_TAG_STR && v.v.s && v.v.s[0]) fputc(v.v.s[0], f->fp);
   return v;
 }
 const char *sp_file_ftype(const char *path) {SP_GC_ROOT_STR(path);
@@ -1942,10 +1941,10 @@ static int sp_stat_pathless(sp_File *f) {
   return f && f->fp && (!f->path || f->path[0] == 0);
 }
 sp_File *sp_io_stat_handle(sp_File *f) {SP_GC_ROOT(f);
-  if (!f) sp_raise_cls("IOError", "closed stream");
+  SP_IO_OPEN(f);
   if (f->path && f->path[0]) return sp_file_stat_handle(f->path);
   struct stat st;
-  if (!f->fp || fstat(fileno(f->fp), &st) != 0)
+  if (fstat(fileno(f->fp), &st) != 0)
     sp_raise_cls("Errno::EBADF", "Bad file descriptor");
   sp_File *h = (sp_File *)sp_gc_alloc(sizeof(sp_File), NULL, sp_file_stat_scan);
   h->fp = f->fp;
@@ -2114,7 +2113,7 @@ sp_Dir *sp_Dir_for_fd(sp_int fd) {
    to re-open, and re-opening by path would miss a directory that has since been
    renamed. Rewinds first so the listing is complete however far #read got. */
 sp_StrArray *sp_Dir_entries_h(sp_Dir *d, sp_int children) {SP_GC_ROOT(d);
-  if (!d || !d->dp) sp_raise_cls("IOError", "closed directory");
+  SP_DIR_OPEN(d);
   rewinddir(d->dp);
   sp_StrArray *a = sp_StrArray_new();
   SP_GC_ROOT(a);
@@ -2131,8 +2130,11 @@ sp_int sp_Dir_fchdir(sp_int fd) {
     sp_raise_cls("Errno::EBADF", "Bad file descriptor - fchdir");
   return 0;
 }
+SP_NORETURN SP_COLD void sp_dir_raise_closed(void) {
+  sp_raise_cls("IOError", "closed directory");
+}
 const char *sp_Dir_read(sp_Dir *d) {
-  if (!d || !d->dp) return NULL;
+  SP_DIR_OPEN(d);
   struct dirent *e = readdir(d->dp);
   return e ? sp_sprintf("%s", e->d_name) : NULL;
 }
@@ -2140,10 +2142,10 @@ const char *sp_Dir_read(sp_Dir *d) {
    and CRuby answers nil for it rather than an empty string (#3365). */
 const char *sp_Dir_path(sp_Dir *d) { return d ? d->path : NULL; }
 sp_RbVal sp_Dir_close(sp_Dir *d) { if (d && d->dp) { closedir(d->dp); d->dp = NULL; } return sp_box_nil(); }
-sp_Dir *sp_Dir_rewind(sp_Dir *d) { if (d && d->dp) rewinddir(d->dp); return d; }
-sp_int sp_Dir_tell(sp_Dir *d) { return d && d->dp ? (sp_int)telldir(d->dp) : 0; }
-sp_Dir *sp_Dir_seek(sp_Dir *d, sp_int pos) { if (d && d->dp) seekdir(d->dp, (long)pos); return d; }
-sp_int sp_Dir_fileno(sp_Dir *d) { return d && d->dp ? (sp_int)dirfd(d->dp) : -1; }
+sp_Dir *sp_Dir_rewind(sp_Dir *d) { SP_DIR_OPEN(d); rewinddir(d->dp); return d; }
+sp_int sp_Dir_tell(sp_Dir *d) { SP_DIR_OPEN(d); return (sp_int)telldir(d->dp); }
+sp_Dir *sp_Dir_seek(sp_Dir *d, sp_int pos) { SP_DIR_OPEN(d); seekdir(d->dp, (long)pos); return d; }
+sp_int sp_Dir_fileno(sp_Dir *d) { SP_DIR_OPEN(d); return (sp_int)dirfd(d->dp); }
 sp_StrArray *sp_dir_entries(const char *path) {SP_GC_ROOT_STR(path); return sp_dir_entries_impl(path, 0); }
 sp_bool sp_dir_empty(const char *path) {SP_GC_ROOT_STR(path);
   struct stat st;
@@ -3234,9 +3236,8 @@ static short sp_io_park_events(sp_int kind) {
 }
 #endif
 sp_File *sp_io_wait_events(sp_File *f, double timeout, sp_int kind) {SP_GC_ROOT(f);
-  if (!f || !f->fp) sp_raise_cls("IOError", "closed stream");
+  SP_IO_OPEN(f);
   int fd = fileno(f->fp);
-  if (fd < 0) sp_raise_cls("IOError", "closed stream");
 #ifdef SP_THREADS
   if (sp_io_park_events(kind) && timeout != 0.0) {
     extern int sp_sched_wait_io_timeout(int fd, short events, double timeout_s);
@@ -3310,7 +3311,7 @@ sp_RbVal sp_io_select(sp_PolyArray *rd, sp_PolyArray *wr, sp_PolyArray *er, doub
       int g1 = nrd ? 0 : 1;
       sp_RbVal io1 = src[g1]->data[0];
       sp_File *f1 = sp_select_io_of(io1);
-      if (!f1 || !f1->fp) sp_raise_cls("IOError", "closed stream");
+      SP_IO_OPEN(f1);
       if (!sp_sched_wait_io_timeout(fileno(f1->fp), g1 == 0 ? POLLIN : POLLOUT, timeout))
         return sp_box_nil();
       sp_PolyArray *one1 = sp_PolyArray_new();
@@ -3330,9 +3331,8 @@ sp_RbVal sp_io_select(sp_PolyArray *rd, sp_PolyArray *wr, sp_PolyArray *er, doub
       sp_int n = src[g] ? src[g]->len : 0;
       for (sp_int i = 0; i < n; i++) {
         sp_File *f = sp_select_io_of(src[g]->data[i]);
-        int fd = (f && f->fp) ? fileno(f->fp) : -1;
-        if (fd < 0) { free(pfs); sp_raise_cls("IOError", "closed stream"); }
-        pfs[k].fd = fd;
+        if (!f || !f->fp) { free(pfs); sp_io_raise_closed(); }
+        pfs[k].fd = fileno(f->fp);
         pfs[k].events = (short)(g == 0 ? POLLIN : POLLOUT);
         pfs[k].revents = 0;
         k++;
@@ -3382,8 +3382,9 @@ sp_RbVal sp_io_select(sp_PolyArray *rd, sp_PolyArray *wr, sp_PolyArray *er, doub
     sp_int n = src[g] ? src[g]->len : 0;
     for (sp_int i = 0; i < n; i++) {
       sp_File *f = sp_select_io_of(src[g]->data[i]);
-      int fd = (f && f->fp) ? fileno(f->fp) : -1;
-      if (fd < 0 || fd >= FD_SETSIZE) sp_raise_cls("IOError", "file descriptor out of range");
+      SP_IO_OPEN(f);
+      int fd = fileno(f->fp);
+      if (fd >= FD_SETSIZE) sp_raise_cls("IOError", "file descriptor out of range");
       FD_SET(fd, &sets[g]);
       if (fd > maxfd) maxfd = fd;
     }

--- a/lib/sp_io.c
+++ b/lib/sp_io.c
@@ -243,7 +243,7 @@ static sp_int sp_sock_write(sp_File *f, const char *s, size_t n) {
 
 /* Shared write core: `n` is the operand byte length (strlen for the
    bare-literal-safe entry, sp_str_byte_len for the binary one). */
-SP_COLD void sp_io_raise_closed(void) {
+SP_NORETURN SP_COLD void sp_io_raise_closed(void) {
   sp_raise_cls("IOError", "closed stream");
 }
 
@@ -276,24 +276,25 @@ sp_int sp_File_write_bin(sp_File *f, const char *s) {SP_GC_ROOT(f);SP_GC_ROOT_ST
 }
 
 sp_bool sp_File_tty_p(sp_File *f) {
-  return (f && f->fp && isatty(fileno(f->fp))) ? 1 : 0;
+  SP_IO_OPEN(f);
+  return isatty(fileno(f->fp)) ? 1 : 0;
 }
 
 sp_int sp_File_fileno(sp_File *f) {
-  if (f && f->fno_plus1) return (sp_int)(f->fno_plus1 - 1);
   SP_IO_OPEN(f);
+  if (f->fno_plus1) return (sp_int)(f->fno_plus1 - 1);
   return (sp_int)fileno(f->fp);
 }
 
-/* IO#winsize -> [rows, cols]. Queries the terminal; a non-tty (pipe/file) has
-   no size, so CRuby raises there, but returning [0, 0] keeps the common
-   "STDOUT.winsize" probe compiling and running without an exception path. */
+/* IO#winsize -> [rows, cols]. Queries the terminal; an OPEN non-tty
+   (pipe/file) has no size, so CRuby raises there, but returning [0, 0] keeps
+   the common "STDOUT.winsize" probe compiling and running without an
+   exception path. A closed handle is the macro's IOError, as everywhere. */
 sp_IntArray *sp_File_winsize(sp_File *f) {
+  SP_IO_OPEN(f);
   sp_int rows = 0, cols = 0;
-  if (f && f->fp) {
-    struct winsize ws;
-    if (ioctl(fileno(f->fp), TIOCGWINSZ, &ws) == 0) { rows = ws.ws_row; cols = ws.ws_col; }
-  }
+  struct winsize ws;
+  if (ioctl(fileno(f->fp), TIOCGWINSZ, &ws) == 0) { rows = ws.ws_row; cols = ws.ws_col; }
   sp_IntArray *a = sp_IntArray_new();
   sp_IntArray_push(a, rows);
   sp_IntArray_push(a, cols);
@@ -661,7 +662,7 @@ sp_Addrinfo *sp_sock_address(sp_File *f, sp_int peer) {SP_GC_ROOT(f);
     sp_raise_cls("NoMethodError",
                  sp_sprintf("undefined method '%s' for an instance of %s",
                             peer ? "remote_address" : "local_address", sp_io_kind_name(f)));
-  if (!f->fp) sp_raise_cls("IOError", "closed stream");
+  SP_IO_OPEN(f);
   int fd = fileno(f->fp);
   const char *k = sp_io_kind_name(f);
   int is_unix = (strcmp(k, "UNIXSocket") == 0 || strcmp(k, "UNIXServer") == 0);
@@ -683,7 +684,7 @@ static void sp_sock_require(sp_File *f, const char *m) {SP_GC_ROOT(f);SP_GC_ROOT
   if (!f || !f->is_sock)
     sp_raise_cls("NoMethodError",
                  sp_sprintf("undefined method '%s' for an instance of %s", m, sp_io_kind_name(f)));
-  if (!f->fp) sp_raise_cls("IOError", "closed stream");
+  SP_IO_OPEN(f);
 }
 sp_int sp_sock_bind(sp_File *f, const char *host, sp_int port) {SP_GC_ROOT(f);SP_GC_ROOT_STR(host);
   extern int sp_net_udp_bind(int fd, const char *host, int port);
@@ -797,7 +798,7 @@ static void sp_sock_nb_prepare(sp_File *f, const char *m) {SP_GC_ROOT(f);SP_GC_R
   if (!f || !f->is_sock)
     sp_raise_cls("NoMethodError",
                  sp_sprintf("undefined method '%s' for an instance of %s", m, sp_io_kind_name(f)));
-  if (!f->fp) sp_raise_cls("IOError", "closed stream");
+  SP_IO_OPEN(f);
 }
 SP_NORETURN static void sp_sock_raise_wait(int writable, const char *op) {SP_GC_ROOT_STR(op);
   sp_raise_cls(writable ? "IO::EAGAINWaitWritable" : "IO::EAGAINWaitReadable",
@@ -839,7 +840,8 @@ sp_File *sp_sock_accept_nb(sp_File *f, sp_bool exc) {SP_GC_ROOT(f);
    before a #readpartial would lose bytes. Then a single BLOCKING read -- that
    is the only difference from the nonblocking sibling below. */
 const char *sp_File_readpartial(sp_File *f, sp_int n) {SP_GC_ROOT(f);
-  if (!f || !f->fp || n < 0) sp_raise_cls("EOFError", "end of file reached");
+  SP_IO_OPEN(f);
+  if (n < 0) sp_raise_cls("EOFError", "end of file reached");
   if (n == 0) return sp_str_from_bytes("", 0);
   char *r = sp_str_alloc((size_t)n);
   ssize_t got;
@@ -861,7 +863,7 @@ const char *sp_File_readpartial(sp_File *f, sp_int n) {SP_GC_ROOT(f);
 const char *sp_sock_read_nb(sp_File *f, sp_int len, sp_bool exc, sp_bool is_recv, sp_bool *eof) {SP_GC_ROOT(f);
   if (eof) *eof = 0;
   if (is_recv) sp_sock_nb_prepare(f, "recv_nonblock");
-  else if (!f || !f->fp) sp_raise_cls("IOError", "closed stream");
+  else SP_IO_OPEN(f);
   if (len <= 0) return sp_str_from_bytes("", 0);
   char *buf = (char *)malloc((size_t)len);
   if (!buf) sp_raise_cls("NoMemoryError", "read_nonblock");
@@ -916,11 +918,11 @@ static sp_int sp_sock_write_nb_len(sp_File *f, const char *data, size_t len, sp_
   sp_file_raise_errno("write", "");
 }
 sp_int sp_sock_write_nb(sp_File *f, const char *data, sp_bool exc) {SP_GC_ROOT(f);SP_GC_ROOT_STR(data);
-  if (!f || !f->fp) sp_raise_cls("IOError", "closed stream");
+  SP_IO_OPEN(f);
   return sp_sock_write_nb_len(f, data, data ? strlen(data) : 0, exc);
 }
 sp_int sp_sock_write_nb_bin(sp_File *f, const char *data, sp_bool exc) {SP_GC_ROOT(f);SP_GC_ROOT_STR(data);
-  if (!f || !f->fp) sp_raise_cls("IOError", "closed stream");
+  SP_IO_OPEN(f);
   return sp_sock_write_nb_len(f, data, data ? sp_str_byte_len(data) : 0, exc);
 }
 /* connect_nonblock: an in-flight connect is IO::EINPROGRESSWaitWritable. */
@@ -981,7 +983,7 @@ sp_File *sp_sock_accept(sp_File *f) {SP_GC_ROOT(f);
   if (!f || !f->is_sock)
     sp_raise_cls("NoMethodError",
                  sp_sprintf("undefined method 'accept' for an instance of %s", sp_io_kind_name(f)));
-  if (!f->fp) sp_raise_cls("IOError", "closed stream");
+  SP_IO_OPEN(f);
   sp_io_wait_readable(f);
   return sp_io_fdopen_sock(sp_net_accept(fileno(f->fp)), "tcp");
 }
@@ -1180,20 +1182,37 @@ void sp_file_rename(const char *from, const char *to) { rename(from, to); }
 
 /* IO#readbyte: like #getbyte but EOFError at end of file. */
 sp_int sp_File_readbyte(sp_File *f) {
-  int ch = (f && f->fp) ? fgetc(f->fp) : EOF;
+  SP_IO_OPEN(f);
+  int ch = fgetc(f->fp);
   if (ch == EOF) sp_raise_cls("EOFError", "end of file reached");
   return (sp_int)(unsigned char)ch;
 }
 /* IO#ungetbyte: push one byte back onto the read buffer; returns nil. */
 void sp_File_ungetbyte(sp_File *f, sp_int byte) {
-  if (f && f->fp) ungetc((int)(unsigned char)byte, f->fp);
+  SP_IO_OPEN(f);
+  ungetc((int)(unsigned char)byte, f->fp);
 }
 /* IO#binmode?: true after #binmode, or for a handle opened in binary mode. */
 sp_bool sp_File_binmode_p(sp_File *f) {
-  if (f && f->bin_flag) return 1;
-  return f && f->mode && strchr(f->mode, 'b') != NULL;
+  SP_IO_OPEN(f);
+  if (f->bin_flag) return 1;
+  return f->mode && strchr(f->mode, 'b') != NULL;
 }
-void sp_File_set_binmode(sp_File *f) { if (f) f->bin_flag = 1; }
+void sp_File_set_binmode(sp_File *f) { SP_IO_OPEN(f); f->bin_flag = 1; }
+/* The handle flags codegen used to read straight off the struct (#2792,
+   #3131): a closed handle answers IOError for them as for everything else.
+   #sync= keeps the flush a truthy value implies (#4229). */
+sp_int sp_File_lineno(sp_File *f) { SP_IO_OPEN(f); return f->lineno; }
+sp_int sp_File_set_lineno(sp_File *f, sp_int n) { SP_IO_OPEN(f); f->lineno = n; return n; }
+sp_bool sp_File_sync_p(sp_File *f) { SP_IO_OPEN(f); return (f->is_sock || f->sync_on) ? 1 : 0; }
+sp_bool sp_File_set_sync(sp_File *f, sp_bool on) {
+  SP_IO_OPEN(f);
+  f->sync_on = on ? 1 : 0;
+  if (on) fflush(f->fp);
+  return on;
+}
+sp_bool sp_File_autoclose_p(sp_File *f) { SP_IO_OPEN(f); return !f->no_autoclose; }
+void sp_File_set_autoclose(sp_File *f, sp_bool on) { SP_IO_OPEN(f); f->no_autoclose = !on; }
 /* IO#reopen(io): rebind this handle's descriptor onto the other stream. */
 sp_File *sp_File_reopen_io(sp_File *f, sp_File *other) {SP_GC_ROOT(f);SP_GC_ROOT(other); sp_gc_wb((void*)f);
   if (!f || !f->fp || !other || !other->fp) return f;
@@ -1208,43 +1227,41 @@ sp_File *sp_File_reopen_io(sp_File *f, sp_File *other) {SP_GC_ROOT(f);SP_GC_ROOT
 }
 /* IO#close_on_exec? / #close_on_exec= via the FD_CLOEXEC descriptor flag. */
 sp_bool sp_File_close_on_exec_p(sp_File *f) {
-  int fd = (f && f->fp) ? fileno(f->fp) : -1;
-  if (fd < 0) return 0;
-  int fl = fcntl(fd, F_GETFD);
+  SP_IO_OPEN(f);
+  int fl = fcntl(fileno(f->fp), F_GETFD);
   return fl >= 0 && (fl & FD_CLOEXEC) != 0;
 }
 void sp_File_set_close_on_exec(sp_File *f, sp_bool on) {
-  int fd = (f && f->fp) ? fileno(f->fp) : -1;
-  if (fd < 0) return;
+  SP_IO_OPEN(f);
+  int fd = fileno(f->fp);
   int fl = fcntl(fd, F_GETFD);
   if (fl < 0) return;
   fcntl(fd, F_SETFD, on ? (fl | FD_CLOEXEC) : (fl & ~FD_CLOEXEC));
 }
 /* IO#fcntl(cmd, arg=0): the raw descriptor command. */
 sp_int sp_File_fcntl(sp_File *f, sp_int cmd, sp_int arg) {SP_GC_ROOT(f);
-  int fd = (f && f->fp) ? fileno(f->fp) : -1;
-  if (fd < 0) sp_raise_cls("IOError", "closed stream");
-  int r = fcntl(fd, (int)cmd, (long)arg);
+  SP_IO_OPEN(f);
+  int r = fcntl(fileno(f->fp), (int)cmd, (long)arg);
   if (r < 0) sp_file_raise_errno("fcntl", f->path ? f->path : "");
   return (sp_int)r;
 }
 /* IO#pwrite(str, offset): write without moving the file position. */
 sp_int sp_File_pwrite(sp_File *f, const char *s, sp_int off) {SP_GC_ROOT(f);SP_GC_ROOT_STR(s);
-  int fd = (f && f->fp) ? fileno(f->fp) : -1;
-  if (fd < 0) sp_raise_cls("IOError", "closed stream");
+  SP_IO_OPEN(f);
   size_t n = s ? strlen(s) : 0;
   fflush(f->fp);
-  ssize_t put = pwrite(fd, s ? s : "", n, (off_t)off);
+  ssize_t put = pwrite(fileno(f->fp), s ? s : "", n, (off_t)off);
   if (put < 0) sp_file_raise_errno("pwrite", f->path ? f->path : "");
   return (sp_int)put;
 }
 /* IO#advise(sym, offset=0, len=0): a hint, and nil either way. POSIX
    fadvise is Linux-ish; where it is absent the hint is simply dropped. */
 void sp_File_advise(sp_File *f, const char *kind, sp_int off, sp_int len) {
+  SP_IO_OPEN(f);
 #ifdef POSIX_FADV_NORMAL
-  int fd = (f && f->fp) ? fileno(f->fp) : -1;
+  int fd = fileno(f->fp);
   int a = POSIX_FADV_NORMAL;
-  if (fd < 0 || !kind) return;
+  if (!kind) return;
   if (!strcmp(kind, "sequential")) a = POSIX_FADV_SEQUENTIAL;
   else if (!strcmp(kind, "random")) a = POSIX_FADV_RANDOM;
   else if (!strcmp(kind, "willneed")) a = POSIX_FADV_WILLNEED;
@@ -1252,7 +1269,7 @@ void sp_File_advise(sp_File *f, const char *kind, sp_int off, sp_int len) {
   else if (!strcmp(kind, "noreuse")) a = POSIX_FADV_NOREUSE;
   posix_fadvise(fd, (off_t)off, (off_t)len, a);
 #else
-  (void)f; (void)kind; (void)off; (void)len;
+  (void)kind; (void)off; (void)len;
 #endif
 }
 /* IO#close_read / #close_write. A plain file is not duplex, so half-closing

--- a/lib/sp_io.h
+++ b/lib/sp_io.h
@@ -75,12 +75,27 @@ sp_int sp_File_close(sp_File *f);
 /* Every operation on a handle whose descriptor is gone raises IOError in
    CRuby. Some of the read side already did; the write side and the position
    queries answered a seed instead, so a write to a closed socket looked like
-   a successful send of zero bytes and the loss went unnoticed. #closed?,
-   #close and #inspect stay exempt: they are the three that are meant to work
-   on a closed handle. */
-void sp_io_raise_closed(void);
+   a successful send of zero bytes and the loss went unnoticed. The byte and
+   character readers, the flag accessors and the descriptor queries answered
+   nil, EOF or a default the same way, so a program that kept using a handle
+   it had closed ran on silently. #closed?, #close, #inspect and #path stay
+   exempt: they are the ones that are meant to work on a closed handle. The
+   metadata a File answers by its path (#size, #mtime, #chmod ...) still
+   answers here where CRuby raises: a File::Stat rides this same struct with
+   no descriptor, so that check cannot be this one. */
+SP_NORETURN SP_COLD void sp_io_raise_closed(void);
 #define SP_IO_OPEN(f) do { if (!(f) || !(f)->fp) sp_io_raise_closed(); } while (0)
 sp_bool sp_File_closed_p(sp_File *f);
+/* The handle flags codegen read straight off the struct (#lineno, #sync,
+   #autoclose? and their setters): through here so a closed handle answers
+   IOError for them too. #lineno= and #sync= answer their value, which is the
+   expression's; #autoclose='s emitter keeps its own operand. */
+sp_int  sp_File_lineno(sp_File *f);
+sp_int  sp_File_set_lineno(sp_File *f, sp_int n);
+sp_bool sp_File_sync_p(sp_File *f);
+sp_bool sp_File_set_sync(sp_File *f, sp_bool on);
+sp_bool sp_File_autoclose_p(sp_File *f);
+void    sp_File_set_autoclose(sp_File *f, sp_bool on);
 const char *sp_File_inspect(sp_File *f);
 const char *sp_io_kind_name(sp_File *f);
 sp_File *sp_sock_accept(sp_File *f);
@@ -177,6 +192,10 @@ void sp_file_rename(const char *from, const char *to);
 #include <dirent.h>
 /* Dir handle (Dir.open / Dir.each_child ...): ops live in lib/sp_cold.c. */
 typedef struct { DIR *dp; const char *path; } sp_Dir;
+/* The Dir counterpart of SP_IO_OPEN: reading or positioning a closed handle
+   is IOError "closed directory" in CRuby; #close, #path and #inspect work. */
+SP_NORETURN SP_COLD void sp_dir_raise_closed(void);
+#define SP_DIR_OPEN(d) do { if (!(d) || !(d)->dp) sp_dir_raise_closed(); } while (0)
 
 /* ---- sp_io_pipe/sysopen relocated from spinel_rt.h (0 optcarrot uses). ---- */
 sp_PolyArray *sp_io_pipe(void);

--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -1100,11 +1100,10 @@ const char *sp_File_readpartial(sp_File *f, sp_int n);
 /* IO#pread(len, offset): read without moving the file position. Inline
    because it allocates from this TU's string heap (#3038). */
 static inline const char *sp_File_pread(sp_File *f, sp_int len, sp_int off) {
-  int fd = (f && f->fp) ? fileno(f->fp) : -1;
-  if (fd < 0) sp_raise_cls("IOError", "closed stream");
+  SP_IO_OPEN(f);
   if (len < 0) len = 0;
   char *buf = (char *)sp_str_alloc((size_t)len);
-  ssize_t got = pread(fd, buf, (size_t)len, (off_t)off);
+  ssize_t got = pread(fileno(f->fp), buf, (size_t)len, (off_t)off);
   if (got < 0) sp_raise_cls("IOError", "pread failed");
   if (got == 0 && len > 0) sp_raise_cls("EOFError", "end of file reached");
   buf[got] = '\0';
@@ -2036,10 +2035,11 @@ static sp_PolyArray *sp_sock_addr(sp_File *f, int peer) {
   if (!f || !f->is_sock)
     sp_raise_cls("NoMethodError", sp_sprintf("undefined method '%s' for an instance of %s",
                                              peer ? "peeraddr" : "addr", sp_io_kind_name(f)));
+  SP_IO_OPEN(f);
   sp_PolyArray *a = sp_PolyArray_new();
   SP_GC_ROOT(a);
   char ip[64];
-  int port = (f && f->fp) ? sp_net_sock_ip(fileno(f->fp), peer, ip, (int)sizeof ip) : -1;
+  int port = sp_net_sock_ip(fileno(f->fp), peer, ip, (int)sizeof ip);
   if (port < 0) { ip[0] = '\0'; port = 0; }
   const char *fam = strchr(ip, ':') ? "AF_INET6" : "AF_INET";
   sp_PolyArray_push(a, sp_box_str(sp_sprintf("%s", fam)));

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -18138,7 +18138,10 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
       int tdh = ++g_tmp, tdn = ++g_tmp;
       int skip_dots = sp_streq(name, "each_child");
       buf_puts(b, "({ ");
-      buf_printf(b, "sp_Dir *_t%d = %s; const char *_t%d; ", tdh, dr, tdn);
+      /* rooted for the block's duration: a temporary receiver (Dir.open(d).each)
+         has no other reference, and a body that allocates would let the
+         collector close it mid-loop (the File loops below root theirs too) */
+      buf_printf(b, "sp_Dir *_t%d = %s; SP_GC_ROOT(_t%d); const char *_t%d; ", tdh, dr, tdh, tdn);
       buf_printf(b, "while ((_t%d = sp_Dir_read(_t%d)) != NULL) {", tdn, tdh);
       if (skip_dots)
         buf_printf(b, " if (sp_str_eq(_t%d, (&(\"\\xff\" \".\")[1])) ||"
@@ -18512,7 +18515,7 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
          has to drive #autoclose? (#3131) */
       if (sp_streq(name, "close_on_exec="))
         buf_printf(b, "sp_File_set_close_on_exec(%s, _t%d); ", r, tv);
-      else buf_printf(b, "(%s)->no_autoclose = !_t%d; ", r, tv);
+      else buf_printf(b, "sp_File_set_autoclose(%s, _t%d); ", r, tv);
       buf_printf(b, "_t%d; })", tv);
       free(rb.p); return;
     }
@@ -18651,7 +18654,7 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
       buf_printf(b, "sp_File_fsync(%s)", r); free(rb.p); return;
     }
     if (sp_streq(name, "autoclose?") && argc == 0) {
-      buf_printf(b, "(!(%s)->no_autoclose)", r); free(rb.p); return;
+      buf_printf(b, "sp_File_autoclose_p(%s)", r); free(rb.p); return;
     }
     if (sp_streq(name, "pid") && argc == 0) {
       buf_printf(b, "({ (void)%s; sp_box_nil(); })", r); free(rb.p); return;
@@ -18660,10 +18663,10 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
       buf_printf(b, "sp_File_fileno(%s)", r); free(rb.p); return;
     }
     if (sp_streq(name, "lineno") && argc == 0) {
-      buf_printf(b, "((%s)->lineno)", r); free(rb.p); return;
+      buf_printf(b, "sp_File_lineno(%s)", r); free(rb.p); return;
     }
     if (sp_streq(name, "lineno=") && argc == 1) {
-      buf_printf(b, "((%s)->lineno = ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ")");
+      buf_printf(b, "sp_File_set_lineno(%s, ", r); emit_int_expr(c, argv[0], b); buf_puts(b, ")");
       free(rb.p); return;
     }
     if (sp_streq(name, "pos=") && argc == 1) {
@@ -18716,7 +18719,7 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
       int is_cp = sp_streq(name, "each_codepoint");
       int rf2 = ++g_tmp, lt2 = ++g_tmp;
       buf_puts(b, "({ ");
-      buf_printf(b, "sp_File *_t%d = %s; ", rf2, r);
+      buf_printf(b, "sp_File *_t%d = %s; SP_GC_ROOT(_t%d); ", rf2, r, rf2);
       if (is_byte)
         buf_printf(b, "sp_int _t%d; while ((_t%d = sp_File_getbyte(_t%d)) != SP_INT_NIL) {", lt2, lt2, rf2);
       else if (is_cp)
@@ -18915,7 +18918,7 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
          sync = true -- and spinel's socket writes really do bypass stdio, so
          reporting false contradicted the implementation. Per-handle sync state
          is still not modelled beyond that (#2792). */
-      buf_printf(b, "((%s)->is_sock || (%s)->sync_on ? (sp_bool)1 : (sp_bool)0)", r, r);
+      buf_printf(b, "sp_File_sync_p(%s)", r);
       free(rb.p); return;
     }
     if (sp_streq(name, "sync=") && argc >= 1) {
@@ -18923,8 +18926,7 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
       buf_printf(b, "({ sp_bool _t%d = (", ts2);
       if (comp_ntype(c, argv[0]) == TY_BOOL) emit_expr(c, argv[0], b);
       else { buf_puts(b, "sp_poly_truthy("); emit_boxed(c, argv[0], b); buf_puts(b, ")"); }
-      buf_printf(b, "); %s->sync_on = _t%d ? 1 : 0; if (_t%d) sp_File_flush(%s); _t%d; })",
-                 r, ts2, ts2, r, ts2);
+      buf_printf(b, "); sp_File_set_sync(%s, _t%d); })", r, ts2);
       free(rb.p); return;
     }
     if (sp_streq(name, "flush") || sp_streq(name, "binmode")) {
@@ -18947,7 +18949,10 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
       int esep = (argc >= 1 && comp_ntype(c, argv[0]) == TY_STRING) ? argv[0] : -1;
       int lt = ++g_tmp, rf = ++g_tmp;
       buf_puts(b, "({ ");
-      buf_printf(b, "sp_File *_t%d = %s; ", rf, r);
+      /* rooted as the File.open block form roots its handle (below): a
+         temporary receiver -- File.open(p).each_line -- is otherwise swept by
+         a GC inside the body and the loop ends early */
+      buf_printf(b, "sp_File *_t%d = %s; SP_GC_ROOT(_t%d); ", rf, r, rf);
       free(rb.p); r = NULL;
       /* Each iteration yields a FRESH heap line string, matching CRuby --
          a stored reference must keep its own line, not a mutated shared
@@ -19045,15 +19050,12 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
          sync reads the handle kind, sync= flushes on a truthy value and
          answers it (#4229) */
       else if (sp_streq(name, "sync") && argc == 0)
-        buf_printf(b, "(_t%d && (_t%d->is_sock || _t%d->sync_on) ? (sp_bool)1 : (sp_bool)0); })",
-                   tio2, tio2, tio2);
+        buf_printf(b, "sp_File_sync_p(_t%d); })", tio2);
       else if (sp_streq(name, "sync=") && argc >= 1) {
         int ts3 = ++g_tmp;
         buf_printf(b, "sp_bool _t%d = sp_poly_truthy(", ts3);
         emit_boxed(c, argv[0], b);
-        buf_printf(b, "); if (_t%d) _t%d->sync_on = 1; else _t%d->sync_on = 0;"
-                      " if (_t%d) sp_File_flush(_t%d); _t%d; })",
-                   ts3, tio2, tio2, ts3, tio2, ts3);
+        buf_printf(b, "); sp_File_set_sync(_t%d, _t%d); })", tio2, ts3);
       }
       /* read_nonblock / write_nonblock, the same answers the typed-receiver
          arms give: `exception: false` answers the wait symbol (read) or nil

--- a/test/io_closed_stream.rb
+++ b/test/io_closed_stream.rb
@@ -1,0 +1,211 @@
+# Every operation on a closed handle raises IOError, as in CRuby: the byte and
+# character readers, the flag accessors, the descriptor queries and the
+# positioning calls used to answer nil, EOF, false or a default instead.
+# #closed?, #close, #inspect and #path keep working on a closed handle. The
+# loops that read a handle keep it rooted for their whole run, and the sync
+# accessors evaluate their receiver once.
+
+require "io/console"
+require "socket"
+
+def try(label)
+  r = yield
+  puts "#{label} => #{r.inspect}"
+rescue IOError, EOFError => e
+  puts "#{label}: #{e.class}: #{e.message}"
+end
+
+path = "/tmp/sp_io_closed_stream.txt"
+lines_path = "/tmp/sp_io_closed_stream_lines.txt"
+dir = "/tmp/sp_io_closed_stream_dir"
+if Dir.exist?(dir)
+  Dir.children(dir).each { |e| File.delete("#{dir}/#{e}") }
+  Dir.rmdir(dir)
+end
+Dir.mkdir(dir)
+3.times { |i| File.write("#{dir}/f#{i}", "") }
+# a wider directory for the temporary-receiver loops: master only loses the
+# handle once the sweep runs, which a three-entry listing never reaches
+bigdir = "/tmp/sp_io_closed_stream_bigdir"
+if Dir.exist?(bigdir)
+  Dir.children(bigdir).each { |e| File.delete("#{bigdir}/#{e}") }
+  Dir.rmdir(bigdir)
+end
+Dir.mkdir(bigdir)
+20.times { |i| File.write("#{bigdir}/g#{i}", "") }
+File.write(path, "abc\ndef\n")
+File.write(lines_path, (1..200).map { |i| "line #{i}" }.join("\n") + "\n")
+
+io = File.open(path, "r+")
+io.close
+
+puts "--- still answering"
+try("closed?") { io.closed? }
+try("close") { io.close }
+try("inspect") { io.inspect }
+try("path") { io.path }
+try("to_path") { io.to_path }
+
+puts "--- readers"
+try("eof?") { io.eof? }
+try("read") { io.read }
+try("read(1)") { io.read(1) }
+try("readpartial") { io.readpartial(1) }
+try("sysread") { io.sysread(1) }
+try("pread") { io.pread(1, 0) }
+try("gets") { io.gets }
+try("gets(sep)") { io.gets("e") }
+try("readline") { io.readline }
+try("readlines") { io.readlines }
+try("each_line") { io.each_line { |l| puts l } }
+try("getc") { io.getc }
+try("readchar") { io.readchar }
+try("getbyte") { io.getbyte }
+try("readbyte") { io.readbyte }
+try("ungetc") { io.ungetc("x") }
+try("ungetbyte") { io.ungetbyte(120) }
+try("each_byte") { io.each_byte { |b| puts b } }
+try("each_char") { io.each_char { |c| puts c } }
+try("each_codepoint") { io.each_codepoint { |c| puts c } }
+
+puts "--- writers"
+try("write") { io.write("x") }
+try("puts") { io.puts("x") }
+try("print") { io.print("x") }
+try("<<") { io << "x" }
+try("putc") { io.putc("x") }
+try("syswrite") { io.syswrite("x") }
+try("pwrite") { io.pwrite("x", 0) }
+try("flush") { io.flush }
+try("fsync") { io.fsync }
+try("fdatasync") { io.fdatasync }
+
+puts "--- position"
+try("pos") { io.pos }
+try("tell") { io.tell }
+try("pos=") { io.pos = 0 }
+try("seek") { io.seek(0) }
+try("sysseek") { io.sysseek(0) }
+try("rewind") { io.rewind }
+try("lineno") { io.lineno }
+try("lineno=") { io.lineno = 3 }
+
+puts "--- flags and descriptor"
+try("sync") { io.sync }
+try("sync=") { io.sync = true }
+try("autoclose?") { io.autoclose? }
+try("autoclose=") { io.autoclose = false }
+try("close_on_exec?") { io.close_on_exec? }
+try("close_on_exec=") { io.close_on_exec = true }
+try("binmode") { io.binmode }
+try("binmode?") { io.binmode? }
+try("tty?") { io.tty? }
+try("isatty") { io.isatty }
+try("fileno") { io.fileno }
+try("to_i") { io.to_i }
+try("stat") { io.stat }
+try("flock") { io.flock(0) }
+try("advise") { io.advise(:normal) }
+try("fcntl") { io.fcntl(1) }
+try("wait_readable") { io.wait_readable(0) }
+try("wait_writable") { io.wait_writable(0) }
+try("wait") { io.wait(0, :read) }
+try("winsize") { io.winsize }
+
+puts "--- a pipe end read back out of its pair"
+r, w = IO.pipe
+r.close
+w.close
+try("pipe sync") { r.sync }
+try("pipe sync=") { r.sync = false }
+try("pipe gets") { r.gets }
+try("pipe write") { w.write("x") }
+try("pipe closed?") { [r.closed?, w.closed?] }
+
+puts "--- an open handle keeps its answers"
+io = File.open(path)
+try("open lineno") { io.lineno }
+try("open gets") { io.gets }
+try("open lineno after gets") { io.lineno }
+try("open lineno=") { io.lineno = 7 }
+try("open sync") { io.sync }
+try("open sync=") { io.sync = true }
+try("open autoclose?") { io.autoclose? }
+try("open autoclose=") { io.autoclose = true }
+try("open getbyte") { io.getbyte }
+try("open eof? at end") { io.read; io.eof? }
+try("open getc at end") { io.getc }
+try("open getbyte at end") { io.getbyte }
+try("open readbyte at end") { io.readbyte }
+io.close
+
+puts "--- a temporary receiver keeps its handle for the whole loop"
+n = 0
+File.open(lines_path).each_line { |l| 100.times { "x" * 64 }; n += 1 }
+puts "each_line on a temporary receiver saw #{n} lines"
+n = 0
+File.new(lines_path).each_byte { |b| 20.times { "y" * 64 }; n += 1 }
+puts "each_byte on a temporary receiver saw #{n} bytes"
+n = 0
+File.open(lines_path).each_char { |c| 20.times { "z" * 64 }; n += 1 }
+puts "each_char on a temporary receiver saw #{n} chars"
+n = 0
+File.open(lines_path).each_codepoint { |c| 20.times { "v" * 64 }; n += 1 }
+puts "each_codepoint on a temporary receiver saw #{n} codepoints"
+n = 0
+Dir.open(bigdir).each { |e| 100.times { "w" * 64 }; n += 1 }
+puts "Dir#each on a temporary receiver saw #{n} entries"
+n = 0
+Dir.open(bigdir).each_child { |e| 100.times { "u" * 64 }; n += 1 }
+puts "Dir#each_child on a temporary receiver saw #{n} children"
+
+puts "--- sync and sync= evaluate their receiver once"
+$count = 0
+$handle = File.open(lines_path)
+def handle
+  $count += 1
+  $handle
+end
+handle.sync
+puts "sync evaluated its receiver #{$count} time(s)"
+$count = 0
+handle.sync = true
+puts "sync= evaluated its receiver #{$count} time(s)"
+$handle.close
+
+puts "--- a closed socket"
+srv = TCPServer.new("127.0.0.1", 0)
+port = srv.addr[1]
+c = TCPSocket.new("127.0.0.1", port)
+s = srv.accept
+c.close
+srv.close
+try("socket addr") { c.addr }
+try("socket peeraddr") { c.peeraddr }
+try("server addr") { srv.addr }
+s.close
+
+puts "--- Dir"
+d = Dir.open(dir)
+d.close
+try("dir close") { d.close }
+try("dir path") { d.path }
+try("dir inspect") { d.inspect }
+try("dir read") { d.read }
+try("dir rewind") { d.rewind }
+try("dir tell") { d.tell }
+try("dir pos") { d.pos }
+try("dir seek") { d.seek(0) }
+try("dir pos=") { d.pos = 0 }
+try("dir fileno") { d.fileno }
+try("dir each") { d.each { |e| puts e } }
+try("dir each_child") { d.each_child { |e| puts e } }
+try("dir children") { d.children }
+try("dir entries") { d.entries }
+
+File.delete(path)
+File.delete(lines_path)
+Dir.children(bigdir).each { |e| File.delete("#{bigdir}/#{e}") }
+Dir.rmdir(bigdir)
+Dir.children(dir).each { |e| File.delete("#{dir}/#{e}") }
+Dir.rmdir(dir)

--- a/test/io_closed_stream.rb.expected
+++ b/test/io_closed_stream.rb.expected
@@ -1,0 +1,117 @@
+--- still answering
+closed? => true
+close => nil
+inspect => "#<File:/tmp/sp_io_closed_stream.txt (closed)>"
+path => "/tmp/sp_io_closed_stream.txt"
+to_path => "/tmp/sp_io_closed_stream.txt"
+--- readers
+eof?: IOError: closed stream
+read: IOError: closed stream
+read(1): IOError: closed stream
+readpartial: IOError: closed stream
+sysread: IOError: closed stream
+pread: IOError: closed stream
+gets: IOError: closed stream
+gets(sep): IOError: closed stream
+readline: IOError: closed stream
+readlines: IOError: closed stream
+each_line: IOError: closed stream
+getc: IOError: closed stream
+readchar: IOError: closed stream
+getbyte: IOError: closed stream
+readbyte: IOError: closed stream
+ungetc: IOError: closed stream
+ungetbyte: IOError: closed stream
+each_byte: IOError: closed stream
+each_char: IOError: closed stream
+each_codepoint: IOError: closed stream
+--- writers
+write: IOError: closed stream
+puts: IOError: closed stream
+print: IOError: closed stream
+<<: IOError: closed stream
+putc: IOError: closed stream
+syswrite: IOError: closed stream
+pwrite: IOError: closed stream
+flush: IOError: closed stream
+fsync: IOError: closed stream
+fdatasync: IOError: closed stream
+--- position
+pos: IOError: closed stream
+tell: IOError: closed stream
+pos=: IOError: closed stream
+seek: IOError: closed stream
+sysseek: IOError: closed stream
+rewind: IOError: closed stream
+lineno: IOError: closed stream
+lineno=: IOError: closed stream
+--- flags and descriptor
+sync: IOError: closed stream
+sync=: IOError: closed stream
+autoclose?: IOError: closed stream
+autoclose=: IOError: closed stream
+close_on_exec?: IOError: closed stream
+close_on_exec=: IOError: closed stream
+binmode: IOError: closed stream
+binmode?: IOError: closed stream
+tty?: IOError: closed stream
+isatty: IOError: closed stream
+fileno: IOError: closed stream
+to_i: IOError: closed stream
+stat: IOError: closed stream
+flock: IOError: closed stream
+advise: IOError: closed stream
+fcntl: IOError: closed stream
+wait_readable: IOError: closed stream
+wait_writable: IOError: closed stream
+wait: IOError: closed stream
+winsize: IOError: closed stream
+--- a pipe end read back out of its pair
+pipe sync: IOError: closed stream
+pipe sync=: IOError: closed stream
+pipe gets: IOError: closed stream
+pipe write: IOError: closed stream
+pipe closed? => [true, true]
+--- an open handle keeps its answers
+open lineno => 0
+open gets => "abc\n"
+open lineno after gets => 1
+open lineno= => 7
+open sync => false
+open sync= => true
+open autoclose? => true
+open autoclose= => true
+open getbyte => 100
+open eof? at end => true
+open getc at end => nil
+open getbyte at end => nil
+open readbyte at end: EOFError: end of file reached
+--- a temporary receiver keeps its handle for the whole loop
+each_line on a temporary receiver saw 200 lines
+each_byte on a temporary receiver saw 1692 bytes
+each_char on a temporary receiver saw 1692 chars
+each_codepoint on a temporary receiver saw 1692 codepoints
+Dir#each on a temporary receiver saw 22 entries
+Dir#each_child on a temporary receiver saw 20 children
+--- sync and sync= evaluate their receiver once
+sync evaluated its receiver 1 time(s)
+sync= evaluated its receiver 1 time(s)
+--- a closed socket
+socket addr: IOError: closed stream
+socket peeraddr: IOError: closed stream
+server addr: IOError: closed stream
+--- Dir
+dir close => nil
+dir path => "/tmp/sp_io_closed_stream_dir"
+dir inspect => "#<Dir:/tmp/sp_io_closed_stream_dir>"
+dir read: IOError: closed directory
+dir rewind: IOError: closed directory
+dir tell: IOError: closed directory
+dir pos: IOError: closed directory
+dir seek: IOError: closed directory
+dir pos=: IOError: closed directory
+dir fileno: IOError: closed directory
+dir each: IOError: closed directory
+dir each_child: IOError: closed directory
+dir children: IOError: closed directory
+dir entries: IOError: closed directory


### PR DESCRIPTION
## Why

Using a handle after closing it is a bug in the program, and Ruby reports it: every read, write, positioning call, flag query and descriptor query on a closed File or IO raises IOError "closed stream", and the same calls on a closed Dir raise IOError "closed directory". Only `closed?`, `close`, `inspect` and `path` still answer. In Spinel the write side and the position queries already did that, but most of the rest answered something plausible instead: `getc` and `getbyte` answered nil, `readchar`, `readbyte`, `readpartial` and `readline` raised EOFError, `each_line`, `each_byte` and `each_char` silently ran zero iterations, `lineno`, `sync`, `autoclose?`, `close_on_exec?`, `tty?`, `binmode?` answered their defaults, `stat` answered a File::Stat, `sysseek`, `flock` and `fsync` answered 0, and a closed Dir's `read` answered nil, `tell` 0, `fileno` -1 and `rewind`/`seek` the handle. A program that kept using a handle it had closed ran on as if nothing had happened, and a `rescue IOError` around it never ran.

Concretely: sp_io.h already had the check, `SP_IO_OPEN(f)`, raising through `sp_io_raise_closed`, with a comment saying every operation should use it; about twenty entry points did not. Seven of them (`fcntl`, `pwrite`, `pread`, `stat` and the three readiness waits) carried their own hand-written copy of the same test, as did the socket entries, `IO.select` and `addr`/`peeraddr`, which answered a zero address for a closed socket. Four (`lineno`, `sync`, `autoclose?` and their setters) were not runtime calls at all: codegen read the struct field inline, so there was nowhere to put the check. Dir had no counterpart at all except in `children`/`entries`.

## What

Every IO handle operation starts with `SP_IO_OPEN`: `getc`, `readchar`, `getbyte`, `readbyte`, `ungetc`, `ungetbyte`, `readpartial` (and so `sysread`), `gets` with a separator (and so `readline`, `readlines` with a separator, and `each_line`), `each_byte`, `each_char`, `each_codepoint`, `binmode`, `binmode?`, `close_on_exec?` and `close_on_exec=`, `tty?`/`isatty`, `fileno`/`to_i` (the check now comes before the `for_fd` descriptor answer, so a closed autoclose-false wrapper raises as it does in CRuby), `stat`, `sysseek`, `flock`, `fsync`/`fdatasync`, `putc`, `advise`, `winsize`, and `wait_readable`/`wait_writable`/`wait`. `fcntl`, `pwrite`, `pread`, the waits, `stat`, the socket entries (`read_nonblock`, `write_nonblock`, `send`, `recv`, `shutdown`, `listen`, `connect_nonblock`) and `IO.select` drop their hand-rolled copies of the check in favour of the macro, and a socket's `addr` and `peeraddr` get it, so a closed socket raises instead of answering `["AF_INET", 0, "", ""]`.

The loops that read a handle in the generated code, `each_line`/`each`, `each_byte`/`each_char`/`each_codepoint` and `Dir#each`/`each_child`, now root the handle for their whole run, as the block form of `File.open` already rooted its handle. With a temporary receiver, `File.open(p).each_line { }`, `Dir.open(d).each { }`, the loop's C local was the only reference, and a body that allocates let the collector finalize the handle mid-loop: master silently read 28 of 200 lines, or 2 of 22 entries, and with the readers now raising the same program would have stopped with "closed stream". They read every line now, as CRuby does.

The typed `sync` and `sync=` emitters used to spell the receiver expression twice, so `mk.sync` evaluated `mk` twice on master; the accessor call evaluates it once, as CRuby does.

`lineno`, `lineno=`, `sync`, `sync=`, `autoclose?` and `autoclose=` get runtime accessors (`sp_File_lineno`, `sp_File_set_lineno`, `sp_File_sync_p`, `sp_File_set_sync`, `sp_File_autoclose_p`, `sp_File_set_autoclose`) that make the check and then read or write the field; codegen emits calls to those in both the typed-receiver arm and the poly-carried-handle arm instead of the inline field reads. `sync=` keeps the flush a truthy value implies, once, inside the accessor.

Dir gets the counterpart, `SP_DIR_OPEN(d)` raising through `sp_dir_raise_closed` ("closed directory"), used by `read`, `rewind`, `tell`/`pos`, `seek`/`pos=`, `fileno`, `children` and `entries`; `each` and `each_child` read through `sp_Dir_read` and so raise with it. `Dir#close` on a closed handle still answers nil, and `path` and `inspect` still work, as in CRuby.

## How

One rule, one macro; the closed-check functions are declared `SP_NORETURN SP_COLD` in sp_io.h as `sp_raise_cls` is, so the generated code past a check is not kept for a return that cannot happen. `gets` with a separator checks again after its readiness park, where another thread could have closed the handle meanwhile (a close does not yet wake a parked reader here, so that second check is a guard for the day it does). The runtime's own callers of the changed readers (`readline_sep` and `readlines_sep` through `gets_sep`, `readchar` through `getc`) want the raise, and nothing in the standard streams, ARGF or the packages calls them on a closed handle (the standard streams are never closed here; `close` on them is a no-op, unchanged). `sp_poly_as_io`, which the poly arm unboxes through, never hands back NULL (it raises NoMethodError for a non-handle), so the `_t && ...` guard the old inline `sync` read carried was dead and is gone with it.

## Validation

`make gate` (the local mirror of CI): 3490 tests, 61 benchmarks, the optcarrot checksum (59662), ext-cruby, rbs-seed, rubyspec 6/6 and the property checks all pass; the macOS-only spin-e2e progress line is the known red it is on master, and one corpus program timed out under the replay's load as it does on master. Compatibility corpus (a differential corpus of ~2,100 minimized programs that behave differently under CRuby 4.0.6 and Spinel, the same corpus behind #3999/#4003/#4029): 847 to 860 of 2131, 13 gained, 0 lost. The thirteen are the twelve closed-handle programs of this family (the readers, the flag accessors, `stat`, `tty?`, `sysseek`/`flock`/`advise`, `readline`, `each_line`, the byte and character iterators, and a closed Dir's `read` and positioning calls) plus a thirteenth that calls `each` on a closed Dir. The one program of the family that does not flip compares `io.rewind.equal?(io)` on a closed handle: its first three lines now match, and the fourth still answers false because a statically-false `equal?` between an Integer receiver and a handle folds away the receiver call, so `rewind` is never called; that is a different rule and is left for its own change.

Generated-C sweep over the suite and benchmarks against 3041feb9 with the `#line` paths normalised: 3492 same, 13 changed, 0 failed of 3505. The thirteen are the new test, eight IO tests (io_for_fd_autoclose, io_handle_value_surface, io_instance_read_surface, io_pipe_sync_write, io_poly_sync_assign, issue_3038, issue_3131, socket_handle_kind) whose inline `lineno`, `sync`, `sync=`, `autoclose?` and `autoclose=` field reads became the accessor calls, 1 to 7 lines each, and four (bm_io_wordcount, bundle_io_sys, dir_handle_objects, each_entry_returns_receiver) that iterate a temporary handle and gain the one root line at the loop's entry. Every changed line is one of those two substitutions and nothing else. optcarrot's generated C is identical, and its checksum unchanged.

New test `test/io_closed_stream.rb`, expectation generated by Ruby 4.0.6, 0.01 s compiled at -O2: every reader, writer, positioning call, flag accessor and descriptor query on a closed File, `wait` and `winsize` included; the four exempt methods; a closed pipe end read back out of its pair (the poly arm); the open-handle answers the new accessors replace (`lineno` counting across `gets`, `sync=`, `autoclose=`, `getbyte`, the EOF answers of `getc`/`getbyte`/`readbyte`); `each_line`, `each_byte`, `each_char`, `each_codepoint`, `Dir#each` and `Dir#each_child` on a temporary receiver with an allocating block, counting every line, byte, character, codepoint and entry of a twenty-file directory; `sync` and `sync=` evaluating their receiver once; `addr` and `peeraddr` on a closed TCP socket and a closed server; and every read and positioning call on a closed Dir. Compiled on 3041feb9 it prints 117 lines of which 63 are identical to the expectation; the temporary-receiver loops there lose their handle at a point the collector picks, so which of those six counts fall short varies run to run, and the one-file-and-three-entries fixture of an earlier version sometimes fell short nowhere at all, which is why the directory has twenty entries now. Clean under `SPINEL_GC_STRESS=1` and under ASAN and UBSAN, plain and stressed.

Checked by hand against CRuby and not pinned: closing the handle inside its own `each_line`, `each_byte` or `each_char` block raises "closed stream" on the next read; a pipe read end whose writer closed reads to EOF without error; `IO.select` on a closed end raises; a handle closed inside a Thread raises; `ensure` runs and sees `closed?` true. (Closing a Dir inside its own `each` segfaults CRuby 4.0.6 itself, so that shape is not compared; here it raises "closed directory".)

## Left alone, on purpose

The metadata a File answers by its path (`size`, `mtime`, `atime`, `ctime`, `birthtime`, `lstat`, `chmod`, `chown`) still answers on a closed handle here, where CRuby raises. A File::Stat is carried as the same `sp_File` struct with no descriptor, so `SP_IO_OPEN` in those accessors would refuse every File::Stat; that check needs to tell the two apart and is a different rule. The comment in sp_io.h says so.

The write family (`write`, `print`, `puts`) on a handle opened read-only answers here and raises IOError "not opened for writing" in CRuby, `wait_writable` on one answers the handle, `lineno` on a write-only handle answers 0, and `read(-1)` answers the rest of the file where CRuby raises ArgumentError: mode and argument checks, not the closed check. `pid` on a closed handle answers nil (its emitter makes no runtime call that could hold the check). `each_line` and `each` with no block are not supported on IO here (CRuby answers an Enumerator without raising).

The string those same loops yield to the block is not rooted either: `f.each_line { |l| ... }` with an allocating body yields "" for some lines (19 of 300 plain, every line under GC stress), and `each_char` likewise; on master the same, once the handle survives long enough for the string to be the thing swept. That is the yielded value's root, not the handle's, and Matz asked in #4350 that memory-safety fixes stay one rule each; it is the next change after this one, in the same three loops.

Also as on master: a close does not wake a reader parked on the handle in another thread (CRuby raises "stream closed in another thread"; both sides wait); `$stdin`/`$stdout` answer after `close`, which is a no-op on the standard streams here, and `Kernel#gets` on a closed `$stdin` is a NameError; `close_read`/`close_write` on a closed non-duplex File raise where CRuby answers nil; `pread(0, 0)` on a closed handle raises where CRuby answers ""; `io.sync = "x"` answers true, not "x"; a pipe end's `path` renders as `[]`. Two readers in spinel_rt.h that no emitter uses (`sp_File_gets_buf`, `sp_File_gets_into`) keep answering NULL, and `reopen` on a closed handle answers the handle where CRuby raises: its rebinding of the descriptor is a different shape from the check and is left for its own line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Operations on closed files, pipes, sockets, and directories now consistently raise `IOError` instead of returning misleading values or silently doing nothing.
  * Closed-handle behavior now more closely matches CRuby, including appropriate `EOFError` responses.
  * File iteration and directory traversal are more reliable during garbage collection.
  * File settings such as line number, synchronization, and autoclose are handled consistently.

* **Tests**
  * Added comprehensive coverage for closed-handle behavior, iteration safety, and receiver evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->