### PR TITLE
Kernel#Integer and Kernel#Float convert a user object through its own methods, the way CRuby does

### DIFF
--- a/lib/sp_gc.c
+++ b/lib/sp_gc.c
@@ -62,6 +62,7 @@ const char *(*sp_obj_to_s_fn)(int cls_id, void *p) = NULL;
 sp_int (*sp_obj_to_int_fn)(int cls_id, void *p, int *ok) = NULL;
 const char *(*sp_obj_to_str_fn)(int cls_id, void *p) = NULL;
 const char *(*sp_obj_to_path_fn)(int cls_id, void *p) = NULL;
+int (*sp_obj_conv_fn)(int cls_id, void *p, int which, sp_RbVal *out) = NULL;
 const char *(*sp_obj_cls_name_fn)(int cls_id) = NULL;
 sp_marshal_vt sp_marshal_v = {0};   /* filled by the generated TU (sp_re_init) */
 

--- a/lib/sp_gc.h
+++ b/lib/sp_gc.h
@@ -376,6 +376,12 @@ extern const char *(*sp_obj_to_str_fn)(int cls_id, void *p);
 /* #to_path, which File/Dir/IO's path slots ask before #to_str (CRuby's
    rb_get_path); NULL when the class defines none. */
 extern const char *(*sp_obj_to_path_fn)(int cls_id, void *p);
+/* Kernel#Integer / Kernel#Float on a boxed user object: the class's #to_int,
+   #to_i, #to_f or #to_str (`which`, in that order), WHATEVER the method's
+   static type -- CRuby calls it and judges the answer -- boxed into *out.
+   Answers 1 when the class has the method, 0 when it does not; with a NULL
+   `out` it only answers that, calling nothing. */
+extern int (*sp_obj_conv_fn)(int cls_id, void *p, int which, sp_RbVal *out);
 /* Ruby class name for a user cls_id (the generated id->name table), so a
    runtime TU can word a TypeError the way CRuby does. */
 extern const char *(*sp_obj_cls_name_fn)(int cls_id);

--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -1772,6 +1772,8 @@ static const char *sp_class_to_s(sp_Class c);
 #endif
 static const char *sp_poly_class_name(sp_RbVal v);  /* fwd: user-object to_s default */
 static const char *sp_convert_src_name(sp_RbVal v);  /* fwd: nil/true/false spell themselves */
+static sp_int sp_poly_Integer_ex(sp_RbVal v, sp_int base, int raise);  /* fwd: Kernel#Integer / #Float on a user object */
+static sp_float sp_poly_Float_ex(sp_RbVal v, int raise);
 static inline int sp_poly_is_hash_kind(int cls_id);
 static inline const char *sp_poly_inspect(sp_RbVal v);
 static const char *sp_PolyArray_inspect(sp_PolyArray *a);  /* fwd: Array#to_s == inspect */
@@ -2700,13 +2702,22 @@ static const char *sp_convert_src_name(sp_RbVal v) {
    unparseable String, matching CRuby's conversion methods. */
 static sp_int sp_poly_Integer(sp_RbVal v) {
   if (v.tag == SP_TAG_INT) return v.v.i;
-  if (v.tag == SP_TAG_BIGINT) return (sp_int)sp_bigint_to_int((sp_Bigint *)v.v.p);
+  if (v.tag == SP_TAG_BIGINT) {
+    /* the Integer slot cannot carry a Bignum: the value when it fits, a
+       loud RangeError otherwise, never a number cut to 64 bits */
+    sp_Bigint *bg = (sp_Bigint *)v.v.p;
+    sp_int n = (sp_int)sp_bigint_to_int(bg);
+    if (sp_bigint_bit_length(bg) <= 63 && n != SP_INT_NIL) return n;
+    sp_raise_cls("RangeError", "bignum too big to convert into 'long'");
+  }
   if (v.tag == SP_TAG_FLT) {
-    if (isnan(v.v.f) || isinf(v.v.f))
-      sp_raise_cls("FloatDomainError", sp_sprintf("%g", v.v.f));
+    if (!isfinite(v.v.f))
+      sp_raise_cls("FloatDomainError", isnan(v.v.f) ? "NaN" : v.v.f > 0 ? "Infinity" : "-Infinity");
     return (sp_int)v.v.f;
   }
   if (v.tag == SP_TAG_STR) return (sp_int)sp_str_to_i_strict(v.v.s ? v.v.s : sp_str_empty);
+  /* a user object converts through its own #to_int / #to_str / #to_i */
+  if (sp_poly_is_user_obj(v)) return sp_poly_Integer_ex(v, 0, 1);
   sp_raise_cls("TypeError", sp_sprintf("can't convert %s into Integer", sp_convert_src_name(v)));
   return 0;
 }
@@ -2718,6 +2729,8 @@ static sp_float sp_poly_Float(sp_RbVal v) {
      without an arm it reached the raise below as "can't convert Rational" */
   if (sp_poly_is_rational(v) || sp_poly_is_brat(v)) return sp_poly_to_f(v);
   if (v.tag == SP_TAG_STR) return sp_str_to_f_strict(v.v.s ? v.v.s : sp_str_empty);
+  /* a user object converts through its own #to_f */
+  if (sp_poly_is_user_obj(v)) return sp_poly_Float_ex(v, 1);
   sp_raise_cls("TypeError", sp_sprintf("can't convert %s into Float", sp_convert_src_name(v)));
   return 0.0;
 }
@@ -10696,6 +10709,188 @@ static int sp_at_exit_run(int status) {
   }
   return st;
 }
+/* ---- Kernel#Integer / Kernel#Float on a user object ----
+   CRuby's rb_convert_to_integer / rb_convert_to_float for an object of a
+   user class: its #to_int, #to_str and #to_i (Integer) or its #to_f
+   (Float), reached through the generated bridge (sp_obj_conv_fn) whatever
+   each method's static type, every answer judged here. One path for a
+   statically typed object and for one read out of a container, for the
+   strict and the `exception: false` forms; the typed entry points at the
+   end unbox for the slot the call site has. */
+enum { SP_CONV_TO_INT, SP_CONV_TO_I, SP_CONV_TO_F, SP_CONV_TO_STR };
+
+/* rb_protect: run fn(ctx) under a frame of its own and answer 1 when it
+   did not return -- the at_exit drain's frame shape. A raise lands here with
+   the exception discarded; so does a `throw`, a `break` or a proc `return`
+   started inside fn, which CRuby's rb_protect catches the same way and
+   rb_convert_to_integer discards. Their initiators cut the catch and break
+   stacks down to the target and leave the unwind in flight for the ensures
+   on the way, so the landing puts every handler stack back to what it was
+   when the frame was armed and takes the unwind out of flight; otherwise
+   the next ensure epilogue would resume it into a frame that has returned.
+   Kernel#Integer probes #to_int this way, and the `exception: false` forms
+   probe every conversion this way. */
+static int sp_exc_protect(void (*fn)(void *), void *ctx) {
+  int catch_top = sp_catch_top, brk_top = sp_brk_top;
+  sp_proc_home *ret_head = sp_proc_ret_head;
+  sp_exc_check_depth();
+  sp_exc_rootmark[sp_exc_top] = sp_gc_nroots; sp_rescue_mark[sp_exc_top] = sp_rescue_sp;
+  sp_exc_msg[sp_exc_top] = 0; sp_exc_obj[sp_exc_top] = 0; sp_exc_top++;
+  if (setjmp(sp_exc_stack[sp_exc_top - 1]) == 0) { fn(ctx); sp_exc_top--; return 0; }
+  sp_exc_top--;
+  sp_gc_nroots = sp_exc_rootmark[sp_exc_top]; sp_rescue_sp = sp_rescue_mark[sp_exc_top];
+  sp_catch_top = catch_top; sp_brk_top = brk_top; sp_proc_ret_head = ret_head;
+  sp_unwind_kind = SP_UNWIND_NONE;
+  /* a `raise x, cause: expr` stages its cause before evaluating expr; an
+     unwind out of expr that lands here must not leave it staged for the next
+     raise */
+  sp_explicit_cause = NULL; sp_explicit_cause_set = 0;
+  return 1;
+}
+typedef struct { sp_RbVal obj; int which; int had; sp_RbVal ans; } sp_obj_conv_probe;
+static void sp_obj_conv_probe_run(void *p) {
+  sp_obj_conv_probe *c = (sp_obj_conv_probe *)p;
+  c->had = sp_obj_conv_fn((int)c->obj.cls_id, c->obj.v.p, c->which, &c->ans);
+}
+/* One conversion method of the object: 0 when its class has none (asked of
+   the bridge first, so no frame is armed for nothing), 1 with the boxed
+   answer in *ans, -1 when the call did not return (only under `protect`;
+   *ans is left alone). The caller roots the object across the call and the
+   answer after it. */
+static int sp_obj_conv(sp_RbVal obj, int which, int protect, sp_RbVal *ans) {
+  sp_obj_conv_probe c;
+  if (!sp_obj_conv_fn || !sp_obj_conv_fn((int)obj.cls_id, obj.v.p, which, NULL)) return 0;
+  c.obj = obj; c.which = which; c.had = 0; c.ans = sp_box_nil();
+  if (!protect) sp_obj_conv_probe_run(&c);
+  else if (sp_exc_protect(sp_obj_conv_probe_run, &c)) return -1;
+  *ans = c.ans;
+  return c.had;
+}
+static int sp_obj_conv_is_integer(sp_RbVal a) { return a.tag == SP_TAG_INT || a.tag == SP_TAG_BIGINT; }
+/* The bytes of a String answer, or NULL for an answer of any other kind. */
+static const char *sp_obj_conv_str_of(sp_RbVal a) {
+  if (a.tag == SP_TAG_STR) return a.v.s ? a.v.s : sp_str_empty;
+  if (sp_poly_is_strbuf(a)) return sp_String_cstr((sp_String *)a.v.p);
+  return NULL;
+}
+/* Integer("...") on a String: strict, or nil-answering for the
+   `exception: false` form. `base` 0 is the bare form. */
+static sp_RbVal sp_obj_conv_str_Integer(const char *s, sp_int base, int raise) {
+  sp_int r;
+  if (raise) return sp_box_int(base ? sp_str_to_i_strict_base(s, base) : sp_str_to_i_strict(s));
+  r = sp_str_to_i_lenient_base(s, base);
+  return r == SP_INT_NIL ? sp_box_nil() : sp_box_int(r);
+}
+static sp_RbVal sp_obj_Integer_val(sp_RbVal v, sp_int base, int raise) {
+  sp_RbVal a = sp_box_nil();
+  const char *cn, *s;
+  int had;
+  SP_GC_ROOT_RBVAL(v); SP_GC_ROOT_RBVAL(a);
+  cn = sp_poly_class_name(v);
+  if (!base) {
+    /* #to_int, protected: an Integer answer wins; nil, another kind, or a
+       raise inside it are all swallowed and the search goes on */
+    had = sp_obj_conv(v, SP_CONV_TO_INT, 1, &a);
+    if (had > 0 && sp_obj_conv_is_integer(a)) return a;
+  }
+  /* #to_str, bare: a String parses as Integer("...") does, with the base if
+     one was given, and an answer of any other kind is the conversion's own
+     TypeError, in the `exception: false` form too */
+  had = sp_obj_conv(v, SP_CONV_TO_STR, 0, &a);
+  if (had > 0 && (s = sp_obj_conv_str_of(a)) != NULL) return sp_obj_conv_str_Integer(s, base, raise);
+  if (had > 0 && a.tag != SP_TAG_NIL)
+    sp_raise_cls("TypeError", sp_sprintf("can't convert %s to String (%s#to_str gives %s)",
+                                         cn, cn, sp_poly_class_name(a)));
+  if (base) {
+    /* with a base only a String converts */
+    if (raise) sp_raise_cls("ArgumentError", "base specified for non string value");
+    return sp_box_nil();
+  }
+  /* #to_i: bare in the strict form, so a raise inside it propagates;
+     protected in the `exception: false` form, which answers nil for every
+     failure */
+  had = sp_obj_conv(v, SP_CONV_TO_I, !raise, &a);
+  if (had > 0 && sp_obj_conv_is_integer(a)) return a;
+  if (!raise) return sp_box_nil();
+  if (had == 0) sp_raise_cls("TypeError", sp_sprintf("can't convert %s into Integer", cn));
+  sp_raise_cls("TypeError", sp_sprintf("can't convert %s to Integer (%s#to_i gives %s)",
+                                       cn, cn, sp_poly_class_name(a)));
+  return sp_box_nil();
+}
+static sp_RbVal sp_obj_Float_val(sp_RbVal v, int raise) {
+  sp_RbVal a = sp_box_nil();
+  const char *cn;
+  int had;
+  SP_GC_ROOT_RBVAL(v); SP_GC_ROOT_RBVAL(a);
+  cn = sp_poly_class_name(v);
+  /* #to_f alone (never #to_str, never #to_int): bare in the strict form,
+     protected and nil-answering under `exception: false` */
+  had = sp_obj_conv(v, SP_CONV_TO_F, !raise, &a);
+  if (had > 0 && a.tag == SP_TAG_FLT) return a;
+  if (!raise) return sp_box_nil();
+  if (had == 0) sp_raise_cls("TypeError", sp_sprintf("can't convert %s into Float", cn));
+  sp_raise_cls("TypeError", sp_sprintf("can't convert %s to Float (%s#to_f gives %s)",
+                                       cn, cn, sp_poly_class_name(a)));
+  return sp_box_nil();
+}
+/* Kernel#Integer's answer, boxed: a user object through its conversions; a
+   plain value through the strict arms (sp_poly_Integer), or, under
+   `exception: false`, nil for everything those arms raise for. */
+static sp_RbVal sp_kernel_Integer_val(sp_RbVal v, sp_int base, int raise) {
+  const char *s;
+  if (sp_poly_is_user_obj(v)) return sp_obj_Integer_val(v, base, raise);
+  /* an Integer or a Bignum is its own answer in either form: through the
+     strict arm below a Bignum would be cut to 64 bits before the slot's own
+     check could refuse it */
+  if (!base && (v.tag == SP_TAG_INT || v.tag == SP_TAG_BIGINT)) return v;
+  if (raise && !base) return sp_box_int(sp_poly_Integer(v));
+  /* with a base only a String converts (a plain one or a shared handle) */
+  if (base) {
+    if ((s = sp_obj_conv_str_of(v)) != NULL) return sp_obj_conv_str_Integer(s, base, raise);
+    if (raise) sp_raise_cls("ArgumentError", "base specified for non string value");
+    return sp_box_nil();
+  }
+  if (v.tag == SP_TAG_INT || v.tag == SP_TAG_BIGINT) return v;
+  if (v.tag == SP_TAG_FLT) return isnan(v.v.f) || isinf(v.v.f) ? sp_box_nil() : sp_box_int((sp_int)v.v.f);
+  if (v.tag == SP_TAG_STR) return sp_obj_conv_str_Integer(v.v.s ? v.v.s : sp_str_empty, 0, 0);
+  return sp_box_nil();
+}
+/* The entry points the Kernel#Integer / Kernel#Float emits call, one per
+   slot kind: the Integer slot, the Bignum slot the analysis types a call as
+   when the object's #to_int or #to_i answers one (or answers a boxed value
+   that may be one), and the Float slot. An Integer slot cannot carry a
+   Bignum: the one a boxed object's conversion answers is the value when it
+   fits, and a loud RangeError otherwise (nil under `exception: false`) --
+   never a truncated number in silence. */
+static sp_int sp_poly_Integer_ex(sp_RbVal v, sp_int base, int raise) {
+  sp_RbVal r = sp_kernel_Integer_val(v, base, raise);
+  if (r.tag == SP_TAG_NIL) return SP_INT_NIL;
+  if (r.tag == SP_TAG_BIGINT) {
+    sp_Bigint *bg = (sp_Bigint *)r.v.p;
+    sp_int n = (sp_int)sp_bigint_to_int(bg);
+    if (sp_bigint_bit_length(bg) <= 63 && n != SP_INT_NIL) return n;
+    if (raise) sp_raise_cls("RangeError", "bignum too big to convert into 'long'");
+    return SP_INT_NIL;
+  }
+  return sp_poly_to_i(r);
+}
+static sp_Bigint *sp_poly_Integer_big(sp_RbVal v, sp_int base, int raise) {
+  sp_RbVal r = sp_kernel_Integer_val(v, base, raise);
+  return r.tag == SP_TAG_NIL ? NULL : sp_poly_as_bigint(r);
+}
+static sp_float sp_poly_Float_ex(sp_RbVal v, int raise) {
+  if (sp_poly_is_user_obj(v)) {
+    sp_RbVal r = sp_obj_Float_val(v, raise);
+    return r.tag == SP_TAG_NIL ? sp_float_nil() : r.v.f;
+  }
+  if (raise) return sp_poly_Float(v);
+  if (v.tag == SP_TAG_FLT) return v.v.f;
+  if (v.tag == SP_TAG_INT) return (sp_float)v.v.i;
+  if (v.tag == SP_TAG_BIGINT) return sp_poly_to_f(v);
+  if (v.tag == SP_TAG_STR) return sp_str_to_f_lenient(v.v.s ? v.v.s : sp_str_empty);
+  return sp_float_nil();
+}
+
 
 /* ---- Enumerable on a builtin Array receiver, driven by a real sp_Proc ----
 

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -371,18 +371,22 @@ void compute_reachable(Compiler *c) {
       while (qhead < qtail) { int s = queue[qhead++]; for (int ni = 0; ni < sc_n[s]; ni++) MARK_NAME(scope_calls[s][ni]); }
   }
 
-  /* Kernel#Integer / Kernel#Float convert their argument through its #to_int /
-     #to_f, which the conversion call site names nowhere in the AST. */
+  /* Kernel#Integer converts its argument through its #to_int, then #to_str,
+     then #to_i, and Kernel#Float through its #to_f -- calls the conversion
+     site names nowhere in the AST. The receiver forms (obj.send(:Integer, x)
+     desugared, Kernel.Float(x)) convert the same way, so any call by the name
+     counts, and the program is marked as one that converts at all. */
   {
     int has_kint = 0, has_kflt = 0;
     for (int id = 0; id < c->nt->count; id++) {
-      if (nt_kind(c->nt, id) != NK_CallNode || nt_ref(c->nt, id, "receiver") >= 0) continue;
+      if (nt_kind(c->nt, id) != NK_CallNode) continue;
       const char *nm = nt_str(c->nt, id, "name");
       if (!nm) continue;
       if (sp_streq(nm, "Integer")) has_kint = 1;
       else if (sp_streq(nm, "Float")) has_kflt = 1;
     }
-    if (has_kint) MARK_NAME("to_int");
+    c->uses_kconv = has_kint || has_kflt;
+    if (has_kint) { MARK_NAME("to_int"); MARK_NAME("to_str"); MARK_NAME("to_i"); }
     if (has_kflt) MARK_NAME("to_f");
     if (has_kint || has_kflt)
       while (qhead < qtail) { int s = queue[qhead++]; for (int ni = 0; ni < sc_n[s]; ni++) MARK_NAME(scope_calls[s][ni]); }

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -1025,6 +1025,48 @@ TyKind infer_call(Compiler *c, int id) {
   return t;
 }
 
+/* The call's trailing keyword hash says `exception: false` (the literal:
+   the form that asks for nil instead of a raise). */
+static int kconv_noraise_kw(Compiler *c, int argc, const int *argv) {
+  if (argc < 1) return 0;
+  int kw = argv[argc - 1];
+  const char *kt = nt_type(c->nt, kw);
+  if (!kt || !sp_streq(kt, "KeywordHashNode")) return 0;
+  int en = 0; const int *el = nt_arr(c->nt, kw, "elements", &en);
+  for (int e = 0; e < en; e++) {
+    int k = nt_ref(c->nt, el[e], "key"), v = nt_ref(c->nt, el[e], "value");
+    const char *kn = (k >= 0 && nt_type(c->nt, k) && sp_streq(nt_type(c->nt, k), "SymbolNode"))
+                     ? nt_str(c->nt, k, "value") : NULL;
+    const char *vt = v >= 0 ? nt_type(c->nt, v) : NULL;
+    if (kn && sp_streq(kn, "exception") && vt && sp_streq(vt, "FalseNode")) return 1;
+  }
+  return 0;
+}
+/* Kernel#Integer's static kind. Integer, unless the argument is a user
+   object whose #to_int or #to_i is typed as answering a Bignum: then the
+   answer is carried, not truncated, in a Bignum slot for the strict form
+   (which never answers nil; a Bignum slot holds the small values too) and
+   in a boxed slot for the `exception: false` form, whose nil a Bignum slot
+   cannot hold. A method whose answer the analysis cannot pin keeps the
+   Integer slot in the strict form, where a Bignum answer is a loud
+   RangeError at run time: typing it as a Bignum would refuse to build every
+   site that needs an Integer, a Range bound for one. The `exception: false`
+   form of such a call is boxed already, so it carries the answer. */
+static TyKind kconv_integer_kind(Compiler *c, int arg, int noraise) {
+  static const char *const names[] = { "to_int", "to_i" };
+  TyKind at = infer_type(c, arg);
+  if (!ty_is_object(at)) return TY_INT;
+  for (int k = 0; k < 2; k++) {
+    int mi = comp_method_in_chain(c, ty_object_class(at), names[k], NULL);
+    /* the same admission as conv_bridge_callee's: a method with parameters
+       or one that yields has no bridge row, so it must not type the slot */
+    if (mi < 0 || c->scopes[mi].nparams != 0 || c->scopes[mi].yields) continue;
+    if (c->scopes[mi].ret == TY_BIGINT) return noraise ? TY_POLY : TY_BIGINT;
+    if (c->scopes[mi].ret == TY_POLY && noraise) return TY_POLY;
+  }
+  return TY_INT;
+}
+
 static TyKind infer_call_inner(Compiler *c, int id) {
 
   /* a yielder push (`y << v` inside an Enumerator.new generator) lowers to a
@@ -3707,7 +3749,8 @@ else {
                 ((krt == TY_NIL || krt == TY_POLY || krt == TY_UNKNOWN) &&
                  comp_method_index(c, name) < 0);
     if (kdisp) {
-      if (sp_streq(name, "Integer") && (kw_argc == 1 || kw_argc == 2)) return TY_INT;
+      if (sp_streq(name, "Integer") && (kw_argc == 1 || kw_argc == 2))
+        return kconv_integer_kind(c, argv[0], kw_argc < argc && kconv_noraise_kw(c, argc, argv));
       if (kw_argc == 1) {
         if (sp_streq(name, "Float"))    return TY_FLOAT;
         if (sp_streq(name, "String"))   return TY_STRING;
@@ -3736,7 +3779,8 @@ else {
     if (mi < 0) mi = comp_included_method_index(c, name);
     if (mi >= 0) return method_call_ret(c, mi, id);
     /* Kernel conversions */
-    if (sp_streq(name, "Integer") && (kw_argc == 1 || kw_argc == 2)) return TY_INT;
+    if (sp_streq(name, "Integer") && (kw_argc == 1 || kw_argc == 2))
+        return kconv_integer_kind(c, argv[0], kw_argc < argc && kconv_noraise_kw(c, argc, argv));
     if (sp_streq(name, "Float") && kw_argc == 1) return TY_FLOAT;
     if (sp_streq(name, "String") && argc == 1) return TY_STRING;
     if (sp_streq(name, "Array") && argc == 1) {

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -6460,17 +6460,25 @@ static void emit_obj_with_dispatch(Compiler *c, Buf *b) {
    every callee it names, then the cls_id switch. `with_ok` adds the *ok
    out-flag the sp_int form needs (NULL can carry "no method" for a string). */
 static int conv_bridge_callee(Compiler *c, int i, const char *mname, TyKind want,
-                              int *out_mi) {
+                              int any_shape, int *out_mi) {
   ClassInfo *ci2 = &c->classes[i];
   if (is_builtin_reopen(ci2->name) || ci2->is_native_class) return -1;
-  if (comp_ty_value_obj(c, ty_object(i))) return -1;
+  if (!any_shape && comp_ty_value_obj(c, ty_object(i))) return -1;
   int dn = ci2->def_node;
   const char *dt = dn >= 0 ? nt_type(c->nt, dn) : NULL;
   if (dt && sp_streq(dt, "ModuleNode")) return -1;   /* no instances */
   int tdef = -1;
   int tmi = comp_method_in_chain(c, i, mname, &tdef);
-  if (tmi < 0 || !c->scopes[tmi].reachable || c->scopes[tmi].ret != want ||
-      c->scopes[tmi].nparams != 0) return -1;
+  /* a no-parameter method only (a `&block` parameter is not in nparams; the
+     bridges pass it as no block, which is what a bare call passes). A method
+     that yields is inlined at its call sites and has no function of its own
+     to call, so the bridge cannot reach it: the class counts as not having
+     the method, which is also what the Kernel#Integer site answered before. */
+  if (tmi < 0 || !c->scopes[tmi].reachable || c->scopes[tmi].nparams != 0 ||
+      c->scopes[tmi].yields) return -1;
+  /* the Kernel#Integer / #Float bridge takes the method whatever it answers
+     (`any_shape`), and a value-type class's too, called on the boxed copy */
+  if (!any_shape && c->scopes[tmi].ret != want) return -1;
   int ddn = c->classes[tdef].def_node;
   const char *ddt = ddn >= 0 ? nt_type(c->nt, ddn) : NULL;
   *out_mi = tmi;
@@ -6478,28 +6486,90 @@ static int conv_bridge_callee(Compiler *c, int i, const char *mname, TyKind want
      real function the child casts into */
   return (ddt && sp_streq(ddt, "ModuleNode")) ? i : tdef;
 }
+/* A conversion method declared with a named `&block` parameter takes it as a
+   second C parameter (emit_method_signature's rule: a named block on a method
+   that does not yield); the bridges declare it and pass no block, as a bare
+   call does. An anonymous `&` adds no parameter. */
+static int bridge_has_blk(Compiler *c, int mi) {
+  Scope *s = &c->scopes[mi];
+  return s->blk_param && s->blk_param[0] && !s->yields;
+}
+static const char *bridge_blk_param(Compiler *c, int mi) { return bridge_has_blk(c, mi) ? ", sp_Proc *blk" : ""; }
+static const char *bridge_blk_arg(Compiler *c, int mi)   { return bridge_has_blk(c, mi) ? ", NULL" : ""; }
+
 static void emit_conv_bridge(Compiler *c, Buf *b, const char *mname, TyKind want,
                              const char *rett, const char *sig, int with_ok,
                              const char *dflt) {
   for (int i = 0; i < c->nclasses; i++) {
     int tmi = -1;
-    int callee = conv_bridge_callee(c, i, mname, want, &tmi);
+    int callee = conv_bridge_callee(c, i, mname, want, 0, &tmi);
     if (callee != i) continue;   /* an ancestor's own row declares it */
-    buf_printf(b, "%s%s sp_%s_%s(sp_%s *self);\n", g_debug ? "" : "static ",
+    buf_printf(b, "%s%s sp_%s_%s(sp_%s *self%s);\n", g_debug ? "" : "static ",
                rett, c->classes[callee].c_name, mc(c->scopes[tmi].name),
-               c->classes[callee].c_name);
+               c->classes[callee].c_name, bridge_blk_param(c, tmi));
   }
   buf_printf(b, "%s {\n  switch (cls_id) {\n", sig);
   for (int i = 0; i < c->nclasses; i++) {
     int tmi = -1;
-    int callee = conv_bridge_callee(c, i, mname, want, &tmi);
+    int callee = conv_bridge_callee(c, i, mname, want, 0, &tmi);
     if (callee < 0) continue;
-    buf_printf(b, "    case %d: %sreturn sp_%s_%s((sp_%s *)p);\n",
+    buf_printf(b, "    case %d: %sreturn sp_%s_%s((sp_%s *)p%s);\n",
                i, with_ok ? "*ok = 1; " : "",
                c->classes[callee].c_name, mc(c->scopes[tmi].name),
-               c->classes[callee].c_name);
+               c->classes[callee].c_name, bridge_blk_arg(c, tmi));
   }
   buf_printf(b, "    default: %s\n  }\n}\n", dflt);
+}
+
+/* The Kernel#Integer / Kernel#Float bridge (sp_obj_conv_fn): the runtime's
+   conversion search reaches a boxed user object's #to_int, #to_i, #to_f and
+   #to_str through it WHATEVER each method's static type. CRuby calls the
+   method and judges the answer, so a #to_int answering a String or a
+   Bignum, or nothing at all (a body that raises), is called and its answer
+   boxed for the runtime to judge. Answers 1 with the boxed value, 0 for a
+   class without the method -- and asked with a NULL `out`, whether the
+   method exists, calling nothing. Emitted only for a program that calls
+   Kernel#Integer or Kernel#Float somewhere (Compiler.uses_kconv). */
+static void emit_kconv_bridge(Compiler *c, Buf *b) {
+  static const char *const names[] = { "to_int", "to_i", "to_f", "to_str" };
+  for (int i = 0; i < c->nclasses; i++) {
+    for (int w = 0; w < 4; w++) {
+      int tmi = -1;
+      int callee = conv_bridge_callee(c, i, names[w], TY_UNKNOWN, 1, &tmi);
+      if (callee != i) continue;   /* an ancestor's own row declares it */
+      buf_puts(b, g_debug ? "" : "static ");
+      emit_ctype(c, (TyKind)c->scopes[tmi].ret, b);
+      buf_printf(b, " sp_%s_%s(sp_%s %sself%s);\n", c->classes[callee].c_name,
+                 mc(c->scopes[tmi].name), c->classes[callee].c_name,
+                 comp_ty_value_obj(c, ty_object(callee)) ? "" : "*", bridge_blk_param(c, tmi));
+    }
+  }
+  buf_puts(b, "static int sp_obj_conv_sw(int cls_id, void *p, int which, sp_RbVal *out) {\n"
+              "  switch (cls_id) {\n");
+  for (int i = 0; i < c->nclasses; i++) {
+    int rows = 0;
+    for (int w = 0; w < 4; w++) {
+      int tmi = -1;
+      int callee = conv_bridge_callee(c, i, names[w], TY_UNKNOWN, 1, &tmi);
+      if (callee < 0) continue;
+      if (rows++ == 0) buf_printf(b, "    case %d: switch (which) {\n", i);
+      char call[256];
+      snprintf(call, sizeof call, "sp_%s_%s(%s(sp_%s *)p%s)", c->classes[callee].c_name,
+               mc(c->scopes[tmi].name),
+               comp_ty_value_obj(c, ty_object(callee)) ? "*" : "", c->classes[callee].c_name,
+               bridge_blk_arg(c, tmi));
+      TyKind rt = (TyKind)c->scopes[tmi].ret;
+      buf_printf(b, "      case %d: if (out) *out = ", w);
+      /* a Float slot's nil is a NaN payload, which the plain box would carry
+         as a Float answer */
+      if (rt == TY_FLOAT)
+        buf_printf(b, "({ sp_float _f = %s; sp_float_is_nil(_f) ? sp_box_nil() : sp_box_float(_f); })", call);
+      else emit_boxed_text(c, rt, call, b);
+      buf_puts(b, "; return 1;\n");
+    }
+    if (rows) buf_puts(b, "      default: return 0;\n    }\n");
+  }
+  buf_puts(b, "    default: return 0;\n  }\n}\n");
 }
 
 static int class_inspectable(Compiler *c, int i) {
@@ -6565,6 +6635,7 @@ static void emit_obj_inspect_dispatch(Compiler *c, Buf *b) {
   emit_conv_bridge(c, b, "to_path", TY_STRING,
                    "const char *", "static const char *sp_obj_to_path_sw(int cls_id, void *p)",
                    0, "return NULL;");
+  if (c->uses_kconv) emit_kconv_bridge(c, b);
   buf_puts(b, "static const char *sp_obj_cls_name_rt(int cls_id) {\n"
               "  sp_Class _c = {cls_id}; return sp_class_to_s(_c);\n}\n");
   buf_puts(b, "static const char *sp_obj_inspect_sw(int cls_id, void *p) {\n");
@@ -7680,6 +7751,7 @@ void emit_regex_section(Compiler *c, Buf *b) {
     buf_puts(b, "  sp_obj_to_int_fn = sp_obj_to_int_sw;\n");
     buf_puts(b, "  sp_obj_to_str_fn = sp_obj_to_str_sw;\n");
     buf_puts(b, "  sp_obj_to_path_fn = sp_obj_to_path_sw;\n");
+    if (c->uses_kconv) buf_puts(b, "  sp_obj_conv_fn = sp_obj_conv_sw;\n");
     buf_puts(b, "  sp_obj_cls_name_fn = sp_obj_cls_name_rt;\n");
   }
   if (g_uses_marshal) {
@@ -9781,6 +9853,8 @@ char *codegen_program(const NodeTable *nt) {
     buf_puts(&b, "static sp_int sp_obj_to_int_sw(int cls_id, void *p, int *ok) __attribute__((cold, noinline));\n");
     buf_puts(&b, "static const char *sp_obj_to_str_sw(int cls_id, void *p) __attribute__((cold, noinline));\n");
     buf_puts(&b, "static const char *sp_obj_to_path_sw(int cls_id, void *p) __attribute__((cold, noinline));\n");
+    if (c->uses_kconv)
+      buf_puts(&b, "static int sp_obj_conv_sw(int cls_id, void *p, int which, sp_RbVal *out) __attribute__((cold, noinline));\n");
     buf_puts(&b, "static const char *sp_obj_cls_name_rt(int cls_id) __attribute__((cold, noinline));\n");
   }
   /* The #message / #to_s dispatchers below call these bodies unconditionally,

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -14374,6 +14374,30 @@ static int emit_numeric_coerce_call(Compiler *c, int id, Buf *b) {
   return 1;
 }
 
+
+/* The Kernel#Integer call the runtime completes: the value boxed, the base
+   (the two-argument form; 0 otherwise), and whether a failure raises or
+   answers nil. The entry point matches the kind the analysis gave the call
+   (kconv_integer_kind): an Integer slot, the Bignum slot of a strict call
+   whose object may answer one, or the boxed slot of the `exception: false`
+   form of such a call. A temporary object is rooted across the base's
+   evaluation. */
+static void emit_kconv_call(Compiler *c, int id, const int *av, int ac, int raise, Buf *b) {
+  TyKind kt = comp_ntype(c, id);
+  const char *fn = kt == TY_BIGINT ? "sp_poly_Integer_big"
+                 : kt == TY_POLY   ? "sp_kernel_Integer_val" : "sp_poly_Integer_ex";
+  if (ac < 2) {
+    buf_printf(b, "%s(", fn); emit_boxed(c, av[0], b);
+    buf_printf(b, ", 0, %d)", raise);
+    return;
+  }
+  int tv = ++g_tmp;
+  buf_printf(b, "({ sp_RbVal _kv%d = ", tv); emit_boxed(c, av[0], b);
+  buf_printf(b, "; SP_GC_ROOT_RBVAL(_kv%d); %s(_kv%d, ", tv, fn, tv);
+  emit_int_expr(c, av[1], b);
+  buf_printf(b, ", %d); })", raise);
+}
+
 static void emit_call_body(Compiler *c, int id, Buf *b) {
   /* deep-return pickup (#3227 P6): a marked receiverless call to a method
      whose every return path yields a shared handle -- reset the side
@@ -19374,8 +19398,15 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
         buf_puts(b, ")");
         return;
       }
-      if (at0 == TY_INT) { emit_expr(c, av[0], b); return; }
-      if (at0 == TY_FLOAT) { buf_puts(b, "((sp_int)("); emit_expr(c, av[0], b); buf_puts(b, "))"); return; }
+      /* with a base only a String converts, so a number is nil here */
+      if (at0 == TY_INT && ac == 1) { emit_expr(c, av[0], b); return; }
+      /* a user object, a boxed value that may hold one, or a Float (NaN and
+         Infinity are nil, CRuby's FloatDomainError swallowed) converts
+         through the runtime's Kernel#Integer path, nil for every failure */
+      if (ty_is_object(at0) || at0 == TY_POLY || (at0 == TY_FLOAT && ac == 1)) {
+        emit_kconv_call(c, id, av, ac, 0, b);
+        return;
+      }
       buf_puts(b, "((void)("); emit_expr(c, av[0], b); buf_puts(b, "), SP_INT_NIL)");
       return;
     }
@@ -19384,6 +19415,10 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
       if (at0 == TY_STRING) { buf_puts(b, "sp_str_to_f_lenient("); emit_expr(c, av[0], b); buf_puts(b, ")"); return; }
       if (at0 == TY_INT) { buf_puts(b, "((sp_float)("); emit_expr(c, av[0], b); buf_puts(b, "))"); return; }
       if (at0 == TY_FLOAT) { emit_expr(c, av[0], b); return; }
+      if (ty_is_object(at0) || at0 == TY_POLY) {
+        buf_puts(b, "sp_poly_Float_ex("); emit_boxed(c, av[0], b); buf_puts(b, ", 0)");
+        return;
+      }
       buf_puts(b, "((void)("); emit_expr(c, av[0], b); buf_puts(b, "), sp_float_nil())");
       return;
     }
@@ -19396,7 +19431,13 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
         if (at == TY_UNKNOWN && (ek == NK_HashNode || ek == NK_KeywordHashNode || ek == NK_ArrayNode))
           at = TY_POLY_ARRAY; }
       if (at == TY_STRING) { buf_puts(b, "sp_str_to_i_strict("); emit_expr(c, av[0], b); buf_puts(b, ")"); }
-      else if (at == TY_FLOAT) { buf_puts(b, "((sp_int)("); emit_expr(c, av[0], b); buf_puts(b, "))"); }
+      /* a Float truncates, and NaN or an infinity is CRuby's FloatDomainError
+         rather than the C cast's undefined value */
+      else if (at == TY_FLOAT) {
+        int tf = ++g_tmp;
+        buf_printf(b, "({ sp_float _t%d = ", tf); emit_expr(c, av[0], b);
+        buf_printf(b, "; sp_poly_flo_domain_ck(_t%d); (sp_int)_t%d; })", tf, tf);
+      }
       else if (at == TY_NIL) { buf_puts(b, "((void)("); emit_expr(c, av[0], b); buf_puts(b, "), sp_raise_cls(\"TypeError\", \"can't convert nil into Integer\"), (sp_int)0)"); }  /* #2514 */
       else if (at == TY_POLY) { buf_puts(b, "sp_poly_Integer("); emit_expr(c, av[0], b); buf_puts(b, ")"); }
       else if (at == TY_INT || at == TY_UNKNOWN) { buf_puts(b, "("); emit_expr(c, av[0], b); buf_puts(b, ")"); }
@@ -19411,16 +19452,15 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
         buf_printf(b, "; if (_t%d.im != 0) sp_raise_cls(\"RangeError\", "
                       "\"can't convert into Integer\"); (sp_int)_t%d.re; })", tc, tc);
       }
-      else if (ty_is_object(at) &&
-               comp_method_in_chain(c, ty_object_class(at), "to_int", NULL) >= 0) {
-        int dcls = ty_object_class(at);
-        comp_method_in_chain(c, dcls, "to_int", &dcls);
-        buf_printf(b, "sp_%s_to_int((sp_%s *)", c->classes[dcls].c_name, c->classes[dcls].c_name);
-        emit_expr(c, av[0], b); buf_puts(b, ")");
+      /* a user object converts through its own #to_int, #to_str and #to_i,
+         each answer judged by the runtime as CRuby judges it; a class whose
+         #to_int or #to_i answers a Bignum types the call as one */
+      else if (ty_is_object(at)) {
+        emit_kconv_call(c, id, av, ac, 1, b);
       }
       else {
-        /* an Array, Hash, Range, Symbol or object has no to_int: CRuby's
-           TypeError, not the value reinterpreted as an integer (#3717) */
+        /* an Array, Hash, Range or Symbol has no to_int: CRuby's TypeError,
+           not the value reinterpreted as an integer (#3717) */
         buf_puts(b, "((void)("); emit_expr(c, av[0], b);
         buf_puts(b, "), sp_raise_cls(\"TypeError\", sp_sprintf(\"can't convert %s into Integer\", sp_poly_class_name(");
         emit_boxed(c, av[0], b);
@@ -19435,23 +19475,11 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
         /* Integer("5", nil) is CRuby's TypeError, not base 0 */
         buf_puts(b, ", "); emit_int_expr(c, av[1], b); buf_puts(b, ")");
       }
-      else if (at == TY_POLY || at == TY_UNKNOWN) {
-        /* a poly value is only known at runtime: a string (plain or shared
-           handle) parses with the base; nil and non-strings raise as CRuby */
-        int tv = ++g_tmp;
-        buf_printf(b, "({ sp_RbVal _kv%d = ", tv); emit_boxed(c, av[0], b);
-        buf_printf(b, "; const char *_ks%d = _kv%d.tag == SP_TAG_STR ? (_kv%d.v.s ? _kv%d.v.s : \"\") : "
-                      "(_kv%d.tag == SP_TAG_OBJ && _kv%d.cls_id == SP_BUILTIN_STRBUF && _kv%d.v.p) ? "
-                      "sp_String_cstr((sp_String *)_kv%d.v.p) : NULL; ",
-                   tv, tv, tv, tv, tv, tv, tv, tv);
-        buf_printf(b, "_ks%d ? sp_str_to_i_strict_base(_ks%d, ", tv, tv);
-        emit_int_expr(c, av[1], b);
-        buf_printf(b, ") : (sp_raise_cls(\"ArgumentError\", "
-                      "\"base specified for non string value\"), (sp_int)0); })");
-        (void)tv;
-      }
-      /* a base with a non-String value raises ArgumentError, as CRuby (#2515) */
-      else { buf_puts(b, "((void)("); emit_expr(c, av[0], b); buf_puts(b, "), (void)("); emit_expr(c, av[1], b); buf_puts(b, "), sp_raise_cls(\"ArgumentError\", \"base specified for non string value\"), (sp_int)0)"); }
+      /* only a String converts with a base, and whether a boxed value or a
+         user object is one -- a plain String, a shared handle, an object's
+         #to_str -- the runtime decides, raising CRuby's ArgumentError for
+         anything else (#2515) */
+      else emit_kconv_call(c, id, av, ac, 1, b);
       return;
     }
     if (sp_streq(name, "Float") && ac == 1) {
@@ -19475,16 +19503,14 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
         buf_printf(b, "; if (_t%d.im != 0) sp_raise_cls(\"RangeError\", "
                       "\"can't convert into Float\"); _t%d.re; })", tc, tc);
       }
-      else if (ty_is_object(at) &&
-               comp_method_in_chain(c, ty_object_class(at), "to_f", NULL) >= 0) {
-        int dcls = ty_object_class(at);
-        comp_method_in_chain(c, dcls, "to_f", &dcls);
-        buf_printf(b, "((sp_float)(sp_%s_to_f((sp_%s *)", c->classes[dcls].c_name, c->classes[dcls].c_name);
-        emit_expr(c, av[0], b); buf_puts(b, ")))");
+      /* a user object converts through its own #to_f, the answer judged by
+         the runtime as CRuby judges it */
+      else if (ty_is_object(at)) {
+        buf_puts(b, "sp_poly_Float_ex("); emit_boxed(c, av[0], b); buf_puts(b, ", 1)");
       }
       else {
-        /* a Boolean, Symbol, Array, Hash or object with no #to_f is CRuby's
-           TypeError, not the value reinterpreted as a double (#3888) */
+        /* a Boolean, Symbol, Array or Hash has no #to_f: CRuby's TypeError,
+           not the value reinterpreted as a double (#3888) */
         buf_puts(b, "((void)("); emit_expr(c, av[0], b);
         buf_puts(b, "), sp_raise_cls(\"TypeError\", sp_sprintf(\"can't convert %s into Float\", sp_poly_class_name(");
         emit_boxed(c, av[0], b);

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -561,6 +561,10 @@ typedef struct {
      sp_obj_to_hash when the program defines Structs. No feature is named in the
      compiler -- the package's require is the declaration. */
   int native_obj_reflect;
+  /* the program calls Kernel#Integer / Kernel#Float somewhere: codegen emits
+     and installs the conversion bridge (sp_obj_conv_sw) only then, so a
+     program that never converts an object carries no extra dispatch. */
+  int uses_kconv;
   /* body-node id -> enclosing BlockNode id (lazy; emit_stmts block-local
      resets). Sized nt->count; -1 = not a block body. */
   int *blk_body_map;

--- a/test/kernel_conv_protocol.rb
+++ b/test/kernel_conv_protocol.rb
@@ -1,0 +1,234 @@
+# Kernel#Integer and Kernel#Float on a user object: the object's own
+# conversion methods, probed in CRuby's order, each answer judged the way
+# CRuby judges it, in the strict and the `exception: false` forms.
+$calls = []
+def note(name) = $calls << name
+
+def try
+  r = yield
+  puts "=> #{r.inspect}"
+rescue => e
+  puts "=> #{e.class}: #{e.message}"
+end
+
+def show(label)
+  $calls = []
+  print label, " "
+  yield
+  puts "   calls: #{$calls.inspect}" unless $calls.empty?
+end
+
+# --- #to_int answers ---------------------------------------------------
+class IntAnswer;   def to_int; note(:to_int); 7; end; end
+class BigAnswer;   def to_int; note(:to_int); 1 << 70; end; end
+class NilAnswer;   def to_int; note(:to_int); nil; end; end
+class NilThenToI;  def to_int; note(:to_int); nil; end; def to_i; note(:to_i); 5; end; end
+class StrAnswer;   def to_int; note(:to_int); "7"; end; end
+class StrThenToI;  def to_int; note(:to_int); "7"; end; def to_i; note(:to_i); 5; end; end
+class RaisesToInt; def to_int; note(:to_int); raise "boom"; end; end
+class RaiseThenToI; def to_int; note(:to_int); raise "boom"; end; def to_i; note(:to_i); 5; end; end
+
+# --- #to_i alone --------------------------------------------------------
+class ToIOnly;     def to_i; note(:to_i); 5; end; end
+class ToIBig;      def to_i; note(:to_i); 1 << 70; end; end
+class ToIString;   def to_i; note(:to_i); "7"; end; end
+class ToINil;      def to_i; note(:to_i); nil; end; end
+class ToIRaises;   def to_i; note(:to_i); raise "boom"; end; end
+
+# --- #to_str ------------------------------------------------------------
+class StrConv;     def to_str; note(:to_str); "12"; end; end
+class BadStrConv;  def to_str; note(:to_str); "zz"; end; end
+class StrAndToI;   def to_str; note(:to_str); "12"; end; def to_i; note(:to_i); 99; end; end
+class WrongStrConv; def to_str; note(:to_str); 3; end; end
+class Plain; end
+
+show("Integer(IntAnswer)")    { try { Integer(IntAnswer.new) } }
+show("Integer(BigAnswer)")    { try { Integer(BigAnswer.new) } }
+show("Integer(NilAnswer)")    { try { Integer(NilAnswer.new) } }
+show("Integer(NilThenToI)")   { try { Integer(NilThenToI.new) } }
+show("Integer(StrAnswer)")    { try { Integer(StrAnswer.new) } }
+show("Integer(StrThenToI)")   { try { Integer(StrThenToI.new) } }
+show("Integer(RaisesToInt)")  { try { Integer(RaisesToInt.new) } }
+show("Integer(RaiseThenToI)") { try { Integer(RaiseThenToI.new) } }
+show("Integer(ToIOnly)")      { try { Integer(ToIOnly.new) } }
+show("Integer(ToIBig)")       { try { Integer(ToIBig.new) } }
+show("Integer(ToIString)")    { try { Integer(ToIString.new) } }
+show("Integer(ToINil)")       { try { Integer(ToINil.new) } }
+show("Integer(ToIRaises)")    { try { Integer(ToIRaises.new) } }
+show("Integer(StrConv)")      { try { Integer(StrConv.new) } }
+show("Integer(BadStrConv)")   { try { Integer(BadStrConv.new) } }
+show("Integer(StrAndToI)")    { try { Integer(StrAndToI.new) } }
+show("Integer(WrongStrConv)") { try { Integer(WrongStrConv.new) } }
+show("Integer(Plain)")        { try { Integer(Plain.new) } }
+
+puts "--- exception: false"
+show("Integer(IntAnswer, exception: false)")   { try { Integer(IntAnswer.new, exception: false) } }
+show("Integer(BigAnswer, exception: false)")   { try { Integer(BigAnswer.new, exception: false) } }
+show("Integer(StrAnswer, exception: false)")   { try { Integer(StrAnswer.new, exception: false) } }
+show("Integer(RaisesToInt, exception: false)") { try { Integer(RaisesToInt.new, exception: false) } }
+show("Integer(RaiseThenToI, exception: false)") { try { Integer(RaiseThenToI.new, exception: false) } }
+show("Integer(ToIString, exception: false)")   { try { Integer(ToIString.new, exception: false) } }
+show("Integer(ToIRaises, exception: false)")   { try { Integer(ToIRaises.new, exception: false) } }
+show("Integer(StrConv, exception: false)")     { try { Integer(StrConv.new, exception: false) } }
+show("Integer(BadStrConv, exception: false)")  { try { Integer(BadStrConv.new, exception: false) } }
+show("Integer(Plain, exception: false)")       { try { Integer(Plain.new, exception: false) } }
+
+puts "--- with a base"
+show("Integer(StrConv, 16)")                    { try { Integer(StrConv.new, 16) } }
+show("Integer(StrConv, 10, exception: false)")  { try { Integer(StrConv.new, 10, exception: false) } }
+show("Integer(IntAnswer, 16)")                  { try { Integer(IntAnswer.new, 16) } }
+show("Integer(IntAnswer, 16, exception: false)") { try { Integer(IntAnswer.new, 16, exception: false) } }
+show("Integer(Plain, 10)")                      { try { Integer(Plain.new, 10) } }
+
+puts "--- Float"
+class FltAnswer;   def to_f; note(:to_f); 2.5; end; end
+class FltIntAnswer; def to_f; note(:to_f); 3; end; end
+class FltStrAnswer; def to_f; note(:to_f); "2.5"; end; end
+class FltNilAnswer; def to_f; note(:to_f); nil; end; end
+class FltRaises;   def to_f; note(:to_f); raise "boom"; end; end
+class FltStrOnly;  def to_str; note(:to_str); "2.5"; end; end
+class FltIntOnly;  def to_int; note(:to_int); 4; end; end
+
+show("Float(FltAnswer)")     { try { Float(FltAnswer.new) } }
+show("Float(FltIntAnswer)")  { try { Float(FltIntAnswer.new) } }
+show("Float(FltStrAnswer)")  { try { Float(FltStrAnswer.new) } }
+show("Float(FltNilAnswer)")  { try { Float(FltNilAnswer.new) } }
+show("Float(FltRaises)")     { try { Float(FltRaises.new) } }
+show("Float(FltStrOnly)")    { try { Float(FltStrOnly.new) } }
+show("Float(FltIntOnly)")    { try { Float(FltIntOnly.new) } }
+show("Float(Plain)")         { try { Float(Plain.new) } }
+show("Float(FltAnswer, exception: false)")    { try { Float(FltAnswer.new, exception: false) } }
+show("Float(FltIntAnswer, exception: false)") { try { Float(FltIntAnswer.new, exception: false) } }
+show("Float(FltRaises, exception: false)")    { try { Float(FltRaises.new, exception: false) } }
+show("Float(Plain, exception: false)")        { try { Float(Plain.new, exception: false) } }
+
+puts "--- through a container"
+mixed = [IntAnswer.new, StrConv.new, Plain.new, "42", 9, 2.75, nil, FltAnswer.new]
+mixed.each_with_index do |x, i|
+  show("Integer(mixed[#{i}])")                  { try { Integer(x) } }
+  show("Integer(mixed[#{i}], exception: false)") { try { Integer(x, exception: false) } }
+  show("Float(mixed[#{i}], exception: false)")  { try { Float(x, exception: false) } }
+end
+show("Integer(mixed[1], 16)") { try { Integer(mixed[1], 16) } }
+show("Integer(mixed[3], 16)") { try { Integer(mixed[3], 16) } }
+show("Integer(mixed[4], 16)") { try { Integer(mixed[4], 16) } }
+show("Integer(mixed[4], 16, exception: false)") { try { Integer(mixed[4], 16, exception: false) } }
+
+puts "--- the answer is carried"
+big = Integer(BigAnswer.new)
+p big + 1
+p big.class
+p Integer(IntAnswer.new) + 1
+p Float(FltAnswer.new) * 2
+
+puts "--- a throw, a break or a proc return out of a probed conversion"
+class ThrowsToI;  def to_i; throw :x, 1; end; end
+class ThrowsToInt; def to_int; throw :a, 1; end; def to_i; 7; end; end
+class CallsProc
+  def initialize(pr) = @pr = pr
+  def to_int; @pr.call; end
+  def to_i; 7; end
+end
+p(catch(:x) { Integer(ThrowsToI.new, exception: false) })
+begin
+  p :body
+ensure
+  p :ensure
+end
+r = catch(:a) do
+  catch(:b) do
+    p Integer(ThrowsToInt.new)
+    throw :b, 55
+    :no
+  end
+end
+p r
+def returns_through_proc
+  pr = proc { return :returned }
+  p Integer(CallsProc.new(pr))
+  :fell_through
+end
+p returns_through_proc
+def breaks_out
+  [1, 2].each do |i|
+    pr = proc { break :broke }
+    p Integer(CallsProc.new(pr))
+  end
+  :done
+end
+p breaks_out
+begin
+  p :body
+ensure
+  p :ensure
+end
+p :after
+
+puts "--- an answer the analysis cannot pin down"
+$flag = true
+class Sometimes;    def to_int; $flag ? 7 : nil; end; end
+class SometimesBig; def to_int; $flag ? (1 << 70) : nil; end; end
+class SometimesToI; def to_int; $flag ? (1 << 70) : nil; end; def to_i; 3; end; end
+[true, false].each do |f|
+  $flag = f
+  show("Sometimes (#{f})")    { try { Integer(Sometimes.new) } }
+  show("Sometimes ef (#{f})") { try { Integer(Sometimes.new, exception: false) } }
+  # a sometimes-Bignum answer through an Integer slot is a loud RangeError
+  # here where CRuby carries it (see the PR); either is an Integer or that
+  r = begin; Integer(SometimesBig.new); rescue RangeError => e; :range; rescue TypeError => e; e.message; end
+  puts "SometimesBig (#{f}): #{r == (1 << 70) || r == :range ? "the Bignum or the RangeError" : r}"
+  show("SometimesBig ef (#{f})") { try { Integer(SometimesBig.new, exception: false) } }
+  r = begin; Integer(SometimesToI.new); rescue RangeError => e; :range; rescue TypeError => e; e.message; end
+  puts "SometimesToI (#{f}): #{r == (1 << 70) || r == :range ? "the Bignum or the RangeError" : r}"
+  show("SometimesToI ef (#{f})") { try { Integer(SometimesToI.new, exception: false) } }
+  x = Integer(SometimesBig.new, exception: false)
+  p [x.class, x.nil? ? nil : x + 1]
+end
+
+puts "--- a conversion method declared with a block parameter is called with none"
+class BlkToI;   def to_i(&b);   $blk_seen = b; 5;   end; end
+class BlkToF;   def to_f(&b);   $blk_seen = b; 9.5; end; end
+class BlkToInt; def to_int(&b); $blk_seen = b; 3;   end; end
+$blk_seen = :unset
+p [Integer(BlkToI.new), $blk_seen]
+p [Float(BlkToF.new), $blk_seen]
+p [Integer(BlkToInt.new), $blk_seen]
+p Integer(BlkToI.new, exception: false)
+p Float(BlkToF.new, exception: false)
+
+puts "--- a plain Bignum read out of a container"
+mixed_big = [1 << 70, "s"]
+r = begin; Integer(mixed_big[0]); rescue RangeError; :range; end
+puts "Integer(boxed Bignum): #{r == (1 << 70) || r == :range ? "the Bignum or the RangeError" : r}"
+p Integer(mixed_big[0], exception: false).nil? || Integer(mixed_big[0], exception: false) == (1 << 70)
+
+puts "--- a Float argument"
+begin
+  Integer(Float::NAN)
+rescue FloatDomainError => e
+  puts "Integer(NaN): #{e.class}: #{e.message}"
+end
+begin
+  Integer(-Float::INFINITY)
+rescue FloatDomainError => e
+  puts "Integer(-Infinity): #{e.class}: #{e.message}"
+end
+p Integer(2.75)
+
+puts "--- the implicit-conversion bridge with a block parameter, and to_str with a base"
+class IdxBlk; def to_int(&b); 1; end; end
+class WrongStrBase; def to_str; 7; end; end
+# a mixed Array, so the element is boxed and the index goes through the bridge
+# (a typed slot calls the method directly and is a different site)
+boxed = [IdxBlk.new, "not an index"]
+p [10, 20, 30][boxed[0]]
+begin
+  Integer(WrongStrBase.new, 16)
+rescue TypeError => e
+  puts "to_str answering an Integer, with a base: #{e.message}"
+end
+begin
+  p Integer(WrongStrBase.new, 16, exception: false)
+rescue TypeError => e
+  puts "with exception false: #{e.class}"
+end

--- a/test/kernel_conv_protocol.rb.expected
+++ b/test/kernel_conv_protocol.rb.expected
@@ -1,0 +1,170 @@
+Integer(IntAnswer) => 7
+   calls: [:to_int]
+Integer(BigAnswer) => 1180591620717411303424
+   calls: [:to_int]
+Integer(NilAnswer) => TypeError: can't convert NilAnswer into Integer
+   calls: [:to_int]
+Integer(NilThenToI) => 5
+   calls: [:to_int, :to_i]
+Integer(StrAnswer) => TypeError: can't convert StrAnswer into Integer
+   calls: [:to_int]
+Integer(StrThenToI) => 5
+   calls: [:to_int, :to_i]
+Integer(RaisesToInt) => TypeError: can't convert RaisesToInt into Integer
+   calls: [:to_int]
+Integer(RaiseThenToI) => 5
+   calls: [:to_int, :to_i]
+Integer(ToIOnly) => 5
+   calls: [:to_i]
+Integer(ToIBig) => 1180591620717411303424
+   calls: [:to_i]
+Integer(ToIString) => TypeError: can't convert ToIString to Integer (ToIString#to_i gives String)
+   calls: [:to_i]
+Integer(ToINil) => TypeError: can't convert ToINil to Integer (ToINil#to_i gives NilClass)
+   calls: [:to_i]
+Integer(ToIRaises) => RuntimeError: boom
+   calls: [:to_i]
+Integer(StrConv) => 12
+   calls: [:to_str]
+Integer(BadStrConv) => ArgumentError: invalid value for Integer(): "zz"
+   calls: [:to_str]
+Integer(StrAndToI) => 12
+   calls: [:to_str]
+Integer(WrongStrConv) => TypeError: can't convert WrongStrConv to String (WrongStrConv#to_str gives Integer)
+   calls: [:to_str]
+Integer(Plain) => TypeError: can't convert Plain into Integer
+--- exception: false
+Integer(IntAnswer, exception: false) => 7
+   calls: [:to_int]
+Integer(BigAnswer, exception: false) => 1180591620717411303424
+   calls: [:to_int]
+Integer(StrAnswer, exception: false) => nil
+   calls: [:to_int]
+Integer(RaisesToInt, exception: false) => nil
+   calls: [:to_int]
+Integer(RaiseThenToI, exception: false) => 5
+   calls: [:to_int, :to_i]
+Integer(ToIString, exception: false) => nil
+   calls: [:to_i]
+Integer(ToIRaises, exception: false) => nil
+   calls: [:to_i]
+Integer(StrConv, exception: false) => 12
+   calls: [:to_str]
+Integer(BadStrConv, exception: false) => nil
+   calls: [:to_str]
+Integer(Plain, exception: false) => nil
+--- with a base
+Integer(StrConv, 16) => 18
+   calls: [:to_str]
+Integer(StrConv, 10, exception: false) => 12
+   calls: [:to_str]
+Integer(IntAnswer, 16) => ArgumentError: base specified for non string value
+Integer(IntAnswer, 16, exception: false) => nil
+Integer(Plain, 10) => ArgumentError: base specified for non string value
+--- Float
+Float(FltAnswer) => 2.5
+   calls: [:to_f]
+Float(FltIntAnswer) => TypeError: can't convert FltIntAnswer to Float (FltIntAnswer#to_f gives Integer)
+   calls: [:to_f]
+Float(FltStrAnswer) => TypeError: can't convert FltStrAnswer to Float (FltStrAnswer#to_f gives String)
+   calls: [:to_f]
+Float(FltNilAnswer) => TypeError: can't convert FltNilAnswer to Float (FltNilAnswer#to_f gives NilClass)
+   calls: [:to_f]
+Float(FltRaises) => RuntimeError: boom
+   calls: [:to_f]
+Float(FltStrOnly) => TypeError: can't convert FltStrOnly into Float
+Float(FltIntOnly) => TypeError: can't convert FltIntOnly into Float
+Float(Plain) => TypeError: can't convert Plain into Float
+Float(FltAnswer, exception: false) => 2.5
+   calls: [:to_f]
+Float(FltIntAnswer, exception: false) => nil
+   calls: [:to_f]
+Float(FltRaises, exception: false) => nil
+   calls: [:to_f]
+Float(Plain, exception: false) => nil
+--- through a container
+Integer(mixed[0]) => 7
+   calls: [:to_int]
+Integer(mixed[0], exception: false) => 7
+   calls: [:to_int]
+Float(mixed[0], exception: false) => nil
+Integer(mixed[1]) => 12
+   calls: [:to_str]
+Integer(mixed[1], exception: false) => 12
+   calls: [:to_str]
+Float(mixed[1], exception: false) => nil
+Integer(mixed[2]) => TypeError: can't convert Plain into Integer
+Integer(mixed[2], exception: false) => nil
+Float(mixed[2], exception: false) => nil
+Integer(mixed[3]) => 42
+Integer(mixed[3], exception: false) => 42
+Float(mixed[3], exception: false) => 42.0
+Integer(mixed[4]) => 9
+Integer(mixed[4], exception: false) => 9
+Float(mixed[4], exception: false) => 9.0
+Integer(mixed[5]) => 2
+Integer(mixed[5], exception: false) => 2
+Float(mixed[5], exception: false) => 2.75
+Integer(mixed[6]) => TypeError: can't convert nil into Integer
+Integer(mixed[6], exception: false) => nil
+Float(mixed[6], exception: false) => nil
+Integer(mixed[7]) => TypeError: can't convert FltAnswer into Integer
+Integer(mixed[7], exception: false) => nil
+Float(mixed[7], exception: false) => 2.5
+   calls: [:to_f]
+Integer(mixed[1], 16) => 18
+   calls: [:to_str]
+Integer(mixed[3], 16) => 66
+Integer(mixed[4], 16) => ArgumentError: base specified for non string value
+Integer(mixed[4], 16, exception: false) => nil
+--- the answer is carried
+1180591620717411303425
+Integer
+8
+5.0
+--- a throw, a break or a proc return out of a probed conversion
+nil
+:body
+:ensure
+7
+55
+7
+:fell_through
+7
+7
+:done
+:body
+:ensure
+:after
+--- an answer the analysis cannot pin down
+Sometimes (true) => 7
+Sometimes ef (true) => 7
+SometimesBig (true): the Bignum or the RangeError
+SometimesBig ef (true) => 1180591620717411303424
+SometimesToI (true): the Bignum or the RangeError
+SometimesToI ef (true) => 1180591620717411303424
+[Integer, 1180591620717411303425]
+Sometimes (false) => TypeError: can't convert Sometimes into Integer
+Sometimes ef (false) => nil
+SometimesBig (false): can't convert SometimesBig into Integer
+SometimesBig ef (false) => nil
+SometimesToI (false): 3
+SometimesToI ef (false) => 3
+[NilClass, nil]
+--- a conversion method declared with a block parameter is called with none
+[5, nil]
+[9.5, nil]
+[3, nil]
+5
+9.5
+--- a plain Bignum read out of a container
+Integer(boxed Bignum): the Bignum or the RangeError
+true
+--- a Float argument
+Integer(NaN): FloatDomainError: NaN
+Integer(-Infinity): FloatDomainError: -Infinity
+2
+--- the implicit-conversion bridge with a block parameter, and to_str with a base
+20
+to_str answering an Integer, with a base: can't convert WrongStrBase to String (WrongStrBase#to_str gives Integer)
+with exception false: TypeError


### PR DESCRIPTION
## Why

Handing an object of your own class to `Integer(x)` or `Float(x)` is ordinary Ruby: the object answers through its `to_int`, `to_str`, `to_i` or `to_f`, and CRuby judges each answer before trusting it. In Spinel that worked only when the class's `to_int` or `to_f` was declared with exactly the answer the slot wanted. A `to_int` that answers a String, one that answers a Bignum, or one whose body raises made the generated C refuse to build, because the compiled method was called directly and its return type, whatever it was, was assigned into the integer slot. A boxed value that happened to hold such an object raised without consulting it at all. And `exception: false`, the form that asks for nil instead of a raise, answered nil for every object and for every boxed value, a plain Integer or a numeric String included.

Concretely, on master: `Integer(C.new)` with `def to_int; "7"; end` fails the C build with an incompatible pointer conversion, as does `def to_int; 1 << 70; end`, `def to_int; raise "boom"; end`, `def to_f; "2.5"; end` and `def to_f; raise "boom"; end`; `Integer(x, exception: false)` answers nil for `x = [1, "12"][i]` where CRuby answers 1 or 12, and for `x = C.new` with a `to_int` answering 7; `Integer(L.new)` with `def to_str; "12"; end` raises "can't convert L into Integer" where CRuby answers 12.

CRuby's rule (object.c, rb_convert_to_integer and rb_convert_to_float, checked against Ruby 4.0.6 with a sixty-case matrix that also counts the calls): `Integer(obj)` probes `to_int` under rb_protect, so an Integer answer wins and nil, an answer of another kind, or a raise inside it are all swallowed and the search goes on; then `to_str`, bare, whose String answer parses as `Integer("...")` does; then `to_i`, bare in the strict form, whose Integer answer wins, whose answer of another kind is `TypeError: can't convert C to Integer (C#to_i gives String)`, whose raise propagates, and whose absence is `TypeError: can't convert C into Integer`. With `exception: false` the `to_i` probe is protected too and every failure is nil. With a base, only `to_str` counts: anything else is `ArgumentError: base specified for non string value`. `Float(obj)` asks `to_f` alone, never `to_str` or `to_int`: its Float answer wins, an answer of any other kind, an Integer included, is `TypeError: can't convert C to Float (C#to_f gives Integer)`, a raise propagates, and `exception: false` protects the call and answers nil. Every probe is called exactly once.

## What

The runtime does exactly that, once, in one place, for a statically typed object and for one read out of a container alike, in the strict and the `exception: false` forms, with and without a base. A `to_int` that answers a String, a Bignum or nothing at all is now called and judged rather than refused by clang; a `to_str` on an object makes it a String for `Integer(obj)` and `Integer(obj, base)`; `exception: false` answers the value where there is one and nil where CRuby answers nil, for objects and for plain boxed values; and a class whose `to_int` or `to_i` answers a Bignum types `Integer(obj)` as a Bignum, so the value is carried rather than truncated.

The shared `to_int`, `to_str` and `to_path` bridges, which serve the implicit-conversion slots, referenced a conversion method that yields as if it had a function of its own, and the generated program failed to link on master; declining such a method at the bridge fixes that too: the program builds and the slot answers CRuby's TypeError for the object, where CRuby would call the method, so that line is checked by hand rather than pinned. A conversion method declared with a named `&block` parameter is called with none, as a bare call passes none, through this bridge and the implicit-conversion bridges alike (a typed slot that calls the method directly is not a bridge and is unchanged); master refused the C build for that shape. An anonymous `&` is inlined at its call sites like a yielding method and has no function of its own, so it is not consulted, as on master.

## How

A generated bridge, `sp_obj_conv_sw`, reaches a boxed user object's `to_int`, `to_i`, `to_f` and `to_str` whatever each method's static return type: the compiled method is called and its answer boxed (a body that raises is called and reports nil, a Float slot's nil payload boxes as nil), and a class without the method reports so. It sits next to the existing `to_int` / `to_str` / `to_path` bridges, which keep serving the implicit-conversion slots and take only a method of the slot's own type; the shared row resolver gained an `any_shape` switch for the new one, which also admits a value-type class, called on the boxed copy.

`sp_exc_protect` is rb_protect: a frame of its own, the at_exit drain's shape, that answers whether the call raised and discards the exception. `sp_obj_Integer_val` and `sp_obj_Float_val` run the search above through the bridge, rooting the object across every call and each answer after it; `sp_kernel_Integer_val` puts the plain-value arms next to them, so the `exception: false` form of a boxed Integer, Float or String answers the value. Three typed entry points unbox for the slot the call site has: `sp_poly_Integer_ex` for an Integer slot, `sp_poly_Integer_big` for the Bignum slot the analysis types a call as when the class's `to_int` or `to_i` answers one, and `sp_poly_Float_ex`.

In the compiler, the receiverless-Kernel arm's object cases for `Integer` (strict, `exception: false`, with a base) and `Float` box the object and call those entry points; a temporary object is rooted across the base's evaluation. The poly `exception: false` arms, which answered nil for every boxed value, call them too, and the strict `Integer(x, base)` arm for a non-String static kind hands the runtime the decision, since a boxed value or an object may be a String there. `sp_poly_Integer` and `sp_poly_Float` route a user object to the same path, so a boxed object converts as a typed one does. The analysis marks `to_str` and `to_i` reachable next to `to_int` when a program calls `Integer()`, and `kconv_integer_kind` types `Integer(obj)` as a Bignum when the class's `to_int` or `to_i` answers one.

## Validation

`make gate`: 3490 tests, 61 benchmarks, the optcarrot checksum (59662), ext-cruby, rbs-seed, rubyspec 6/6 and the property checks all pass; the macOS-only spin-e2e progress line is the known red it is on master, and one corpus program timed out under the replay's load as it does on master. Compatibility corpus (a differential corpus of ~2,100 minimized programs that behave differently under CRuby 4.0.6 and Spinel, the same corpus behind #3999/#4003/#4029): 847 to 852 of 2131, 5 gained, 0 lost. The five are the programs of this family: a `to_int` answering a String, one answering a Bignum, one that raises, a `to_f` answering a String and one that raises, each a C build failure on master.

Generated-C sweep over the suite and benchmarks against 3041feb9 with the `#line` paths normalised: 3488 same, 17 changed, 0 failed of 3505. Ten of the seventeen (four benchmarks, bm_binary_trees, bm_huffman, bm_ao_render and bm_nbody, which read their sizes with `Integer(ARGV[0])`, and six tests) call `Kernel#Integer` or `Kernel#Float` somewhere and define no class with a conversion method, so they gain the empty bridge, seven lines: a cold, noinline `sp_obj_conv_sw` whose switch has only its default, and the line that installs it; nothing on any hot path, and bm_nbody at -O2 times the same on both trees (1.30 to 1.36 s in three runs each). kernel_conversion_arguments gains the bridge rows for its classes. issue_3299_integer_base_poly's and issue_3331_poly_to_sym_arm's poly `Integer(x, base)` now call the runtime entry point where they folded before, the same answers for the values those tests use; kernel_integer_float_errors' `Integer(5, 16)` reaches the same ArgumentError through the runtime instead of a folded raise; Three, expr_retry_equal_curry_methodobj, kernel_integer_float_convert and kernel_integer_float_errors, call `Integer` on a statically Float value and gain the domain check before the cast, where the bare cast was undefined for NaN and the infinities; the first of those also renumbers its temporaries after that line. The seventeenth is the new test. The runtime's reserved-prefix list is unchanged: the new helpers sit on `sp_obj_` and `sp_exc_`, so no user method is renamed. optcarrot's generated C is identical, and its checksum unchanged. The inference fixpoint reports no new non-convergence.

New test `test/kernel_conv_protocol.rb`, expectation generated by Ruby 4.0.6, under 10 ms compiled: every answer shape of `to_int` (an Integer, a Bignum, nil, a String, a Float, a raise), `to_str` (a String, a numeric String, another kind, a raise), `to_i` (an Integer, another kind, a raise, absent) and `to_f` (a Float, an Integer, a String, a raise, absent), each in the strict and the `exception: false` forms, with a base, through a statically typed object and through one read out of an Array and a Hash, counting every call; a throw, a break and a proc return out of a probed conversion, with the `ensure` and `catch` around them still answering afterwards; a `to_int` whose answer the analysis cannot pin, sometimes a Bignum and sometimes nil; the block-parameter form, called with no block; and `Integer` of a Float, NaN and an infinity. Compiled on master the test does not build, on the block-parameter methods among other shapes. Clean under `SPINEL_GC_STRESS=1` and under ASAN and UBSAN, plain and stressed.

## Left alone, on purpose

A conversion method that takes an optional, splat or keyword parameter, or one that yields or takes an anonymous `&`, is not the protocol here, as it is not for the argument-slot protocol already in the compiler: the class counts as not having the method, so `def to_int(x = 1)` is `TypeError: can't convert C into Integer` where CRuby calls it with no arguments and answers; master refuses the C build for the optional, splat and keyword shapes and answers the same TypeError for the yielding one, the anonymous `&` and `def to_i(x = 0)`. A yielding method is inlined at its call sites and has no function of its own for a bridge to reach; filling a default from a bridge is its own change.

A Bignum reaching an Integer-typed site. `Integer(x)` on a boxed value that holds a plain Bignum answers a truncated number on master and still does, since the site is typed as an Integer; a Bignum answered by a user object through such a boxed value, or by a method whose answer the analysis cannot pin (one that answers a Bignum sometimes and nil otherwise), is now a loud `RangeError: bignum too big to convert into 'long'` rather than a silent number in the strict form; the `exception: false` form of such a call is boxed already and carries it. Only a class whose `to_int` or `to_i` is typed as answering a Bignum carries it in the strict form, as the What says; typing the unpinned case as a Bignum would refuse to build every site that needs an Integer, a Range bound among them. CRuby carries the Bignum in both forms. A `to_str` answering a numeric String wider than 64 bits is the string parser's `RangeError: integer overflow parsing`, on master as here.

The `to_int` probe holds one exception-frame slot while it runs, as a `begin`/`rescue` around it would, and the `exception: false` probes do too. A program already sixty-four rescue frames deep at that point hits the handler-stack bound, which prints `stack level too deep (SystemStackError)` and exits, where master, which armed no frame, answered; a `to_int` that recurses into `Integer()` without end hits the same bound, where CRuby's own stack error is swallowed inside the probe and the search goes on to `to_i`.

Pre-existing and identical on master, found by the review rounds and not touched: a finite Float beyond 2**63 through `Integer()` is the C cast's saturated value (`Integer(1e30)` and `Integer(-1e30)`, which CRuby answers as Bignums); a `&block` conversion method reached from a typed slot that calls it directly (`a[Idx.new]`, `"x" + Cat.new`) still refuses the C build; `x.to_i` on a NaN still spells its FloatDomainError `nan` where `Integer(x)` now says `NaN`; `Integer#coerce` reaches a user object's conversion only in a program that names `Integer` or `Float` somewhere, since the bridge is emitted only then; `Integer("08")` answers 8 (the two-character leading-zero form); a negative radix is `invalid radix` rather than CRuby's auto-detect and a Bignum radix is `invalid value` rather than `RangeError`; `exception:` is honored only as the literal `false`, so a variable or a `**opts` splat raises; `public_send(:Integer, x)` reaches the private Kernel method; a class that redefines `respond_to?` to deny `to_int` is still converted through it; a `String` subclass instance is not a String to `Integer()`; and a class reopened after the call site converts through its final definition, as every ahead-of-time dispatch here does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `Kernel#Integer` and `Kernel#Float` now convert user-defined objects through their conversion methods.
  - Supports `to_int`, `to_i`, `to_str`, and `to_f`, including strict and `exception: false` forms.
  - Conversion behavior now handles large integers, custom return types, base arguments, and special float values more accurately.

- **Bug Fixes**
  - Invalid conversions of `NaN` and infinities now report the appropriate domain errors or return `nil` when requested.
  - Conversion methods with block parameters and control-flow behavior are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->