### PR TITLE
A reduce or inject roots both the array it walks and the accumulator it rebuilds

### DIFF
--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -3424,24 +3424,34 @@ int emit_reduce_block_expr(Compiler *c, int id, Buf *b) {
   int ta = ++g_tmp, tacc = ++g_tmp, ti = ++g_tmp;
   buf_puts(b, "({ ");
   emit_ctype(c, rt, b); buf_printf(b, " _t%d = ", ta); emit_expr(c, recv, b); buf_puts(b, "; ");
-
+  /* The loop below re-reads this temp's length as its bound on every turn and
+     takes the element out of it on every turn, with the block running in
+     between. The array a method call returned has no other holder at all, and
+     one held in a named local loses that holder the moment the block rebinds
+     the local -- the walk still belongs to the array the fold started on. So
+     the hoist is rooted itself, whatever the receiver expression was. No
+     needs_root test here, unlike the accumulator below: this emitter has
+     already returned 0 unless rt is an array kind, and every array kind needs
+     a root and none of them is a value-type object, so the root and its
+     separator are always wanted. */
+  emit_gc_root_tmp(c, rt, ta, b); buf_puts(b, " ");
   emit_ctype(c, acc_ty, b); buf_printf(b, " _t%d = ", tacc);
   int start;
   if (init_empty_arr) {
     /* the empty [] would emit as an IntArray without the poly context; the
-       heap accumulator is rooted since block-body pushes may collect. A slot
-       that widened to poly (the block hands the accumulator to a callable,
-       whose result is boxed) takes the boxed form (#3657). */
-    if (acc_ty == TY_POLY) buf_printf(b, "sp_box_poly_array(sp_PolyArray_new()); SP_GC_ROOT_RBVAL(_t%d); ", tacc);
-    else buf_printf(b, "sp_PolyArray_new(); SP_GC_ROOT(_t%d); ", tacc);
+       heap accumulator is rooted below, since block-body pushes may collect.
+       A slot that widened to poly (the block hands the accumulator to a
+       callable, whose result is boxed) takes the boxed form (#3657). */
+    if (acc_ty == TY_POLY) buf_puts(b, "sp_box_poly_array(sp_PolyArray_new()); ");
+    else buf_puts(b, "sp_PolyArray_new(); ");
     start = 0;
   }
   else if (init_empty_hash) {
     /* the empty {} would emit as its default variant; force the general
-       boxed-key/value hash so any key type fits, and root it (#2958) */
+       boxed-key/value hash so any key type fits (#2958) */
     if (acc_ty == TY_POLY)
-      buf_printf(b, "sp_box_obj(sp_PolyPolyHash_new(), SP_BUILTIN_POLY_POLY_HASH); SP_GC_ROOT_RBVAL(_t%d); ", tacc);
-    else buf_printf(b, "sp_PolyPolyHash_new(); SP_GC_ROOT(_t%d); ", tacc);
+      buf_puts(b, "sp_box_obj(sp_PolyPolyHash_new(), SP_BUILTIN_POLY_POLY_HASH); ");
+    else buf_puts(b, "sp_PolyPolyHash_new(); ");
     start = 0;
   }
   else if (init >= 0) {
@@ -3468,6 +3478,16 @@ int emit_reduce_block_expr(Compiler *c, int id, Buf *b) {
                     acc_ty == TY_INT ? "SP_INT_NIL" : acc_ty == TY_FLOAT ? "sp_float_nil()"
                     : acc_ty == TY_STRING ? "NULL"
                     : acc_ty == TY_POLY ? "sp_box_nil()" : "0"); start = 1; }
+  /* The loop reassigns this slot from a freshly allocated value on every turn,
+     and the next turn's block reads it back, so it is a root for the whole
+     walk -- as the empty-[] and empty-{} seeds above already were. The root
+     records the slot's address, so one push covers every reassignment. The
+     test is here rather than left to emit_gc_root_tmp because the separator
+     goes with the root: a scalar accumulator gets neither, and neither does a
+     value-type object, which lives in the temp itself. */
+  if (needs_root(acc_ty) && !comp_ty_value_obj(c, acc_ty)) {
+    emit_gc_root_tmp(c, acc_ty, tacc, b); buf_puts(b, " ");
+  }
   /* Temporarily override block param types to match acc_ty/et so the body
      expression uses the correct C types (same pattern as emit_sort_cmp_expr). */
   Scope *rsc = comp_scope_of(c, block);

--- a/test/reduce_root.rb
+++ b/test/reduce_root.rb
@@ -1,0 +1,281 @@
+# Array#reduce / Array#inject walk a receiver held only in a temporary and
+# rebuild the accumulator from a freshly allocated value on every turn, so
+# both slots have to stay live across the block. Every receiver here is the
+# return value of a method call, so nothing else holds it -- except the one
+# arm that deliberately holds it in a local and then rebinds that local
+# inside the block. Every block allocates BEFORE it reads the accumulator it
+# was handed, and every arm prints the accumulated content as well as the
+# number of turns, so an arm that loses either slot shows up as a changed
+# answer rather than as a passing test.
+
+N = 40
+CHURN = 100
+
+def churn
+  CHURN.times { "q" * 64 }
+end
+
+def strs
+  (1..N).map { |i| "a#{i}" }
+end
+
+def ints
+  (1..N).to_a
+end
+
+def nested
+  [[1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5, 6]]
+end
+
+def four
+  ["p", "q", "r", "s"]
+end
+
+def mix(acc, e)
+  e.even? ? "s#{e}" : acc
+end
+
+class Box
+  attr_reader :n
+
+  def initialize(n)
+    @n = n
+  end
+
+  def plus(k)
+    Box.new(@n + k)
+  end
+end
+
+# --- a seed the block rebuilds: String, Array, Hash, object, nil ---
+
+turns = 0
+s = strs.reduce("") do |acc, x|
+  churn
+  turns += 1
+  acc + x
+end
+puts "reduce str seed turns=#{turns} len=#{s.size} head=#{s[0, 4]}"
+
+turns = 0
+a = ints.reduce([9]) do |acc, x|
+  churn
+  turns += 1
+  acc + [x]
+end
+puts "reduce array seed turns=#{turns} len=#{a.size} sum=#{a.sum}"
+
+turns = 0
+h = ints.reduce({}) do |acc, x|
+  churn
+  turns += 1
+  acc[x] = "v#{x}"
+  acc
+end
+puts "reduce empty hash turns=#{turns} len=#{h.size} last=#{h[N]}"
+
+turns = 0
+e = ints.reduce([]) do |acc, x|
+  churn
+  turns += 1
+  acc << x
+end
+puts "reduce empty array turns=#{turns} len=#{e.size} sum=#{e.sum}"
+
+turns = 0
+b = ints.reduce(Box.new(0)) do |acc, x|
+  churn
+  turns += 1
+  acc.plus(x)
+end
+puts "reduce object seed turns=#{turns} n=#{b.n}"
+
+turns = 0
+n = strs.reduce(nil) do |acc, x|
+  churn
+  turns += 1
+  acc.nil? ? x : acc + x
+end
+puts "reduce nil seed turns=#{turns} len=#{n.size} head=#{n[0, 4]}"
+
+turns = 0
+i = ints.reduce(0) do |acc, x|
+  churn
+  turns += 1
+  acc + x
+end
+puts "reduce int seed turns=#{turns} sum=#{i}"
+
+# --- no seed: the accumulator starts at element 0 and is rebuilt from there ---
+
+turns = 0
+u = strs.reduce do |acc, x|
+  churn
+  turns += 1
+  acc + x
+end
+puts "reduce no seed turns=#{turns} len=#{u.size} head=#{u[0, 4]}"
+
+turns = 0
+m = ints.reduce do |acc, x|
+  churn
+  turns += 1
+  mix(acc, x)
+end
+puts "reduce no seed boxed turns=#{turns} out=#{m.inspect}"
+
+turns = 0
+k = nested.reduce do |acc, x|
+  churn
+  turns += 1
+  acc & x
+end
+puts "reduce nested turns=#{turns} out=#{k.inspect}"
+
+# --- the same walk under the #inject spelling ---
+
+turns = 0
+j = ints.inject("") do |acc, x|
+  churn
+  turns += 1
+  acc + x.to_s
+end
+puts "inject str seed turns=#{turns} len=#{j.size} head=#{j[0, 4]}"
+
+turns = 0
+w = strs.inject do |acc, x|
+  churn
+  turns += 1
+  acc + x
+end
+puts "inject no seed turns=#{turns} len=#{w.size} head=#{w[0, 4]}"
+
+# A receiver held in a named local is not enough on its own: the block can
+# reassign that local, and the walk still belongs to the array the fold
+# started on.
+
+def rebound
+  list = strs
+  turns = 0
+  out = list.reduce("") do |acc, x|
+    churn
+    turns += 1
+    list = []
+    acc + x
+  end
+  "turns=#{turns} len=#{out.size} head=#{out[0, 4]}"
+end
+puts "reduce rebound receiver #{rebound}"
+
+# The fold is a statement expression, so its roots are pushed and popped where
+# the expression is evaluated: inside another fold's block rather than ahead of
+# it, and once per turn of an enclosing loop.
+
+turns = 0
+nest = four.reduce("") do |acc, x|
+  churn
+  turns += 1
+  acc + strs.reduce("") { |a, y| churn; a + y[0] }[0, 1]
+end
+puts "nested folds turns=#{turns} len=#{nest.size}"
+
+rounds = 0
+while strs.reduce("") { |acc, x| churn; acc + x }.size == 111 && rounds < 3
+  rounds += 1
+end
+puts "fold in a while condition rounds=#{rounds}"
+
+# A fold suspended inside a Fiber keeps both slots across the switch: the
+# collection happens on the main side while the fold is parked mid-walk.
+
+fib = Fiber.new do
+  strs.reduce("") do |acc, x|
+    Fiber.yield acc.size if x == "a5"
+    acc + x
+  end
+end
+part = fib.resume
+20.times { churn }
+puts "fiber fold part=#{part} rest=#{fib.resume.size}"
+
+# --- leaving the walk early: break, next, return, raise ---
+
+br = strs.reduce("") do |acc, x|
+  churn
+  break "B#{acc.size}" if x == "a5"
+  acc + x
+end
+puts "break out=#{br}"
+
+nx = strs.reduce("") do |acc, x|
+  churn
+  next acc if x.size == 3
+  acc + x
+end
+puts "next len=#{nx.size}"
+
+def early(list)
+  list.reduce("") do |acc, x|
+    churn
+    return "R#{acc.size}" if x == "a4"
+    acc + x
+  end
+end
+puts "return out=#{early(strs)}"
+
+def boom(list)
+  list.reduce("") do |acc, x|
+    churn
+    raise "stop#{acc.size}" if x == "a6"
+    acc + x
+  end
+end
+begin
+  boom(strs)
+rescue RuntimeError => ex
+  puts "raise out=#{ex.message}"
+end
+
+rin = strs.reduce("") do |acc, x|
+  churn
+  begin
+    raise "inner"
+  rescue RuntimeError
+    acc + x
+  end
+end
+puts "rescue inside len=#{rin.size}"
+
+# The walk's answer has to survive one more allocating step after the fold.
+tail = strs.reduce("") do |acc, x|
+  churn
+  acc + x
+end
+churn
+puts "tail len=#{tail.size} head=#{tail[0, 4]}"
+
+# Every early exit pops the roots it pushed: 60_000 folds that leave through
+# break, return and raise, then one more full fold. A leaked push would pass
+# SP_GC_STACK_MAX and the last fold would answer short.
+def esc(list)
+  list.reduce("") { |acc, x| return "R" if x == "r"; acc + x }
+end
+
+def bang(list)
+  list.reduce("") { |acc, x| raise "x" if x == "r"; acc + x }
+end
+
+seen = 0
+60_000.times do |round|
+  out = case round % 3
+        when 0 then four.reduce("") { |acc, x| break "B" if x == "r"; acc + x }
+        when 1 then esc(four)
+        else (begin; bang(four); rescue RuntimeError; "E"; end)
+        end
+  seen += out.size
+end
+last = strs.reduce("") do |acc, x|
+  churn
+  acc + x
+end
+puts "after 60000 exits seen=#{seen} last=#{last.size}"

--- a/test/reduce_root.rb.expected
+++ b/test/reduce_root.rb.expected
@@ -1,0 +1,23 @@
+reduce str seed turns=40 len=111 head=a1a2
+reduce array seed turns=40 len=41 sum=829
+reduce empty hash turns=40 len=40 last=v40
+reduce empty array turns=40 len=40 sum=820
+reduce object seed turns=40 n=820
+reduce nil seed turns=40 len=111 head=a1a2
+reduce int seed turns=40 sum=820
+reduce no seed turns=39 len=111 head=a1a2
+reduce no seed boxed turns=39 out="s40"
+reduce nested turns=2 out=[3, 4]
+inject str seed turns=40 len=71 head=1234
+inject no seed turns=39 len=111 head=a1a2
+reduce rebound receiver turns=40 len=111 head=a1a2
+nested folds turns=4 len=4
+fold in a while condition rounds=3
+fiber fold part=8 rest=111
+break out=B8
+next len=18
+return out=R6
+raise out=stop10
+rescue inside len=111
+tail len=111 head=a1a2
+after 60000 exits seen=60000 last=111


### PR DESCRIPTION
## Why

`Array#reduce` and `Array#inject` compile to a C loop that keeps two things in local temporaries: the array being walked, whose length is re-read as the loop bound on every turn, and the accumulator, which is thrown away and replaced by a freshly allocated value on every turn. Neither of them was a GC root. So a block that allocates anything at all could collect the array in the middle of walking it, or collect the accumulator between the turn that built it and the turn that reads it, and the fold quietly answered short — for a string accumulator, with the empty string.

This is a rule the file already states and this emitter already half follows. #4369 rooted the receiver at ten hoists in this same file — Hash's `map`/`select`/`filter`/`reject`, both `transform_*` arms, both `min_by`/`max_by`/`minmax_by` arms, `group_by`, `partition`, `grep`/`grep_v` and both `each_with_object` arms; `SP_GC_ROOT` mentions in `src/codegen_fold.c` go from 173 to 183 — and it was not starting from nothing, since rooting the container a builtin loop walks is what most of the fold and collect emitters here already did. `#reduce`/`#inject` is the one it deliberately left out, and its body says why: rooting this receiver alone moves the fault instead of removing it, because the accumulator beside it is unrooted too. This change is that receiver hoist together with the accumulator that made it insufficient on its own — it finishes the emitter #4369 started.

Inside the emitter the same rule is half-followed already: two of the accumulator's six seed arms root it today — the empty `[]` seed and the empty `{}` seed — and their own comments say why, that the heap accumulator is rooted since block-body pushes may collect. The other four arms did not, and the receiver was rooted in none of the six.

Folding forty strings with `{ |acc, x| churn; acc + x }`, where `churn` allocates two hundred short-lived strings before the accumulator is read, answers a 111-character string in CRuby 4.0.6. Master, built at the default `-O2`, answers a 0-length string on a plain build, ten runs of ten. Under `SPINEL_GC_STRESS=1` it either answers 0 or dies with SIGSEGV, and which of those you get depends on the build: across seven master builds of the same program — two revisions, three optimisation levels, byte-identical generated C — the crash rate ranged from none of ten runs to nine of ten. That instability is itself the symptom, and ASAN names it exactly: on a plain build, a heap-use-after-free.

## What

One emitter, `emit_reduce_block_expr` in `src/codegen_fold.c`, and nothing else. The receiver hoist is rooted right after it is declared. The accumulator is rooted once, after the seed arms rather than inside each of them, so every arm is covered by one statement — a root records the slot's address, so a single push covers every reassignment the loop makes. The two arms that already rooted the accumulator now get their root from that one statement instead of printing their own; the generated C for those two arms is unchanged. A scalar accumulator gets no root, and neither does a value-type object, which lives in the temporary itself rather than behind it.

The receiver root is not conditional on the receiver being anonymous, and that is deliberate. A named local is a root of its own, but the block can rebind that local — `list.reduce("") { |acc, x| list = []; acc + x }` — and the walk still belongs to the array the fold started on. The test's arm for this takes 29 of its 40 turns on master at `-O2` and answers the empty string; it takes all 40 now. How far it gets depends on how much the block allocates — a heavier block takes it to 15 — which is why the number quoted here is the one the test line pins.

Both halves are in one change because neither one fixes the bug on its own. Rooting the receiver alone moves the fault rather than removing it, and rooting the accumulator alone leaves the walk truncating; Validation has both columns, measured with the other root stripped out of the generated C.

## How

The roots go in through `emit_gc_root_tmp`, the shared helper that picks `SP_GC_ROOT_RBVAL` for a boxed poly slot and the plain `SP_GC_ROOT` for everything else, so the six accumulator shapes — `const char *`, a typed array pointer, a hash pointer, an object pointer, an `sp_RbVal`, and the scalars that need no root — are each handled by the rule the rest of the compiler uses rather than by a fresh judgement here.

The one place that judgement was checked by measurement rather than assumed is the string accumulator, whose C type is `const char *` and whose root is therefore the untagged `SP_GC_ROOT`. Nine string shapes were folded with a block that allocates first — a frozen `""` seed, no seed, `+""`, `String.new`, `"s".dup`, `m << x` in place, `m += x`, the accumulator handed to a lambda so it comes back boxed, and a shared-string shim seed — and every one answers exactly what CRuby answers, on a plain build and under `SPINEL_GC_STRESS=1`, where master is wrong on all nine. So the untagged macro is the right one for every string accumulator that holds a sweep-owned heap string, which is what this emitter builds, and this change does not need `SP_GC_ROOT_STR`.

It is worth being exact about where that stops. The untagged macro does not hold a `const char *` that points at a *mutable* String's payload: `sp_gc_mark` returns on that marker byte without following the owner link `sp_mark_string` follows. A fold can reach such a value, and one does still crash under `SPINEL_GC_STRESS=1` here. But it is not this rule and not this change's to fix: the same crash reproduces with no fold anywhere in the program, on an ordinary String local that codegen already roots with the same untagged macro, and master is strictly worse at the folding slot, where it has no root at all. It is `emit_gc_root_tmp`'s house-wide `TY_STRING` policy, and it is named in "Left alone, on purpose".

The accumulator's root is guarded by `needs_root` and by the value-object test, and the receiver's is not, which is deliberate rather than an oversight: the emitter returns 0 before this point unless the receiver's type is an array kind, and every array kind needs a root and none of them is a value-type object, so the guard could only ever be true there. The accumulator's type is chosen from the seed or the element and really does range over scalars and value objects, which is what the guard is for — and keeping it on the caller's side is what leaves the scalar arms byte-identical, since the separator goes with the root.

The whole fold is emitted as a statement expression, so both roots are declared inside it and their cleanup pops when it ends — the retention window is the fold itself, not the enclosing method. There is no Ruby-level way to see that window from a test: `ObjectSpace` is refused by the compiler and `GC.count` is not implemented, and `GC.stat` reports bytes rather than objects. That is why the evidence for this change is the generated C, the sanitizer, and the answers themselves.

## Validation

New test `test/reduce_root.rb`, 281 lines printing twenty-three, expectation generated by CRuby 4.0.6, 0.05 s compiled and 0.09 s under `SPINEL_GC_STRESS=1`. Every receiver in it is the return value of a method call, so nothing else holds it; every block allocates before it reads the accumulator it was handed; and every arm prints its number of turns as well as its content, so an arm that loses either slot shows up as a changed answer rather than as a passing test. The seed arms are covered one apiece — String seed, Array seed, empty `[]`, empty `{}`, object seed, nil seed, int seed, no seed over Strings, no seed with a boxed first element, and the nested-int-array fold — under both spellings. On master the program prints 13 of its 23 lines, 11 of them different from what CRuby prints, and then dies at the nested-folds line with a spurious `no implicit conversion of nil into String (TypeError)` and exit 1.

Measured against CRuby 4.0.6 on a 40-element receiver whose block allocates before it reads the accumulator. The stress number comes first: a plain count records when today's allocator lands a collection, not whether the value can be collected. Every figure below was re-taken after the four allocator and collector changes that landed while this was in review, against a pristine build of the current master; the probe's generated C is byte-identical before and after them, so anything that moved would have had to be pure runtime. No figure below moved.

| fold | CRuby | this branch, stress / plain | master, stress / plain |
|---|---|---|---|
| `reduce("") { churn; m + x }` | 111 | 111 / 111 | SIGSEGV or 0 / 0 |
| `reduce { churn; m + x }` | 111 | 111 / 111 | SIGSEGV or 4 / 0 |
| `reduce([9]) { churn; m + [x] }` | 41 | 41 / 41 | SIGSEGV or 2 / 1 |
| `reduce([]) { churn; m << x }` | 40 | 40 / 40 | SIGSEGV or 1 / 14 |

Both columns are the default `-O2`, master built from a pristine checkout. The branch's four answers are the same at `-O0`, `-O1` and `-O2`, thirty stress runs of thirty, and its plain column is ten of ten. Master's plain column is the wrong answer 299 times in 300 runs, with one SIGSEGV; the previous master answered it 100 times in 100, and one in three hundred against none in one hundred does not tell the two apart, so the figure is stated and no change of rate is claimed. Master's stress column is the unstable one: the program either answers the number given or takes SIGSEGV, and the split moves with the build rather than with anything in the source — across seven master builds whose generated C is byte-identical the crash rate ran from 0 of 10 to 9 of 10, with every surviving run answering exactly those four numbers. A wrong answer that is sometimes a crash instead, depending on where the allocator happened to put things, is what reading freed memory looks like from outside the process; the sanitizer below is the same fact stated deterministically.

Neither half of the change stands alone. With the receiver rooted and the accumulator not, those four folds answer 3 / 3 / 1 / 40 under stress, five runs of five, and 36 / 21 / 3 / 40 on a plain build in the two of five runs that do not crash. With only the accumulator rooted they answer 0 / 4 / 2 / 1 under stress and 33 / 33 / 16 / 14 plain, five of five each. Both columns are `-O2`, taken from this one branch build with the other root stripped out of the generated C before it was compiled, so the only difference between them is which roots survive.

Under ASAN on a plain build, folding forty strings with `acc + x` reports a heap-use-after-free on master: a 33-byte read in `sp_str_concat`, on bytes freed by `sp_str_sweep_gen` during the collection the block's own allocation triggered, allocated by the previous turn's `sp_str_concat`. The same program is clean on this branch, plain and under stress, as is the whole new test under the sanitizers.

Where the roots are pushed and popped was checked as well as whether they exist. A fold inside another fold's block, a fold in a `while` condition, a fold in a ternary arm, in an `||` arm and beside another allocating argument all answer what CRuby answers, and so does a fold parked mid-walk inside a Fiber while the main side allocates enough to collect — master answers the empty string there, this branch answers the full 111 characters; so do `break`, `next`, `return` and `raise` out of the block and a `rescue` inside it; and 60,000 folds leaving through `break`, `return` and `raise` followed by one more full fold answer in full — a leaked push would have passed `SP_GC_STACK_MAX` and made that last fold answer short. Master raises a spurious `no implicit conversion of nil into String (TypeError)` on the nested-fold and ternary shapes, on a plain build.

Of 3529 programs — every `test/*.rb` and `benchmark/*.rb`, plus `build/optcarrot-single.rb` — the generated C moves for 67, and every one of those is byte-identical to master once the added `SP_GC_ROOT` lines are removed and runs of spaces squeezed: 336 root statements added, none removed, nothing else changed. For the two arms that already rooted the accumulator the emitted text is unchanged down to the byte, the added receiver root being the whole diff. No benchmark is among the 67: `benchmark/*.rb` and `build/optcarrot-single.rb` all compile to byte-identical C, so the one or two extra root pushes per fold do not reach any program the benchmarks measure and optcarrot's instruction count is untouched.

The full gate is green: 3514 tests and 61 benchmarks pass, optcarrot runs, and the sanitizer leg on the new test is clean plain and under stress. The differential corpus does not move — 905 of 2131 before and after, nothing gained and nothing lost. That is worth saying rather than leaving to be noticed: none of its minimized programs has a fold whose block allocates, which is why this survived it and had to be found by reading the generated C.

## Left alone, on purpose

Seven other unrooted receiver hoists in this same file — `max` and `min` with a comparator block, `sort!` with a block, `sum("")` with a block, `each_cons(n).map`, `each_slice(n).map`, `each.with_index(n).inject`, and `slice_when` — are the same rule at emitters #4369 did not reach either, and want their own change. This diff is confined to one function, so it touches none of them, and one probe apiece at `-O2` answers identically with and without it: `max` and `min` raise `undefined method 'length' for nil` where CRuby answers `a10` and `a1`; `sum("")` takes SIGSEGV, three runs of three, where CRuby prints 111; `each_cons(2).map` walks 15 of 39, `each_slice(2).map` 15 of 20, and `each.with_index(1).inject` sums 120 where CRuby sums 820.

`_sp_gc_root_push` silently returns 0 at `SP_GC_STACK_MAX`, which is 65536 and is not changed here, and the matching pop then does nothing, so a root added past the cap is dropped rather than corrupting the stack. Every change that adds roots moves that cap nearer, and how far depends on the fold: the receiver is always rooted, the accumulator only when its type needs one, so a fold gains one root or two. Both were measured with a peak-`sp_gc_nroots` counter compiled into the generated C, on a method whose body is a single fold that recurses inside the block. With a String accumulator that frame carries 3 roots on master and 5 here, so the cap arrives at depth 13107 where master reaches it at 21845. With an Integer accumulator, where `needs_root` declines the accumulator, the same frame carries none on master and one here — folds alone never reached the cap before and now reach it at 65536 frames. Pushed deliberately past saturation on the String shape, where pushes are being refused, the program still answers correctly: depths 14000, 20000 and 30000 on a plain build, and 13000, 14000 and 20000 under `SPINEL_GC_STRESS=1`. So I could not turn the cap into a wrong answer on that shape, which is narrower than saying no program could. Raising the cap, or making an overflow say so, is its own change.

A `const char *` slot is rooted with the untagged `SP_GC_ROOT` throughout the compiler, and that macro does not hold a mutable String's payload, because `sp_gc_mark` returns on its marker byte without following the owner link `sp_mark_string` follows. A `while` loop that assigns such a payload to an ordinary String local, with no fold anywhere in the program, segfaults under `SPINEL_GC_STRESS=1` on master and here alike, and changing that one local's macro to `SP_GC_ROOT_STR` in the generated C makes it correct. A fold whose accumulator holds one crashes here too — this change roots that slot, but with the macro the house picks for its type, so the slot goes from unrooted to rooted-by-the-wrong-macro: an improvement that stops short of a fix.

It is left whole because the choice is not made where a special case here would reach, and it is not one edit either. For temporaries it is made once, in `emit_gc_root_tmp`, which picks `SP_GC_ROOT_RBVAL` for a boxed slot and the untagged `SP_GC_ROOT` for everything else including `TY_STRING`; an arm there would cover the 34 slots that route through it. Everywhere else the emitters print the macro into the generated C by hand — 563 emissions of the untagged form across seven files, against 147 boxed and 32 already string-tagged — and each of those picked its macro by hand as well. The path that declares a named local is one of them, and it already discriminates: `src/codegen.c` roots a String range's two endpoints with `SP_GC_ROOT_STR` and, in the next arm of the same `if`/`else` chain, gives a plain String local the untagged macro. Working out which of the hand-written emissions can hold a mutable payload is the audit, and that is what makes this its own change rather than a clause in this one.

`arr.reduce(:+)` — the blockless symbol fold — loses its walk under GC stress, nondeterministically, and the generated C for it is byte-identical on master and on this branch. It is the same disease at a different emitter, reached by a different path through `#reduce`, and it is not fixed here.

`redo` inside a fold block answers wrongly on master and here alike, with no allocation involved at all, so it is a control-flow bug rather than a rooting one. The new test does not exercise it.

A pre-existing semantic difference around these emitters is untouched and answers identically on both binaries: a `next <value>` inside a fold block drops the element instead of contributing the value, so `[1, 2, 3, 4].partition { |x| next false if x == 3; x.odd? }` answers `[[1], [2, 4]]` where CRuby answers `[[1], [2, 3, 4]]`, and `{"a" => 1, "b" => 2}.transform_values { |v| next 0 if v == 2; v }` answers `{"a" => 1}` where CRuby answers `{"a" => 1, "b" => 0}`. That is a wrong answer rather than a short one, and a different rule. It is one of a set of pre-existing differences around these emitters that were checked while this change was reviewed and answer identically with and without it; none is touched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved garbage-collection safety for `Array#reduce` and `Array#inject`, including seeded and seedless operations.
  - Ensured reductions remain reliable with nested operations, fibers, exceptions, early exits, and repeated iterations.
- **Tests**
  - Added comprehensive coverage for reductions involving strings, arrays, hashes, objects, `nil`, integers, control flow, and allocation-heavy workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->