### PR TITLE
A container a builtin loop reads from is rooted for the whole loop

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -28389,7 +28389,12 @@ else {
     Scope *cs_ech = p0 ? comp_scope_of(c, id) : NULL;
     LocalVar *clv_ech = (p0 && cs_ech) ? scope_local(cs_ech, p0) : NULL;
     int p0_box_poly_ech = clv_ech && clv_ech->type == TY_POLY;
-    buf_printf(b, "({ const char *_t%d = %s; ", ts, rb.p ? rb.p : ""); free(rb.p);
+    /* The loop below reads the receiver on every turn -- as its bound, and as
+       the string it takes the next character or byte out of -- and the block
+       between two turns may allocate. A temporary receiver (`array.join.
+       each_char { }`) has no other holder at that point, so the temp is a
+       root, the way the array iterators root their hoisted receiver. */
+    buf_printf(b, "({ const char *_t%d = %s; SP_GC_ROOT_STR(_t%d); ", ts, rb.p ? rb.p : "", ts); free(rb.p);
     /* Save outer variable before loop to restore it afterward */
     int tsv_ech = 0;
     if (p0 && clv_ech) {
@@ -28416,6 +28421,12 @@ else {
       else
         buf_printf(b, "sp_StrArray *_t%d = %s(_t%d); ",
                    tl, eline_chomp ? "sp_str_lines_chomp" : "sp_str_lines", ts);
+      /* The array of lines is this loop's own value -- nothing in the Ruby
+         program names it -- and its length is the loop bound, re-read every
+         turn. Unrooted, a block that allocated collected it, and the loop
+         then ended early rather than yielding a wrong line: the symptom is a
+         short answer, not a bad one. */
+      buf_printf(b, "SP_GC_ROOT(_t%d); ", tl);
       buf_printf(b, "for (sp_int _t%d = 0; _t%d < sp_StrArray_length(_t%d); _t%d++) { ",
                  ti, ti, tl, ti);
       if (p0) {

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -2142,7 +2142,10 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
           int trecv = ++g_tmp, ti = ++g_tmp;
           Buf rb = expr_buf(c, recv);
           emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
-          buf_printf(g_pre, " _t%d = %s;\n", trecv, rb.p ? rb.p : ""); free(rb.p);
+          buf_printf(g_pre, " _t%d = %s; ", trecv, rb.p ? rb.p : ""); free(rb.p);
+          /* rooted, as the poly each_index above already roots its own hoist:
+             the length is the loop bound and the block can allocate */
+          emit_gc_root_tmp(c, rt, trecv, g_pre); buf_puts(g_pre, "\n");
           emit_indent(g_pre, g_indent);
           buf_printf(g_pre, "for (sp_int _t%d = 0; _t%d < sp_%sArray_length(_t%d); _t%d++) {\n",
                      ti, ti, ek, trecv, ti);

--- a/src/codegen_iter.c
+++ b/src/codegen_iter.c
@@ -2613,12 +2613,16 @@ int emit_iteration_stmt(Compiler *c, int id, Buf *b, int indent) {
        loop bound and every key/val access. When the receiver is an inlined
        block-method statement-expression (e.g. a Ruby-defined `group_by` that
        lowers to `({ ...produce hash... })`), re-emitting it per access both
-       truncates into invalid C and re-runs its side effects. */
+       truncates into invalid C and re-runs its side effects. The temp is a
+       root, as each_key's and each_value's hoist below already is: the loop
+       reads its `len` as the bound on every turn and its `order` on every
+       yield, and a receiver that is itself a temporary -- the hash a method
+       call returned -- has no other holder while the block allocates. */
     int th = ++g_tmp;
     emit_indent(b, indent);
     buf_printf(b, "sp_%sHash *_t%d = ", hn, th);
     emit_expr(c, recv, b);
-    buf_puts(b, ";\n");
+    buf_printf(b, "; SP_GC_ROOT(_t%d);\n", th);
     Buf rb; memset(&rb, 0, sizeof rb);
     buf_printf(&rb, "_t%d", th);
     /* Mutating the key set during #each: CRuby refuses a new key outright, and
@@ -3415,7 +3419,9 @@ int emit_iteration_stmt(Compiler *c, int id, Buf *b, int indent) {
 
   /* array.each_cons(n) { |a, b, ...| } -- sliding window of n consecutive
      elements; a single param binds the n-element sub-array, multiple params
-     destructure the window */
+     destructure the window. The hoisted receiver is rooted for the same
+     reason Hash#each's above is: its length is the loop bound, re-read every
+     turn, and a receiver the program does not name has no other holder. */
   if (sp_streq(name, "each_cons") && ty_is_array(rt)) {
     int args = nt_ref(nt, id, "arguments");
     int ec = 0; const int *eav = args >= 0 ? nt_arr(nt, args, "arguments", &ec) : NULL;
@@ -3425,7 +3431,8 @@ int emit_iteration_stmt(Compiler *c, int id, Buf *b, int indent) {
     int np = 0; while (block_param_name(c, block, np)) np++;
     int ta = ++g_tmp, tnn = ++g_tmp, ti = ++g_tmp;
     Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);
-    emit_indent(b, indent); emit_ctype(c, rt, b); buf_printf(b, " _t%d = %s;\n", ta, rb.p ? rb.p : ""); free(rb.p);
+    emit_indent(b, indent); emit_ctype(c, rt, b); buf_printf(b, " _t%d = %s; ", ta, rb.p ? rb.p : ""); free(rb.p);
+    emit_gc_root_tmp(c, rt, ta, b); buf_puts(b, "\n");
     emit_indent(b, indent); buf_printf(b, "sp_int _t%d = ", tnn); emit_int_expr(c, eav[0], b); buf_puts(b, ";\n");
     emit_indent(b, indent);
     buf_printf(b, "for (sp_int _t%d = 0; _t%d + _t%d - 1 < sp_%sArray_length(_t%d); _t%d++) {\n", ti, ti, tnn, k, ta, ti);
@@ -3691,7 +3698,8 @@ int emit_iteration_stmt(Compiler *c, int id, Buf *b, int indent) {
   }
 
   /* array.cycle(n) { |p| body } -- repeat n times over the array; the
-     argless form cycles forever (a block `break` is the only exit) */
+     argless form cycles forever (a block `break` is the only exit). Rooted
+     hoist, as each_cons above. */
   if (sp_streq(name, "cycle") && ty_is_array(rt)) {
     int args = nt_ref(nt, id, "arguments");
     int cyc_argc = 0; const int *cyc_argv = args >= 0 ? nt_arr(nt, args, "arguments", &cyc_argc) : NULL;
@@ -3706,7 +3714,8 @@ int emit_iteration_stmt(Compiler *c, int id, Buf *b, int indent) {
     int ta = ++g_tmp, tn = ++g_tmp, ti = ++g_tmp, tj = ++g_tmp;
     Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);
     emit_indent(b, indent); emit_ctype(c, rt, b);
-    buf_printf(b, " _t%d = %s;\n", ta, rb.p ? rb.p : ""); free(rb.p);
+    buf_printf(b, " _t%d = %s; ", ta, rb.p ? rb.p : ""); free(rb.p);
+    emit_gc_root_tmp(c, rt, ta, b); buf_puts(b, "\n");
     emit_indent(b, indent);
     if (cyc_argc == 1) {
       buf_printf(b, "sp_int _t%d = ", tn);
@@ -3743,7 +3752,8 @@ int emit_iteration_stmt(Compiler *c, int id, Buf *b, int indent) {
     return 1;
   }
 
-  /* array.each_slice(n) { |p| body } -- yield subarrays of size n */
+  /* array.each_slice(n) { |p| body } -- yield subarrays of size n. Rooted
+     hoist, as each_cons above. */
   if (sp_streq(name, "each_slice") && ty_is_array(rt)) {
     int args = nt_ref(nt, id, "arguments");
     int es_argc = 0; const int *es_argv = args >= 0 ? nt_arr(nt, args, "arguments", &es_argc) : NULL;
@@ -3758,7 +3768,8 @@ int emit_iteration_stmt(Compiler *c, int id, Buf *b, int indent) {
     int ta = ++g_tmp, ts = ++g_tmp, ti = ++g_tmp;
     Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);
     emit_indent(b, indent); emit_ctype(c, rt, b);
-    buf_printf(b, " _t%d = %s;\n", ta, rb.p ? rb.p : ""); free(rb.p);
+    buf_printf(b, " _t%d = %s; ", ta, rb.p ? rb.p : ""); free(rb.p);
+    emit_gc_root_tmp(c, rt, ta, b); buf_puts(b, "\n");
     emit_indent(b, indent); buf_printf(b, "sp_int _t%d = ", ts);
     emit_int_expr(c, es_argv[0], b); buf_puts(b, ";\n");
     emit_indent(b, indent);

--- a/test/container_loop_root.rb
+++ b/test/container_loop_root.rb
@@ -1,0 +1,237 @@
+# A container a builtin block loop reads from stays live for the whole loop:
+# the String each_line/each_char/each_byte forms hold the receiver and the
+# array of lines in temporaries, Hash#each holds the hash in one, and the
+# block between two turns allocates. Every block here allocates before it
+# looks at what it was handed, and every arm prints its iteration count as
+# well as its content check: an arm that ends early shows up as a changed
+# answer rather than as a passing test.
+
+LINES = 300
+CHARS = 300
+CHURN = 200
+
+def churn
+  CHURN.times { "q" * 64 }
+end
+
+def make_lines
+  (1..LINES).map { |i| "L#{i}" }.join("\n")
+end
+
+def make_chars
+  (1..CHARS).map { |_i| "c" }.join
+end
+
+def make_hash
+  h = {}
+  (1..40).each { |i| h["k#{i}"] = "v#{i}" }
+  h
+end
+
+# --- String#each_line: the receiver AND the array of lines it walks ---
+
+text = make_lines
+seen = 0
+bad = 0
+text.each_line do |l|
+  churn
+  seen += 1
+  bad += 1 unless l.start_with?("L")
+end
+puts "each_line local seen=#{seen} bad=#{bad}"
+
+seen = 0
+bad = 0
+make_lines.each_line do |l|
+  churn
+  seen += 1
+  bad += 1 unless l.start_with?("L")
+end
+puts "each_line temp seen=#{seen} bad=#{bad}"
+
+seen = 0
+bad = 0
+make_lines.each_line(chomp: true) do |l|
+  churn
+  seen += 1
+  bad += 1 if l.end_with?("\n")
+end
+puts "each_line chomp seen=#{seen} bad=#{bad}"
+
+seen = 0
+bad = 0
+make_lines.each_line("\n") do |l|
+  churn
+  seen += 1
+  bad += 1 unless l.start_with?("L")
+end
+puts "each_line sep seen=#{seen} bad=#{bad}"
+
+# --- String#each_char / each_byte / each_grapheme_cluster: the receiver ---
+
+chars = make_chars
+seen = 0
+bad = 0
+chars.each_char do |ch|
+  churn
+  seen += 1
+  bad += 1 unless ch == "c"
+end
+puts "each_char local seen=#{seen} bad=#{bad}"
+
+seen = 0
+bad = 0
+make_chars.each_char do |ch|
+  churn
+  seen += 1
+  bad += 1 unless ch == "c"
+end
+puts "each_char temp seen=#{seen} bad=#{bad}"
+
+seen = 0
+bad = 0
+make_chars.each_byte do |b|
+  churn
+  seen += 1
+  bad += 1 unless b == 99
+end
+puts "each_byte temp seen=#{seen} bad=#{bad}"
+
+seen = 0
+bad = 0
+make_chars.each_grapheme_cluster do |g|
+  churn
+  seen += 1
+  bad += 1 unless g == "c"
+end
+puts "each_grapheme_cluster temp seen=#{seen} bad=#{bad}"
+
+# The loop answers its receiver, which is the same temporary it walked.
+ret = make_chars.each_char { churn }
+puts "each_char returns the receiver len=#{ret.length} head=#{ret[0, 3]}"
+ret = make_lines.each_line { churn }
+puts "each_line returns the receiver len=#{ret.length} head=#{ret[0, 3]}"
+
+# --- Hash#each / #each_pair: the hash the loop reads its bound from ---
+
+HCHURN = 400
+
+seen = 0
+bad = 0
+make_hash.each do |k, v|
+  HCHURN.times { "q" * 64 }
+  seen += 1
+  bad += 1 unless k.start_with?("k") && v.start_with?("v")
+end
+puts "Hash#each temp seen=#{seen} bad=#{bad}"
+
+seen = 0
+bad = 0
+make_hash.each_pair do |k, v|
+  HCHURN.times { "q" * 64 }
+  seen += 1
+  bad += 1 unless k.start_with?("k") && v.start_with?("v")
+end
+puts "Hash#each_pair temp seen=#{seen} bad=#{bad}"
+
+# a solo block parameter takes the [key, value] pair
+seen = 0
+bad = 0
+make_hash.each do |pair|
+  HCHURN.times { "q" * 64 }
+  seen += 1
+  bad += 1 unless pair.length == 2 && pair[0].start_with?("k")
+end
+puts "Hash#each solo param seen=#{seen} bad=#{bad}"
+
+# --- Array#each_cons / #each_slice / #each_index / #cycle: the array ---
+
+def make_array
+  a = []
+  (1..LINES).each { |i| a << i }
+  a
+end
+
+seen = 0
+bad = 0
+make_array.each_cons(3) do |w|
+  churn
+  seen += 1
+  bad += 1 unless w.length == 3
+end
+puts "each_cons temp seen=#{seen} bad=#{bad}"
+
+seen = 0
+bad = 0
+make_array.each_slice(3) do |w|
+  churn
+  seen += 1
+  bad += 1 if w.empty?
+end
+puts "each_slice temp seen=#{seen} bad=#{bad}"
+
+seen = 0
+bad = 0
+make_array.each_index do |i|
+  churn
+  seen += 1
+  bad += 1 unless i >= 0
+end
+puts "each_index temp seen=#{seen} bad=#{bad}"
+
+seen = 0
+bad = 0
+make_array.cycle(2) do |x|
+  churn
+  seen += 1
+  bad += 1 unless x >= 1
+end
+puts "cycle temp seen=#{seen} bad=#{bad}"
+
+# --- leaving the loop early: the root pops on every way out ---
+
+# The root is a cleanup-attribute declaration, so it pops when the statement
+# expression is left -- off the end, through a `break`, or through a `return`
+# from inside the block. A `raise` does not run cleanups and does not need to:
+# the rescue emitters snapshot and restore the root count around the handler.
+
+def first_line(text)
+  text.each_line { |l| return l }
+  "none"
+end
+
+def upto_third(text)
+  seen = 0
+  text.each_line do |l|
+    churn
+    seen += 1
+    break if seen >= 3
+  end
+  seen
+end
+
+def broke_with(text)
+  text.each_char { |ch| churn; break ch }
+end
+
+def raised_in(text)
+  text.each_line { |_l| churn; raise "boom" }
+rescue RuntimeError => e
+  e.message
+end
+
+def first_key(hash)
+  hash.each { |k, _v| return k }
+  "none"
+end
+
+p first_line(make_lines)
+p upto_third(make_lines)
+p broke_with(make_chars)
+p raised_in(make_lines)
+p first_key(make_hash)
+
+# the loop still walks correctly after all of that
+seen = 0
+make_lines.each_line { churn; seen += 1 }
+puts "after early exits seen=#{seen}"

--- a/test/container_loop_root.rb.expected
+++ b/test/container_loop_root.rb.expected
@@ -1,0 +1,23 @@
+each_line local seen=300 bad=0
+each_line temp seen=300 bad=0
+each_line chomp seen=300 bad=0
+each_line sep seen=300 bad=0
+each_char local seen=300 bad=0
+each_char temp seen=300 bad=0
+each_byte temp seen=300 bad=0
+each_grapheme_cluster temp seen=300 bad=0
+each_char returns the receiver len=300 head=ccc
+each_line returns the receiver len=1391 head=L1
+Hash#each temp seen=40 bad=0
+Hash#each_pair temp seen=40 bad=0
+Hash#each solo param seen=40 bad=0
+each_cons temp seen=298 bad=0
+each_slice temp seen=100 bad=0
+each_index temp seen=300 bad=0
+cycle temp seen=600 bad=0
+"L1\n"
+3
+"c"
+"boom"
+"k1"
+after early exits seen=300


### PR DESCRIPTION
## Why

Seven builtin block loops begin by copying the container they are about to walk into a C temporary, and then read that temporary again on every turn. `String#each_line`, `#each_char`, `#each_byte` and `#each_grapheme_cluster` read the receiver as their bound and as the thing each line or character comes out of; the line forms also hold the array of lines they split the receiver into. `Hash#each` and `#each_pair` read the hash's entry count as their bound. `Array#each_cons`, `#each_slice`, `#each_index` and `#cycle` read the array's length as theirs. None of those temporaries was a GC root, and the block between two turns allocates, so a container that nothing else holds — the string a `join` produced, the hash or array a method returned — could be collected while its own loop was still walking it.

```ruby
(1..300).map { |i| "L#{i}" }.join("\n").each_line do |line|
  200.times { "q" * 64 }   # any allocation will do
  puts line
end
```

The symptom is a short answer rather than a wrong one, which is what makes it easy to miss: the loop reads a length out of freed memory and stops, and the program exits 0 having quietly skipped the rest. That program prints no lines at all under `SPINEL_GC_STRESS=1` and 14 of its 300 on a plain release build of master, three runs each; here it prints 300 either way, as CRuby does.

Under `SPINEL_GC_STRESS=1`, which collects at every allocation and so does not depend on when the allocator would otherwise have run, every one of these loops delivers one turn of its work or none. Measured one arm at a time, each arm its own program, three runs each: `each_line` yields 1 line of 300 from a named local and 0 from a temporary receiver, 0 with `chomp: true` and 1 with a `"\n"` separator; `each_char`, `each_byte` and `each_grapheme_cluster` over a temporary yield 1 of 300; `Hash#each`, `#each_pair` and the solo-parameter `#each` yield 1 pair of 40; `each_cons`, `each_slice`, `each_index` and `cycle` yield 1 turn each. Reading the receiver back after the loop — the String forms answer self — gives a String of length 0.

On a plain release build the same arms answer 14, 14, 14 and 14 lines; 15, 15 and 15 characters or bytes; 8, 8 and 8 pairs; and 15, 15, 15 and 15 turns. Those counts are stable across three runs on an idle machine and fall toward one turn when the machine is busy, because they measure something else: whether the allocator happens to land a collection inside the window, not whether the container can be collected. I took them again on this PR's base after #4364 merged, since two of that PR's four loops stopped showing the defect on a plain build of the newer master while all four still showed it under stress. None of these arms moved — but the stress column is the one worth quoting either way, because the hoist is unrooted whichever way the plain count lands.

The whole of the new test crashes on master before printing anything — five runs of SIGSEGV in one set and 139, 138, 138 in another, so it is a crash rather than one particular signal.

`String#each_char` over an ordinary named local is the one arm of the family that is right on master, 300 of 300 plain and under stress, because the local's own root already covers the string the temporary copied. Every other combination is short: a temporary receiver has no other holder, and the array of lines has none in any case, because nothing in the Ruby program names it. The fix also reaches receivers that only look held, because what was unrooted was the loop's own copy rather than the container's other names: an `@ivar` of an object a method returned, and a String read out of a hash a method returned, each walk 15 of their 300 characters on a plain master build, 1 under stress, and 300 here.

## What

Three files, seven temporaries.

`src/codegen_call.c` holds the block forms of `String#each_char`, `#each_line`, `#each_byte`, `#chars`, `#lines`, `#bytes` and `#codepoints` — and of `#each_grapheme_cluster`, which the analyzer rewrites to `#each_char`. It now roots the receiver it copies into a temporary, and, for the line forms, the `sp_StrArray` of lines it splits that receiver into.

`src/codegen_iter.c` holds `Hash#each` and `#each_pair`, and `Array#each_cons`, `#each_slice` and `#cycle`, all five in `emit_iteration_stmt`. Each now roots the container it hoists.

`src/codegen_call_recv.c` holds the block form of `Array#each_index`. It now roots its hoist, which is what the poly `each_index` seven hundred lines above it in the same file already did.

## How

The roots go on the temporaries themselves. `SP_GC_ROOT` and `SP_GC_ROOT_STR` record the address of a slot rather than the value in it, so one push ahead of the loop covers every turn of it, and the pop is the cleanup attribute's, which runs on every way out of the scope the declaration is in — off the end, a `break`, a `break` with a value, a `return` from inside the block, a `redo` back to a label outside it. A `raise` does not run cleanups and does not need to: the rescue emitters already snapshot `sp_gc_nroots` before the guarded body and restore it in the handler. Five test arms leave a loop each of those ways and then walk a whole string again; all five already answer correctly on master, and they are in the test because a way out that skipped the pop would leak a root per loop rather than give a wrong answer.

The two String roots sit inside the loop's own statement expression, so they pop where the loop ends. The other five are plain declarations in whatever C block encloses the statement, so they pop at the end of that block, which for a loop written at method-body level is later than the loop: the container stays reachable until the method returns. That is a retention window, not a leak — every `while`, `if` and `when` body is braced in the emitted C, so a loop inside one pops per turn rather than accumulating, and a hundred thousand turns through the exits above leave the root stack where they found it.

`SP_GC_ROOT_STR` is the macro for a `const char *` slot: it routes the mark through `sp_mark_string`, which reads the marker byte in front of the characters and touches nothing that is not a spinel string — the receiver can be a static frozen literal, which the plain macro's header walk would have read as an object. That is the macro `emit_hash_filter_loop` uses for the String keys and values it holds across `Hash#delete_if`'s block, for the same reason. The arrays and hashes are ordinary GC objects, so they take the plain `SP_GC_ROOT`, and rooting the array of lines transitively keeps every line string alive through the array's own scan.

Four of the seven go through `emit_gc_root_tmp` rather than writing the macro out, which is what that helper is for: its comment says sites emitting a temp from a type the inference chose "keep getting this wrong one at a time, so they go through here". The idiom is otherwise the files' own — `Hash#each_key` and `#each_value` root their hoist one branch below `Hash#each`; `Array#each_with_index`, `#zip` and `#reverse_each` root theirs through `hoist_loop_recv`; the poly `each_index` roots its own. What the seven loops changed here had in common is that they hoisted and did not root.

The cost is one root push and one pop per loop, not per turn, and it does not show. A program that yields six million characters through `each_char`, six hundred thousand lines through `each_line` and one million pairs through `Hash#each` answers in 0.198-0.201 s on master and 0.198-0.206 s here, five runs each on release builds of both, on an idle machine.

optcarrot's generated C gains exactly one line, and it is not in the render loop: `Parser#initialize` copies `DEFAULT_OPTIONS` into `@options` with a `Hash#each`, once, before the first frame, and that hoisted hash is now rooted (`sp_Parser_initialize` in the generated C). Seven runs of each binary on an idle machine give 59662 every time and a median of 1837.1 fps on master against 1868.8 here, master ranging 1726.1-1886.0 and this branch 1818.9-1889.6 — the branch's median is the higher one, and both medians sit inside the other's range.

## Validation

Gate GREEN on 9fce4cc3: the suite is 3509 pass / 0 fail (the new test is the extra one, and the spin-e2e leg is red on macOS on master too), 61 benchmarks pass, optcarrot answers 59662, and a differential corpus of ~2,100 minimized programs that behave differently under CRuby 4.0.6 and Spinel stays at 905 matching with nothing gained and nothing lost — nothing in that corpus lands on these loops, so this change does not move it.

The inference fixpoint gains no non-convergences over 3462 programs, and on this base it reports no differing round counts at all. On an earlier run it reported one, `test/enumerator_block_returns_self.rb` at 4 rounds against 3; that is noise in the program rather than a change, and measuring it ten times each way shows why — a master built the same way as the branch gives 4 4 3 3 4 4 3 3 3 3 and the branch gives 4 3 3 3 3 4 3 3 3 3, while the differently-built base the gate compares against is a steady 4.

ASAN and UBSAN are clean on the new test, plain and under `SPINEL_GC_STRESS=1`, and the test answers the same bytes in all four combinations. Worth being exact about what that covers: `--cc` instruments the generated translation unit and the collector headers inlined into it, not the prebuilt runtime archive, so it covers the loops' own reads of the temporaries this change roots, and not the collector's later walk of the root stack. The evidence for the root stack itself is that a hundred thousand turns through every early exit leave it where they found it — a leaked pop would have passed the 65536-entry cap and dropped the very roots this adds.

The generated-C sweep over all 3524 programs in the tree is byte-identical except for 89: 88 that already existed, differing by 211 lines, plus the new test's own 23. Every one of those 234 lines is the same line with one or more of the two additions on it. Normalising the numbered temporaries and then deleting exactly `SP_GC_ROOT_STR(_t<n>);` and `SP_GC_ROOT(_t<n>);` from the new side makes all 89 files compare equal to master, with nothing left over — no line moved, no line was removed, and no other text changed. Those lines carry 262 new roots: 58 through `SP_GC_ROOT_STR`, one per String block loop, and 204 through `SP_GC_ROOT` on the arrays of lines, the hashes and the arrays; more roots than lines, because one line can hold more than one loop. `build/optcarrot-single.rb` is one of the 88, and its whole diff is the single line described above.

`test/container_loop_root.rb` has twenty-three arms. Every block allocates before it looks at what it was handed, and every arm prints its iteration count as well as its content check, so an arm that ends early reads as a changed answer rather than as a passing test. The String arms cover both receiver shapes — a named local and a temporary — across `each_line` plain, with `chomp: true` and with a separator, and `each_char`, `each_byte` and `each_grapheme_cluster`; two more read the receiver back out of the loop, which is what those forms answer. The Hash arms cover `each`, `each_pair` and the solo block parameter that takes the `[key, value]` pair. The Array arms cover `each_cons`, `each_slice`, `each_index` and `cycle` over a receiver a method returned. The last six are the five early exits described above and one full walk after them.

## Left alone, on purpose

The fold and collect emitters in `src/codegen_fold.c` have the same defect in a different shape, and it is a larger change than this one. They are expression-form emitters that hoist into the statement prelude rather than statement-form loops, in a file this PR does not touch, and on a plain release build `Hash#map`, `#transform_values`, `#each_with_object`, `Array#min_by`, `#max_by`, `#minmax_by`, `#group_by` and `#each_with_object` all deliver 15 of a 40- or 300-element receiver while `Hash#select`, `#reject` and `#transform_keys` segfault outright. Several other emitters in that same file do root the receiver they hoist, so the fix is the same one, but three of the symptoms are crashes that deserve their own reading, and a partial pass would leave the rule true at some call sites and false at others.

`emit_inline_call_x` — the method inliner in `src/codegen_iter.c` — hoists the receiver of the call it is inlining into an unrooted temp, so any user class whose `each` gets inlined truncates the same way when its receiver is a temporary: a `Set` a method returned walks 13 of 300 on a plain release build, and so does a hand-written class with its own `while` loop over an ivar. That is the same missing root, but on a call's `self` rather than on a container a builtin loop reads, so it is a different rule and it is left for its own change.

`s.each_line.with_index { }` lowers through the enumerator path to an `sp_Enumerator_to_a` array that is not rooted either, and answers 0 of 300 under `SPINEL_GC_STRESS=1` on master and on this branch alike; `s.lines.each { }` over a temporary receiver does the same, because there the joined string is a bare C argument temporary while `sp_str_lines` allocates. Both are the same rule at emitters this change does not reach, and both are unchanged here.

`String#each_codepoint` with a block raises `NoMethodError: undefined method 'each_codepoint' for an instance of String` on master, and `String#each_line` on a poly receiver raises the same for `each_line`: missing emitters rather than missing roots. `String#codepoints` with a block yields bytes rather than codepoints (`"aé".codepoints { }` gives 97, 195, 169 where CRuby gives 97, 233) on master and here alike, because that name routes down the `each_byte` branch. This change adds the receiver root to that branch and alters nothing else about it.

The block parameter's saved outer value, the third temporary the String emitter declares, is still unrooted. It exists so the loop can restore the block parameter's shadowed value afterwards, and no Ruby program can read that value: a block parameter that would collide with an enclosing local is renamed rather than shadowed, so what the slot holds is a previous execution's dead value. I could not construct a program that observes its collection, so it is left as it is rather than rooted on an argument.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed loop processing so temporary strings, hashes, and arrays remain available while loop bodies perform memory allocations.
  - Prevented iteration from being prematurely truncated or producing invalid values during allocation-heavy loops.
  - Ensured loop cleanup works correctly when exiting early through `break`, `return`, or exceptions.

- **Tests**
  - Added coverage for container iteration methods, receiver returns, iteration counts, and early-exit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->