### PR TITLE
A raise out of a user #to_json is the answer, and the walk it leaves keeps what it was holding

### DIFF
--- a/packages/json/sp_json.c
+++ b/packages/json/sp_json.c
@@ -15,27 +15,87 @@
    (matches spinel_rt.h's SPL). Used for the fixed tokens true/false/null. */
 #define JSPL(s) (&("\xff" s)[1])
 
-/* Off-GC-heap growable buffer; finalized into a GC string at the end. */
-typedef struct { char *p; size_t len, cap; } jbuf;
-/* `s` is not rooted: this buffer is off the GC heap and grows with realloc,
-   so nothing here can collect -- and most callers hand it a raw literal or a
-   stack byte, which have no marker byte in front for the collector to read
-   (ASAN: global-buffer-overflow, and a stray write into rodata or the stack). */
+/* Growable buffer, finalized into a right-sized GC string at the end.
+
+   It starts off the GC heap, and it has to: the escaper below reads an
+   unrooted source through it -- one that may be a rodata literal, whose [-1]
+   is not a marker byte for the collector to read -- and that is only safe
+   while nothing in here can collect.
+
+   A document walk, though, does not always return through its frame. A user
+   #to_json can raise, throw, or return from a proc, and every one of those
+   longjmps over the frame, leaving a malloc'd block owned by nothing at all.
+   So a walk MOVES its buffer onto the GC string heap before it calls user code
+   (jb_to_heap), into a slot it has rooted, and from then on the collector owns
+   it: the landing frame drops that root along with every other root the walk
+   was holding, whichever way the walk was left. Once moved, growing the buffer
+   allocates -- so an append whose source is a GC string roots that source too
+   (jb_gcs). The move happens at most once per walk, and not at all for a
+   document with no user objects in it, which is why it costs nothing to
+   measure. */
+typedef struct {
+  char *p; size_t len, cap;
+  char *heap;   /* NULL while p is malloc'd; == p once moved, and the rooted slot */
+} jbuf;
+/* A moved buffer's grow, out of line: jb_add is inlined into loops that append
+   a byte at a time, and a second allocator inside its body stops that. With
+   the grow written inline, nm gives jb_add a symbol of its own and the
+   generate benchmark goes from 1.98 s to 2.58 s. */
+SP_COLD static __attribute__((noinline)) void jb_grow_heap(jbuf *b, size_t cap) {
+  char *q = sp_str_alloc(cap);   /* collects; b->heap is the walk's root */
+  if (b->len) memcpy(q, b->p, b->len);
+  b->p = b->heap = q;
+  b->cap = cap;
+}
 static void jb_add(jbuf *b, const char *s, size_t n) {
   if (b->len + n + 1 > b->cap) {
-    b->cap = (b->len + n + 1) * 2;
-    b->p = (char *)realloc(b->p, b->cap);
-    if (!b->p) sp_oom_die();
+    size_t cap = (b->len + n + 1) * 2;
+    if (b->heap) jb_grow_heap(b, cap);
+    else {
+      b->p = (char *)realloc(b->p, cap);
+      if (!b->p) sp_oom_die();
+      b->cap = cap;
+    }
   }
   memcpy(b->p + b->len, s, n);
   b->len += n;
 }
 static void jb_c(jbuf *b, char c) { jb_add(b, &c, 1); }
+/* Hand the buffer to the collector before running code that may not come back.
+   The allocation here can collect, and that is safe at exactly this moment:
+   b->heap is still NULL, so the walk's root marks nothing, and what it is
+   copying out of is a malloc'd block the collector cannot touch. */
+static void jb_to_heap(jbuf *b) {
+  if (b->heap) return;
+  size_t cap = b->cap ? b->cap : 1;
+  char *q = sp_str_alloc(cap);
+  if (b->len) memcpy(q, b->p, b->len);
+  free(b->p);
+  b->p = b->heap = q;
+  b->cap = cap;
+}
+/* Append a GC string to a buffer that has moved: growing it allocates now, and
+   the source is held in nothing but this argument slot -- the same reason
+   sp_json_parse roots its input. A source with no marker byte in front of it must not come through
+   here: the collector reads that byte. Every caller's does -- a fresh heap
+   string, sp_str_empty, or a JSPL literal. */
+static void jb_gcs_rooted(jbuf *b, const char *s, size_t n) {
+  SP_GC_ROOT_STR(s);
+  jb_add(b, s, n);
+}
+/* Every GC string a walk appends comes through here, once per scalar and once
+   per key. Before the buffer moves nothing in jb_add can collect, so no root
+   is pushed; the push is in its own function above to keep the cleanup it
+   declares out of the path that runs when there is nothing to root. */
+static inline void jb_gcs(jbuf *b, const char *s, size_t n) {
+  if (b->heap) { jb_gcs_rooted(b, s, n); return; }
+  jb_add(b, s, n);
+}
 static const char *jb_finish(jbuf *b) {
   char *r = sp_str_alloc(b->len);
   if (b->len) memcpy(r, b->p, b->len);
   sp_str_set_len(r, b->len);
-  free(b->p);
+  if (!b->heap) free(b->p);
   return r;
 }
 
@@ -75,11 +135,13 @@ static const char *sp_json_key(sp_RbVal k) {
    whether or not anything repeats. */
 #define SP_JSON_MAX_NESTING 100
 SP_COLD static __attribute__((noinline, noreturn)) void sp_json_too_deep(jbuf *b) {
-  free(b->p);  /* this walk's buffer; a walk a user #to_json runs inside it owns its own */
+  /* The walk's own raise, so the walk can hand it the buffer to release (#4355).
+     One it has already moved onto the GC heap needs nothing: the collector
+     takes that with the root the landing frame drops. */
+  if (!b->heap) free(b->p);
   sp_raise_cls("JSON::NestingError",
                "nesting of 100 is too deep. Did you try to serialize objects with circular references?");
 }
-static void jb_s(jbuf *b, const char *s) { jb_add(b, s, strlen(s)); }
 /* Everything but a container: the leaf arms, answering one GC string. */
 static const char *sp_json_scalar(sp_RbVal v) {
   switch (v.tag) {
@@ -94,18 +156,26 @@ static const char *sp_json_scalar(sp_RbVal v) {
 }
 static void sp_json_val_b(jbuf *b, sp_RbVal v, int depth);
 /* A compact document is appended into ONE buffer for the whole walk, as the
-   pretty form below already does, so the nesting error has exactly one
-   allocation to release before it unwinds (sp_json_too_deep frees it). */
+   pretty form below already does, so the walk has exactly one allocation to
+   account for.
+
+   That buffer is released whichever way the walk is left. Its own nesting
+   error is handed it to free. The raises it cannot be handed -- a user
+   #to_json that raises, throws or returns from a proc, and a #to_json answer
+   that does not parse -- leave this frame without coming back to it, so the
+   walk moves the buffer to the collector before it calls any of that code. */
 const char *sp_json_val(sp_RbVal v) {
   if (v.tag != SP_TAG_OBJ) return sp_json_scalar(v);
+  SP_GC_ROOT_RBVAL(v);   /* see sp_json_pretty below */
   jbuf b; memset(&b, 0, sizeof b);
+  SP_GC_ROOT_STR(b.heap);
   sp_json_val_b(&b, v, 0);
   return jb_finish(&b);
 }
 /* `depth` counts the containers already entered, so a container reached at
    depth 100 would be the 101st level. */
 static void sp_json_val_b(jbuf *b, sp_RbVal v, int depth) {
-  if (v.tag != SP_TAG_OBJ) { jb_s(b, sp_json_scalar(v)); return; }
+  if (v.tag != SP_TAG_OBJ) { const char *sc = sp_json_scalar(v); jb_gcs(b, sc, strlen(sc)); return; }
   int kind = sp_json_kind_fn ? sp_json_kind_fn(v) : 0;
   if (kind == 1) {  /* array */
     if (depth >= SP_JSON_MAX_NESTING) sp_json_too_deep(b);
@@ -126,7 +196,7 @@ static void sp_json_val_b(jbuf *b, sp_RbVal v, int depth) {
       if (i) jb_c(b, ',');
       sp_RbVal k, val;
       sp_json_hpair_fn(v, i, &k, &val);
-      jb_s(b, sp_json_key(k));
+      { const char *jk = sp_json_key(k); jb_gcs(b, jk, strlen(jk)); }
       jb_c(b, ':');
       sp_json_val_b(b, val, depth + 1);
     }
@@ -141,8 +211,9 @@ static void sp_json_val_b(jbuf *b, sp_RbVal v, int depth) {
   /* the answer is a Ruby String, appended by its own length: a NUL inside it
      is the user's to keep */
   if (sp_obj_to_json_fn) {
+    jb_to_heap(b);   /* the user's method may raise, throw, or return past us */
     const char *uj = sp_obj_to_json_fn(v);
-    if (uj) { jb_add(b, uj, (size_t)sp_str_byte_len(uj)); return; }
+    if (uj) { jb_gcs(b, uj, (size_t)sp_str_byte_len(uj)); return; }
   }
   if (sp_obj_to_hash_fn) {
     /* The reflected hash is fresh, and the walk below allocates a GC string for
@@ -155,7 +226,7 @@ static void sp_json_val_b(jbuf *b, sp_RbVal v, int depth) {
     sp_json_val_b(b, h, depth);
     return;
   }
-  jb_s(b, "null");
+  jb_add(b, "null", 4);
 }
 
 /* ---------- JSON.pretty_generate ----------
@@ -197,7 +268,7 @@ static void sp_json_pretty_val(jbuf *b, sp_RbVal v, int depth) {
         sp_json_indent(b, depth + 1);
         sp_RbVal k, val;
         sp_json_hpair_fn(v, i, &k, &val);
-        jb_s(b, sp_json_key(k));
+        { const char *jk = sp_json_key(k); jb_gcs(b, jk, strlen(jk)); }
         jb_add(b, ": ", 2);
         sp_json_pretty_val(b, val, depth + 1);
       }
@@ -209,6 +280,7 @@ static void sp_json_pretty_val(jbuf *b, sp_RbVal v, int depth) {
     /* the user's #to_json answers a compact document; re-read it so it lays
        out with the surrounding indentation instead of on one line */
     if (sp_obj_to_json_fn) {
+      jb_to_heap(b);   /* the user's method may raise, throw, or return past us */
       const char *uj = sp_obj_to_json_fn(v);
       if (uj) {
         /* the re-parsed document is this walk's only reference to it */
@@ -227,11 +299,20 @@ static void sp_json_pretty_val(jbuf *b, sp_RbVal v, int depth) {
     jb_add(b, "null", 4);
     return;
   }
-  jb_s(b, sp_json_val(v));
+  { const char *sc = sp_json_val(v); jb_gcs(b, sc, strlen(sc)); }
 }
 
+/* The document is rooted for the walk, for the reason sp_json_parse roots its
+   input and the reflection arms root theirs: a caller that hands over an
+   expression -- JSON.generate(Foo.new) -- holds it in nothing but the C
+   argument slot, and everything the walk reaches is reached through it. The
+   walk allocates from its first escaped string onward, and moving the buffer
+   to the heap allocates too, so an unrooted document is read after it is
+   freed. */
 const char *sp_json_pretty(sp_RbVal v) {
+  SP_GC_ROOT_RBVAL(v);
   jbuf b; memset(&b, 0, sizeof b);
+  SP_GC_ROOT_STR(b.heap);
   sp_json_pretty_val(&b, v, 0);
   return jb_finish(&b);
 }

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -6169,11 +6169,26 @@ static void emit_obj_to_hash_dispatch(Compiler *c, Buf *b) {
   buf_puts(b, "    default: return sp_box_nil();\n  }\n}\n");
 }
 
+/* The method answers no value: its emitted C return type is `void`. A body
+   whose only statement is a raise infers that, and so does one that ends in an
+   assignment. */
+static int scope_ret_is_void(Compiler *c, int mi) {
+  TyKind r = (TyKind)c->scopes[mi].ret;
+  return !ty_is_object(r) && !c_type_name(r);
+}
+
 /* A user class's own #to_json, keyed by cls_id and installed as
    sp_obj_to_json_fn: the json package asks for it before the generic field
    reflection, so an object nested in a container serializes the way CRuby's
    json does (which calls #to_json on every value). Only the two shapes that
-   occur in practice are dispatched: `def to_json` and `def to_json(*args)`. */
+   occur in practice are dispatched: `def to_json` and `def to_json(*args)`.
+
+   A method that answers no value is dispatched too, for its effect. Refusing
+   it here is what kept a `to_json` that only raises from ever running: the
+   object fell through to the reflection arm below and serialized as if the
+   method were not there, and CRuby's ArgumentError never came. The call
+   answers NULL, so the document is what it always was for a method that
+   returns -- and for one that does not, the raise is the answer. */
 static int obj_to_json_method(Compiler *c, int cid, int *defc) {
   ClassInfo *ci = &c->classes[cid];
   if (ci->is_native_class || !ci->instantiated) return -1;
@@ -6181,7 +6196,16 @@ static int obj_to_json_method(Compiler *c, int cid, int *defc) {
   int mi = comp_method_in_chain(c, cid, "to_json", &dc);
   if (mi < 0) return -1;
   Scope *m = &c->scopes[mi];
-  if (m->is_cmethod || m->ret != TY_STRING) return -1;
+  if (m->is_cmethod) return -1;
+  if (m->ret != TY_STRING) {
+    /* The no-value arm takes only a shape the dispatch below can call and
+       CRuby's json would call: an `&block` parameter is one the emitted call
+       does not pass, and a private or protected #to_json is one CRuby never
+       reaches, so it serializes the object instead. Both fell through to the
+       reflection arm before this arm existed, and still do. */
+    if (!scope_ret_is_void(c, mi) || m->blk_param) return -1;
+    if (comp_method_vis_in_chain(c, cid, "to_json") != SP_VIS_PUBLIC) return -1;
+  }
   if (!scope_has_callable_symbol(c, mi)) return -1;
   if (m->nparams > 1 || (m->nparams == 1 && m->rest_idx != 0)) return -1;
   if (m->nparams == 1) {
@@ -6208,10 +6232,13 @@ static void emit_obj_to_json_dispatch(Compiler *c, Buf *b) {
     int mi = obj_to_json_method(c, i, &defc);
     if (mi < 0) continue;
     int vobj = comp_ty_value_obj(c, ty_object(defc));
-    buf_printf(b, "    case %d: return sp_%s_%s(%s(sp_%s *)v.v.p%s);\n", i,
+    int novalue = scope_ret_is_void(c, mi);
+    buf_printf(b, "    case %d: %s", i, novalue ? "" : "return ");
+    buf_printf(b, "sp_%s_%s(%s(sp_%s *)v.v.p%s);",
                c->classes[defc].c_name, mc(c->scopes[mi].name), vobj ? "*" : "",
                c->classes[defc].c_name,
                c->scopes[mi].nparams == 1 ? ", sp_PolyArray_new()" : "");
+    buf_puts(b, novalue ? " return NULL;\n" : "\n");
   }
   buf_puts(b, "    default: return NULL;\n  }\n}\n");
 }

--- a/test/json_raise_through.rb
+++ b/test/json_raise_through.rb
@@ -1,0 +1,150 @@
+require "json"
+
+# A #to_json that can only raise is still called. CRuby's json calls #to_json
+# on every value before it looks at anything else, so the exception is what
+# JSON.generate answers -- for the object itself, and for one nested anywhere
+# inside the document.
+class Boom
+  def to_json(*args)
+    raise ArgumentError, "boom"
+  end
+end
+
+# The same method, able to answer as well as raise, is the shape that already
+# worked: it must keep working in both directions.
+class Sometimes
+  def initialize(fail)
+    @fail = fail
+  end
+
+  def to_json(*args)
+    raise ArgumentError, "sometimes" if @fail
+    "1"
+  end
+end
+
+# A walk inside a walk: the inner one raises, and the outer one is left holding
+# the document it had built so far.
+$deep = []
+$deep << $deep
+
+class Nested
+  def to_json(*args)
+    JSON.pretty_generate($deep)
+    "0"
+  end
+end
+
+# A #to_json need not raise to leave the walk behind: a throw and a proc's
+# return jump over its frame the same way, and what the walk was holding has to
+# survive that too -- the raise that comes after is where a buffer left dangling
+# would show up.
+class Thrower
+  def to_json(*args)
+    throw :out, 1
+  end
+end
+
+class Returner
+  def to_json(*args)
+    $ret.call
+    "1"
+  end
+end
+
+# A #to_json with a block parameter, and a private one, are not dispatched --
+# here or before this change. CRuby calls the first and skips the second. The
+# lines below are here so both shapes stay compilable and neither raises.
+class Blocky
+  def to_json(*args, &blk)
+    raise ArgumentError, "blocky"
+  end
+end
+
+class Hidden
+  def to_json(*args)
+    raise ArgumentError, "hidden"
+  end
+  private :to_json
+end
+
+def answer
+  yield
+rescue => e
+  "#{e.class}: #{e.message}"
+end
+
+# The same, for a walk that was left by a throw or a proc's return rather than
+# by a raise: what the raise below reports is whether the walk left anything
+# behind that the next unwind would trip over.
+def raises_after
+  yield
+  raise "after"
+rescue => e
+  "#{e.class}: #{e.message}"
+end
+
+puts answer { JSON.generate(Boom.new) }
+puts answer { JSON.generate(["x", Boom.new, "y"]) }
+puts answer { JSON.pretty_generate(["x", Boom.new, "y"]) }
+puts answer { JSON.generate(["a", { "k" => Boom.new }, "b"]) }
+puts answer { JSON.generate([[[Boom.new]]]) }
+puts answer { JSON.generate(["x", Sometimes.new(false), "y"]) }
+puts answer { JSON.generate(["x", Sometimes.new(true), "y"]) }
+puts answer { JSON.pretty_generate(["x", Sometimes.new(false), "y"]) }
+puts answer { JSON.generate(["x", Nested.new, "y"]) }
+
+# Every one of those raises leaves a walk holding a document buffer. Two
+# hundred of them, over a document large enough that a buffer kept per raise
+# would be worth megabytes, and the answer is still the same one.
+$ret = nil
+
+def returns_early
+  $ret = proc { return "the proc returned out of the walk" }
+  JSON.pretty_generate(["x", Returner.new, "y"])
+  "not reached"
+end
+
+def caught
+  catch(:out) { JSON.generate(["x", Thrower.new, "y"]) }
+  "no raise after the throw"
+rescue => e
+  "#{e.class}: #{e.message}"
+end
+
+puts caught
+puts raises_after { catch(:out) { JSON.generate(["x", Thrower.new, "y"]) } }
+puts returns_early
+puts raises_after { returns_early }
+JSON.generate(["x", Blocky.new, "y"]) rescue nil   # CRuby calls it and raises; Spinel does not
+puts answer { JSON.generate(["x", Hidden.new, "y"]); "no raise" }
+
+# The document itself is one of the things the walk has to hold: a caller that
+# hands over an expression keeps it nowhere else, and the walk allocates from
+# its first escaped string onward. Eight hundred fresh arrays, each checked
+# against its own last element -- on master three of them come back with the
+# tail serialized as null, on a release build with no GC stress at all.
+def fresh(i)
+  a = []
+  40.times { |j| a << "s#{i}-#{j}" }
+  a
+end
+
+wrong = 0
+800.times do |i|
+  # bound to a local first: a String receiver held across an allocating
+  # argument is a separate rule, and wrong on both trees under GC stress
+  doc = JSON.generate(fresh(i))
+  wrong += 1 unless doc.end_with?("\"s#{i}-39\"]")
+end
+puts "documents wrong: #{wrong}"
+
+pad = "q" * 4000
+big = []
+40.times { big << pad }
+big << Boom.new
+40.times { big << pad }
+
+seen = {}
+200.times { seen[answer { JSON.generate(big) }] = true }
+p seen.keys

--- a/test/json_raise_through.rb.expected
+++ b/test/json_raise_through.rb.expected
@@ -1,0 +1,20 @@
+ArgumentError: boom
+ArgumentError: boom
+ArgumentError: boom
+ArgumentError: boom
+ArgumentError: boom
+["x",1,"y"]
+ArgumentError: sometimes
+[
+  "x",
+  1,
+  "y"
+]
+JSON::NestingError: nesting of 100 is too deep. Did you try to serialize objects with circular references?
+no raise after the throw
+RuntimeError: after
+the proc returned out of the walk
+RuntimeError: after
+no raise
+documents wrong: 0
+["ArgumentError: boom"]


### PR DESCRIPTION
## Why

CRuby's `json` calls `#to_json` on every value before it looks at anything else, so a `#to_json` that raises makes `JSON.generate` raise. Spinel called a user class's `#to_json` too — but only when the compiler could see that the method answered a String, and a method whose body only raises answers nothing at all. So the hook was never installed for it, the object fell through to the generic field reflection below, and the exception never happened.

```ruby
class Boom
  def to_json(*args)
    raise ArgumentError, "boom"
  end
end

JSON.generate(["x", Boom.new, "y"])
```

CRuby 4.0.6 raises `ArgumentError: boom`. Spinel answered `"[\"x\",null,\"y\"]"` — a document, exit 0, and nothing to say the object had a `#to_json` at all. `JSON.pretty_generate` did the same, and so did the object on its own or nested in a hash or three arrays deep.

That is one end of this site. The other end is what happens once something does leave the walk. The walk holds the document it has built so far in a `malloc`'d buffer on its own C frame, and a non-local exit jumps over that frame, leaving the block owned by nothing. #4355 gave the walk's own nesting error that buffer to free before it raises — but a walk can only be handed its buffer for a raise it makes itself. User code can leave it three other ways, and all three lose the buffer on master today: a `#to_json` that runs a `JSON.pretty_generate` deep enough to raise, one whose answer the pretty walk cannot re-read, and one that throws. Four thousand rescued exits of each grow the process to 631.4 MiB, 638.1 MiB and 631.2 MiB, three runs apiece and stable to the tenth. Nothing ever gets it back.

Rooting the walk's buffer meant looking at what else the walk holds, and the document itself was not rooted either — not by the caller, which hands over an expression and keeps it nowhere, and not in the package. A walk allocates from its first escaped string onward, so under a collection it was serializing a document that had been freed. That one is not about raises at all, and it is not stress-only:

```ruby
def fresh(i)
  a = []
  40.times { |j| a << "s#{i}-#{j}" }
  a
end

800.times { |i| doc = JSON.generate(fresh(i)) }
```

Under `SPINEL_GC_STRESS=1` master gets 796 of those eight hundred documents wrong, their elements serialized as `null`. On a release build with no stress at all it still gets four, the same four every run. This branch gets none in either mode. (The new test runs the same arm inside a larger program and master gets six rather than four there: which documents land on a collection depends on what else has allocated, while the stress count does not.)

## What

`obj_to_json_method` (`src/codegen.c`) installs the hook for a `#to_json` that answers no value as well as one that answers a String, and `emit_obj_to_json_dispatch` calls it and answers NULL.

In `packages/json/sp_json.c`: `sp_json_val` and `sp_json_pretty` root the document for the walk; both move their buffer onto the GC string heap (`jb_to_heap`) before they call user code; a GC string appended to a moved buffer is rooted across the append (`jb_gcs`); `sp_json_too_deep` frees the buffer it is handed only when the walk has not moved it; and `jb_s`, down to one caller, folds into it.

## How

The compiler kept `m->ret != TY_STRING` as a refusal because the dispatch has to `return` what the method answers, and a method that answers an Integer cannot be returned into a `const char *`. A method that answers *nothing* is the case that refusal caught by accident: its C signature is `void`, so the dispatch calls it as a statement and answers NULL on the next one. For a method that returns, that leaves the document exactly as it was — NULL is what the walk already saw, and it goes on to the reflection arm below. For a method that does not return, the call is the whole of it.

The new arm takes only shapes the dispatch can call and CRuby's json would call. A `#to_json` with a block parameter is not one: the emitted call does not pass it, and widening to it turned a program that compiled into one that does not. A private or protected `#to_json` is not one either: CRuby does not reach a method the object does not publicly respond to. Both keep falling through to the reflection arm, exactly as they did before this arm existed.

On the walk's side the rule is the one `sp_json_parse` and the reflection arms already follow, and #4360 wrote down: a value the walk needs for the whole walk is rooted for the whole walk. The document is such a value, and so is the buffer — with the difference that `SP_GC_ROOT` covers something the collector can reclaim, and a `malloc`'d block has no owner at all once its frame is gone. So the buffer becomes a GC string exactly where the walk is about to run code that may not come back, which is the call to the user's `#to_json` and nothing else: the container reflection and the scalar formatting below it are the generated program's own field accessors, with no user code in them. From there the landing frame drops the walk's roots along with every other root it was holding, whichever way the walk was left — a raise, a `throw`, a proc's return — and both the document and the buffer go with them.

The move happens at most once per walk, and not at all for a document with no user object in it. What such a document pays is the branch that decides not to move: 1.95 s against 1.98 s on a benchmark of 800 compact and 400 pretty generations of a 2,000-entry document, medians of seven interleaved runs, ranges 1.95–1.97 and 1.97–2.02. A document that does move pays about a tenth of its peak memory as well, since the abandoned copies wait for a collection instead of a `free`. One shape in the file is load-bearing for that: the moved buffer's grow is out of line, because `jb_add` is inlined into loops that append a byte at a time and a second allocator in its body stops that — `nm` shows `jb_add` with no symbol of its own on either tree, and writing the grow inline instead gives it one and takes the same benchmark from 1.98 s to 2.58 s.

## Validation

Gate GREEN on d64bd563, against a master worktree at the merge-base: the suite is 3509 pass / 0 fail / 0 error with the new test among them, the benchmarks 61 pass / 0 fail, optcarrot answers 59662 (the spin-e2e leg is red on macOS on master too), a differential corpus of ~2,100 minimized programs that behave differently under CRuby 4.0.6 and Spinel stays at 905 matching with nothing gained, nothing lost and no timeouts, the inference fixpoint gains no non-convergence (its one "round count differs" line, on `test/enumerator_block_returns_self.rb`, is pre-existing: that program's generated C is byte-identical on both trees, and the leg flips direction between runs with master on both sides), and the generated-C sweep over all 3524 programs in the tree changes exactly one file — the new test. Nothing already in the tree has a `#to_json` that answers nothing, so the compiler change rewrites nothing that was there, and optcarrot's C is byte-identical. ASAN and UBSAN are clean on the new test, plain and under `SPINEL_GC_STRESS=1`; both instrument the generated program and not `packages/json/sp_json.o`, which is linked prebuilt without the sanitizer, so what they cover here is the program's own reads and every free in the process.

The four exit loops, four thousand rescued exits each over a 313 KiB document, release builds, on a pristine master worktree at the merge-base and on this branch, three runs each and stable to the tenth of a mebibyte: a nested `pretty_generate`'s nesting error 631.4 → 4.1 MiB, a `#to_json` answer that does not parse 638.1 → 3.4 MiB, a `#to_json` that throws 631.2 → 2.8 MiB, and a `#to_json` that raises 3.4 → 3.2 MiB, the last being a loop master never ran, since it answered the document instead of raising.

`test/json_raise_through.rb` prints twenty lines, all of them CRuby 4.0.6's, in 0.07 s, and master differs on eleven of them. The raise reaching the caller from a `#to_json` on its own, at the top of a document, inside a hash, three arrays deep, out of `JSON.pretty_generate`, and out of a `pretty_generate` the `#to_json` ran itself. Then the walks left another way: a `throw` caught outside the generate, a proc returning through it, and after each of those a plain `raise`, which is where a walk that left something behind is caught out. The conditional shape that already worked answers in both directions, compact and pretty. A `#to_json` with a block parameter and a private one are there so both stay compilable and neither raises. The eight-hundred-document arm answers `documents wrong: 0` where master answers `6`. And the last line is the single answer two hundred rescued raises over the 313 KiB document all give.

## Left alone, on purpose

A `#to_json` that answers `nil` is now called where it was not, and its answer is still discarded: the document reads `null`, or the object's reflected fields, exactly as before. CRuby raises `TypeError: wrong argument type nil (expected String)` there. One that answers an Integer is still not called at all, because its C return type is `sp_int` and the dispatch has nowhere to put it. Calling the method is closer to CRuby than not calling it, and what a `#to_json` answer has to be is a different rule.

`def to_json` with no parameters is dispatched with no arguments, as it always was, so a zero-arity one that raises now raises the user's own exception. CRuby always passes a state argument, so it raises `ArgumentError: wrong number of arguments (given 1, expected 0)` for that shape instead. Both raise; the exception differs, and the arity of the hook is a rule of its own.

The two refusals above apply only to the no-value arm, so nothing about a String-returning `#to_json` moves. One with a block parameter is still dispatched and still fails to compile — `too few arguments to function call` — on master and here alike, because the emitted call passes no block. A private or protected one is still dispatched too, splicing its answer where CRuby serializes the object's `to_s`. Both are pre-existing and belong with the arity rule.

`JSON.pretty_generate` re-parses a user `#to_json` answer and re-indents it, where CRuby splices the answer in verbatim — which is why a `#to_json` answering `"not json"` raises `JSON::ParserError` on both trees while CRuby prints it inside the document. The leak that raise caused is fixed here; the re-parse itself is a separate rule and is not touched.

A String receiver that is a temporary is still held unrooted across an allocating argument: `mk(i).end_with?("-#{i}")`, where `mk` answers a fresh string, is wrong 24 times in 800 under `SPINEL_GC_STRESS=1`, identically on both trees, and binding the receiver to a local first is clean. That is the rule #4356 fixed for binary operators, reaching a method call with an allocating argument, and it is why the new test's eight-hundred-document arm binds its document before checking it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed JSON generation when custom `to_json` methods raise exceptions, throw, or return early.
  - Prevented buffer corruption, dangling state, and crashes during interrupted nested serialization.
  - Ensured compact and pretty-printed JSON consistently propagate errors and preserve valid output.
  - Improved handling of public, no-block `to_json` methods that produce no value, while maintaining existing validation for unsupported methods and return types.

- **Tests**
  - Added coverage for repeated failures, deep nesting, large documents, and interrupted serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->