### PR TITLE
A value built for the JSON walk is rooted for the walk

### DIFF
--- a/packages/json/sp_json.c
+++ b/packages/json/sp_json.c
@@ -144,7 +144,17 @@ static void sp_json_val_b(jbuf *b, sp_RbVal v, int depth) {
     const char *uj = sp_obj_to_json_fn(v);
     if (uj) { jb_add(b, uj, (size_t)sp_str_byte_len(uj)); return; }
   }
-  if (sp_obj_to_hash_fn) { sp_json_val_b(b, sp_obj_to_hash_fn(v), depth); return; }
+  if (sp_obj_to_hash_fn) {
+    /* The reflected hash is fresh, and the walk below allocates a GC string for
+       every key it reaches and for every numeric, string or symbol scalar (true,
+       false and nil are rodata), so it has to be rooted for the walk: a C
+       argument slot is not a root, and the first collection under it leaves the
+       walk reading freed members. Same reason sp_json_parse roots its input. */
+    sp_RbVal h = sp_obj_to_hash_fn(v);
+    SP_GC_ROOT_RBVAL(h);
+    sp_json_val_b(b, h, depth);
+    return;
+  }
   jb_s(b, "null");
 }
 
@@ -200,9 +210,20 @@ static void sp_json_pretty_val(jbuf *b, sp_RbVal v, int depth) {
        out with the surrounding indentation instead of on one line */
     if (sp_obj_to_json_fn) {
       const char *uj = sp_obj_to_json_fn(v);
-      if (uj) { sp_json_pretty_val(b, sp_json_parse(uj), depth); return; }
+      if (uj) {
+        /* the re-parsed document is this walk's only reference to it */
+        sp_RbVal d = sp_json_parse(uj);
+        SP_GC_ROOT_RBVAL(d);
+        sp_json_pretty_val(b, d, depth);
+        return;
+      }
     }
-    if (sp_obj_to_hash_fn) { sp_json_pretty_val(b, sp_obj_to_hash_fn(v), depth); return; }
+    if (sp_obj_to_hash_fn) {
+      sp_RbVal h = sp_obj_to_hash_fn(v);
+      SP_GC_ROOT_RBVAL(h);
+      sp_json_pretty_val(b, h, depth);
+      return;
+    }
     jb_add(b, "null", 4);
     return;
   }

--- a/test/json_walk_roots.rb
+++ b/test/json_walk_roots.rb
@@ -1,0 +1,63 @@
+# A value built for the JSON walk stays rooted for the walk. The hash a Struct
+# or a Data reflects into, and the document pretty_generate re-reads out of a
+# user #to_json answer, are each the walk's only reference to themselves while
+# the walk allocates a GC string for every key it reaches, and for every
+# numeric, string or symbol scalar -- unrooted, the walk reads them back after
+# a collection has already freed them.
+require "json"
+
+# A member whose INFERRED type is poly -- here, because pick can answer an Array,
+# a Hash or a String -- keeps its container through the reflection; every other
+# container type reflects as null. That is the shape that makes the walk recurse
+# under the value being rooted, so it is the shape worth testing.
+Z = Struct.new(:m, :n)
+def pick(i)
+  return [1, 2, "three"] if i == 0
+  return { "k" => "v" } if i == 1
+  "plain"
+end
+doc = ["a", Z.new(pick(0), pick(1)), "b"]
+
+# The members really do reach the walk: without this line the arms below would
+# still print true if the reflection went back to answering null for them.
+puts JSON.generate(doc).include?("three")
+
+# Spinel reflects a Struct into a JSON object where CRuby renders its to_s, so
+# what the three arms below pin is that every answer is the SAME answer:
+# unrooted, the reflected hash is freed while the walk is still reading it.
+first = JSON.generate(doc)
+flat_stable = true
+2000.times { flat_stable = false if JSON.generate(doc) != first }
+puts flat_stable
+
+first_pretty = JSON.pretty_generate(doc)
+pretty_stable = true
+500.times { pretty_stable = false if JSON.pretty_generate(doc) != first_pretty }
+puts pretty_stable
+
+# a Data reflects through the same hook
+D = Data.define(:x, :y)
+ddoc = ["a", D.new(x: pick(0), y: pick(2)), "b"]
+first_data = JSON.generate(ddoc)
+data_stable = true
+2000.times { data_stable = false if JSON.generate(ddoc) != first_data }
+puts data_stable
+
+class Point
+  def initialize(x, y)
+    @x = x
+    @y = y
+  end
+
+  def to_json(*args)
+    { x: @x, y: @y }.to_json(*args)
+  end
+end
+
+# test/user_to_json_nested.rb already pins this same Point through the same walk;
+# new here are the siblings and the loop, so a collection lands inside the
+# re-read walk. A #to_json that forwards its state is the case where the re-read
+# agrees with CRuby, so the document itself is CRuby's.
+reparsed = nil
+2000.times { reparsed = JSON.pretty_generate(["x", Point.new(5, 6), "y"]) }
+puts reparsed

--- a/test/json_walk_roots.rb.expected
+++ b/test/json_walk_roots.rb.expected
@@ -1,0 +1,12 @@
+true
+true
+true
+true
+[
+  "x",
+  {
+    "x": 5,
+    "y": 6
+  },
+  "y"
+]


### PR DESCRIPTION
## Why

Serializing a Struct, or an object with its own `#to_json`, is ordinary Ruby: `JSON.generate(["x", Point.new(1, 2), "y"])`, `JSON.pretty_generate(config)`. The serializer is a standalone translation unit that knows nothing about the generated program's objects; it reaches a plain object through two generic hooks, one that reflects it into a hash of its members and one that asks the object for its own document. Both hooks answer a brand new value, and at all three sites the value built for the walk went straight into the recursive walk as a C argument. A C argument slot is not a GC root. The walk allocates as it goes -- every key it reaches becomes a GC string, as does every numeric, string or symbol scalar -- so a collection under the walk frees the very value being walked, and the walk reads it back out of freed memory.

On master this is a use-after-free that crashes. The new test segfaults there with no environment set and under `SPINEL_GC_STRESS=1` alike, three runs of three in each mode, and under ASAN each of those runs reports a read of freed memory. Whether any one document crashes depends on whether a collection happens to land between the hook's answer and the walk that reads it, which is a question of where the allocation counter falls rather than of which site is at fault: taken apart, the test's arms do not all die in the same mode, a Struct of six members can survive a run that a Struct of five dies in, and one more byte in a sibling string flips a survivor into a crash. Under ASAN the diagnosis tracks the crash exactly -- a use-after-free in every run that dies, none in the runs that pass -- so what varies is the timing, not whether the value is being held. What is invariant is that each of the three sites hands the walk a value nothing is holding.

This is the rule the parser in the same file already follows: `sp_json_parse` roots the string it walks in place, because a caller passing one straight in holds it in nothing but a C argument slot. The three sites here are the serializer's half of that.

## What

Each of the three sites binds the value built for the walk to a local and roots it for the walk that reads it. Nothing else changes: the same hooks are called in the same order, exactly once each, the documents are the same, and the buffer handling from the nesting-error fix is untouched.

## How

`packages/json/sp_json.c`. In the compact walk, `sp_json_val_b` reflected a plain object with `sp_json_val_b(b, sp_obj_to_hash_fn(v), depth)`; the hash is now a local rooted with `SP_GC_ROOT_RBVAL` before the recursive call. The pretty walk, `sp_json_pretty_val`, had the same shape for the reflection and one more for the user document: it re-reads a user `#to_json` answer with `sp_json_parse` and walks the result, which is likewise fresh and reachable from nothing else. Both are bound and rooted the same way.

The fourth hook site needs no root and did not get one: the compact walk appends a user `#to_json` answer straight into the buffer with `jb_add`, which is off the GC heap and grows with `realloc`, so nothing between the hook and the append can collect.

## Validation

`.compat/gate.sh` GREEN on top of master 0f0497b8: 3500 tests, 61 benchmarks, optcarrot checksum 59662, ext-cruby, rbs-seed and rubyspec all as on master (the spin-e2e leg is red on macOS on master too). The compatibility corpus is 905 of 2131 before and after, 0 gained and 0 lost: this is a memory-safety rule, not a corpus family. The generated-C sweep over 3515 programs is 3515 SAME, 0 CHANGED, 0 FAIL, optcarrot included -- the change is package C that every program links rather than codegen, so no program's generated C moves. The inference fixpoint leg reports no new non-convergence. The new test is clean under GC stress and under ASAN plain and stressed alike.

New test `test/json_walk_roots.rb`, expectations generated by Ruby 4.0.6 and byte-identical to CRuby's. Three arms pin that the walk answers the same document every time -- a Struct reflected into a compact document two thousand times, into a pretty one five hundred times, and a Data reflected through the same hook -- rather than the document itself, because Spinel reflects a Struct or a Data into a JSON object where CRuby's json has no support for either and renders its `to_s`. A fourth line pins that the members reach the walk at all (`JSON.generate(doc).include?("three")`, true in CRuby too, where the same substring appears inside the `to_s` rendering): a member whose inferred type is poly -- here because the method behind it can answer an Array, a Hash or a String -- keeps its container through the reflection, and that is what makes the walk recurse under the value being rooted rather than run over a flat row of scalars. Without that line the three stability arms would answer the same if every member reflected as `null`. The last arm pins the full pretty document for a `#to_json` that forwards its state, which is CRuby's answer exactly; `test/user_to_json_nested.rb` already pins the same `Point` through the same walk, and new here are the siblings around it and the loop, so a collection lands inside the re-read walk. On master the test segfaults on three runs of three plain and three of three under `SPINEL_GC_STRESS=1`, ASAN reporting a read of freed memory in each; here it passes both ways, ASAN-clean, in about ten milliseconds either way.

## Left alone, on purpose

Several more findings from the same review of this file are separate rules and are not touched here: a GC-root imbalance when `JSON::NestingError` is raised inside a green thread, the walk's buffer leaking when a user `#to_json` raises mid-walk (which needs the raise site to know which walk owns it), and a user `#to_json` that raises unconditionally never being called at all, so `JSON.generate(["x", Boom.new, "y"])` answers `["x",null,"y"]` where CRuby raises.

Spinel serializing a Struct or a Data as a JSON object at all is a divergence from CRuby, which renders its `to_s`. It is deliberate in the package (`json.rb` asks for `native_obj_reflect`), it is what makes these sites reachable, and changing it is not this rule.

The reflection is also lossy in a way this change does not touch: a Struct member whose inferred type is a container reflects as `sp_box_nil()`, so `Struct.new(:m).new([1, 2])` generates `{"m":null}`. A member whose inferred type is poly survives, which is the shape the new test uses; going through a method is neither necessary nor sufficient, it is the union of more than one type that keeps the container. Both trees do this identically.

The third site rooted here re-reads the user's `#to_json` answer and lays it out with the surrounding indentation. That agrees with CRuby only when the object forwards the pretty state, as CRuby's own `pretty_generate` splices whatever the object answers verbatim: an answer that ignores its arguments comes back re-indented here, and an answer that is not valid JSON raises `JSON::ParserError` where CRuby prints it. The compact walk splices like CRuby for all of them. That divergence is older than this change, it is what the re-read is, and correcting it is its own rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON generation reliability for reflected objects and custom `to_json` results, preventing intermittent failures during repeated serialization.
  * Ensured compact and pretty-printed JSON output remains stable for supported object types.

* **Tests**
  * Added coverage for repeated JSON generation and pretty-printing involving structured objects and custom serialization.
  * Added expected output for the new JSON stability tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->