### PR TITLE
A search or in-place loop roots the receiver it reads on every turn

### DIFF
--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -1827,7 +1827,12 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
         const char *ip = block_param_name(c, fblk, 0); if (ip) ip = rename_local(ip);
         Buf rb = expr_buf(c, recv);
         emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
-        buf_printf(g_pre, " _t%d = %s;\n", trecv, rb.p ? rb.p : ""); free(rb.p);
+        buf_printf(g_pre, " _t%d = %s; ", trecv, rb.p ? rb.p : ""); free(rb.p);
+        /* rooted, as the TY_POLY map!/collect! near the top of this file
+           already roots its own hoist: fill stores into the receiver on every
+           turn, and the block never mentions the receiver, so this temporary is
+           the only thing holding it while the block allocates */
+        emit_gc_root_tmp(c, rt, trecv, g_pre); buf_puts(g_pre, "\n");
         emit_indent(g_pre, g_indent);
         buf_printf(g_pre, "sp_int _t%d = sp_%sArray_length(_t%d);\n", tn, fk, trecv);
         /* resolve the [start, end) span from the arguments */
@@ -2180,9 +2185,19 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
           int trecv = ++g_tmp, tout = ++g_tmp, ti = ++g_tmp;
           Buf rb = expr_buf(c, recv);
           emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
-          buf_printf(g_pre, " _t%d = %s;\n", trecv, rb.p ? rb.p : ""); free(rb.p);
+          buf_printf(g_pre, " _t%d = %s; ", trecv, rb.p ? rb.p : ""); free(rb.p);
+          /* rooted, as the each_index hoist above is, and as the TY_POLY arm of
+             this same pair of methods near the top of the file already is: the
+             length is the loop bound, the element comes out of the receiver on
+             every turn, and the block between two turns allocates */
+          emit_gc_root_tmp(c, rt, trecv, g_pre); buf_puts(g_pre, "\n");
           emit_indent(g_pre, g_indent);
-          buf_printf(g_pre, "sp_%sArray *_t%d = sp_%sArray_new();\n", ek, tout, ek);
+          /* The result array is rooted for the same reason and by the same
+             precedent: the TY_POLY arm of this pair roots its own result
+             beside its receiver. It is built empty here and pushed into on
+             every kept turn, so nothing but this temporary holds it while the
+             block allocates. */
+          buf_printf(g_pre, "sp_%sArray *_t%d = sp_%sArray_new(); SP_GC_ROOT(_t%d);\n", ek, tout, ek, tout);
           if (is_drop) {
             emit_indent(g_pre, g_indent);
             buf_puts(g_pre, "{ sp_bool _dropping = 1;\n");
@@ -2436,14 +2451,26 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
           int trecv = ++g_tmp, tlo = ++g_tmp, thi = ++g_tmp, tres = ++g_tmp, tmid = ++g_tmp;
           Buf rbs = expr_buf(c, recv);
           emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
-          buf_printf(g_pre, " _t%d = %s;\n", trecv, rbs.p ? rbs.p : "NULL"); free(rbs.p);
+          buf_printf(g_pre, " _t%d = %s; ", trecv, rbs.p ? rbs.p : "NULL"); free(rbs.p);
+          /* rooted, as the poly-array find_index above already roots its own
+             hoist: a halving search still reads its element out of the receiver
+             on every turn, and the block allocates between turns */
+          emit_gc_root_tmp(c, rt, trecv, g_pre); buf_puts(g_pre, "\n");
           emit_indent(g_pre, g_indent);
           buf_printf(g_pre, "sp_int _t%d = 0, _t%d = sp_%sArray_length(_t%d) - 1;\n", tlo, thi, k, trecv);
           emit_indent(g_pre, g_indent); emit_ctype(c, et, g_pre);
-          buf_printf(g_pre, " _t%d = %s;\n", tres,
+          buf_printf(g_pre, " _t%d = %s;", tres,
                      et == TY_INT ? "SP_INT_NIL" :
                      et == TY_FLOAT ? "sp_float_nil()" :
                      et == TY_POLY ? "sp_box_nil()" : "NULL");
+          /* The running answer is lifted OUT of the receiver and held while the
+             search narrows, so rooting the receiver does not cover it: a turn
+             that drops the captured element from the array leaves this
+             temporary as its only holder. The element type picks the macro --
+             an Integer or Float answer roots to nothing, which is why
+             bsearch_index needs none. */
+          if (needs_root(et)) { buf_puts(g_pre, " "); emit_gc_root_tmp(c, et, tres, g_pre); }
+          buf_puts(g_pre, "\n");
           emit_indent(g_pre, g_indent);
           buf_printf(g_pre, "while (_t%d <= _t%d) {\n", tlo, thi);
           emit_indent(g_pre, g_indent + 1);
@@ -2512,7 +2539,12 @@ int emit_array_call(Compiler *c, int id, Buf *b) {
           int trecv = ++g_tmp, tlo = ++g_tmp, thi = ++g_tmp, tres = ++g_tmp, tmid = ++g_tmp;
           Buf rbs = expr_buf(c, recv);
           emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
-          buf_printf(g_pre, " _t%d = %s;\n", trecv, rbs.p ? rbs.p : "NULL"); free(rbs.p);
+          buf_printf(g_pre, " _t%d = %s; ", trecv, rbs.p ? rbs.p : "NULL"); free(rbs.p);
+          /* rooted, as the poly-array find_index above already roots its own
+             hoist: the element the block judges comes out of the receiver on
+             every turn, and the block allocates between turns. The answer here
+             is an index rather than an element, so it needs no root of its own. */
+          emit_gc_root_tmp(c, rt, trecv, g_pre); buf_puts(g_pre, "\n");
           emit_indent(g_pre, g_indent);
           buf_printf(g_pre, "sp_int _t%d = 0, _t%d = sp_%sArray_length(_t%d) - 1, _t%d = SP_INT_NIL;\n", tlo, thi, bk, trecv, tres);
           emit_indent(g_pre, g_indent);
@@ -3380,7 +3412,12 @@ else {
           int trecv = ++g_tmp, ti = ++g_tmp, tres = ++g_tmp;
           Buf rfi = expr_buf(c, recv);
           emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
-          buf_printf(g_pre, " _t%d = %s;\n", trecv, rfi.p ? rfi.p : "NULL"); free(rfi.p);
+          buf_printf(g_pre, " _t%d = %s; ", trecv, rfi.p ? rfi.p : "NULL"); free(rfi.p);
+          /* rooted, as the poly-array find_index above already roots its own
+             hoist. rindex takes its bound once and then counts down, so a
+             collection mid-walk shows up in the elements rather than in the
+             turn count. */
+          emit_gc_root_tmp(c, rt, trecv, g_pre); buf_puts(g_pre, "\n");
           emit_indent(g_pre, g_indent); buf_printf(g_pre, "sp_int _t%d = SP_INT_NIL;\n", tres);
           emit_indent(g_pre, g_indent);
           if (sp_streq(name, "rindex"))
@@ -3460,7 +3497,10 @@ else {
           int trecv = ++g_tmp, ti = ++g_tmp, tres = ++g_tmp;
           Buf rb = expr_buf(c, recv);
           emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
-          buf_printf(g_pre, " _t%d = %s;\n", trecv, rb.p ? rb.p : ""); free(rb.p);
+          buf_printf(g_pre, " _t%d = %s; ", trecv, rb.p ? rb.p : ""); free(rb.p);
+          /* rooted, as the find(ifnone) arm above and the poly-array find
+             already are: same loop, same per-turn reads, same allocating block */
+          emit_gc_root_tmp(c, rt, trecv, g_pre); buf_puts(g_pre, "\n");
           emit_indent(g_pre, g_indent); emit_ctype(c, et, g_pre);
           if (et == TY_STRING) buf_printf(g_pre, " _t%d = NULL;\n", tres);
           else if (et == TY_INT) buf_printf(g_pre, " _t%d = SP_INT_NIL;\n", tres);
@@ -3504,7 +3544,12 @@ else {
           int trecv = ++g_tmp, ti = ++g_tmp;
           Buf rb = expr_buf(c, recv);
           emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
-          buf_printf(g_pre, " _t%d = %s;\n", trecv, rb.p ? rb.p : ""); free(rb.p);
+          buf_printf(g_pre, " _t%d = %s; ", trecv, rb.p ? rb.p : ""); free(rb.p);
+          /* rooted, as the TY_POLY map!/collect! near the top of this file
+             already roots its own hoist: this loop WRITES the block value back
+             into the receiver on every turn, so an unrooted hoist is a store
+             into freed memory and not only a short walk */
+          emit_gc_root_tmp(c, rt, trecv, g_pre); buf_puts(g_pre, "\n");
           emit_indent(g_pre, g_indent);
           buf_printf(g_pre, "for (sp_int _t%d = 0; _t%d < sp_%sArray_length(_t%d); _t%d++) {\n",
                      ti, ti, k, trecv, ti);
@@ -3662,7 +3707,11 @@ else {
           int trecv = ++g_tmp, tcnt = ++g_tmp, ti = ++g_tmp;
           Buf rb2 = expr_buf(c, recv);
           emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
-          buf_printf(g_pre, " _t%d = %s;\n", trecv, rb2.p ? rb2.p : ""); free(rb2.p);
+          buf_printf(g_pre, " _t%d = %s; ", trecv, rb2.p ? rb2.p : ""); free(rb2.p);
+          /* rooted, as the find(ifnone) arm above already is: the same walk
+             over the same hoist, differing only in what it does with the
+             predicate */
+          emit_gc_root_tmp(c, rt, trecv, g_pre); buf_puts(g_pre, "\n");
           emit_indent(g_pre, g_indent); buf_printf(g_pre, "sp_int _t%d = 0;\n", tcnt);
           emit_indent(g_pre, g_indent);
           buf_printf(g_pre, "for (sp_int _t%d = 0; _t%d < sp_%sArray_length(_t%d); _t%d++) {\n",
@@ -4285,7 +4334,10 @@ else {
           int trecv = ++g_tmp, tcnt = ++g_tmp, ti = ++g_tmp;
           Buf rb2 = expr_buf(c, recv);
           emit_indent(g_pre, g_indent);
-          buf_printf(g_pre, "sp_PolyArray *_t%d = %s;\n", trecv, rb2.p ? rb2.p : ""); free(rb2.p);
+          buf_printf(g_pre, "sp_PolyArray *_t%d = %s; ", trecv, rb2.p ? rb2.p : ""); free(rb2.p);
+          /* rooted, as the poly find/detect and find_index above already are:
+             the length is the loop bound and the block allocates */
+          emit_gc_root_tmp(c, rt, trecv, g_pre); buf_puts(g_pre, "\n");
           emit_indent(g_pre, g_indent); buf_printf(g_pre, "sp_int _t%d = 0;\n", tcnt);
           emit_indent(g_pre, g_indent);
           buf_printf(g_pre, "for (sp_int _t%d = 0; _t%d < sp_PolyArray_length(_t%d); _t%d++) {\n",
@@ -4753,7 +4805,11 @@ else {
         if (bn >= 1) {
           int trecv = ++g_tmp, ti = ++g_tmp;
           Buf rb = expr_buf(c, recv);
-          emit_indent(g_pre, g_indent); buf_printf(g_pre, "sp_PolyArray *_t%d = %s;\n", trecv, rb.p ? rb.p : ""); free(rb.p);
+          emit_indent(g_pre, g_indent); buf_printf(g_pre, "sp_PolyArray *_t%d = %s; ", trecv, rb.p ? rb.p : ""); free(rb.p);
+          /* rooted, as the TY_POLY map!/collect! near the top of this file
+             already roots its own hoist: the loop stores into the receiver on
+             every turn, so an unrooted hoist is a write into freed memory */
+          emit_gc_root_tmp(c, rt, trecv, g_pre); buf_puts(g_pre, "\n");
           emit_indent(g_pre, g_indent);
           buf_printf(g_pre, "for (sp_int _t%d = 0; _t%d < sp_PolyArray_length(_t%d); _t%d++) {\n", ti, ti, trecv, ti);
           if (bp) { emit_indent(g_pre, g_indent + 1); buf_printf(g_pre, "lv_%s = sp_PolyArray_get(_t%d, _t%d);\n", bp, trecv, ti); }

--- a/test/call_receiver_root.rb
+++ b/test/call_receiver_root.rb
@@ -1,0 +1,199 @@
+# A search or in-place loop roots the receiver it reads on every turn.
+#
+# Each of these builtins hoists its receiver into a C temporary and reads that
+# temporary again on every turn: its length is the loop bound, the element the
+# block is handed comes out of it, and map!, collect! and fill write back into
+# it. A receiver that no Ruby name holds is exactly the one that can be
+# collected while its own loop is still walking it, so most arms below call a
+# method for their receiver rather than naming it first, and their blocks
+# allocate before they look at what they were handed.
+#
+# The exceptions are deliberate and labelled where they appear: four control
+# arms hold the receiver in a local, which is itself a root, and the two arms
+# that test bsearch's running answer rather than its receiver need a named
+# receiver to mutate and must NOT allocate on the turn that captures the
+# answer.
+#
+# Each arm prints the number of turns it took as well as its answer, except
+# where a note says why it cannot: a loop that ends early is a changed line
+# rather than a silent pass.
+
+def make_array
+  (1..40).map { |i| "a#{i}" }
+end
+
+def make_mixed
+  a = []
+  (1..40).each { |i| a << (i.even? ? "a#{i}" : i) }
+  a
+end
+
+def make_hash
+  h = {}
+  (1..40).each { |i| h["k#{i}"] = "v#{i}" }
+  h
+end
+
+def churn
+  100.times { "q" * 64 }
+end
+
+# A halving search takes only log2(n) turns, so it needs a larger receiver and
+# a block that allocates harder than the rest before a collection lands inside
+# its window. These are the smallest values that still misbehave on master --
+# see the pull request for what a lighter block does instead.
+def make_sorted
+  (1..4096).map { |i| "z%06d" % i }
+end
+
+def churn_hard
+  500.times { "q" * 512 }
+end
+
+# For the two arms that test bsearch's running answer rather than its receiver.
+# Whether that answer survives depends on when the block allocates, not only on
+# how much: an allocation before the answer is captured promotes the string out
+# of the young generation and it can no longer be collected mid-search. So
+# these arms keep the capturing turn quiet and allocate only afterwards.
+def churn_young
+  400.times { "q" * 512 }
+end
+
+# --- search loops over a typed array ---
+
+n = 0
+r = make_array.find { |x| churn; n += 1; x == "a40" }
+puts "find              turns=#{n} answer=#{r.inspect}"
+
+n = 0
+r = make_array.detect { |x| churn; n += 1; x == "a40" }
+puts "detect            turns=#{n} answer=#{r.inspect}"
+
+n = 0
+r = make_array.find_index { |x| churn; n += 1; x == "a40" }
+puts "find_index        turns=#{n} answer=#{r.inspect}"
+
+n = 0
+r = make_array.index { |x| churn; n += 1; x == "a40" }
+puts "index             turns=#{n} answer=#{r.inspect}"
+
+# rindex takes its bound once and counts down, so a collection mid-walk shows
+# up in the elements it reads back rather than in the turn count.
+n = 0
+r = make_array.rindex { |x| churn; n += 1; x == "a1" }
+puts "rindex            turns=#{n} answer=#{r.inspect}"
+
+n = 0
+r = make_array.count { |x| churn; n += 1; x.size > 1 }
+puts "count             turns=#{n} answer=#{r}"
+
+# --- the two that also build a result array ---
+
+n = 0
+r = make_array.take_while { |x| churn; n += 1; x.size > 1 }
+puts "take_while        turns=#{n} answer=#{r.size} last=#{r[-1].inspect}"
+
+# The drop_while arms print no turn count: Spinel runs the block for every
+# element where CRuby stops at the first falsy one, a pre-existing difference
+# this change does not touch. The kept suffix says whether the walk finished.
+r = make_array.drop_while { |x| churn; x != "a11" }
+puts "drop_while        answer=#{r.size} first=#{r[0].inspect} last=#{r[-1].inspect}"
+
+# --- the in-place ones, which write back through the hoist ---
+
+n = 0
+r = make_array.map! { |x| churn; n += 1; x + "!" }
+puts "map!              turns=#{n} answer=#{r.size} last=#{r[-1].inspect}"
+
+n = 0
+r = make_array.collect! { |x| churn; n += 1; x + "?" }
+puts "collect!          turns=#{n} answer=#{r.size} last=#{r[-1].inspect}"
+
+# --- the same loops with a mixed-element receiver, which takes the poly arms ---
+
+n = 0
+r = make_mixed.count { |x| churn; n += 1; x.to_s.size > 1 }
+puts "poly count        turns=#{n} answer=#{r}"
+
+n = 0
+r = make_mixed.take_while { |x| churn; n += 1; !x.nil? }
+puts "poly take_while   turns=#{n} answer=#{r.size} last=#{r[-1].inspect}"
+
+r = make_mixed.drop_while { |x| churn; x != "a12" }
+puts "poly drop_while   answer=#{r.size} first=#{r[0].inspect} last=#{r[-1].inspect}"
+
+n = 0
+r = make_mixed.map! { |x| churn; n += 1; x }
+puts "poly map!         turns=#{n} answer=#{r.size} last=#{r[-1].inspect}"
+
+n = 0
+r = make_mixed.collect! { |x| churn; n += 1; x }
+puts "poly collect!     turns=#{n} answer=#{r.size} last=#{r[-1].inspect}"
+
+# --- a Hash receiver reaches the same two array loops through its pairs ---
+
+n = 0
+r = make_hash.take_while { |k, _v| churn; n += 1; k.size > 1 }
+puts "hash take_while   turns=#{n} answer=#{r.size}"
+
+r = make_hash.drop_while { |k, _v| churn; k != "k11" }
+puts "hash drop_while   answer=#{r.size} first=#{r[0].inspect}"
+
+# --- fill, which writes into a receiver its block never mentions ---
+
+r = make_array.fill { |i| churn; "f#{i}" }
+puts "fill              answer=#{r.size} first=#{r[0].inspect} last=#{r[-1].inspect}"
+
+r = make_array.fill(2, 30) { |i| churn; "f#{i}" }
+puts "fill span         answer=#{r.size} first=#{r[0].inspect} last=#{r[-1].inspect}"
+
+r = make_mixed.fill { |i| churn; i }
+puts "poly fill         answer=#{r.size} first=#{r[0].inspect} last=#{r[-1].inspect}"
+
+# --- the halving searches, which read one element per turn out of the hoist ---
+
+n = 0
+r = make_sorted.bsearch { |x| churn_hard; n += 1; x >= "z000100" }
+puts "bsearch           turns=#{n} answer=#{r.inspect}"
+
+n = 0
+r = make_sorted.bsearch_index { |x| churn_hard; n += 1; x >= "z000100" }
+puts "bsearch_index     turns=#{n} answer=#{r.inspect}"
+
+# bsearch lifts its running answer out of the receiver and holds it while the
+# search narrows, so rooting the receiver is not enough on its own: the turn
+# after the capture drops that element from the array, and nothing else holds
+# it. One arm per element kind, because they root through different macros.
+
+a = make_sorted
+n = 0
+r = a.bsearch { |x| n += 1; a[99] = "z%06d" % 100; churn_young if n >= 11; x >= "z000100" }
+puts "bsearch answer    turns=#{n} answer=#{r.inspect}"
+
+a = []
+(1..4096).each { |i| a << ("z%06d" % i) }
+n = 0
+r = a.bsearch { |x| n += 1; a[99] = "z%06d" % 100; churn_young if n >= 11; x >= "z000100" }
+puts "poly bsearch answ turns=#{n} answer=#{r.inspect}"
+
+# --- controls: a receiver held in a local was always safe, because the local
+# --- is itself a root. These are here to say so.
+
+n = 0
+held = make_array
+r = held.find { |x| churn; n += 1; x == "a40" }
+puts "held find         turns=#{n} answer=#{r.inspect}"
+
+n = 0
+held = make_array
+r = held.map! { |x| churn; n += 1; x + "!" }
+puts "held map!         turns=#{n} answer=#{r.size} last=#{r[-1].inspect}"
+
+held = make_array
+r = held.fill { |i| churn; "f#{i}" }
+puts "held fill         answer=#{r.size} first=#{r[0].inspect} last=#{r[-1].inspect}"
+
+n = 0
+held = make_sorted
+r = held.bsearch { |x| churn; n += 1; x >= "z000100" }
+puts "held bsearch      turns=#{n} answer=#{r.inspect}"

--- a/test/call_receiver_root.rb.expected
+++ b/test/call_receiver_root.rb.expected
@@ -1,0 +1,28 @@
+find              turns=40 answer="a40"
+detect            turns=40 answer="a40"
+find_index        turns=40 answer=39
+index             turns=40 answer=39
+rindex            turns=40 answer=0
+count             turns=40 answer=40
+take_while        turns=40 answer=40 last="a40"
+drop_while        answer=30 first="a11" last="a40"
+map!              turns=40 answer=40 last="a40!"
+collect!          turns=40 answer=40 last="a40?"
+poly count        turns=40 answer=35
+poly take_while   turns=40 answer=40 last="a40"
+poly drop_while   answer=29 first="a12" last="a40"
+poly map!         turns=40 answer=40 last="a40"
+poly collect!     turns=40 answer=40 last="a40"
+hash take_while   turns=40 answer=40
+hash drop_while   answer=30 first=["k11", "v11"]
+fill              answer=40 first="f0" last="f39"
+fill span         answer=40 first="a1" last="a40"
+poly fill         answer=40 first=0 last=39
+bsearch           turns=12 answer="z000100"
+bsearch_index     turns=12 answer=99
+bsearch answer    turns=12 answer="z000100"
+poly bsearch answ turns=12 answer="z000100"
+held find         turns=40 answer="a40"
+held map!         turns=40 answer=40 last="a40!"
+held fill         answer=40 first="f0" last="f39"
+held bsearch      turns=12 answer="z000100"


### PR DESCRIPTION
## Why

Ten of the search and in-place emitters begin by copying the receiver they are about to walk into a C temporary, and then read that temporary again on every turn: its length is the loop bound, the element the block is handed comes out of it, and `map!` and `fill` write back into it. None of those ten hoists was a GC root, and the block between two turns allocates, so a receiver that nothing else holds — the array a method call answered — could be collected while its own loop was still walking it.

Two of them fail badly enough to lead with. Every measurement here is from a default `-O 2` build of master at `03a698df`, one program per arm. `fill` writes into a receiver its block never mentions, so nothing on the C stack keeps that array alive at all, and not one of its arms ever answers correctly. What varies is how it fails: sometimes `FrozenError`, "can't modify frozen Array", which is the freed array's header read back with the frozen bit set, and sometimes the process simply dies. Which of the two comes out differs between runs of the same binary, and between one measurement of it and the next, so the manner is worth naming and a tally is not. And `bsearch` gets it silently wrong, deterministically: over a 4,096-element sorted receiver it answers `nil` where CRuby answers `"z000100"`, twenty-four runs of twenty-four, and `bsearch_index` answers 511 where CRuby answers 99 — 2047 under `SPINEL_GC_STRESS=1` — with the turn count identical at 12 in every row. No crash, no short walk, no error — just the wrong answer, which is the failure a differential corpus is least likely to surface.

```ruby
def make_array
  (1..40).map { |i| "a#{i}" }
end

make_array.find { |x| 100.times { "q" * 64 }; x == "a40" }   # nil on master, "a40" in CRuby
```

This is the rule of PR #4369 at the emitters that PR did not reach. #4369 covered the fold and collect loops in `src/codegen_fold.c` — `Hash#map`, `#select`, `#transform_values`, `Array#min_by`, `#group_by`, `#partition` and their neighbours. These are the loops that search a container for one answer, or rewrite it where it stands: `Array#find` and `#detect`, `#find_index`, `#index` and `#rindex` with a block, `#count` with a block, `#take_while` and `#drop_while`, `#map!` and `#collect!`, `#fill` with a block, and `#bsearch` and `#bsearch_index`. `#count`, `#map!` and `#collect!` appear twice, because a typed array and a mixed-element one have separate emitters and both were unrooted; the mixed-element `#find`, `#detect`, `#find_index` and `#index` were already rooted and are untouched; and `#take_while` and `#drop_while` have one emitter that serves a typed array, a mixed-element one, and a Hash receiver reaching it through its pairs.

How hard the block has to work before either of those shows is itself worth stating, because it says what the plain numbers below are and are not. A halving search over four thousand elements takes twelve turns, and with a block that allocates a hundred 64-byte strings a turn, master answers `bsearch` correctly on three runs of three at either optimization level, with ASAN clean. What tips it is how much the block allocates, not how often: five hundred 64-byte strings a turn is still correct, while a hundred and seventy-five 512-byte ones is already wrong every time. Nothing about the receiver changes across that range — the heavier block only gives the allocator more reason to run a cycle while the array is unreachable — and the boundary is not monotonic in the receiver's size either: at five hundred 512-byte strings a turn every receiver from a thousand to eight thousand elements is wrong, and sixteen thousand is right again. A count from a plain build records when a collection lands in the window, not whether the value can be collected, which is why every claim here has a `SPINEL_GC_STRESS=1` column beside it.

The symptom is usually a short walk rather than a wrong answer, which is what makes it easy to miss: the loop reads a length out of freed memory and stops, and the program exits 0 having quietly skipped the rest of the array. Over a 40-element receiver whose block allocates 100 short strings a turn, three runs each on an idle machine, a release build of master delivers 1 of the 40 turns under `SPINEL_GC_STRESS=1`, or 7 with a Hash receiver, and 29 or 30 of 40 on a plain build, depending on the arm. The plain count is worth reading for what it is: it says when a collection lands inside the window, not whether the receiver can be collected, and it moves with how much the block allocates. The stress column is the one that says the hoist is unrooted.

Where the answer is picked from the walk rather than accumulated, a short walk is a wrong answer rather than a partial one. On master, `find` and `detect` looking for `"a40"` answer `nil`; `index` looking for `"a40"` answers `nil` where CRuby answers 39; `count { |x| x.size > 1 }` answers 29 where CRuby answers 40; and `take_while { |x| x.size > 1 }` answers an empty array where CRuby answers all 40 elements.

`rindex` is the one with no short walk at all. It takes its bound once and counts down, so the turn count stays 40 and only the elements are wrong: `make_array.rindex { |x| x == "a1" }` answers `nil` on master, plain and stressed alike, where CRuby answers 0. Reading the loop bound is not what makes these unsafe — reading the receiver at all is.

The two in-place forms do not answer short either: they crash. `map!` and `collect!` store the block's value back through the freed hoist, which is a write into memory the collector has handed out again. On the same builds, `map!` and `collect!` on a typed array have taken the process down in every run measured, and on a mixed-element receiver they give the same mixture `fill` does — the `FrozenError` on some runs, a crash on others. Again the fact of the failure is stable and the manner is not.

## What

One file, `src/codegen_call_recv.c`: ten receiver hoists in ten emitters, and twelve roots once the two carried values below are counted.

`find` and `detect` with a block on a typed array, `find_index`, `index` and `rindex` with a block on a typed array, `count` with a block on a typed array and again on a mixed-element one, `map!` and `collect!` on a typed array and again on a mixed-element one, `fill` with a block, `bsearch` and `bsearch_index`, and `take_while` and `drop_while`, whose one emitter serves a typed array, a mixed-element one and a Hash alike. Each hoist becomes a GC root, ahead of the loop that reads it.

Three of them carry a second value across the turns, and it is rooted too. `take_while` and `drop_while` build their answer in a fresh array and push into it on every kept turn while the block allocates: rooting the receiver alone moves the fault rather than closing it, since with the receiver rooted and the result not, `make_array.take_while { |x| x.size > 1 }` answers 5 elements instead of 40 on a plain build and aborts under `SPINEL_GC_STRESS=1`, three runs of three, where master answered 0 elements. That is what the same pair of methods already does near the top of this file when the receiver is a boxed poly value.

`bsearch` is the third. It lifts its running answer out of the receiver and holds it while the search narrows, so the turn after the capture can drop that element from the array and leave this temporary as its only holder. Rooting the receiver does not cover it: over a 4,096-element receiver whose block replaces the captured slot, master answers an empty string where CRuby answers `"z000100"`, five runs of five on a plain release build, and takes the process down with a segmentation fault on three of three under `SPINEL_GC_STRESS=1`. It takes the element type rather than the receiver's, so an Integer or Float answer roots to nothing at all — which is why `bsearch_index`, whose answer is an index, takes no second root.

## How

The root goes on the temporary itself. `SP_GC_ROOT` records the address of the slot rather than the value in it, so one push ahead of the loop covers every turn, and the pop is the cleanup attribute's, which runs on every way out of the enclosing scope. All twelve roots are plain declarations in the pre-statement buffer. Measured rather than assumed: a program that leaves these loops 400,000 times by a `break` with a value, by a `return` from inside the block, and by a raise rescued outside the method answers exactly as CRuby does, twice over — six times past the root stack's 65,536-entry cap, which it would hit if any of those exits leaked a slot. The same program is where master's own answer shows: it is wrong by one in 400,000, on all three runs.

Eleven of the twelve go through `emit_gc_root_tmp`, which is how the rooted hoists beside them in this file are written: it picks `SP_GC_ROOT_RBVAL` for a boxed-poly temp, skips a value-object type, and emits nothing at all for a type that does not need rooting. Ten of those pass the receiver's own inferred type, and every one of these emitters has already decided the receiver is an array before it hoists. The eleventh passes the element type, for `bsearch`'s running answer, which is how that root disappears by itself on an Integer or Float array and how `bsearch_index` gets none. The twelfth, the result array `take_while` and `drop_while` build, is a `sp_..Array_new()` of a kind the emitter chose itself, so it takes the macro directly, exactly as the same two methods' poly arm does.

The idiom is the file's own. Nine emitters in it already root the receiver they hoist and then walk with a block: `find` and `detect`, `map!` and `collect!`, `each_index`, and the `select`/`reject`/`find_all`/`take_while`/`drop_while` group on a boxed-poly receiver; `each_index` on a typed array; `find` and `detect`, `find_index` and `index`, and `to_h` with a block on a mixed-element array; and `find(ifnone)` with a block on a typed array, whose comment already says why. Two of those nine are the very methods changed here, on a receiver of a different type — `map!` and `collect!`, and `take_while` and `drop_while`, which roots its result array alongside its receiver. What the ten changed here had in common is that they hoisted and did not root.

Rooting only when the receiver has no other holder would be wrong, not merely fiddly, so the roots go on unconditionally. A named local is a root, but only for as long as it still points at the array, and the block may rebind it in the middle of the walk. With the receiver in a local and the block assigning a fresh array to that same local on every turn, master walks 29 of the 40 turns on a plain build and 2 of 40 under `SPINEL_GC_STRESS=1`, three runs each; this branch walks all 40 in both. The `reduce` change reached the same conclusion for the same reason.

The roots are plain declarations in whatever C block encloses the statement, so they pop at the end of that block rather than at the end of the loop: for a search written at method-body level the receiver stays reachable until the method returns. That is a retention window, not a leak — every `while`, `if` and `when` body is braced in the emitted C, so a search inside one pops per turn rather than accumulating — and it is exactly what writing the receiver into a local first, which any Ruby program may do, already costs.

A root also costs a root-stack slot, and `_sp_gc_root_push` returns 0 silently once that stack reaches its 65,536-entry cap, so a program deep enough to fill it stops rooting rather than saying anything. This change puts one more slot on such a loop's frame, or two for `take_while` and `drop_while`, for the rest of the enclosing method. The cap is a pre-existing silent one; rooting more moves any program that reaches it nearer.

## Validation

Gate GREEN on `03a698df`: the suite is 3514 pass / 0 fail / 0 error, 61 benchmarks pass, optcarrot answers 59662, and the corpus does not move — a differential corpus of ~2,100 minimized programs that behave differently under CRuby 4.0.6 and Spinel stays at 905 matching, with nothing gained and nothing lost, because nothing in it lands on these loops. The inference fixpoint gains no non-convergences over 3467 programs.

`test/call_receiver_root.rb` has twenty-eight arms, one per method and per receiver shape. Each calls a method for its receiver rather than naming it first, so nothing but the loop's own temporary holds the array it walks, and every block allocates before it looks at what it was handed. Every arm prints its turn count as well as its answer, so a loop that ends early reads as a changed line rather than as a passing test. The `drop_while` arms print the kept suffix instead of a turn count, because Spinel runs their block for every element where CRuby stops at the first falsy one — a difference that predates this change and that this change does not touch. Four arms hold the receiver in a local first; those were always safe, because the local is itself a root, and they are there to say so. The four halving-search arms need a 4,096-element receiver and a block that allocates harder than the rest, because a search that takes twelve turns gives a collection very little room to land in; the file says where it defines them why they are shaped that way. Two of the four test the receiver and two test the answer, and those two keep their capturing turn free of allocation on purpose: a string that survives one sweep is promoted, so a block that allocates before the answer is captured hides the very thing the arm is for. The control beside them keeps the light block, since its job is to show that a receiver with a name is unaffected, which does not need the expensive one.

The whole program fails on master before it prints anything, with its output redirected as the suite runs it — a bus error on three runs of three on a plain build, a segmentation fault on three of three under `SPINEL_GC_STRESS=1` — and under ASAN it reports a heap-use-after-free. Run by hand onto a terminal it prints some of its earlier lines first, because that changes how stdout is buffered, so a reviewer trying it should redirect. On this branch it matches CRuby 4.0.6 byte for byte in all four of the ways it is run, three runs each: 0.03 s plain, 0.07 s under `SPINEL_GC_STRESS=1`, 0.21 s under ASAN, and 0.41 s under both. ASAN and UBSAN are clean throughout. What that covers: `--cc` instruments the generated translation unit and the collector headers inlined into it, not the prebuilt runtime archive — so it covers these loops' own reads of the temporaries this change roots, and not the collector's later walk of the root stack.

One benchmark in the tree gets slower, and it is the shape worth naming rather than leaving to be found. `benchmark/bm_life.rb` gains two roots, and one of them is the receiver of the `OFFSETS.count { |ix| ... }` that sits in the innermost loop of `neighbors`: 80 columns by 40 rows by 200 generations by three offsets is 1,920,000 extra root pushes and pops over the run. Its answer does not change and still matches its CRuby oracle, and optcarrot's translation unit is unchanged, so the interpreter loop the callgrind count comes from pays nothing.

Measured on `03a698df` under the machine lock on an idle machine, both builds at `-O 2`. The benchmark as it is checked in runs in about 17 ms, which is too short to resolve a few percent directly: fifty alternating runs of each build give 17.3 ms against 18.0 ms. Scaled by a hundred generations — a variant made for the measurement, not the benchmark as it stands — the best of five alternating runs gives 1.468 s against 1.541 s, with every branch run slower than every master run. Sampled several ways on two different allocator revisions the figure has come out between three and five percent, so the honest statement is that this benchmark costs roughly four to five percent, not a number to three figures. `SPINEL_GC_STATS` reports the same collection counts on both builds, so what is being paid for is the push and the pop, not any extra retention.

That particular root is redundant, and saying so is fairer than leaving it implied: the receiver it guards is `OFFSETS`, a constant, and the generated program already marks it from `sp_mark_user_globals`. It is the clearest instance of the dead weight named below — the rule roots the hoist without asking whether something else already holds it, because deciding that per call site is a second rule with its own analysis to get wrong.

The change was found and checked by reading the C each emitter produces, not by reading the emitter, because a sibling branch that roots the same C variable makes a neighbouring branch look rooted when it is not. That is how `rindex` came in — a scan for a loop bound re-read from a temporary cannot see it, because it counts down — and how the `take_while` result array came in, which no probe of the receiver alone would have shown.

What the completeness claim rests on is worth stating exactly, because the first pass got it wrong. Fifty-seven hand-written probes, one method per file over three receiver kinds, missed `fill`, `bsearch` and `bsearch_index` — `fill` because its loop bound is hoisted into a separate temporary before the loop, so a bound-re-read scan cannot see it either, and the two searches because their loop is a halving `while` rather than an indexed `for`. They are absent from the older parked probe set for the same reason. What found them was a sweep of every block-taking form these emitters answer — 73 of them across four receiver kinds — with a brace-matching scan of the emitted C rather than a line pattern. Every hoist that sweep reports in the emitters this change touches is rooted on this branch. It still reports fifteen elsewhere: six are `flat_map`'s inner loop, named below, and nine are `min`, `max` and `sort!` with a comparator block, which live in the fold file and are named below too.

The generated-C sweep over all 3529 programs in the tree is byte-identical except for 56, and optcarrot's translation unit is one of the unchanged ones, as are sixty of the sixty-one benchmarks; `benchmark/bm_life.rb` is the exception, and it is the one whose cost is disclosed above. Those 56 differ by exactly 274 lines, and those lines carry exactly 274 added roots, one apiece. Removing every `SP_GC_ROOT` token from both sides and collapsing each line's whitespace leaves all 56 pairs identical, no pre-existing root disappears from any of them, and no file changes its line count: no line moved, no line was removed, and no other text changed. Every one of the 56 calls one of these methods, and `test/array_conformance_batch.rb` reaches the `find` emitter through `rfind`, which is rewritten into a reversed copy and a `find`. The `bsearch` answer root accounts for seven of the 274, across three files; the five other changed programs that call `bsearch` gain none, because their answer is an index or an unboxed number.

## Left alone, on purpose

`Array#drop_while` runs its block for every element; CRuby stops calling it at the first element the block rejects. `[1, 2, 3, 4, 5].drop_while { |x| n += 1; x < 3 }` counts 5 turns on master and 5 on this branch, where CRuby counts 3. It is not only a side-effect count: when the block raises, breaks or throws on an element CRuby never reaches, the answer differs too — `[1, 2, 3, 4].drop_while { |x| raise "boom" if x == 4; x < 2 }` answers `[2, 3, 4]` in CRuby and raises on both trees. This change neither causes nor fixes it: it is a question about when the loop stops calling the block, not about what the loop may read, so it wants its own change.

The typed `find`/`detect` arm this change edits builds its predicate with `expr_buf` where the mixed-element `find` beside it routes through `emit_cond`, so a block whose tail is a boxed value emits `if (<struct>)` and the C build stops on it: `arr.find { |x| pick(x) }`, where `pick` answers `true` or `nil`, does not compile. A proc read out of a container fails the same way; a plain lambda called directly does not, because its answer is not boxed. It is in the arm being touched, so it is named here rather than left to be found, but it is a condition-emission bug and not a rooting one, and it is pre-existing on both trees.

`rindex` with a block on a mixed-element array raises `NoMethodError`, "undefined method 'rindex' for an instance of Array", where CRuby answers the index. Only the typed-array form is emitted; the poly arm is simply missing. That is a gap to fill rather than a root to add, and it is pre-existing and untouched here.

`make_mixed.map! { |x| x.to_s + "!" }` does not compile: the result is inferred as a String array while the receiver stays a mixed-element one, and the C compiler stops on the incompatible slot assignment. `collect!` fails identically. It takes a temporary receiver — the same call on a receiver held in a local, or on an array literal, compiles and answers what CRuby answers. Pre-existing on both trees, an inference question rather than a rooting one.

Separately, and it is a different fault with a different error, chaining a call straight onto the answer of a mixed-element `map!` or `collect!` does not compile either, even when the receiver is a named local: `a.map! { |x| x.to_s + "!" }.size` passes the mixed-element array to the String-array length function. Storing the answer in a local first compiles and runs. Also pre-existing on both trees.

`Array#min`, `#max` and `#sort!` with a comparator block are the same rule again, and they are not in this file: `src/codegen_fold.c` emits them, at the comparator arm of its min/max lowering and at its `sort!`. They are worse than anything fixed here — over a 600-element receiver whose comparator allocates, master answers `""` for `min` and for `max` where CRuby answers `"a0001"` and `"a0600"`, and `sort!` answers a `nil` first and last element, three runs of three on a plain build, with a segmentation fault on two of three under `SPINEL_GC_STRESS=1`. That is on current master, after the fold change landed; it did not reach them. They belong to the next change on that file, not to this one.

`emit_inline_call_x`'s receiver hoist in `src/codegen_iter.c`, and `Array#reduce` and `#inject`'s receiver and accumulator, are the same rule at two more sites and are each being handled separately — `reduce` because rooting its receiver without its accumulator is known to move the fault rather than close it.

`_sp_gc_root_push` returning 0 in silence at `SP_GC_STACK_MAX` is named here because this change adds roots, but it is not changed here: a cap that fails quietly deserves either a larger stack or a loud death, and either is its own decision.

Some of the roots this adds are dead weight, and deliberately so. Where the receiver is a local that the block never rebinds, the local's own root already covers the walk and the new one costs a slot and a push for nothing. Narrowing them would mean deciding, per call site, whether any path through the block can rebind the receiver — a second rule, with its own analysis to get wrong, guarding a rule that is one line and always correct. The unconditional root is the cheaper thing to be sure of.

Five more divergences around these loops turned up while checking this change and are pre-existing and identical on both trees, none of them touched here: `map!` silently drops the value of a statement-modifier `next`, so `[1, 2].map! { |x| next 9 if x == 1; x }` answers `[1, 2]` where CRuby answers `[9, 2]`; `redo` inside these blocks behaves as `next`, skipping the element instead of re-running the block for it; a `count { }` used as a `while` condition raises `NoMethodError` at run time; a Bignum literal in a ternary pushed into an array inside a block segfaults, where the `if`/`else` form is fine; and a `break` inside a block passed as `&proc` does not compile.

The argument forms of `#count`, `#all?`, `#any?`, `#none?` and `#one?` on a mixed-element array have the same omission, and one of them does misbehave. They hoist the receiver unrooted, and the comparison they run reaches a user-defined `==` through `sp_poly_eq`'s object arm — Ruby code, running between two reads of that hoist, allocating as it goes. With a class whose `==` allocates, `arr.count(k)` answers 0 under `SPINEL_GC_STRESS=1` where CRuby answers 1, three runs of three, while `arr.index(k)` on the very next line answers correctly because its own arm already roots its hoist. A plain build is wrong too when the needle is a bare local rather than an expression, because an expression needle gets hoisted and rooted by the argument pass before this arm runs. It is left for its own change: these are the no-block argument forms, a different call shape with a different set of emitters, and folding them in would widen this PR past the loops it is about. Both trees behave identically, so nothing here makes it worse.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of collection searches and in-place loops when garbage collection occurs during block execution.
  * Prevented receivers and intermediate results from being reclaimed prematurely, preserving correct operation results.

* **Tests**
  * Added coverage for search, iteration, mutation, and binary-search operations under garbage-collection pressure.
  * Added expected results for receiver and result lifetime scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->