### PR TITLE
Root the splice's intermediate pieces while it builds them

### DIFF
--- a/lib/sp_cold.c
+++ b/lib/sp_cold.c
@@ -960,8 +960,21 @@ const char *sp_str_splice_at(const char *s, sp_int from, sp_int n, const char *v
     return s;
   }
   if (from + n > len) n = len - from;
-  return sp_str_concat(sp_str_concat(sp_str_sub_range(s, 0, from), val),
-                       sp_str_sub_range(s, from + n, len - from - n));
+  /* Root each piece as soon as it exists. As one nested expression, whichever
+     argument C evaluates first sits in an unrooted temporary while the other
+     one allocates -- sp_str_sub_range and sp_str_concat both do -- since
+     sp_str_concat roots its parameters only once entered, and by then both are
+     already computed. A collection in that window frees the piece still in
+     flight, and the splice reads it back: the result takes its length from
+     recycled memory, or faults where the allocator had already returned the
+     span to the OS. */
+  const char *head = sp_str_sub_range(s, 0, from);
+  SP_GC_ROOT_STR(head);
+  const char *tail = sp_str_sub_range(s, from + n, len - from - n);
+  SP_GC_ROOT_STR(tail);
+  const char *pre = sp_str_concat(head, val);
+  SP_GC_ROOT_STR(pre);
+  return sp_str_concat(pre, tail);
 }
 
 sp_FloatArray *sp_frange_step(sp_FloatRange r, sp_float st) {

--- a/test/string_splice_repeated_gc.rb
+++ b/test/string_splice_repeated_gc.rb
@@ -1,0 +1,34 @@
+# `str[start, len] = rhs` builds its result from pieces -- a head slice, the
+# replacement, a tail slice -- and each of those allocates. Written as one
+# nested expression the piece C evaluates first sat in an unrooted temporary
+# while the next one allocated, so a collection landing in that window freed it
+# and the splice read it back: the result took its length from recycled memory,
+# or faulted outright where the allocator had returned the span to the OS.
+#
+# One splice never showed it; it needs enough of them for a collection to fall
+# in the window. Before the fix this buffer lost 704 bytes partway through the
+# loop and the next splice raised IndexError, and under SPINEL_GC_STRESS=1 it
+# went wrong within twenty iterations. The invariants are simply that a splice
+# of equal length leaves the length alone and writes what it was given.
+
+N = 4096
+CHUNK = 64
+
+buf = Array.new(N, 65).pack("C*")      # all "A"
+rhs = Array.new(CHUNK, 66).pack("C*")  # all "B"
+
+i = 0
+bad_len = -1
+while i < 2000
+  buf[(i % 32) * CHUNK, CHUNK] = rhs
+  if buf.length != N
+    bad_len = buf.length
+    break
+  end
+  i += 1
+end
+
+puts "completed: #{i}"
+puts "length held: #{bad_len == -1}"
+puts "first #{CHUNK * 32} bytes are the replacement: #{buf.byteslice(0, CHUNK * 32) == Array.new(CHUNK * 32, 66).pack('C*')}"
+puts "tail untouched: #{buf.byteslice(CHUNK * 32, N - CHUNK * 32) == Array.new(N - CHUNK * 32, 65).pack('C*')}"

--- a/test/string_splice_repeated_gc.rb
+++ b/test/string_splice_repeated_gc.rb
@@ -11,6 +11,14 @@
 # went wrong within twenty iterations. The invariants are simply that a splice
 # of equal length leaves the length alone and writes what it was given.
 
+# Force the collector to run on nearly every allocation, so the window is
+# exercised wherever this runs rather than only where the allocator happens to
+# put a collection inside it. Read once at the first allocation, which is why
+# setting it here works. Without it this still failed before the fix on a
+# default macOS build -- at iteration 426 rather than 16 -- but that depended on
+# the allocator, and the point of the test is not to depend on it.
+ENV["SPINEL_GC_STRESS"] = "1"
+
 N = 4096
 CHUNK = 64
 

--- a/test/string_splice_repeated_gc.rb.expected
+++ b/test/string_splice_repeated_gc.rb.expected
@@ -1,0 +1,4 @@
+completed: 2000
+length held: true
+first 2048 bytes are the replacement: true
+tail untouched: true


### PR DESCRIPTION
`str[start, len] = rhs` builds its result from three pieces — a head slice, the replacement, a tail slice — and both `sp_str_sub_range` and `sp_str_concat` allocate. Written as one nested expression:

```c
return sp_str_concat(sp_str_concat(sp_str_sub_range(s, 0, from), val),
                     sp_str_sub_range(s, from + n, len - from - n));
```

whichever argument C evaluates first sits in a bare C temporary while the other one allocates. Nothing roots it there — `sp_str_concat` roots its parameters once entered, and by then both are already computed. A collection landing in that window frees the piece still in flight, and the splice reads it back.

The fix assigns each piece to a rooted local. Same three allocations, same result, no window.

## Test

`test/string_splice_repeated_gc.rb` is the small system-allocator shape: 2000 equal-length splices into a 4096-byte buffer, asserting the length is unchanged, the spliced region holds the replacement, and the tail is untouched. Against a pre-fix build all four assertions fail (it stops at iteration 426); with the fix it completes, and it also completes under `SPINEL_GC_STRESS=1`, where pre-fix it died by iteration 16.

## Not in this PR

While reducing this I found a **separate** defect the same report predicted: the splice reallocates, and where the string is aliased through a constructor parameter stored in an ivar, the alias is left stale. That is a semantics gap in the promotion analysis rather than a memory-safety one, it long predates this change, and `docs/limitations.md` currently promises the opposite. It is being looked at separately.

## Checks

On macOS 25.6.0 (arm64), on `4f3f4bf2`:

- `make test` — 3506 pass, 0 fail, 0 error
- `make bench` — 61 pass, 0 fail, 0 error
- `make optcarrot` — OK, checksum 59662
- `make rubyspec-gate` — all expected-PASS examples still pass across all six legs

There is no `gen2.c == gen3.c` closure target on master, so nothing to run for that item.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved string splicing reliability during garbage collection, preventing corrupted or unexpectedly resized strings during repeated replacements.
  - Preserved replacement content, overall string length, and untouched trailing content during intensive repeated edits.

- **Tests**
  - Added regression coverage for 2,000 repeated string replacements.
  - Verified behavior under frequent garbage collection to ensure consistent results in memory-intensive scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->