### PR TITLE
The string collection budget is sized from a generation, not the heap it marks

### DIFF
--- a/lib/sp_alloc.c
+++ b/lib/sp_alloc.c
@@ -221,23 +221,37 @@ void sp_gc_retune_object(size_t before) {
   else if (live > 0) { sp_gc_threshold = sp_gc_sat_mul(live, 4); if (sp_gc_threshold < sp_gc_threshold_init) sp_gc_threshold = sp_gc_threshold_init; }
   else { sp_gc_threshold = sp_gc_threshold_init; }
 }
-/* `before` is the pre-sweep live bytes; `after` the survivors. The threshold is
-   the PER-WORKER budget (each worker triggers on its own list, so the aggregate
-   heap is bounded by N * threshold). Retune on the per-worker average so the
-   budget tracks a single worker's survivor size and does NOT inflate by N each
-   cycle -- retuning on the aggregate would grow it geometrically for long-lived
-   strings. The single-threaded build works in absolute bytes (N == 1). */
+/* `before` and `after` are both the WHOLE live string set -- young plus old --
+   the way sp_gc_retune_object reads the whole object heap. Sizing from the
+   young generation alone left this budget blind to the old one: a render
+   promotes what it keeps, so `after` read as ~0 however much string data the
+   process was holding, and the trigger fell back to its floor after every
+   sweep. What it gates is a whole-heap stop-the-world, old generation
+   included, so the budget that pays for a collection has to see the bytes the
+   mark walks. Both sides have to move together -- a whole-heap `after` against
+   a young-only `before` reads as an unproductive sweep every time.
+
+   The threshold is the PER-WORKER budget (each worker triggers on its own
+   list, so the aggregate heap is bounded by N * threshold). Retune on the
+   per-worker average so the budget tracks a single worker's share and does NOT
+   inflate by N each cycle -- retuning on the aggregate would grow it
+   geometrically for long-lived strings. The single-threaded build works in
+   absolute bytes (N == 1). */
+static size_t sp_str_gate_old = 0;   /* the old total at the gate, for `before` */
 static void sp_str_retune(size_t before, size_t promoted) {
   if (sp_gc_stress_pin) { sp_str_threshold = sp_str_threshold_init; return; }
 #ifdef SP_THREADS
   int nw = sp_active_workers; if (nw < 1) nw = 1;
-  size_t after = (sp_str_bytes_total() + promoted) / (size_t)nw;
-  before /= (size_t)nw;
+  size_t after = (sp_str_bytes_total() + sp_str_old_total()) / (size_t)nw;
+  before = (before + sp_str_gate_old) / (size_t)nw;
+  (void)promoted;   /* already inside old_total by the time we run */
 #else
-  /* A promoted string is a survivor, not a reclamation: leaving it out of
-     `after` would read as a very productive sweep and shrink the trigger,
-     collecting harder and harder as the old generation grows. */
-  size_t after = sp_str_heap_bytes + promoted;
+  /* sp_str_old_total() already carries what this sweep promoted, so a promoted
+     string is counted once, as the survivor it is: leaving it out would read as
+     a very productive sweep and shrink the trigger, collecting harder and
+     harder as the old generation grows. */
+  size_t after = sp_str_heap_bytes + sp_str_old_total();
+  before += sp_str_gate_old;
 #endif
   size_t freed = before > after ? before - after : 0;   /* saturating; see sp_gc_retune_object */
   if (freed < before / 4) { sp_str_threshold = sp_gc_sat_mul(before, 2); }
@@ -550,6 +564,7 @@ int sp_str_sweep_begin(int *major) {
 #endif
   if (before <= SP_GC_CTR_GET(sp_str_threshold)) return 0;
   sp_str_gate_before = before;
+  sp_str_gate_old = sp_str_old_total();
   /* Walk the old generation only once it has itself grown past a threshold,
      then re-aim that threshold at what survived. Between majors, old strings
      that die are reclaimed late -- the same delayed-reclamation trade this


### PR DESCRIPTION
`sp_str_retune` aims the next string trigger at what survived the sweep, and
reads "what survived" from `sp_str_bytes_total()` — the sum of the per-worker
`young_bytes`. The old generation, which `sp_str_old_total()` tracks and which
the same stop-the-world walks, never enters the calculation. A page render
promotes what it keeps, so `after` comes out at roughly zero however much
string data the process is holding, and the trigger returns to its 256 KB floor
after every sweep.

The object heap does not do this: `sp_gc_retune_object` reads `sp_gc_bytes`,
the whole live object heap, and its trigger floats correctly — measured at
9.5 MB to 146.6 MB on the same runs where the string trigger sat on its floor.
Two heaps in one collector, sized from different quantities.

This puts both sides of the string comparison on the whole live set. `before`
needs the old total captured at the gate, because a whole-heap `after` against
a young-only `before` reads as an unproductive sweep every time and takes the
other branch instead — which is why the two cannot move separately.

## Measured

A Rails-derived application (roundhouse-emitted, 12 OS workers, jemalloc,
`/rooms/1` a 423 KB render). Baseline taken with the unpatched compiler in the
same session, not from an earlier run:

| connections | before | after | GC % of wall | collections / 1k req | cores |
|--:|--:|--:|---|--:|---|
| 8 | 90.4 req/s | **209.1** | 51.7% → 43.4% | 3673 → 1043 | 3.39 → 5.14 |
| 16 | 54.7 | **253.4** | 65.7% → 39.3% | 3697 → 238 | 2.51 → 7.49 |
| 64 | 17.7 | **246.2** | 83.7% → 41.1% | 3487 → 79 | 1.89 → 7.86 |

Throughput stops falling as concurrency rises, which was the complaint in
#4352. A second, much smaller application on the same compiler — 6.5 KB pages,
341 string allocations per request against the first app's 80,272 — is
unchanged in both directions: 18,428 → 18,484 req/s on its HTML route,
30,196 → 30,038 on its JSON one.

## The trade, and what I deliberately did not do

Memory rises: 215 → 442 MB at c=16, 411 → 1,064 MB at c=64. That is `live * 4`
behaving like the object heap's `live * 4` — and, like it, with no ceiling. An
application holding a large long-lived string heap would reserve four times it
as headroom. CRuby caps the analogous budget at 32 MB
(`RUBY_GC_MALLOC_LIMIT_MAX`).

A cap felt like it belonged in its own change, applying to **both** heaps
rather than reintroducing on the string side the asymmetry this removes. If the
headroom is too generous, the multiplier is the cheaper lever than a cap — the
unproductive-sweep branch beside it already uses `* 2`. I can measure `* 2` and
post the curve if you would rather see it before deciding.

`promoted` is now redundant in the threaded path (it is inside `old_total` by
the time the retune runs). I voided it rather than change the signature, since
the single-threaded path still documents the reasoning; removing it is yours to
prefer.

## Validation

Built and tested on Ubuntu 24.04 / gcc 13.3 at 3dc34585, applies to master
unchanged:

- `make test`: **3,506 pass, 1 fail**. The failure is
  `implicit_conversion_protocol` (`"644"` vs `"664"`) and it fails identically
  on an unpatched tree — the machine's umask is 002, not 022.
- The application's two heavy pages come back byte-identical — 423,364 and
  392,227 bytes — before and after 15 s at c=64, on both compilers, with no
  errors logged. A collector running 44x less often is the shape that would
  hide a dropped root, so this seemed worth checking directly.

Refs #4352

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHYkownwPh8mrWTXyNcvA9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved string garbage collection tuning to account for the complete live string heap, including promoted and older-generation strings.
  - Improved consistency of garbage collection behavior across threaded and single-threaded builds.
  - Refined per-worker threshold calculations to better reflect actual memory usage and avoid counting promoted strings twice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->