### PR TITLE
The receiver of an inlined call is rooted while the inlined body runs

### DIFF
--- a/src/codegen_iter.c
+++ b/src/codegen_iter.c
@@ -290,7 +290,21 @@ int emit_inline_call_x(Compiler *c, int id, Buf *b, int indent, int as_expr) {
     buf_printf(b, "sp_%s %s_t%d = ", c->classes[recv_class].c_name, self_is_val ? "" : "*", st);
     if (g_inline_recv_expr) buf_puts(b, g_inline_recv_expr);  /* pre-hoisted cast (#2448) */
     else emit_expr(c, recv, b);
-    buf_puts(b, ";\n");
+    buf_puts(b, ";");
+    /* Root it: for the whole inlined body this temp is the only handle on the
+       receiver, and every ivar read in the body goes through it. The body
+       allocates and so does the caller block spliced at each yield, so a
+       receiver nothing else holds -- `make_ledger.each { churn }`, `Set#each`
+       on a set the call itself built, or a local the block clears partway
+       through -- was collected while the body still ran, and the walk stopped
+       early: 25 of 200 turns on a plain release build, 1 of 200 under
+       SPINEL_GC_STRESS=1, with no error either way.
+       A value-type receiver is a struct copy that lives in the temp itself
+       rather than behind it, so it must not be rooted; emit_gc_root_tmp
+       declines it on its own account, and the test here is only so that the
+       separating space is not emitted when it does. */
+    if (!self_is_val) { buf_puts(b, " "); emit_gc_root_tmp(c, ty_object(recv_class), st, b); }
+    buf_puts(b, "\n");
     snprintf(selfbuf, sizeof selfbuf, "_t%d", st);
     recv_self_deref = self_is_val ? "." : "->";
   }

--- a/test/inline_call_receiver_root.rb
+++ b/test/inline_call_receiver_root.rb
@@ -1,0 +1,172 @@
+# A call to a user-defined method that yields is inlined at the call site, and
+# the call's receiver is copied into a C temporary that the whole inlined body
+# then reads its ivars through. For a receiver no Ruby name holds -- a method's
+# answer, a constructor, a chain -- that temporary is the only reference to the
+# object, while the body allocates and so does the caller's block at every
+# yield. Every arm below hands one of those a fresh receiver and allocates
+# inside the block before it looks at what it was given, so an arm whose
+# receiver went away mid-walk reports a short count instead of passing quietly.
+# The plain local-receiver arm is the control, and it was always safe: the
+# local is a root of its own. The arm after it is not a control -- a local
+# stops holding the object the moment the block rebinds it, and from there the
+# hoisted temporary is again the only reference, so that walk truncates on a
+# tree without this fix as surely as a fresh receiver does. A receiver
+# returned by value has its own test, because a class only stays by-value in a
+# program that does not pull in the set package.
+
+require "set"
+
+ENTRIES = 200
+CHURN = 120
+
+def churn
+  CHURN.times { "q" * 64 }
+end
+
+class Ledger
+  def initialize(n)
+    @rows = []
+    (1..n).each { |i| @rows << i }
+  end
+
+  def each
+    i = 0
+    while i < @rows.length
+      yield @rows[i]
+      i += 1
+    end
+    self
+  end
+
+  def each_scaled(k)
+    i = 0
+    while i < @rows.length
+      yield @rows[i] * k
+      i += 1
+    end
+    self
+  end
+
+  def size = @rows.length
+end
+
+def make_ledger = Ledger.new(ENTRIES)
+def make_set = (1..ENTRIES).map { |i| "s#{i}" }.to_set
+
+# --- a hand-written each, receiver held only by the hoisted temporary ---
+
+n = 0
+make_ledger.each { |x| churn; n += 1 }
+puts "ledger each n=#{n}"
+
+# --- the same, in expression position: the inline is a statement expression ---
+
+n = 0
+r = make_ledger.each { |x| churn; n += 1 }
+puts "ledger each value n=#{n} size=#{r.size}"
+
+# --- Set#each, which is a Ruby-level each in the bundled set package ---
+
+n = 0
+last = nil
+make_set.each { |s| churn; n += 1; last = s }
+puts "set each n=#{n} last=#{last}"
+
+# --- a nested inline: the yielded block inlines another call, and both
+#     receivers are fresh, so the roots have to nest strictly ---
+
+outer = 0
+inner = 0
+Ledger.new(20).each do |a|
+  Ledger.new(10).each do |b|
+    churn
+    inner += b
+  end
+  outer += a
+end
+puts "nested outer=#{outer} inner=#{inner}"
+
+# --- leaving the inlined body early: break, next, return, raise ---
+
+def with_break
+  n = 0
+  make_ledger.each do |x|
+    churn
+    break if x > 100
+    n += 1
+  end
+  n
+end
+puts "break n=#{with_break}"
+
+def with_next
+  n = 0
+  make_ledger.each do |x|
+    churn
+    next if x.even?
+    n += 1
+  end
+  n
+end
+puts "next n=#{with_next}"
+
+def with_return
+  make_ledger.each do |x|
+    churn
+    return x if x > 50
+  end
+  0
+end
+puts "return x=#{with_return}"
+
+def with_raise
+  n = 0
+  begin
+    make_ledger.each do |x|
+      churn
+      raise "stop" if x > 70
+      n += 1
+    end
+  rescue RuntimeError => e
+    return "#{n} #{e.message}"
+  end
+  "no raise"
+end
+puts "raise #{with_raise}"
+
+# --- the argument list is call-site code evaluated after the receiver is
+#     hoisted, and evaluating it allocates ---
+
+n = 0
+tot = 0
+make_ledger.each_scaled(("ab" * 3).size / 2) { |v| churn; n += 1; tot += v }
+puts "scaled n=#{n} tot=#{tot}"
+
+# --- a block forwarded with & rather than written at the call site ---
+
+def each_fresh(&blk)
+  make_ledger.each(&blk)
+end
+
+n = 0
+each_fresh { |x| churn; n += 1 }
+puts "forwarded n=#{n}"
+
+# --- controls ---
+
+led = make_ledger
+n = 0
+led.each { |x| churn; n += 1 }
+puts "local receiver n=#{n}"
+
+# --- ... but only while the local still names it: once the block clears the
+#     local, the hoisted temporary is the only reference again ---
+
+led = make_ledger
+n = 0
+led.each do |x|
+  churn
+  n += 1
+  led = nil if x == 3
+end
+puts "rebound receiver n=#{n} led=#{led.inspect}"

--- a/test/inline_call_receiver_root.rb.expected
+++ b/test/inline_call_receiver_root.rb.expected
@@ -1,0 +1,12 @@
+ledger each n=200
+ledger each value n=200 size=200
+set each n=200 last=s200
+nested outer=210 inner=1100
+break n=100
+next n=100
+return x=51
+raise 70 stop
+scaled n=200 tot=60300
+forwarded n=200
+local receiver n=200
+rebound receiver n=200 led=nil

--- a/test/inline_call_value_receiver.rb
+++ b/test/inline_call_value_receiver.rb
@@ -1,0 +1,53 @@
+# The companion to inline_call_receiver_root.rb, for the receiver that must NOT
+# be rooted. A class whose instance variables are all scalars is returned by
+# value, so the temporary the inliner hoists the receiver into holds the struct
+# itself rather than a pointer to it. Pushing that temporary's address on the
+# GC root stack would hand the mark walker the struct's first field, which is
+# an integer.
+#
+# Nothing here can be collected, so this file does not pin a bug the way its
+# companion does -- it passes on master too. It is a standing guard on the
+# by-value path: these walks must stay correct, and the C this compiles to must
+# stay the C master compiles it to, so a change that starts rooting a struct
+# receiver shows up as both. It is a file of its own because a class stops
+# being by-value as soon as the program pulls in the set package, which is what
+# the companion test does.
+
+ENTRIES = 200
+CHURN = 120
+
+def churn
+  CHURN.times { "q" * 64 }
+end
+
+class Span
+  def initialize(a, b)
+    @a = a
+    @b = b
+  end
+
+  def each
+    i = @a
+    while i <= @b
+      yield i
+      i += 1
+    end
+    self
+  end
+end
+
+def make_span = Span.new(1, ENTRIES)
+
+n = 0
+tot = 0
+make_span.each { |x| churn; n += 1; tot += x }
+puts "value receiver n=#{n} tot=#{tot}"
+
+def with_return
+  make_span.each do |x|
+    churn
+    return x if x > 50
+  end
+  0
+end
+puts "value receiver return x=#{with_return}"

--- a/test/inline_call_value_receiver.rb.expected
+++ b/test/inline_call_value_receiver.rb.expected
@@ -1,0 +1,2 @@
+value receiver n=200 tot=20100
+value receiver return x=51


### PR DESCRIPTION
## Why

When a program calls a user-defined method that yields, Spinel does not emit a function for that method and call it. It inlines the method's body at the call site, because the block has to be spliced in where the `yield` is. Part of that inlining is the receiver: the call's receiver expression is evaluated once into a C temporary, and the method's `self` is bound to that temporary, so every instance-variable read in the inlined body goes through it.

That temporary was not a GC root. If the receiver is an object that no Ruby name holds -- the answer of a method, a constructor written straight into the call, the end of a chain -- then the temporary was the only reference to it, and the collector was free to take it while the inlined body was still running. The body allocates, and so does the caller's block that gets spliced in at every yield, so there is plenty of opportunity.

The effect is a walk that quietly stops early. A hand-written class whose `each` yields its rows, compiled on its own, walked 1 of its 200 rows under `SPINEL_GC_STRESS=1` and 25 of 200 on a plain release build; `Set#each` on a set the call itself built walked 1 of 200 and 23 of 200 the same way. Both exited 0 and printed the short answer with no error, which is what makes this hard to notice. The stressed number is the one that says the value can be collected at all; a plain count only records where the allocator happened to place a collection on that run, so it moves with changes that have nothing to do with the bug.

A receiver a local variable still names was safe, because the local is a root of its own -- but only for as long as it names it. Clear or reassign that local inside the block and the hoisted temporary is once again the only reference: `led.each { |x| churn; led = nil if x == 3 }` walked 4 of its 200 rows under GC stress and 25 of 200 plain. So this is not only about receivers that were never given a name; it is about any receiver whose only remaining hold is the one the inliner made.

This is a different rule from the container rooting in #4367 and #4369. Those are about the container a builtin loop reads its elements out of. This one is about the receiver of a call -- any user class at all, as long as the method it calls yields. That is why the blast radius is wide: it is not tied to a particular builtin method, it is on the path of every user class with an inlined `each`.

## What

`emit_inline_call_x` in `src/codegen_iter.c` now roots the receiver temporary it declares, for the whole inlined body.

The root goes through the existing `emit_gc_root_tmp` helper rather than a hand-written macro, so this site inherits the choices that helper already encodes. One of them matters here: a value-type receiver is a by-value struct that lives in the temporary itself rather than behind it, and rooting one would hand the mark walker the struct's first field. `emit_gc_root_tmp` declines those on its own account, and that is what makes the value case correct. The `if (!self_is_val)` in the emitter is not doing that work -- delete it and the emitted C is the same but for a stray separating space. It is there for the space.

The receiver temporary is only ever declared with a concrete `sp_<Class> *` or `sp_<Class>` C type -- both paths that reach the declaration resolve the receiver to a class index, and the poly-dispatch path declares the same pointer type from a pre-cast expression -- so the string and boxed-value cases that need the other rooting macros cannot arrive here.

## How

The root is emitted immediately after the receiver temporary's declaration, which is ahead of both the argument binding and the method's own local declarations. That ordering is what keeps the pops strictly LIFO, and it is also what protects the receiver during argument evaluation, since the argument expressions are call-site code that can allocate.

The ways out of an inlined body were checked on the generated C. A nested inline -- a yielded block that calls another yielding method -- opens its own C scope and roots its own receiver inside it, so the two roots nest rather than interleave. The per-inline `return` funnel's label is emitted in the same scope as the root and after it, so the `goto` never jumps over the declaration and the root is still live at the label. `break` and `raise` leave through paths that already reset `sp_gc_nroots` from a watermark taken before the inline began, which is the existing discipline for a `longjmp` past a cleanup attribute; nothing new was needed there.

One design choice is worth recording. The root could be made conditional on the inlined body being able to allocate, which is what `subtree_may_allocate` is for and what several neighbouring emitters do. That guard cannot ever be false here, by construction rather than by luck: `subtree_may_allocate` returns 1 for a `YieldNode` unconditionally, and `emit_inline_call_x` refuses the site unless the callee yields, so the callee's body always contains one. Building both compilers and comparing them over every program in `test/` and `benchmark/` bears that out -- the two produce identical C, program for program, line for line -- but the measurement is corroboration, not the argument. A guard that is provably always true is a dead branch in front of a memory-safety root, so the unconditional form went in.

The guard would also be looking in the wrong place if it ever did answer no. The allocation that collects the receiver is as often the caller's block, spliced in at the yield, as anything in the callee's own body -- and the block is not part of the body the predicate would be asked about.

## Validation

Every master figure below and above comes from a pristine worktree at this PR's merge-base, built and run at the default optimisation level -- no `-O` flag, which is `-O 2` -- so they describe the build the gate and CI measure rather than a debug one. Counts under `SPINEL_GC_STRESS=1` are quoted first throughout, because those are the ones that establish a value can be collected; the plain figures are included because that is what a user hits, but a plain count only records where the allocator happened to place a collection.

The generated C was compared against master for all 3528 programs that exist in both trees. 3468 are byte-identical. The other 60 differ only by added roots: stripping every `SP_GC_ROOT` line from both sides and normalising whitespace makes each of the 60 byte-identical to master's, with no residual line anywhere, and comparing the root counts shows none was removed. 168 roots are added in total, and no other character of generated C changes anywhere in that set.

That accounting has one rider, and it is not confined to the tree. `gc_save_take_back` is a textual test: it drops a function's `SP_GC_SAVE()` prologue when the emitted body contains no `SP_GC_ROOT`, no `setjmp` and no `sp_gc_nroots`. Rooting the receiver makes that test false, so any function whose only root is the new one keeps a prologue it used to lose. That happens twice inside `test/inline_call_receiver_root.rb`, and it happens on a twenty-line program that does nothing unusual, so it is a shape ordinary code has. It does not happen anywhere in those 3528 -- but the check above strips only `SP_GC_ROOT` lines, so that says the tree has no function in that state, not that the shape is rare.

The reinstated save is redundant rather than load-bearing. `SP_GC_SAVE()` is itself a `cleanup` attribute, so an unwind skips it exactly as it skips the root's own pop; what actually puts the depth back on a raise is the absolute `sp_gc_nroots = sp_exc_rootmark[...]` at the exception landing. (`SP_GC_RESTORE()` is defined but called nowhere.) On every path this change creates, the root's own cleanup already does the work. The prologue comes back because the elision test is textual, and the cost is that such a function no longer gets to be frameless.

All 61 programs in `benchmark/` are among the byte-identical ones and the optcarrot translation unit is unchanged, so the extra push and pop appear in none of the measured programs and there is no benchmark or optcarrot delta to measure. The gate's optcarrot count is unchanged at 59662.

`test/inline_call_receiver_root.rb` covers the arms that need the root. A hand-written class with an `each`; the same call in value position, where the inline becomes a statement expression; `Set#each`; a nested inline whose two receivers are both fresh; `break`, `next`, `return` and `raise` out of the inlined body; an argument list that allocates after the receiver has been hoisted; a block forwarded with `&` rather than written at the call site; and a local receiver the block itself clears. Every arm allocates inside the block before it looks at what it was given, so an arm whose receiver went away reports a short count rather than passing quietly. The plain local-receiver arm is the control; the one after it, where the block clears the local, is not -- it truncates on master too.

On master every arm of this file answers wrong on every run, and the program sometimes dies partway through as well. Where it lands depends on the allocator and on edits elsewhere in the file, so a file-level tally is not a number worth quoting. Under `SPINEL_GC_STRESS=1` it segfaults every time. The branch matches CRuby in both modes. The stable figures are the per-arm ones quoted earlier: each arm compiled to its own program, where master never crashes and simply answers short, and where the counts have held unchanged across three merge-bases and three different states of the allocator.

`test/inline_call_value_receiver.rb` covers the other side, the receiver that must not be rooted. Nothing in it can be collected, so it does not pin this change the way the first file does: it passes on master too, and it would still pass if the emitter's own `!self_is_val` test were deleted, because `emit_gc_root_tmp` declines a value-type object on its own account. What it is, is a standing guard on the by-value path -- its generated C is byte-identical to master's, so a change that starts rooting a struct receiver shows up here as both a C difference and a runtime one. It is a separate file because a class stops being returned by value as soon as the program pulls in the set package, which the first file does. Both files pass plain, under GC stress, and under ASan and UBSan, in well under a second each.

The full suite, the benchmarks, the RubySpec legs and the CRuby-extension leg pass. A differential corpus of about 2,100 minimized programs that behave differently under CRuby 4.0.6 and Spinel replays with nothing lost. The inference fixpoint converges on the same programs as master.

## Left alone, on purpose

The search and in-place loops -- `find` / `detect` / `take_while` / `drop_while` / `count` / `find_index` / `map!` -- hoist the container they read the same way, in `src/codegen_call_recv.c`. That is the container rule rather than this one, and it is the sibling branch filing alongside this PR, not part of it.

`#reduce` and `#inject` hold an accumulator across the block as well as a receiver, and that pair is being handled separately in `src/codegen_fold.c`, on top of the fold and collect rooting that went in as #4369.

The enumerator constructors -- `sp_Enumerator_with_index` in `lib/sp_cold.c` and `sp_Enumerator_new_from` in `lib/spinel_rt.h` -- and the unrooted `sp_Enumerator_to_a` behind `s.each_line.with_index` are the same shape in the runtime rather than in the emitter.

Two paths next door still do not walk a fresh receiver, and this change does not reach either, so it is worth saying so rather than letting the rest of this imply otherwise. `Enumerator.new { |y| make_ledger.each { |x| y << x } }.to_a` answers `[]` here as it does on master, and it does so whether or not the block allocates, so it is a defect in the Yielder path rather than a rooting one. `make_ledger.enum_for(:each).inject(0) { ... }` stops partway through on both trees when its block allocates, and that one is a rooting problem, but inside the enumerator-and-fold path rather than at this call site.

About half the roots this adds are on a receiver that already had one. Of the 168, 67 are on a receiver that is a bare local read, and in master's own generated C all 67 of those locals already carry a `SP_GC_ROOT` of their own; another 11 are on a cast of a temporary already rooted with `SP_GC_ROOT_RBVAL`. Those roots are correct but they do nothing: the object is already reachable from a root that outlives the inline, so the extra push and pop are pure overhead. Exempting a receiver that is a bare local or ivar read would be a second rule about a different thing, so it is deliberately not in this PR.

`_sp_gc_root_push` returns 0 and drops the root silently when `sp_gc_nroots` reaches `SP_GC_STACK_MAX`, which is 65536. This change costs exactly one root-stack slot per live frame that has an inlined call with an object receiver, so a frame that already holds L roots reaches the ceiling 1/(L+1) sooner than it did. Measured, that is real: a recursion 30000 frames deep with one rooted string local per frame is correct on master and loses 8153 of those strings here, because their own pushes are the ones refused at the cap. It is not reachable by anything CRuby will run -- CRuby raises SystemStackError at around 3000 frames in every shape tried, an order of magnitude before either compiler's root stack fills -- and the silent drop is master's behaviour too, so it is left alone here.

Separately, and not caused by this change: in one program shape a bare `super` into a yielding parent's `each` fails to compile, with the child's call passing one argument to a `sp_<Class>_each_pf` that expects two. It reproduces identically on master, so the `super` arm was dropped from the test rather than fixed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed inline method calls so object receivers remain available throughout execution, including during garbage collection and block yields.
  - Preserved correct handling for value-type receivers and control-flow paths such as early returns and exceptions.

- **Tests**
  - Added regression coverage for object and value receivers, nested calls, iteration, block forwarding, allocation pressure, and control-flow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->