### PR TITLE
A read loop roots the String it hands the block

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -18042,8 +18042,12 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
       int bbn = 0; const int *bbb = bdy >= 0 ? nt_arr(nt, bdy, "body", &bbn) : NULL;
       int lt = ++g_tmp;
       buf_puts(b, "({ ");
-      buf_printf(b, "const char *_t%d; while ((_t%d = sp_argf_gets()) != NULL) {", lt, lt);
-      if (bpn) buf_printf(b, " const char *lv_%s = _t%d;", bpn, lt);
+      /* the line ARGF yields is a fresh string held in this C temporary and
+         nowhere else: root the slot, and the block's parameter with it, the
+         way IO#each_line below does */
+      buf_printf(b, "const char *_t%d = NULL; SP_GC_ROOT_STR(_t%d);"
+                    " while ((_t%d = sp_argf_gets()) != NULL) {", lt, lt, lt);
+      if (bpn) buf_printf(b, " const char *lv_%s = _t%d; SP_GC_ROOT_STR(lv_%s);", bpn, lt, bpn);
       for (int k = 0; k < bbn; k++) emit_stmt(c, bbb[k], b, 0);
       buf_puts(b, " } (&sp_argf_obj); })");
       return;
@@ -18158,13 +18162,17 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
       buf_puts(b, "({ ");
       /* rooted for the block's duration: a temporary receiver (Dir.open(d).each)
          has no other reference, and a body that allocates would let the
-         collector close it mid-loop (the File loops below root theirs too) */
-      buf_printf(b, "sp_Dir *_t%d = %s; SP_GC_ROOT(_t%d); const char *_t%d; ", tdh, dr, tdh, tdn);
+         collector close it mid-loop (the File loops below root theirs too).
+         The entry string the loop yields is a fresh allocation held in a C
+         temporary just the same, so it and the block's parameter take roots
+         of their own. */
+      buf_printf(b, "sp_Dir *_t%d = %s; SP_GC_ROOT(_t%d); const char *_t%d = NULL; SP_GC_ROOT_STR(_t%d); ",
+                 tdh, dr, tdh, tdn, tdn);
       buf_printf(b, "while ((_t%d = sp_Dir_read(_t%d)) != NULL) {", tdn, tdh);
       if (skip_dots)
         buf_printf(b, " if (sp_str_eq(_t%d, (&(\"\\xff\" \".\")[1])) ||"
                       " sp_str_eq(_t%d, (&(\"\\xff\" \"..\")[1]))) continue;", tdn, tdn);
-      if (dbpn) buf_printf(b, " const char *lv_%s = _t%d;", dbpn, tdn);
+      if (dbpn) buf_printf(b, " const char *lv_%s = _t%d; SP_GC_ROOT_STR(lv_%s);", dbpn, tdn, dbpn);
       for (int k = 0; k < dbbn; k++) emit_stmt(c, dbbb[k], b, 0);
       buf_printf(b, " } (sp_Dir *)_t%d; })", tdh);
       return;
@@ -18746,8 +18754,16 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
         buf_printf(b, "const char *_t%dc; sp_int _t%d; while ((_t%dc = sp_File_getc(_t%d)) != NULL"
                       " && (_t%d = sp_str_ord(_t%dc), 1)) {", lt2, lt2, lt2, rf2, lt2, lt2);
       else
-        buf_printf(b, "const char *_t%d; while ((_t%d = sp_File_getc(_t%d)) != NULL) {", lt2, lt2, rf2);
-      if (bpn2) buf_printf(b, " %s lv_%s = _t%d;", (is_byte || is_cp) ? "sp_int" : "const char *", bpn2, lt2);
+        /* the character is a fresh string, rooted -- slot and block parameter
+           -- like the line in each_line below. each_byte and each_codepoint
+           hand the block an sp_int instead; each_codepoint's own string is
+           read by the loop condition and never again, so it needs no root */
+        buf_printf(b, "const char *_t%d = NULL; SP_GC_ROOT_STR(_t%d);"
+                      " while ((_t%d = sp_File_getc(_t%d)) != NULL) {", lt2, lt2, lt2, rf2);
+      if (bpn2) {
+        buf_printf(b, " %s lv_%s = _t%d;", (is_byte || is_cp) ? "sp_int" : "const char *", bpn2, lt2);
+        if (!is_byte && !is_cp) buf_printf(b, " SP_GC_ROOT_STR(lv_%s);", bpn2);
+      }
       for (int k = 0; k < bbn2; k++) emit_stmt(c, bbb2[k], b, 0);
       buf_printf(b, " } (sp_File *)_t%d; })", rf2);
       free(rb.p); return;
@@ -18974,11 +18990,19 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
       free(rb.p); r = NULL;
       /* Each iteration yields a FRESH heap line string, matching CRuby --
          a stored reference must keep its own line, not a mutated shared
-         buffer (#2803). */
-      buf_printf(b, "const char *_t%d; while ((_t%d = sp_File_gets_sep(_t%d, ", lt, lt, rf);
+         buffer (#2803). That string is held in this C temporary and nowhere
+         else, so the slot is rooted for the block: a block that allocates
+         otherwise collects the line it was just handed and reads it back
+         empty. NULL first, because the mark walker reads the slot as it
+         stands. The block's own parameter is rooted for the same reason
+         emit_hash_filter_loop roots its key and value (codegen_iter.c): a
+         block that REBINDS it -- line = line.upcase -- holds the new string
+         in that slot alone. */
+      buf_printf(b, "const char *_t%d = NULL; SP_GC_ROOT_STR(_t%d);"
+                    " while ((_t%d = sp_File_gets_sep(_t%d, ", lt, lt, lt, rf);
       if (esep >= 0) emit_expr(c, esep, b); else buf_puts(b, "\"\\n\"");
       buf_puts(b, ", 0, 0)) != NULL) {");
-      if (bpn) buf_printf(b, " const char *lv_%s = _t%d;", bpn, lt);
+      if (bpn) buf_printf(b, " const char *lv_%s = _t%d; SP_GC_ROOT_STR(lv_%s);", bpn, lt, bpn);
       for (int k = 0; k < bbn; k++) emit_stmt(c, bbb[k], b, 0);
       buf_printf(b, " } (sp_File *)_t%d; })", rf);
       return;

--- a/test/loop_yield_root.rb
+++ b/test/loop_yield_root.rb
@@ -1,0 +1,109 @@
+# The String a builtin read loop yields is rooted for the block that reads it.
+# IO#each_line, IO#each_char, Dir#each and ARGF.each_line hand the block a
+# freshly allocated String every turn, and held it in nothing but C temporaries
+# -- the loop's own, and the block parameter's -- so a block that allocates
+# could collect the very string it had just been handed. The loop counts right
+# either way; the block reads its yield back as "".
+# The last three arms rebind the block parameter, which puts the string the
+# block holds in a slot of its own: that one takes a root too.
+
+path = "/tmp/sp_loop_yield_root.txt"
+argf = "/tmp/sp_loop_yield_root_argf.txt"   # the file named in loop_yield_root.rb.args
+dir  = "/tmp/sp_loop_yield_root_dir"
+File.write(path, (1..300).map { |i| "L#{i}" }.join("\n") + "\n")
+File.write(argf, (1..200).map { |i| "A#{i}" }.join("\n") + "\n")
+if Dir.exist?(dir)
+  Dir.children(dir).each { |e| File.delete("#{dir}/#{e}") }
+  Dir.rmdir(dir)
+end
+Dir.mkdir(dir)
+(1..40).each { |i| File.write("#{dir}/e#{i}.txt", "x") }
+
+# each_line: every line still starts with L after a block that allocates
+f = File.open(path)
+seen = 0
+bad = 0
+f.each_line do |l|
+  200.times { "q" * 64 }
+  seen += 1
+  bad += 1 unless l.start_with?("L")
+end
+f.close
+puts "each_line seen=#{seen} bad=#{bad}"
+
+# each_char: every character is still one byte wide
+g = File.open(path)
+seen2 = 0
+bad2 = 0
+g.each_char do |ch|
+  100.times { "r" * 64 }
+  seen2 += 1
+  bad2 += 1 if ch.bytesize != 1
+end
+g.close
+puts "each_char seen=#{seen2} bad=#{bad2}"
+
+# Dir#each: every entry is still its own name
+d = Dir.open(dir)
+seen3 = 0
+bad3 = 0
+d.each do |e|
+  100.times { "s" * 64 }
+  seen3 += 1
+  bad3 += 1 unless e == "." || e == ".." || e.start_with?("e")
+end
+d.close
+puts "Dir#each seen=#{seen3} bad=#{bad3}"
+
+# ARGF.each_line: the same loop over the files named in ARGV
+seen4 = 0
+bad4 = 0
+ARGF.each_line do |l|
+  100.times { "t" * 64 }
+  seen4 += 1
+  bad4 += 1 unless l.start_with?("A")
+end
+puts "ARGF.each_line seen=#{seen4} bad=#{bad4}"
+
+# the same three loops again, with a block that REBINDS its parameter: the
+# string it holds is then the block's own, not the one the loop handed it
+h = File.open(path)
+seen5 = 0
+bad5 = 0
+h.each_line do |l|
+  l = l.upcase
+  200.times { "q" * 64 }
+  seen5 += 1
+  bad5 += 1 unless l.start_with?("L")
+end
+h.close
+puts "each_line rebound seen=#{seen5} bad=#{bad5}"
+
+i = File.open(path)
+seen6 = 0
+bad6 = 0
+i.each_char do |ch|
+  ch = ch.upcase
+  100.times { "r" * 64 }
+  seen6 += 1
+  bad6 += 1 if ch.bytesize != 1
+end
+i.close
+puts "each_char rebound seen=#{seen6} bad=#{bad6}"
+
+j = Dir.open(dir)
+seen7 = 0
+bad7 = 0
+j.each do |e|
+  e = e.upcase
+  100.times { "s" * 64 }
+  seen7 += 1
+  bad7 += 1 unless e == "." || e == ".." || e.start_with?("E")
+end
+j.close
+puts "Dir#each rebound seen=#{seen7} bad=#{bad7}"
+
+Dir.children(dir).each { |e| File.delete("#{dir}/#{e}") }
+Dir.rmdir(dir)
+File.delete(path)
+File.delete(argf)

--- a/test/loop_yield_root.rb.args
+++ b/test/loop_yield_root.rb.args
@@ -1,0 +1,1 @@
+/tmp/sp_loop_yield_root_argf.txt

--- a/test/loop_yield_root.rb.expected
+++ b/test/loop_yield_root.rb.expected
@@ -1,0 +1,7 @@
+each_line seen=300 bad=0
+each_char seen=1392 bad=0
+Dir#each seen=42 bad=0
+ARGF.each_line seen=200 bad=0
+each_line rebound seen=300 bad=0
+each_char rebound seen=1392 bad=0
+Dir#each rebound seen=42 bad=0


### PR DESCRIPTION
## Why

`IO#each_line` (and its alias `IO#each`), `IO#each_char`, `Dir#each` (with `#each_child` and `#each_entry`) and `ARGF.each_line` hand the block a freshly allocated String on every turn, and each of them held that string in nothing but C temporaries: the one the `while` condition assigns to, and a second one for the block's parameter. Neither is a GC root, so a block that allocates could collect the string the loop had just handed it, and read it back as an empty String.

```ruby
File.open(path).each_line do |line|
  200.times { "q" * 64 }   # any allocation will do
  puts line                # empty, for one line in fifteen here
end
```

Nothing else goes wrong, which is what makes it hard to see: the loop visits every line, stops where it should, and the program exits 0. Only the value in the block's hands is gone.

On a release build of master, with the new test's inputs — a 300-line file, a directory of 40 files, a 200-line ARGF file — 20 of the 300 lines, 48 of the 1392 characters, 2 of the 42 directory entries and 7 of the 200 ARGF lines came back empty, the same on three runs. Those are timing counts rather than a rate — the plain-run numbers shift by one or two as anything around them changes. With `SPINEL_GC_STRESS=1` every yield of all four loops came back empty, which is the answer that does not move.

A block that rebinds its parameter loses the string the same way, in the parameter's own slot — `line = line.upcase`, or `line << "x"`, which lowers to the same rebinding. So does a block that suspends its Fiber in the middle of the loop: 10 of 300 lines on master, and all 300 under stress.

## What

Four emitters in `src/codegen_call.c`, one per loop:

- `ARGF#each_line`, `#each` and `#each_string`, over `sp_argf_gets`
- `Dir#each`, `#each_child` and `#each_entry`, over `sp_Dir_read` — this one already rooted the Dir handle, but not the entry name it yields
- `IO#each_char`, over `sp_File_getc`
- `IO#each_line` and `#each`, over `sp_File_gets_sep`

Each of them now roots both slots: the loop's temporary, declared `NULL` ahead of the loop, and the block's parameter where it is bound.

## How

`SP_GC_ROOT_STR` records the address of a slot rather than the value in it, so one push before the loop covers every iteration of the loop's own temporary: each turn's fresh string lands in a slot the collector already knows to mark. That slot is set to `NULL` first because the mark walker reads it as it stands — `sp_mark_string` returns immediately on a NULL, but on an uninitialized pointer it would read the marker byte at `s[-1]`.

The block's parameter is a separate slot, bound inside the loop, so its root is pushed and popped once per iteration where the parameter is declared. That is not measurable: 2 million `each_line` yields followed by 7 million `each_char` yields answer in 0.53–0.54 s on both trees, three runs each, and optcarrot's generated C does not change at all.

This is the shape `emit_hash_filter_loop` already emits for the String keys and values it hands `Hash#delete_if` and its neighbours (`src/codegen_iter.c`), and for the same two reasons its comment gives: the block can drop the pair it was handed, or rebind the name.

`IO#each_byte` and `IO#each_codepoint` are left as they were: both hand the block an `sp_int`. `each_codepoint` does read a character string, in its loop condition, but never reads it again, so nothing can observe its collection.

## Validation

Gate GREEN on 53e77d76: the suite is 3501 pass / 0 fail (the new test is the extra one, and the spin-e2e leg is red on macOS on master too), optcarrot answers 59662 from byte-identical generated C, the 2131-program compatibility corpus stays at 905 with nothing gained and nothing lost, the inference fixpoint gains no non-convergences (its one "round count differs" line, on `test/enumerator_block_returns_self.rb`, is pre-existing: that program's generated C is byte-identical on both trees, and running the leg with master on both sides reproduces the same flip), and ASAN and UBSAN are clean on the new test both plain and under `SPINEL_GC_STRESS=1`.

The generated-C sweep over all 3516 programs in the tree is byte-identical except for eight, and in those eight every single differing line is one of the two additions — the loop slot's `= NULL` and its `SP_GC_ROOT_STR`, or the parameter's `SP_GC_ROOT_STR` — with nothing else changed: `benchmark/bm_io_wordcount.rb` (2 lines), `test/argf_reads_args.rb` (1), `test/bundle_io_sys.rb` (1), `test/dir_handle_objects.rb` (2), `test/each_entry_returns_receiver.rb` (2), `test/io_instance_read_surface.rb` (3), `test/io_closed_stream.rb` (8), and the new test (7).

`test/loop_yield_root.rb` has seven arms: one per loop, plus three that rebind the block parameter before looking at it. Every block allocates before it reads what it was handed, and counts what came back wrong. The iteration counts are printed too, so an arm that ended early would show as a changed answer rather than as a passing test. The ARGF arm reads a file named in `test/loop_yield_root.rb.args`, which the test writes itself, so no fixture joins the tree. On master the four plain arms answer `bad=20`, `bad=48`, `bad=2` and `bad=7`, the three rebinding arms answer `bad=20`, `bad=45` and `bad=2`, and under `SPINEL_GC_STRESS=1` every count is bad.

## Left alone, on purpose

`String#each_line` and `String#each_char` with a block have a related defect and a different symptom: those loops end EARLY rather than yielding an empty string. `s.each_line` delivers 14 of its 300 lines here and 1 of 300 under GC stress, and `each_char` truncates the same way when its receiver is a temporary (`array.join.each_char { ... }`) — with an ordinary receiver it is fine. What goes uncollected there is the lines array and the receiver, not the yield, so it is a different value, a different macro and a different place; it belongs in its own change. `Hash#each` has the same shape — its hoisted receiver is unrooted where its own `delete_if` twin roots one — and belongs with it.

`File.foreach`, `IO.foreach`, `Dir.foreach` and the `Dir.each_child` class method answer correctly on master, plain and under GC stress: they do not route through these four emitters and are untouched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed built-in file, directory, character, and argument-based iteration so yielded values remain valid while the loop block runs, including when the block allocates objects or reassigns its parameter.

* **Tests**
  * Added coverage for line, character, directory, and argument-file iteration scenarios, including parameter reassignment and garbage-collection pressure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->