### PR TITLE
A fold or collect loop roots the receiver it reads on every turn

### DIFF
--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -303,6 +303,12 @@ int emit_hash_collect_expr(Compiler *c, int id, Buf *b) {
   { Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);
     emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
     buf_printf(g_pre, " _t%d = ", trecv); buf_puts(g_pre, rb.p ? rb.p : ""); buf_puts(g_pre, ";\n"); free(rb.p); }
+  /* The loop below reads this temp's `len` as its bound on every turn and
+     takes the entry out of it on every yield, and the block between two
+     turns allocates. A receiver with no other holder -- the hash a method
+     call returned -- is rooted here, as the Hash sort_by, sum and group_by
+     hoists in this file already were. */
+  emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", trecv);
 
   if (is_sel || is_rej) {
     /* select/reject: produce a same-type hash with matching pairs */
@@ -859,6 +865,9 @@ int emit_transform_hash_expr(Compiler *c, int id, Buf *b) {
     Buf rb2; memset(&rb2, 0, sizeof rb2); emit_expr(c, recv, &rb2);
     emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
     buf_printf(g_pre, " _t%d = ", ts2); buf_puts(g_pre, rb2.p ? rb2.p : ""); buf_puts(g_pre, ";\n"); free(rb2.p);
+    /* rooted for the walk: the entry count below is re-read from this temp
+       on every turn and the block can allocate */
+    emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", ts2);
     emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
     buf_printf(g_pre, " _t%d = sp_%sHash_new(); SP_GC_ROOT(_t%d);\n", td2, shn, td2);
     emit_indent(g_pre, g_indent);
@@ -888,6 +897,7 @@ int emit_transform_hash_expr(Compiler *c, int id, Buf *b) {
   int ts = ++g_tmp, td = ++g_tmp, ti = ++g_tmp, tk = ++g_tmp;
   Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);  /* recv preludes flush to g_pre first */
   emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre); buf_printf(g_pre, " _t%d = ", ts); buf_puts(g_pre, rb.p ? rb.p : ""); buf_puts(g_pre, ";\n"); free(rb.p);
+  emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", ts);
   emit_indent(g_pre, g_indent); emit_ctype(c, dt, g_pre); buf_printf(g_pre, " _t%d = sp_%sHash_new(); SP_GC_ROOT(_t%d);\n", td, dhn, td);
   emit_indent(g_pre, g_indent); buf_printf(g_pre, "for (sp_int _t%d = 0; _t%d < _t%d->len; _t%d++) {\n", ti, ti, ts, ti);
   emit_indent(g_pre, g_indent + 1); emit_ctype(c, skt, g_pre);
@@ -1572,6 +1582,10 @@ int emit_minmax_by_expr(Compiler *c, int id, Buf *b) {
         tf = ++g_tmp, ti = ++g_tmp, tcur = ++g_tmp, tout = ++g_tmp;
     Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);
     emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre); buf_printf(g_pre, " _t%d = ", trecv); buf_puts(g_pre, rb.p ? rb.p : ""); buf_puts(g_pre, ";\n"); free(rb.p);
+    /* the receiver is this walk's bound, re-read every turn, and the block
+       allocates between two turns: root it, as the range the min_by/max_by
+       branch below materializes is rooted */
+    emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", trecv);
     const char *edflt = et == TY_RANGE ? "(sp_Range){0}" : default_value(et);
     emit_indent(g_pre, g_indent); emit_ctype(c, et, g_pre); buf_printf(g_pre, " _t%d = %s;\n", tmin, edflt);
     emit_indent(g_pre, g_indent); emit_ctype(c, et, g_pre); buf_printf(g_pre, " _t%d = %s;\n", tmax, edflt);
@@ -1658,7 +1672,12 @@ int emit_minmax_by_expr(Compiler *c, int id, Buf *b) {
        whose body may allocate and trigger a collection */
     emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", trecv);
   }
-  else { emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre); buf_printf(g_pre, " _t%d = ", trecv); buf_puts(g_pre, rb.p ? rb.p : ""); buf_puts(g_pre, ";\n"); }
+  else {
+    emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre); buf_printf(g_pre, " _t%d = ", trecv); buf_puts(g_pre, rb.p ? rb.p : ""); buf_puts(g_pre, ";\n");
+    /* rooted the same way the materialized range above is: an array receiver
+       that is itself a temporary has no other holder while the block runs */
+    emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", trecv);
+  }
   free(rb.p);
   emit_indent(g_pre, g_indent); emit_ctype(c, et, g_pre); buf_printf(g_pre, " _t%d = %s;\n", tbest, et == TY_RANGE ? "(sp_Range){0}" : default_value(et));
   emit_indent(g_pre, g_indent); emit_ctype(c, bvt_slot, g_pre); buf_printf(g_pre, " _t%d = %s; int _t%d = 1;\n", tbv, default_value(bvt_slot), tf);
@@ -3405,6 +3424,7 @@ int emit_reduce_block_expr(Compiler *c, int id, Buf *b) {
   int ta = ++g_tmp, tacc = ++g_tmp, ti = ++g_tmp;
   buf_puts(b, "({ ");
   emit_ctype(c, rt, b); buf_printf(b, " _t%d = ", ta); emit_expr(c, recv, b); buf_puts(b, "; ");
+
   emit_ctype(c, acc_ty, b); buf_printf(b, " _t%d = ", tacc);
   int start;
   if (init_empty_arr) {
@@ -4412,6 +4432,9 @@ int emit_partition_expr(Compiler *c, int id, Buf *b) {
   Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);
   emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
   buf_printf(g_pre, " _t%d = %s;\n", trecv, rb.p ? rb.p : ""); free(rb.p);
+  /* rooted like the two result arrays below: the length is the loop bound
+     and the block runs between two reads of it */
+  emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", trecv);
 
   emit_indent(g_pre, g_indent);
   buf_printf(g_pre, "sp_%sArray *_t%d = sp_%sArray_new();\n", k, ttrue, k);
@@ -6034,6 +6057,10 @@ int emit_grep_expr(Compiler *c, int id, Buf *b) {
   emit_indent(g_pre, g_indent);
   emit_ctype(c, rt, g_pre);
   buf_printf(g_pre, " _t%d = %s;\n", trecv, rb.p ? rb.p : ""); free(rb.p);
+  /* rooted like the result array below it: the length is the loop bound and
+     the block runs between two reads of it */
+  emit_indent(g_pre, g_indent);
+  buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", trecv);
   emit_indent(g_pre, g_indent);
   buf_printf(g_pre, "sp_%sArray *_t%d = sp_%sArray_new();\n", ok, tres, ok);
   emit_indent(g_pre, g_indent);
@@ -8362,6 +8389,8 @@ int emit_group_by_expr(Compiler *c, int id, Buf *b) {
   Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);
   emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
   buf_printf(g_pre, " _t%d = %s;\n", trecv, rb.p ? rb.p : ""); free(rb.p);
+  /* rooted for the walk below, whose bound re-reads it every turn */
+  emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", trecv);
   /* result hash */
   emit_indent(g_pre, g_indent);
   buf_printf(g_pre, "sp_PolyPolyHash *_t%d = sp_PolyPolyHash_new(); SP_GC_ROOT(_t%d);\n", thash, thash);
@@ -8566,6 +8595,9 @@ int emit_each_with_object_expr(Compiler *c, int id, Buf *b) {
     { Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);
       emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
       buf_printf(g_pre, " _t%d = %s;\n", trecv, rb.p ? rb.p : ""); free(rb.p); }
+    /* the entry count is the loop bound, re-read every turn, and the block
+       between two turns allocates: root the hoist */
+    emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", trecv);
     /* Accumulator: use memo's declared type (may differ from accT if widened) */
     Scope *cs = comp_scope_of(c, id);
     LocalVar *memo_lv = mname_orig && cs ? scope_local(cs, mname_orig) : NULL;
@@ -8704,6 +8736,8 @@ int emit_each_with_object_expr(Compiler *c, int id, Buf *b) {
   Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);
   emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
   buf_printf(g_pre, " _t%d = %s;\n", trecv, rb.p ? rb.p : ""); free(rb.p);
+  /* rooted for the walk, as the hash branch above is */
+  emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", trecv);
 
   /* Accumulator: an empty `[]` seed is built as a fresh typed array of the
      inferred element type, so a string/poly memo isn't materialized as int

--- a/test/fold_receiver_root.rb
+++ b/test/fold_receiver_root.rb
@@ -1,0 +1,114 @@
+# The fold and collect emitters copy their receiver into a C temporary and then
+# read that temporary again on every turn -- as the loop bound, and as the
+# container the entry comes out of -- while the block between two turns
+# allocates. Every arm here hands one of them a receiver no Ruby name holds (a
+# method's answer), and every block allocates before it looks at what it was
+# given, so an arm whose receiver was collected mid-walk reports a short count
+# rather than passing quietly. The local-receiver arms are the control: those
+# were always safe, because the local is a root.
+
+ENTRIES = 40
+CHURN = 100
+
+def churn
+  CHURN.times { "q" * 64 }
+end
+
+def make_hash
+  h = {}
+  (1..ENTRIES).each { |i| h["k#{i}"] = "v#{i}" }
+  h
+end
+
+def make_array
+  (1..ENTRIES).map { |i| "a#{i}" }
+end
+
+# --- Hash#map / #collect, #select / #filter / #find_all, #reject ---
+
+n = 0
+r = make_hash.map { |k, _v| churn; n += 1; k }
+puts "hash map n=#{n} out=#{r.size}"
+
+n = 0
+r = make_hash.collect { |k, _v| churn; n += 1; k }
+puts "hash collect n=#{n} out=#{r.size}"
+
+n = 0
+r = make_hash.select { |_k, _v| churn; n += 1; true }
+puts "hash select n=#{n} out=#{r.size}"
+
+n = 0
+r = make_hash.filter { |_k, _v| churn; n += 1; true }
+puts "hash filter n=#{n} out=#{r.size}"
+
+n = 0
+r = make_hash.reject { |_k, _v| churn; n += 1; false }
+puts "hash reject n=#{n} out=#{r.size}"
+
+h = make_hash
+n = 0
+r = h.select { |_k, _v| churn; n += 1; true }
+puts "hash select local n=#{n} out=#{r.size}"
+
+# --- Hash#transform_keys / #transform_values ---
+
+n = 0
+r = make_hash.transform_keys { |k| churn; n += 1; k.upcase }
+puts "hash transform_keys n=#{n} out=#{r.size} first=#{r.keys.first}"
+
+n = 0
+r = make_hash.transform_values { |v| churn; n += 1; v.upcase }
+puts "hash transform_values n=#{n} out=#{r.size} first=#{r.values.first}"
+
+# --- Array#min_by / #max_by / #minmax_by: a short walk answers from the
+#     prefix it managed to read, so the answer changes, not just the count ---
+
+n = 0
+r = make_array.min_by { |x| churn; n += 1; x }
+puts "array min_by n=#{n} out=#{r}"
+
+n = 0
+r = make_array.max_by { |x| churn; n += 1; x }
+puts "array max_by n=#{n} out=#{r}"
+
+n = 0
+r = make_array.minmax_by { |x| churn; n += 1; x }
+puts "array minmax_by n=#{n} out=#{r.inspect}"
+
+# --- Array#group_by ---
+
+n = 0
+r = make_array.group_by { |x| churn; n += 1; x.size }
+puts "array group_by n=#{n} out=#{r.values.map(&:size).sum}"
+
+# --- Array#grep / #grep_v with a block ---
+
+n = 0
+r = make_array.grep(/a/) { |x| churn; n += 1; x }
+puts "array grep n=#{n} out=#{r.size}"
+
+n = 0
+r = make_array.grep_v(/zz/) { |x| churn; n += 1; x }
+puts "array grep_v n=#{n} out=#{r.size}"
+
+# --- #each_with_object, both receivers ---
+
+n = 0
+r = make_hash.each_with_object([]) { |(k, _v), acc| churn; n += 1; acc << k }
+puts "hash each_with_object n=#{n} out=#{r.size}"
+
+n = 0
+r = make_array.each_with_object([]) { |x, acc| churn; n += 1; acc << x }
+puts "array each_with_object n=#{n} out=#{r.size}"
+
+a = make_array
+n = 0
+r = a.each_with_object([]) { |x, acc| churn; n += 1; acc << x }
+puts "array each_with_object local n=#{n} out=#{r.size}"
+
+# --- Array#partition ---
+
+n = 0
+r = make_array.partition { |x| churn; n += 1; x.size.even? }
+puts "array partition n=#{n} out=#{r[0].size + r[1].size}"

--- a/test/fold_receiver_root.rb.expected
+++ b/test/fold_receiver_root.rb.expected
@@ -1,0 +1,18 @@
+hash map n=40 out=40
+hash collect n=40 out=40
+hash select n=40 out=40
+hash filter n=40 out=40
+hash reject n=40 out=40
+hash select local n=40 out=40
+hash transform_keys n=40 out=40 first=K1
+hash transform_values n=40 out=40 first=V1
+array min_by n=40 out=a1
+array max_by n=40 out=a9
+array minmax_by n=40 out=["a1", "a9"]
+array group_by n=40 out=40
+array grep n=40 out=40
+array grep_v n=40 out=40
+hash each_with_object n=40 out=40
+array each_with_object n=40 out=40
+array each_with_object local n=40 out=40
+array partition n=40 out=40


### PR DESCRIPTION
## Why

Seven of the fold and collect emitters begin by copying the receiver they are about to walk into a C temporary, and then read that temporary again on every turn: its entry count or its length is the loop bound, and the entry the block is handed comes out of it. None of the ten hoists they make was a GC root, and the block between two turns allocates, so a receiver that nothing else holds — the hash or the array a method call answered — could be collected while its own fold was still walking it.

```ruby
def make_hash
  h = {}
  (1..40).each { |i| h["k#{i}"] = "v#{i}" }
  h
end

make_hash.map { |k, _v| 100.times { "q" * 64 }; k }   # 29 of 40 entries on master
```

This is the rule of PR #4367 at a second family of emitters. That PR covered the builtin block loops that walk a container — `String#each_line`, `Hash#each`, `Array#each_cons` and their neighbours. These are the loops that fold a container into an answer, and they hoist the same way: `Hash#map` and `#collect`, `#select`, `#filter` and `#reject`, `#transform_keys` and `#transform_values`; `Array#min_by`, `#max_by`, `#minmax_by`, `#group_by`, `#partition`, `#grep` and `#grep_v` with a block; and `#each_with_object` on both a Hash and an Array receiver.

The symptom is usually a short walk rather than a wrong answer, which is what makes it easy to miss: the loop reads a count out of freed memory and stops, and the program exits 0 having quietly skipped the rest of the collection.

Over a 40-entry receiver whose block allocates 100 short strings a turn, three runs each on an idle machine: a plain release build of master delivers 29 of the 40 turns, and under `SPINEL_GC_STRESS=1` it delivers 1, or 2 for the Hash loops. The plain count is worth reading for what it is — it says when a collection lands inside the window, not whether the receiver can be collected, and it moves with the block: the same arms answer 15 of 40 when the block allocates twice as much. The stress column is the one that says the hoist is unrooted.

Four of the loops do not answer short at all. `Hash#select`, `#filter`, `#reject` and `#transform_keys` segfault on a plain release build of master over that same receiver, every run.

And where the answer is picked from the walk rather than accumulated, a short walk is a wrong answer rather than a partial one. `max_by` over a fresh `["a1", ..., "a40"]` answers `"a1"` under `SPINEL_GC_STRESS=1` on master, where CRuby answers `"a9"`, and `minmax_by` answers `["a1", "a1"]`: the walk ended inside the first turn, so the best-so-far it reports is the first element it saw.

## What

One file, `src/codegen_fold.c`, and ten hoists in seven emitters.

`emit_hash_collect_expr` covers `Hash#map`, `#collect`, `#select`, `#filter` and `#reject`. `emit_transform_hash_expr` covers `#transform_keys` and `#transform_values`, and hoists the receiver twice — once in the empty-block arm and once in the general one. The empty-block arm has no probe that misbehaves, since a block with no body allocates nothing of its own; it hoists the same way as its sibling and is rooted with it. `emit_minmax_by_expr` hoists twice as well: once in the `minmax_by` branch, and once in the `min_by`/`max_by` branch that takes an array receiver — the branch beside it, which materializes a Range into an array first, already rooted its hoist and says why in a comment. `emit_group_by_expr`, `emit_grep_expr` (`#grep` and `#grep_v` in their block form) and `emit_partition_expr` hoist once each. `emit_each_with_object_expr` hoists once for a Hash receiver and once for an Array receiver.

Each of the ten becomes a GC root, ahead of the loop that reads it.

## How

The root goes on the temporary itself. `SP_GC_ROOT` records the address of the slot rather than the value in it, so one push ahead of the loop covers every turn, and the pop is the cleanup attribute's, which runs on every way out of the enclosing scope — off the end, a `break`, a `break` with a value, a `return` from inside the block, a `redo`, and a raise, which restores the root stack from the mark the rescue emitters take. All ten are plain declarations in the pre-statement buffer and take the macro directly, which is how the receivers already rooted in this file are written.

Every one of these emitters has already decided the receiver is a hash or an array before it hoists — `ty_hash_cname` or `ty_is_array` gates each of them, and returns 0 otherwise — so the temporary is always a collectable pointer and the plain macro is the right one.

The roots are plain declarations in whatever C block encloses the statement, so they pop at the end of that block rather than at the end of the loop: for a fold written at method-body level the receiver stays reachable until the method returns. That is a retention window, not a leak — every `while`, `if` and `when` body is braced in the emitted C, so a fold inside one pops per turn rather than accumulating. Measured on an anonymous 200,000-element receiver, the window holds 2.6 MB for the rest of the method; writing the receiver into a local first, which any Ruby program may do, costs exactly the same.

A root also costs a slot. `_sp_gc_root_push` silently returns 0 once the root stack reaches its 65,536-entry cap, so a program deep enough to fill it stops rooting rather than saying anything, and this change puts one more slot on a fold's frame for the rest of the enclosing method. Measured on a recursion that folds a fresh hash in every frame: master answers correctly to about 27,000 frames deep and segfaults past that, and this branch reaches about 13,500. Both are well past the roughly 9,000 frames at which CRuby raises SystemStackError for the same program, so no CRuby-compatible program reaches either — but the cap is a silent one, and rooting more moves any program that does reach it nearer.

The idiom is the file's own. `Hash#sort_by`, `#sum`, `#find`, `#group_by` and `#partition`, and `Array#map`, `#filter_map` and `#each_with_index`, all root the receiver they hoist — measured by reading the C each of them emits, not by reading the emitter, because a branch that roots the same C variable makes a neighbouring branch look rooted when it is not. What the ten changed here had in common is that they hoisted and did not root.

## Validation

Gate GREEN on `d9d85ff1`: the suite is 3512 pass / 0 fail / 0 error (the new test is the extra one; the spin-e2e leg is red on macOS on master too), 61 benchmarks pass, optcarrot answers 59662, and a differential corpus of ~2,100 minimized programs that behave differently under CRuby 4.0.6 and Spinel stays at 905 matching with nothing gained and nothing lost — nothing in that corpus lands on these folds, so this change does not move it. The inference fixpoint gains no non-convergences over 3465 programs and reports no differing round counts at all.

ASAN and UBSAN are clean on the new test, plain and under `SPINEL_GC_STRESS=1`. What that covers: `--cc` instruments the generated translation unit and the collector headers inlined into it, not the prebuilt runtime archive — so it covers these loops' own reads of the temporaries this change roots, and not the collector's later walk of the root stack.

The generated-C sweep over all 3527 programs in the tree is byte-identical except for 125, and optcarrot's is unchanged — the emitters this touches are not on its path at all. Those 125 files differ by 432 lines, and those lines carry exactly 432 added roots, one apiece. Deleting `SP_GC_ROOT(_t<n>);` from the new side of each of them makes all 125 compare equal to master with nothing left over: no line moved, no line was removed, and no other text changed.

`test/fold_receiver_root.rb` has eighteen arms, one per emitter and receiver shape. Every block allocates before it looks at what it was handed, and every arm prints its turn count as well as its answer, so an arm that ends early reads as a changed line rather than as a passing test; the `min_by`/`max_by`/`minmax_by` arms print the element they picked, which a short walk gets wrong. Two arms hold the receiver in a local first — those were always safe, because the local is a root, and they are there to say so. The whole program segfaults on master.

## Left alone, on purpose

The same rule reaches another family, in `src/codegen_call_recv.c` and `src/codegen_iter.c`, and wants its own PR rather than a quiet extension of this one: `Array#find` and `#detect`, `#take_while`, `#drop_while`, `#count` with a block, `#find_index` and `#index`, and `#map!` and `#collect!` all hoist their receiver unrooted. Over the same 40-entry receiver they deliver 29 of the 40 turns on a plain build and 1 under `SPINEL_GC_STRESS=1`; `map!` segfaults on a plain build, and `take_while` answers a 1-element array where CRuby answers 40.

Seven more hoists in this same file are left for a following change, because they are a different shape rather than the same one in a new place — the loop bound is hoisted separately, or the temporary is aliased, or the walk is over a chained enumerator — and each wants its own probe and its own line in a test. All are pre-existing and none is touched here: `arr.max { |a, b| }` and `#min` with a comparator block answer `""` where CRuby answers `"a9"` and `"a1"`; `arr.sort! { |a, b| }` and `arr.sum("") { }` on the String seed arm segfault on a plain build; `each_cons(n).map` walks 9 of 39 turns and `each_slice(n).map` 1 under stress; `arr.each.with_index(n).inject { }` walks 29 of 40; and `slice_when { }.to_a.inspect` answers 176 characters where CRuby answers 236.

`Array#reduce` and `#inject` hoist their receiver the same way and are deliberately not in this PR. Rooting that hoist is not enough to make them right: the accumulator they carry across the block is itself unrooted unless the seed is an empty `[]` or `{}`, so `arr.reduce("") { |m, x| m + x }` with an allocating block answers a 0-length string on a plain build of master where CRuby answers 111, with an ASAN use-after-free in `sp_str_concat`. Rooting only the receiver moves that fault around rather than fixing it — one arm that master happens to get right answers wrong with the receiver rooted and the accumulator not. The two belong together, with their own evidence, in their own change.

`Array#flat_map`'s inner flatten loop reads its bound from an unrooted temporary too — the array the block just answered — while the push it performs can allocate. It is left alone because no probe makes it misbehave: it answers 40 of 40 on a plain build and under stress, three runs each. The window is recorded rather than closed on speculation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of hash and array iteration operations when their receivers are temporary values and the iteration block performs memory allocations.
  - Prevented iteration results from being prematurely truncated during operations such as collect, transform, grouping, filtering, partitioning, and each-with-object.

- **Tests**
  - Added coverage for temporary receivers across supported hash and array operations, including expected invocation counts and result sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->