### PR TITLE
A failing filesystem call raises the Errno CRuby raises

### DIFF
--- a/lib/sp_cold.c
+++ b/lib/sp_cold.c
@@ -808,7 +808,7 @@ sp_Time sp_file_atime(const char *path) {SP_GC_ROOT_STR(path);
   if (!path) { sp_raise_cls("TypeError", "no implicit conversion of nil into String"); return (sp_Time){0, 0, 0}; }
   struct stat st;
   if (stat(path, &st) == -1) {
-    sp_raise_cls(errno == ENOENT ? "Errno::ENOENT" : "RuntimeError", sp_sprintf("%s @ File.atime - %s", strerror(errno), path));
+    sp_file_raise_errno("rb_file_s_atime", path);
     return (sp_Time){0, 0, 0};
   }
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
@@ -821,7 +821,7 @@ sp_Time sp_file_ctime(const char *path) {SP_GC_ROOT_STR(path);
   if (!path) { sp_raise_cls("TypeError", "no implicit conversion of nil into String"); return (sp_Time){0, 0, 0}; }
   struct stat st;
   if (stat(path, &st) == -1) {
-    sp_raise_cls(errno == ENOENT ? "Errno::ENOENT" : "RuntimeError", sp_sprintf("%s @ File.ctime - %s", strerror(errno), path));
+    sp_file_raise_errno("rb_file_s_ctime", path);
     return (sp_Time){0, 0, 0};
   }
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
@@ -837,7 +837,7 @@ sp_Time sp_file_mtime(const char *path) {SP_GC_ROOT_STR(path);
   }
   struct stat st;
   if (stat(path, &st) == -1) {
-    sp_raise_cls(errno == ENOENT ? "Errno::ENOENT" : "RuntimeError", sp_sprintf("%s @ File.mtime - %s", strerror(errno), path));
+    sp_file_raise_errno("rb_file_s_mtime", path);
     return (sp_Time){0, 0, 0};
   }
 #if defined(__APPLE__)
@@ -853,11 +853,16 @@ sp_Time sp_file_birthtime(const char *path) {SP_GC_ROOT_STR(path);  /* (#2985) *
   if (!path) { sp_raise_cls("TypeError", "no implicit conversion of nil into String"); return (sp_Time){0, 0, 0}; }
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
   struct stat st;
-  if (stat(path, &st) == -1) { sp_raise_cls(errno == ENOENT ? "Errno::ENOENT" : "RuntimeError", sp_sprintf("%s @ File.birthtime - %s", strerror(errno), path)); return (sp_Time){0, 0, 0}; }
+  if (stat(path, &st) == -1) sp_file_raise_errno("rb_file_s_birthtime", path);
   return (sp_Time){(int64_t)st.st_birthtimespec.tv_sec, (int32_t)st.st_birthtimespec.tv_nsec, 0};
 #elif defined(__linux__) && defined(STATX_BTIME)
+  /* a statx that fails is the path's Errno (a missing file is ENOENT, as in
+     CRuby's rb_file_s_birthtime); only a filesystem that answers without a
+     birth time is the NotImplementedError */
   struct statx stx;
-  if (statx(AT_FDCWD, path, AT_STATX_SYNC_AS_STAT, STATX_BTIME, &stx) == 0 && (stx.stx_mask & STATX_BTIME))
+  if (statx(AT_FDCWD, path, AT_STATX_SYNC_AS_STAT, STATX_BTIME, &stx) != 0)
+    sp_file_raise_errno("rb_file_s_birthtime", path);
+  if (stx.stx_mask & STATX_BTIME)
     return (sp_Time){(int64_t)stx.stx_btime.tv_sec, (int32_t)stx.stx_btime.tv_nsec, 0};
   sp_raise_cls("NotImplementedError", "birthtime() function is unimplemented on this filesystem");
   return (sp_Time){0, 0, 0};
@@ -893,8 +898,7 @@ sp_int sp_file_size(const char *path) {SP_GC_ROOT_STR(path);
   }
   struct stat st;
   if (stat(path, &st) == -1) {
-    int err = errno;  /* capture once: strerror() may clobber errno */
-    sp_raise_cls(err == ENOENT ? "Errno::ENOENT" : "RuntimeError", sp_sprintf("%s @ File.size - %s", strerror(err), path));
+    sp_file_raise_errno("rb_file_s_size", path);
     return 0;
   }
   /* off_t (typically 64-bit) into sp_int (intptr_t -> 32-bit on a 32-bit
@@ -1783,9 +1787,8 @@ sp_int sp_file_chmod(sp_int mode, const char *path) {SP_GC_ROOT_STR(path);
   return 1;
 }
 sp_int sp_file_truncate(const char *path, sp_int n) {SP_GC_ROOT_STR(path);
-  if (truncate(path ? path : "", (off_t)n) != 0)
-    sp_raise_cls("Errno::ENOENT",
-                 sp_sprintf("No such file or directory @ rb_file_s_truncate - %s", path ? path : ""));
+  sp_file_path_check(path);
+  if (truncate(path, (off_t)n) != 0) sp_file_raise_errno("rb_file_s_truncate", path);
   return 0;
 }
 sp_int sp_file_write_at(const char *path, const char *data, sp_int off) {SP_GC_ROOT_STR(path);SP_GC_ROOT_STR(data);
@@ -2071,14 +2074,30 @@ const char *sp_dir_pwd(void) {
   memcpy(buf, tmp, n + 1);
   return buf;
 }
-sp_int sp_dir_mkdir(const char *path) {
-  return (sp_int)mkdir(path, 0777);
+/* Dir.mkdir / Dir.rmdir / Dir.chdir: 0, or the Errno CRuby raises, under
+   CRuby's labels; its block-form chdir says dir_chdir0 where this wrapper
+   says chdir_path in both forms. A nil path (a NULL string at run time) is
+   CRuby's TypeError, as it is for File.size and the time readers above. */
+sp_int sp_dir_mkdir(const char *path) {SP_GC_ROOT_STR(path);
+  sp_file_path_check(path);
+  if (mkdir(path, 0777) != 0) sp_file_raise_errno("dir_s_mkdir", path);
+  return 0;
 }
-sp_int sp_dir_rmdir(const char *path) {
-  return (sp_int)rmdir(path);
+sp_int sp_dir_rmdir(const char *path) {SP_GC_ROOT_STR(path);
+  sp_file_path_check(path);
+  if (rmdir(path) != 0) sp_file_raise_errno("dir_s_rmdir", path);
+  return 0;
 }
-sp_int sp_dir_chdir(const char *path) {
-  return (sp_int)chdir(path);
+sp_int sp_dir_chdir(const char *path) {SP_GC_ROOT_STR(path);
+  sp_file_path_check(path);
+  if (chdir(path) != 0) sp_file_raise_errno("chdir_path", path);
+  return 0;
+}
+/* the block form: the same switch under CRuby's label for it */
+sp_int sp_dir_chdir0(const char *path) {SP_GC_ROOT_STR(path);
+  sp_file_path_check(path);
+  if (chdir(path) != 0) sp_file_raise_errno("dir_chdir0", path);
+  return 0;
 }
 const char *sp_dir_home(void) {
   const char *h = getenv("HOME");

--- a/lib/sp_io.c
+++ b/lib/sp_io.c
@@ -97,7 +97,6 @@ sp_File *sp_io_fdopen_sock(int fd, const char *kind) {SP_GC_ROOT_STR(kind);
   return f;
 }
 
-SP_NORETURN static void sp_file_raise_errno(const char *op, const char *path);
 /* Park the calling green thread until the handle has readable data, so a
    blocking fgets/fread does not pin its worker while the peer is idle. A
    no-op when stdio already buffered data (waiting then would stall on the
@@ -1078,25 +1077,32 @@ sp_bool sp_file_symlink(const char *path) {
   return path && lstat(path, &st) == 0 && S_ISLNK(st.st_mode);
 }
 
-/* map errno to the matching Errno:: class the way sp_cold.c's File ops do */
-SP_NORETURN static void sp_file_raise_errno(const char *op, const char *path) {SP_GC_ROOT_STR(op);SP_GC_ROOT_STR(path);
-  sp_raise_cls(errno == ENOENT ? "Errno::ENOENT" :
-               errno == EACCES ? "Errno::EACCES" :
-               errno == EEXIST ? "Errno::EEXIST" :
-               errno == EPERM  ? "Errno::EPERM"  :
-               errno == EBADF  ? "Errno::EBADF"  :
-               errno == EINVAL ? "Errno::EINVAL" :
-               errno == EISDIR ? "Errno::EISDIR" :
-               errno == ENOTDIR ? "Errno::ENOTDIR" :
-               errno == EADDRINUSE ? "Errno::EADDRINUSE" :
-               errno == EADDRNOTAVAIL ? "Errno::EADDRNOTAVAIL" :
-               errno == ECONNREFUSED ? "Errno::ECONNREFUSED" :
-               errno == ECONNRESET ? "Errno::ECONNRESET" :
-               errno == EPIPE  ? "Errno::EPIPE"  :
-               errno == EAGAIN ? "Errno::EAGAIN" :
-               errno == EAFNOSUPPORT ? "Errno::EAFNOSUPPORT" :
-               errno == ENOTCONN ? "Errno::ENOTCONN" : "SystemCallError",
-               sp_sprintf("%s @ %s - %s", strerror(errno), op, path ? path : ""));
+/* map errno to the matching Errno:: class (see sp_io.h) */
+SP_NORETURN void sp_file_raise_errno(const char *op, const char *path) {SP_GC_ROOT_STR(op);SP_GC_ROOT_STR(path);
+  int e = errno;   /* read once, before the formatting can touch it */
+  sp_raise_cls(e == ENOENT ? "Errno::ENOENT" :
+               e == EACCES ? "Errno::EACCES" :
+               e == EEXIST ? "Errno::EEXIST" :
+               e == EPERM  ? "Errno::EPERM"  :
+               e == EBADF  ? "Errno::EBADF"  :
+               e == EINVAL ? "Errno::EINVAL" :
+               e == EISDIR ? "Errno::EISDIR" :
+               e == ENOTDIR ? "Errno::ENOTDIR" :
+               e == ENOTEMPTY ? "Errno::ENOTEMPTY" :
+               e == ELOOP ? "Errno::ELOOP" :
+               e == ENAMETOOLONG ? "Errno::ENAMETOOLONG" :
+               e == EROFS ? "Errno::EROFS" :
+               e == EXDEV ? "Errno::EXDEV" :
+               e == EBUSY ? "Errno::EBUSY" :
+               e == EADDRINUSE ? "Errno::EADDRINUSE" :
+               e == EADDRNOTAVAIL ? "Errno::EADDRNOTAVAIL" :
+               e == ECONNREFUSED ? "Errno::ECONNREFUSED" :
+               e == ECONNRESET ? "Errno::ECONNRESET" :
+               e == EPIPE  ? "Errno::EPIPE"  :
+               e == EAGAIN ? "Errno::EAGAIN" :
+               e == EAFNOSUPPORT ? "Errno::EAFNOSUPPORT" :
+               e == ENOTCONN ? "Errno::ENOTCONN" : "SystemCallError",
+               sp_sprintf("%s @ %s - %s", strerror(e), op, path ? path : ""));
 }
 
 sp_bool sp_file_owned(const char *path) {
@@ -1173,8 +1179,24 @@ sp_int sp_file_utime(double atime, double mtime, const char *path) {SP_GC_ROOT_S
    the old fopen probe hung File.exist? on a fresh mkfifo path (#3118). stat
    also answers true for directories, matching CRuby. */
 sp_bool sp_file_exist(const char *path) { struct stat st; return path && stat(path, &st) == 0; }
-void sp_file_delete(const char *path) { remove(path); }
-void sp_file_rename(const char *from, const char *to) { rename(from, to); }
+/* unlink(2), not remove(3): remove would take a directory too, which
+   File.delete refuses (EPERM here, EISDIR on Linux), as CRuby does. */
+void sp_file_path_check(const char *path) {
+  if (!path) sp_raise_cls("TypeError", "no implicit conversion of nil into String");
+}
+void sp_file_delete(const char *path) {SP_GC_ROOT_STR(path);
+  sp_file_path_check(path);
+  if (unlink(path) != 0) sp_file_raise_errno("apply2files", path);
+}
+void sp_file_rename(const char *from, const char *to) {SP_GC_ROOT_STR(from);SP_GC_ROOT_STR(to);
+  sp_file_path_check(from); sp_file_path_check(to);
+  if (rename(from, to) != 0) {
+    int e = errno;
+    const char *pair = sp_sprintf("(%s, %s)", from, to);
+    errno = e;
+    sp_file_raise_errno("rb_file_s_rename", pair);
+  }
+}
 
 /* --- IO instance methods that ride the underlying fd (#3038) ------------- */
 

--- a/lib/sp_io.h
+++ b/lib/sp_io.h
@@ -173,6 +173,17 @@ sp_int sp_file_utime(double atime, double mtime, const char *path);
 const char *sp_file_readlink(const char *path);  /* defined in sp_cold.c */
 void sp_file_delete(const char *path);
 void sp_file_rename(const char *from, const char *to);
+/* A filesystem call that failed raises the Errno:: class CRuby raises for the
+   errno, with CRuby's message shape "<strerror> @ <op> - <path>". op is the
+   label after the @: for the File and Dir class methods it is CRuby's own
+   entry-point name (dir_s_mkdir, apply2files, rb_file_s_rename ...), so a
+   program matching on the text reads the same words; the socket calls and
+   the older File sites (readlink, symlink, mkfifo ...) pass the syscall's
+   name. An errno with no class here raises SystemCallError. */
+SP_NORETURN void sp_file_raise_errno(const char *op, const char *path);
+/* A nil path (a NULL string at run time) is CRuby's TypeError, raised before
+   any syscall sees it; the multi-path File.delete checks every path first. */
+void sp_file_path_check(const char *path);
 
 #include <dirent.h>
 /* Dir handle (Dir.open / Dir.each_child ...): ops live in lib/sp_cold.c. */

--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -9589,6 +9589,7 @@ const char *sp_dir_pwd(void);
 sp_int sp_dir_mkdir(const char *path);
 sp_int sp_dir_rmdir(const char *path);
 sp_int sp_dir_chdir(const char *path);
+sp_int sp_dir_chdir0(const char *path);  /* the block form's label */
 const char *sp_dir_home(void);
 /* Wildcard match for a single path component: `*` (any run, no `/`),
    `?` (one char). Recursive over `*`; adequate for the common

--- a/packages/pathname/pathname.rb
+++ b/packages/pathname/pathname.rb
@@ -380,19 +380,55 @@ class Pathname
     self
   end
 
-  # rm -r. Files and symlinks are unlinked; directories are emptied first.
+  # rm -rf, as CRuby's FileUtils.rm_rf: files and symlinks are unlinked,
+  # directories are emptied first, and a path that is not there or an entry
+  # that cannot be removed is skipped -- the answer is self either way. Like
+  # find, this walks against an explicit stack rather than recursing, so a
+  # deep tree costs one rescue frame at a time, not one per level; the
+  # entries are listed parent-first and removed in reverse, which puts every
+  # child before its directory.
   def rmtree
-    if directory? && !symlink?
-      children.each { |child| child.rmtree }
-      Dir.rmdir(@path)
-    else
-      File.delete(@path)
+    stack = [self]
+    order = []
+    until stack.empty?
+      cur = stack.pop
+      order.push(cur)
+      next unless cur.directory? && !cur.symlink?
+
+      begin
+        cur.children.each { |k| stack.push(k) }
+      rescue SystemCallError
+        # a directory that cannot be listed is left as it is, like rm -rf
+      end
+    end
+    i = order.length - 1
+    while i >= 0
+      order[i].rmtree_entry
+      i -= 1
     end
     self
   end
 
+  # One entry of rmtree: a directory is emptied by then, so rmdir; anything
+  # else, a symlink to a directory included, is unlinked. A failure is
+  # skipped, as rm -rf skips it; the answer is not used. Protected, so the
+  # public surface stays CRuby's.
+  protected def rmtree_entry
+    if directory? && !symlink?
+      Dir.rmdir(@path)
+    else
+      File.delete(@path)
+    end
+  rescue SystemCallError
+    nil
+  end
+
+  # CRuby's order: the directory unlink first, the file unlink on ENOTDIR, so
+  # a missing path reports dir_s_rmdir there and here alike.
   def delete
-    directory? ? Dir.rmdir(@path) : File.delete(@path)
+    Dir.unlink(@path)
+  rescue Errno::ENOTDIR
+    File.unlink(@path)
   end
 
   def unlink

--- a/src/analyze_pass.c
+++ b/src/analyze_pass.c
@@ -5411,7 +5411,9 @@ int desugar_dir_surface(Compiler *c) {
     if (sp_streq(nm, "foreach")) { nt_node_set_str(nt, id, "name", "entries"); changed = 1; continue; }
     if (sp_streq(nm, "each_child")) { nt_node_set_str(nt, id, "name", "children"); changed = 1; continue; }
 
-    /* chdir(d) { body }: save, switch, run, restore -- the paren splice */
+    /* chdir(d) { body }: save, switch, run, restore -- the paren splice; the
+       restore sits in an ensure so a body that raises (a failing filesystem
+       call is enough now that those raise) does not leave the process in d */
     if (sp_streq(nm, "chdir") && blk >= 0 && nt_kind(nt, blk) == NK_BlockNode && an >= 1) {
       int body = nt_ref(nt, blk, "body");
       if (body < 0) continue;
@@ -5447,10 +5449,16 @@ int desugar_dir_surface(Compiler *c) {
       int cd2a = nt_new_node(nt, "ArgumentsNode");
       int rsav = nt_new_node(nt, "LocalVariableReadNode");
       int rval = nt_new_node(nt, "LocalVariableReadNode");
+      /* begin __val = (body) ensure Dir.chdir(__sav) end */
+      int beg = nt_new_node(nt, "BeginNode");
+      int bstmts = nt_new_node(nt, "StatementsNode");
+      int ens = nt_new_node(nt, "EnsureNode");
+      int estmts = nt_new_node(nt, "StatementsNode");
       int ostmts = nt_new_node(nt, "StatementsNode");
       int oparen = nt_new_node(nt, "ParenthesesNode");
       if (pwdc<0||pwdr<0||wsav<0||cd1<0||cd1r<0||cd1a<0||pstmts<0||paren<0||wval<0||
-          cd2<0||cd2r<0||cd2a<0||rsav<0||rval<0||ostmts<0||oparen<0) continue;
+          cd2<0||cd2r<0||cd2a<0||rsav<0||rval<0||beg<0||bstmts<0||ens<0||estmts<0||
+          ostmts<0||oparen<0) continue;
       nt_node_set_str(nt, pwdr, "name", "Dir");
       nt_node_set_str(nt, pwdc, "name", "pwd");
       nt_node_set_ref(nt, pwdc, "receiver", pwdr);
@@ -5460,6 +5468,7 @@ int desugar_dir_surface(Compiler *c) {
       nt_node_set_ref(nt, wsav, "value", pwdc);
       nt_node_set_str(nt, cd1r, "name", "Dir");
       nt_node_set_str(nt, cd1, "name", "chdir");
+      nt_node_set_str(nt, cd1, "chdir_label", "dir_chdir0");  /* CRuby's block-form label */
       nt_node_set_ref(nt, cd1, "receiver", cd1r);
       { int a0 = aav[0]; nt_node_set_arr(nt, cd1a, "arguments", &a0, 1); }
       nt_node_set_ref(nt, cd1, "arguments", cd1a);
@@ -5471,15 +5480,22 @@ int desugar_dir_surface(Compiler *c) {
       nt_node_set_ref(nt, wval, "value", paren);
       nt_node_set_str(nt, cd2r, "name", "Dir");
       nt_node_set_str(nt, cd2, "name", "chdir");
+      nt_node_set_str(nt, cd2, "chdir_label", "dir_chdir0");
       nt_node_set_ref(nt, cd2, "receiver", cd2r);
       nt_node_set_str(nt, rsav, "name", sav);
       { int rs = rsav; nt_node_set_arr(nt, cd2a, "arguments", &rs, 1); }
       nt_node_set_ref(nt, cd2, "arguments", cd2a);
       nt_node_set_ref(nt, cd2, "block", -1);
       nt_node_set_str(nt, rval, "name", valn);
-      { int items[4] = { wsav, cd1, wval, cd2 };
-        int all[5]; for (int k = 0; k < 4; k++) all[k] = items[k]; all[4] = rval;
-        nt_node_set_arr(nt, ostmts, "body", all, 5); }
+      { int w = wval; nt_node_set_arr(nt, bstmts, "body", &w, 1); }
+      { int r2 = cd2; nt_node_set_arr(nt, estmts, "body", &r2, 1); }
+      nt_node_set_ref(nt, ens, "statements", estmts);
+      nt_node_set_ref(nt, beg, "statements", bstmts);
+      nt_node_set_ref(nt, beg, "rescue_clause", -1);
+      nt_node_set_ref(nt, beg, "else_clause", -1);
+      nt_node_set_ref(nt, beg, "ensure_clause", ens);
+      { int all[4] = { wsav, cd1, beg, rval };
+        nt_node_set_arr(nt, ostmts, "body", all, 4); }
       nt_node_set_ref(nt, oparen, "body", ostmts);
       nt_node_set_str(nt, id, "name", "itself");
       nt_node_set_ref(nt, id, "receiver", oparen);

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -23952,10 +23952,22 @@ else {
       buf_printf(b, "; !sp_file_directory(_t%d) && sp_file_exist(_t%d); })", tfp, tfp); return;
     }
     if ((sp_streq(name, "delete") || sp_streq(name, "unlink")) && argc >= 1) {
+      if (argc == 1) {
+        buf_puts(b, "({ sp_file_delete("); emit_path_expr(c, argv[0], b);
+        buf_puts(b, "); (sp_int)1; })"); return;
+      }
+      /* several paths: every one is evaluated, rooted and checked for nil
+         before the first unlink, as CRuby converts them all first -- now
+         that a failing path raises, it must not skip a later argument's
+         effects, and a nil among them must not cost the earlier files */
+      int td = ++g_tmp;
       buf_puts(b, "({ ");
       for (int k = 0; k < argc; k++) {
-        buf_puts(b, "sp_file_delete("); emit_path_expr(c, argv[k], b); buf_puts(b, "); ");
+        buf_printf(b, "const char *_del_%d_%d = ", td, k); emit_path_expr(c, argv[k], b);
+        buf_printf(b, "; SP_GC_ROOT_STR(_del_%d_%d); ", td, k);
       }
+      for (int k = 0; k < argc; k++) buf_printf(b, "sp_file_path_check(_del_%d_%d); ", td, k);
+      for (int k = 0; k < argc; k++) buf_printf(b, "sp_file_delete(_del_%d_%d); ", td, k);
       buf_printf(b, "(sp_int)%d; })", argc); return;
     }
     if (sp_streq(name, "rename") && argc == 2) {
@@ -24229,7 +24241,12 @@ else {
         buf_printf(b, "); sp_dir_mkdir(_t%d); })", tp);
         return;
       }
-      buf_printf(b, "sp_dir_%s(", name); emit_path_expr(c, argv[0], b); buf_puts(b, ")"); return;
+      /* the block form's switch and restore, spliced in by desugar_dir_surface,
+         carry CRuby's label for that form (dir_chdir0, not chdir_path) */
+      if (sp_streq(name, "chdir") && nt_str(c->nt, id, "chdir_label"))
+        buf_puts(b, "sp_dir_chdir0(");
+      else buf_printf(b, "sp_dir_%s(", name);
+      emit_path_expr(c, argv[0], b); buf_puts(b, ")"); return;
     }
   }
 

--- a/test/syscall_errno.rb
+++ b/test/syscall_errno.rb
@@ -1,0 +1,150 @@
+# A filesystem call that fails raises the Errno exception CRuby raises, with
+# CRuby's message, instead of answering -1, 0, nil or a success count:
+# Dir.mkdir / rmdir / delete / unlink / chdir, File.delete / unlink / rename /
+# truncate, and the Pathname methods built on them. The metadata readers
+# (File.size, atime, mtime, ctime, birthtime) name CRuby's entry point in
+# their message too.
+
+require "pathname"
+
+def try(label)
+  r = yield
+  puts "#{label} => #{r.inspect}"
+rescue SystemCallError, TypeError => e
+  puts "#{label}: #{e.class}: #{e.message}"
+end
+
+def second_path(base)
+  puts "second path evaluated"
+  "#{base}/also-missing"
+end
+
+base = "/tmp/sp_syscall_errno"
+# a previous run that died midway leaves its files behind: clear them first
+Pathname.new(base).rmtree if Dir.exist?(base)
+Dir.mkdir(base)
+missing = "#{base}/missing"
+file = "#{base}/file.txt"
+File.write(file, "abc")
+sub = "#{base}/sub"
+Dir.mkdir(sub) unless Dir.exist?(sub)
+File.write("#{sub}/inner", "")
+
+puts "--- Dir"
+try("mkdir existing") { Dir.mkdir(base) }
+try("mkdir under a missing parent") { Dir.mkdir("#{missing}/child") }
+try("mkdir") { Dir.mkdir("#{base}/fresh") }
+try("rmdir") { Dir.rmdir("#{base}/fresh") }
+try("rmdir missing") { Dir.rmdir(missing) }
+try("rmdir non-empty") { Dir.rmdir(sub) }
+try("rmdir a file") { Dir.rmdir(file) }
+try("delete missing") { Dir.delete(missing) }
+try("unlink missing") { Dir.unlink(missing) }
+try("chdir missing") { Dir.chdir(missing) }
+try("chdir a file") { Dir.chdir(file) }
+
+puts "--- File"
+try("delete missing") { File.delete(missing) }
+try("unlink missing") { File.unlink(missing) }
+try("delete") { File.delete(file) }
+try("delete two, second missing") { File.write(file, "abc"); File.delete(file, missing) }
+try("deleted the first before raising") { File.exist?(file) }
+try("delete two, first missing") { File.delete(missing, second_path(base)) }
+try("delete two, nil second") { File.write(file, "abc"); File.delete(file, { "a" => "b" }["zz"]) }
+try("the first survives a nil later in the list") { File.exist?(file) }
+try("rename missing") { File.rename(missing, file) }
+try("rename into a missing directory") { File.write(file, "abc"); File.rename(file, "#{missing}/x") }
+try("rename") { File.rename(file, "#{file}.moved") }
+try("rename back") { File.rename("#{file}.moved", file) }
+try("truncate negative") { File.truncate(file, -1) }
+try("truncate missing") { File.truncate(missing, 0) }
+try("truncate") { File.truncate(file, 1) }
+try("size missing") { File.size(missing) }
+try("atime missing") { File.atime(missing) }
+try("mtime missing") { File.mtime(missing) }
+try("ctime missing") { File.ctime(missing) }
+try("birthtime missing") { File.birthtime(missing) }
+
+puts "--- errnos with a class of their own"
+try("mkdir name too long") { Dir.mkdir("#{base}/" + "a" * 300) }
+File.symlink("#{base}/loop", "#{base}/loop")
+try("chdir symlink loop") { Dir.chdir("#{base}/loop") }
+try("delete through a symlink loop") { File.delete("#{base}/loop/x") }
+File.delete("#{base}/loop")
+
+puts "--- a nil path"
+h = { "a" => "b" }
+x = h["zz"]
+try("mkdir nil") { Dir.mkdir(x) }
+try("rmdir nil") { Dir.rmdir(x) }
+try("chdir nil") { Dir.chdir(x) }
+try("delete nil") { File.delete(x) }
+try("rename nil") { File.rename(x, x) }
+try("truncate nil") { File.truncate(x, 0) }
+
+puts "--- a failing call inside Dir.chdir's block"
+here = Dir.pwd
+begin
+  Dir.chdir(base) { File.delete(missing) }
+rescue SystemCallError => e
+  puts "inside the block: #{e.class}"
+end
+puts "cwd restored: #{Dir.pwd == here}"
+try("chdir block into a missing directory") { Dir.chdir(missing) { :never } }
+r = Dir.chdir(base) { Dir.chdir(sub) { File.basename(Dir.pwd) } }
+puts "nested chdir blocks answer #{r} and restore: #{Dir.pwd == here}"
+
+puts "--- rescue shapes"
+begin
+  Dir.rmdir(missing)
+rescue Errno::ENOENT => e
+  puts "Errno::ENOENT caught: #{e.message}"
+end
+begin
+  File.delete(missing)
+rescue => e
+  puts [e.is_a?(SystemCallError), e.is_a?(StandardError), e.class].inspect
+end
+result = begin
+  Dir.mkdir(base)
+rescue Errno::EEXIST
+  :already_there
+end
+p result
+
+puts "--- Pathname"
+pn = Pathname.new(missing)
+try("rmdir") { pn.rmdir }
+try("delete") { pn.delete }
+try("unlink") { pn.unlink }
+try("rename") { pn.rename("#{base}/elsewhere") }
+try("size") { pn.size }
+try("mkdir existing") { Pathname.new(sub).mkdir }
+try("mkdir") { Pathname.new("#{base}/made").mkdir }
+try("rmdir made") { Pathname.new("#{base}/made").rmdir }
+
+puts "--- Pathname#rmtree and #mkpath"
+try("rmtree missing") { Pathname.new(missing).rmtree }
+try("rmtree answers its receiver") { pn = Pathname.new(missing); pn.rmtree.equal?(pn) }
+try("rmtree_entry is not public") { Pathname.new(missing).respond_to?(:rmtree_entry) }
+try("rmtree deep missing") { Pathname.new("#{missing}/deeper").rmtree }
+Dir.mkdir("#{base}/tree")
+Dir.mkdir("#{base}/tree/in")
+File.write("#{base}/tree/in/f", "x")
+File.write("#{base}/tree/g", "y")
+try("rmtree a tree") { [Pathname.new("#{base}/tree").rmtree.class, Dir.exist?("#{base}/tree")] }
+try("mkpath") { [Pathname.new("#{base}/a/b/c").mkpath.class, Dir.exist?("#{base}/a/b/c")] }
+try("mkpath again") { Pathname.new("#{base}/a/b/c").mkpath.class }
+try("mkpath through a file") { Pathname.new("#{file}/x").mkpath }
+try("rmtree cleans up") { [Pathname.new("#{base}/a").rmtree.class, Dir.exist?("#{base}/a")] }
+deep = "#{base}/deep"
+Dir.mkdir(deep)
+d = deep
+120.times { |i| d = "#{d}/l#{i}"; Dir.mkdir(d); File.write("#{d}/f", "x") }
+try("rmtree a tree 120 deep") { [Pathname.new(deep).rmtree.class, Dir.exist?(deep)] }
+
+File.delete("#{sub}/inner")
+Dir.rmdir(sub)
+File.delete(file)
+Dir.rmdir(base)
+p Dir.exist?(base)

--- a/test/syscall_errno.rb.expected
+++ b/test/syscall_errno.rb.expected
@@ -1,0 +1,75 @@
+--- Dir
+mkdir existing: Errno::EEXIST: File exists @ dir_s_mkdir - /tmp/sp_syscall_errno
+mkdir under a missing parent: Errno::ENOENT: No such file or directory @ dir_s_mkdir - /tmp/sp_syscall_errno/missing/child
+mkdir => 0
+rmdir => 0
+rmdir missing: Errno::ENOENT: No such file or directory @ dir_s_rmdir - /tmp/sp_syscall_errno/missing
+rmdir non-empty: Errno::ENOTEMPTY: Directory not empty @ dir_s_rmdir - /tmp/sp_syscall_errno/sub
+rmdir a file: Errno::ENOTDIR: Not a directory @ dir_s_rmdir - /tmp/sp_syscall_errno/file.txt
+delete missing: Errno::ENOENT: No such file or directory @ dir_s_rmdir - /tmp/sp_syscall_errno/missing
+unlink missing: Errno::ENOENT: No such file or directory @ dir_s_rmdir - /tmp/sp_syscall_errno/missing
+chdir missing: Errno::ENOENT: No such file or directory @ chdir_path - /tmp/sp_syscall_errno/missing
+chdir a file: Errno::ENOTDIR: Not a directory @ chdir_path - /tmp/sp_syscall_errno/file.txt
+--- File
+delete missing: Errno::ENOENT: No such file or directory @ apply2files - /tmp/sp_syscall_errno/missing
+unlink missing: Errno::ENOENT: No such file or directory @ apply2files - /tmp/sp_syscall_errno/missing
+delete => 1
+delete two, second missing: Errno::ENOENT: No such file or directory @ apply2files - /tmp/sp_syscall_errno/missing
+deleted the first before raising => false
+second path evaluated
+delete two, first missing: Errno::ENOENT: No such file or directory @ apply2files - /tmp/sp_syscall_errno/missing
+delete two, nil second: TypeError: no implicit conversion of nil into String
+the first survives a nil later in the list => true
+rename missing: Errno::ENOENT: No such file or directory @ rb_file_s_rename - (/tmp/sp_syscall_errno/missing, /tmp/sp_syscall_errno/file.txt)
+rename into a missing directory: Errno::ENOENT: No such file or directory @ rb_file_s_rename - (/tmp/sp_syscall_errno/file.txt, /tmp/sp_syscall_errno/missing/x)
+rename => 0
+rename back => 0
+truncate negative: Errno::EINVAL: Invalid argument @ rb_file_s_truncate - /tmp/sp_syscall_errno/file.txt
+truncate missing: Errno::ENOENT: No such file or directory @ rb_file_s_truncate - /tmp/sp_syscall_errno/missing
+truncate => 0
+size missing: Errno::ENOENT: No such file or directory @ rb_file_s_size - /tmp/sp_syscall_errno/missing
+atime missing: Errno::ENOENT: No such file or directory @ rb_file_s_atime - /tmp/sp_syscall_errno/missing
+mtime missing: Errno::ENOENT: No such file or directory @ rb_file_s_mtime - /tmp/sp_syscall_errno/missing
+ctime missing: Errno::ENOENT: No such file or directory @ rb_file_s_ctime - /tmp/sp_syscall_errno/missing
+birthtime missing: Errno::ENOENT: No such file or directory @ rb_file_s_birthtime - /tmp/sp_syscall_errno/missing
+--- errnos with a class of their own
+mkdir name too long: Errno::ENAMETOOLONG: File name too long @ dir_s_mkdir - /tmp/sp_syscall_errno/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+chdir symlink loop: Errno::ELOOP: Too many levels of symbolic links @ chdir_path - /tmp/sp_syscall_errno/loop
+delete through a symlink loop: Errno::ELOOP: Too many levels of symbolic links @ apply2files - /tmp/sp_syscall_errno/loop/x
+--- a nil path
+mkdir nil: TypeError: no implicit conversion of nil into String
+rmdir nil: TypeError: no implicit conversion of nil into String
+chdir nil: TypeError: no implicit conversion of nil into String
+delete nil: TypeError: no implicit conversion of nil into String
+rename nil: TypeError: no implicit conversion of nil into String
+truncate nil: TypeError: no implicit conversion of nil into String
+--- a failing call inside Dir.chdir's block
+inside the block: Errno::ENOENT
+cwd restored: true
+chdir block into a missing directory: Errno::ENOENT: No such file or directory @ dir_chdir0 - /tmp/sp_syscall_errno/missing
+nested chdir blocks answer sub and restore: true
+--- rescue shapes
+Errno::ENOENT caught: No such file or directory @ dir_s_rmdir - /tmp/sp_syscall_errno/missing
+[true, true, Errno::ENOENT]
+:already_there
+--- Pathname
+rmdir: Errno::ENOENT: No such file or directory @ dir_s_rmdir - /tmp/sp_syscall_errno/missing
+delete: Errno::ENOENT: No such file or directory @ dir_s_rmdir - /tmp/sp_syscall_errno/missing
+unlink: Errno::ENOENT: No such file or directory @ dir_s_rmdir - /tmp/sp_syscall_errno/missing
+rename: Errno::ENOENT: No such file or directory @ rb_file_s_rename - (/tmp/sp_syscall_errno/missing, /tmp/sp_syscall_errno/elsewhere)
+size: Errno::ENOENT: No such file or directory @ rb_file_s_size - /tmp/sp_syscall_errno/missing
+mkdir existing: Errno::EEXIST: File exists @ dir_s_mkdir - /tmp/sp_syscall_errno/sub
+mkdir => 0
+rmdir made => 0
+--- Pathname#rmtree and #mkpath
+rmtree missing => #<Pathname:/tmp/sp_syscall_errno/missing>
+rmtree answers its receiver => true
+rmtree_entry is not public => false
+rmtree deep missing => #<Pathname:/tmp/sp_syscall_errno/missing/deeper>
+rmtree a tree => [Pathname, false]
+mkpath => [Pathname, true]
+mkpath again => Pathname
+mkpath through a file: Errno::EEXIST: File exists @ dir_s_mkdir - /tmp/sp_syscall_errno/file.txt
+rmtree cleans up => [Pathname, false]
+rmtree a tree 120 deep => [Pathname, false]
+false


### PR DESCRIPTION
## Why

When a filesystem call fails, Ruby raises: `Dir.mkdir` on a path that exists raises Errno::EEXIST, `File.delete` on a missing file Errno::ENOENT, `File.rename` with a missing source Errno::ENOENT, and so on, each carrying the message `<strerror> @ <entry point> - <path>`. In Spinel `Dir.mkdir`, `Dir.rmdir` (and `Dir.delete`/`Dir.unlink`) and `Dir.chdir` answered -1 when the call failed, `File.delete` and `File.unlink` answered the number of arguments, and `File.rename` answered 0, whether or not anything had happened. A program deleting a file it did not have, renaming one that was not there or creating a directory that already existed ran on as if it had succeeded, and a `rescue Errno::ENOENT` around any of them never ran. Pathname's `mkdir`, `rmdir`, `delete`, `unlink` and `rename` are built on those calls and inherited the same silence.

Concretely: the wrappers in lib/sp_cold.c and lib/sp_io.c returned the raw syscall result (`mkdir`, `rmdir`, `chdir`) or discarded it (`remove`, `rename`). lib/sp_io.c already had the errno-to-Errno mapper the socket calls use, `sp_file_raise_errno`, static to that file. `File.truncate`, `File.size` and the four time readers already raised, but only ENOENT (a negative truncate length reported "No such file or directory" where CRuby says Errno::EINVAL "Invalid argument"), and with labels of their own ("@ File.size -") where CRuby names its entry point ("@ rb_file_s_size -").

## What

Each wrapper checks its syscall and raises through `sp_file_raise_errno`, which becomes the shared entry point (declared in sp_io.h). The labels are CRuby's: `dir_s_mkdir`, `dir_s_rmdir` (for `Dir.rmdir`, `Dir.delete` and `Dir.unlink`), `chdir_path`, `apply2files` (for `File.delete` and `File.unlink`), `rb_file_s_rename` with its `(from, to)` pair, `rb_file_s_truncate`, `rb_file_s_size`, `rb_file_s_atime`, `rb_file_s_mtime`, `rb_file_s_ctime`, `rb_file_s_birthtime`. On success the answers are what they were: 0 from `mkdir`, `rmdir`, `chdir`, `rename` and `truncate`, the count from `delete`; a multi-path `File.delete` still deletes in order and raises at the first failure.

The mapper gains the classes a program can reach from these calls and could not name before: Errno::ENOTEMPTY (a non-empty `rmdir`), ELOOP (a symlink cycle), ENAMETOOLONG, EROFS (`Dir.mkdir` on a sealed system volume), EXDEV (a rename across volumes) and EBUSY; it reads `errno` once at entry, before the message formatting. `File.delete` moves from `remove(3)`, which would also remove an empty directory, to `unlink(2)`, so a directory is refused (Errno::EPERM here, EISDIR on Linux) as CRuby refuses it. A nil path that reaches any of these wrappers at run time (a Hash miss, say) raises CRuby's TypeError, `no implicit conversion of nil into String`, through one helper, `sp_file_path_check`, the answer `File.size` and the time readers already gave, instead of an Errno with a blank path; `File.truncate` had that hole before this change and closes it on the same line.

Two things had been safe only because these calls never raised. `File.delete` with several paths now evaluates every path, roots it and checks it for nil before the first unlink, as CRuby converts them all first, so a failing early path no longer skips a later argument's side effects and a nil later in the list no longer costs the earlier files; that is the one codegen change in the emitter for `File.delete`. And the block form of `Dir.chdir`, which the analyzer splices into save, switch, run, restore, now runs the restore in an `ensure`, so a body that raises, which a failing `File.delete` inside the block is now enough for, does not leave the process in the directory. An `ensure` holds one of the runtime's exception frames while the block runs, as any `ensure` does; the cost is named under Left alone.

On Linux, `File.birthtime` on a path that does not exist raised NotImplementedError: the `statx` arm folded a failed call and a filesystem without a birth time into one condition. A failed call is now the path's Errno (Errno::ENOENT for a missing file, as CRuby's `rb_file_s_birthtime`); NotImplementedError stays for a filesystem that answers without one.

`Pathname#delete` takes CRuby's order, the directory unlink first and the file unlink on Errno::ENOTDIR, so a missing path reports `dir_s_rmdir` there and here alike; `mkdir`, `rmdir`, `rename` and `size` ride the same wrappers unchanged, and `mkpath` now raises Errno::EEXIST when an ancestor exists as a file, as CRuby's does. `Pathname#rmtree` is CRuby's `FileUtils.rm_rf`: it must swallow what the calls under it now raise, so a missing path and an entry it cannot remove are skipped and the answer is self either way. It walks against an explicit stack, as the package's `find` already does, listing parent-first and removing in reverse so every child goes before its directory, with one rescue frame live at a time whatever the depth: a rescue on a recursion would have cost a frame per level, and a tree 62 deep would have hit the runtime's ceiling of 64 halfway down.

## How

The mapper already existed and already had the right shape; the change is to call it, and to give it the arms these calls can reach. No C caller of the changed wrappers exists outside the generated code (checked lib/ and packages/); the two Ruby package callers are pathname.rb and tmpdir.rb, whose `Dir.delete` is guarded by `exist?` and `empty?`. The open, write and readlink sites in lib/sp_cold.c keep the errno chains they had: two of them need ENOSPC and ENXIO, which the mapper does not carry, and none of them is one of this rule's calls. The emitted expressions already used the wrappers' 0 as the answer, so codegen changes only where the raise itself changes an ordering: the multi-path `File.delete` and the block-form `Dir.chdir` above.

## Validation

`make gate`: 3490 tests, 61 benchmarks, the optcarrot checksum (59662), ext-cruby, rbs-seed, rubyspec 6/6 and the property checks all pass. Compatibility corpus (a differential corpus of ~2,100 minimized programs that behave differently under CRuby 4.0.6 and Spinel, the same corpus behind #3999/#4003/#4029): 847 to 862 of 2131, 15 gained, 0 lost. Ten are the programs of this family (the Dir and File calls above and the five Pathname ones); a further four call `File.size`, `File.mtime`, `File.atime` or `File.birthtime` on a path that does not exist in the corpus's working directory and matched on the label alone; the fifteenth calls `Pathname#delete` on a directory and now reports CRuby's Errno::EINVAL from `rmdir(".")` instead of an error code.

Generated-C sweep over the suite and benchmarks against 3041feb9 with the `#line` paths normalised and the temporaries renumbered: 3496 same, 9 changed, 0 failed of 3505. They are the new test; the three suite programs that load Pathname (implicit_conversion_protocol, require_value, poly_string_methods), where `Pathname#delete`'s body changes (a rescue frame around `Dir.unlink` where a `directory?` branch was), a `Pathname#unlink` wrapper that master folded away is emitted as a separate, uncalled function because the rescue frame in `delete` stops it inlining, and the symbol table gains one name; `rmtree` and `rmtree_entry` are not called by any of them and are not emitted; four programs with a two-path `File.delete` (dir_handle_objects, file_surface_extended, io_class_methods_surface, io_instance_read_surface), each gaining the hoisted, rooted and checked paths on that one line; and dir_full_surface, whose `Dir.chdir` block gains the `ensure` frame. optcarrot's generated C is identical, and its checksum unchanged.

New test `test/syscall_errno.rb`, expectation generated by Ruby 4.0.6, 0.06 s compiled (it builds and removes a tree 120 directories deep): the class and message for `mkdir` (existing, under a missing parent, a name too long), `rmdir` (missing, non-empty, a file), `delete`, `unlink` and `chdir` (missing, a file, and for `chdir` a symlink cycle) on Dir; `delete`, `unlink`, `rename` (missing source, missing destination directory) and `truncate` (negative, missing) on File; the entry-point labels of `size`, `atime`, `mtime`, `ctime` and `birthtime`; the success answers; that a two-path `delete` removes the first before raising on the second, evaluates the second path's expression before raising on the first, and leaves the first alone when the second is nil; the TypeError for a nil path at each of the six calls; the working directory restored after a `File.delete` fails inside a `Dir.chdir` block, and after two nested blocks answer; the rescue shapes (`Errno::ENOENT`, `SystemCallError`, `StandardError`, a rescued `mkdir` on an existing directory); and the Pathname methods, `rmtree` on a missing path, a deep missing path, a real tree and a tree 120 directories deep, answering its receiver, with `rmtree_entry` not public, and `mkpath` fresh, repeated and through a file. Every line of it is platform-independent by construction: no EPERM/EISDIR line, and the `birthtime` line is CRuby's ENOENT on Linux and macOS alike. Compiled on 3041feb9 it prints 71 lines, and a line diff against the 74-line expectation keeps 31 of them. Clean under `SPINEL_GC_STRESS=1` and under ASAN and UBSAN, plain and stressed. We could not run the Linux build here; the `statx` arm is by reading.

Checked by hand against CRuby and not pinned: `Dir.chdir(missing) { }` raises ENOENT and leaves the working directory alone; `File.delete` on a directory raises EPERM; `File.rename` over an existing file; deleting a symlink to a directory removes the link and keeps the directory; `File.truncate` on a directory raises EISDIR; `rescue SystemCallError => e` sees `Errno::ENOENT`; ELOOP and ENAMETOOLONG are pinned by the test; EROFS, EXDEV and EBUSY need a sealed volume, a second volume or a mount point and are not.

## Left alone, on purpose

The block form of `Dir.chdir` goes through the same wrapper, so a missing directory reports `chdir_path` where CRuby's message says `dir_chdir0`, and it still yields nil for the block parameter, as on master. `File.delete` with no arguments answers 0 in CRuby and does not compile here (the emitter wants at least one path); an arity edge for its own change. `Dir.mkdir(path, mode)` evaluates the mode and discards it (`0700` leaves a `0755` directory), as on master. The older File sites keep the labels they had: `File.readlink`, `File.symlink` and `File.mkfifo` say `readlink`, `symlink` and `mkfifo` where CRuby says `rb_readlink`, `rb_file_s_symlink` and `rb_file_s_mkfifo`. CRuby cuts the `rb_file_s_rename` pair message at about a kilobyte; this one prints the whole pair. `SystemCallError#errno` and `Errno::ENOENT::Errno` are not provided, `Errno::ENOENT === e` and `case e when Errno::ENOENT` raise NoMethodError, and `SystemCallError` as a value does not compile, all as on master: the Errno constants are not class objects here, and `rescue Errno::ENOENT` is the shape that works. `Pathname#delete` on a regular file now costs a failed `rmdir(2)` and a rescue frame it did not pay before. The `ensure` in a `Dir.chdir` block holds one exception frame, so 64 `Dir.chdir` blocks nested inside one another reach the runtime's frame ceiling, where master, which restored nothing on a raise, ran on; that ceiling is the same one any 64 nested `ensure` or `rescue` bodies reach; it aborts the program rather than raising, and lifting it is the runtime's business. `Pathname#truncate` is not provided, as on master. `rmtree` lists the whole tree before it removes anything, so its memory is linear in the tree, about 220 bytes an entry, where master's recursion streamed; `rmtree_entry`, the one-entry step it calls, is a protected method CRuby's Pathname does not have, so `respond_to?` says no and `instance_methods` lists it as protected. `Dir.children` and `Dir.entries` report Errno::ENOENT for every failure to open the directory, EACCES included, as on master.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - File and directory operations now report more accurate, platform-aligned `Errno` exceptions for failures.
  - Invalid or nil paths are detected consistently before filesystem operations.
  - `Dir.chdir` blocks now reliably restore the previous working directory, including when errors occur.
  - Multi-path deletion evaluates and validates all paths consistently before deleting files.
  - File deletion no longer removes directories unintentionally.
  - `Pathname#rmtree` handles nested trees more reliably, including listing and removal failures.
  - `Pathname#delete` now correctly distinguishes directories from files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->