### PR TITLE
A blockless #each roots the receiver it builds its Enumerator from

### DIFF
--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -10501,10 +10501,20 @@ static void sp_endless_range_gen(sp_Fiber *f) {
    Defined out-of-line in sp_cold.c (one linked copy, not per generated TU). */
 sp_Enumerator *sp_loop_enum(void);
 static sp_Enumerator *sp_Enumerator_new_from(sp_RbVal arr) {
+  /* The receiver is the caller's temporary -- `(11..55).each` passes it straight
+     in, unreachable from anywhere else -- and BOTH arms below allocate before
+     they are done with it, then keep it as the enumerator's `source`. Root it
+     for the whole function: the materialized arm reads it back after the
+     enumerator's own allocation, and the endless arm reads `first` and `step`
+     out of it after the capture's. */
+  SP_GC_ROOT_RBVAL(arr);
   if (arr.tag == SP_TAG_OBJ && arr.cls_id == SP_BUILTIN_RANGE && arr.v.p &&
       ((sp_Range *)arr.v.p)->last == INTPTR_MAX) {
     sp_Range *r = (sp_Range *)arr.v.p;
     sp_endless_range_cap *cap = (sp_endless_range_cap *)sp_gc_alloc(sizeof *cap, NULL, NULL);
+    /* The capture is the second slot: it dies inside sp_Enumerator_new_gen and
+       is read later still, when the fiber first runs sp_endless_range_gen. */
+    SP_GC_ROOT(cap);
     cap->first = r->first; cap->step = r->step ? r->step : 1;
     sp_Enumerator *e = sp_Enumerator_new_gen(sp_endless_range_gen, cap, sp_box_nil());
     e->source = arr; e->meth = "each";

--- a/test/enum_ctor_receiver_root.rb
+++ b/test/enum_ctor_receiver_root.rb
@@ -1,0 +1,177 @@
+# A blockless #each builds its Enumerator from the receiver it was called on,
+# and keeps that receiver as the enumerator's source. The receiver is usually
+# the caller's temporary -- `(11..55).each` hands it straight in and names it
+# nowhere else -- and the constructor allocates before it is finished with it.
+#
+# Both arms of the constructor do this. The materialized arm reads the receiver
+# back after allocating the enumerator, to store it as the source; the endless
+# arm reads `first` and `step` out of it after allocating the capture that
+# carries them, and then the capture itself has to survive allocating the
+# enumerator around it. Every arm below builds from a receiver the program never
+# names again, allocates between building and reading, and checks the value it
+# gets rather than merely that it survived.
+#
+# Not every arm below fails on master the same way, and it is worth being exact,
+# because the sweep at the top allocates and so shifts the phase every arm after
+# it sees. Measured against pristine master at the default -O2 -- the build a
+# reader gets -- on a plain run, ten runs out of ten identical:
+#
+#   arm                      wrong out of
+#   swept first                 12   40000
+#   inspect                      3     400
+#   array inspect                4     400
+#   endless first                1     200
+#   StopIteration#result         0     400
+#   endless first offset         0     200
+#   endless next / peek /        0     100
+#     rewind / take                    each
+#
+# So four arms are wrong on the plain run the suite performs, each of them a
+# wrong answer with a zero exit status rather than a crash. That is what this
+# file rests on, and it has been stable across every base measured.
+#
+# Under GC stress master fails this file too, but not reproducibly in one shape:
+# it sometimes aborts before printing anything and sometimes finishes with every
+# arm wrong. The counts in that mode have moved with the collector's budget and
+# are not quoted here for that reason. The branch matches CRuby every run, in
+# both modes.
+
+# --- both roots, pinned separately, with no GC stress ---
+#
+# The arms further down need the collection to land inside the constructor, and
+# on a plain build that is a matter of where the allocation phase happens to be.
+# So sweep the phase: allocate k % 37 throwaway arrays before each construction
+# and repeat until every offset into the collection interval has been tried.
+# With both roots in place the count below is zero on a plain build. Delete the
+# capture root and it reports 11; delete the receiver root and it reports 6;
+# delete both and it reports 12 -- the same numbers on every run. That is what
+# makes this file discriminate under the plain run the suite actually performs,
+# rather than only under GC stress.
+#
+# This runs before anything is held live on purpose: a large live set makes
+# every collection walk it, and under GC stress that costs about four times as
+# long for the same sweep -- 1.2 s here against 4.3 s with it moved below KEEP.
+
+bad = 0
+40000.times do |k|
+  (k % 37).times { [1, 2] }
+  en = (1..Float::INFINITY).each
+  bad += 1 unless en.first(3) == [1, 2, 3]
+end
+puts "swept first bad=#{bad}"
+
+KEEP = (1..3000).map { |i| "s#{i}" }
+
+def churn
+  120.times { [1, 2, 3, 4] }
+end
+
+# --- the materialized arm: the receiver, read back as the enumerator's source ---
+
+bad = 0
+wrong = nil
+400.times do
+  en = (11..55).each
+  churn
+  s = en.inspect
+  unless s == "#<Enumerator: 11..55:each>"
+    bad += 1
+    wrong ||= s
+  end
+end
+puts "inspect bad=#{bad} wrong=#{wrong.inspect}"
+
+# StopIteration#result is the same field read through documented behaviour
+# rather than through #inspect: it answers whatever the underlying each
+# returned, which for a Range#each enumerator is the range itself.
+bad = 0
+wrong = nil
+400.times do
+  en = (11..12).each
+  churn
+  r = nil
+  begin
+    en.next
+    en.next
+    en.next
+  rescue StopIteration => ex
+    r = ex.result.inspect
+  end
+  unless r == "11..12"
+    bad += 1
+    wrong ||= r
+  end
+end
+puts "StopIteration#result bad=#{bad} wrong=#{wrong.inspect}"
+
+# an array receiver takes the same arm. It has to come back from a method: an
+# array LITERAL is held by a temporary the emitter already roots, so writing it
+# inline tests nothing, while an array a method returns has no such holder and
+# is exactly the temporary this constructor drops.
+def make_array
+  [10, 20, 30]
+end
+
+bad = 0
+400.times do
+  en = make_array.each
+  churn
+  bad += 1 unless en.inspect == "#<Enumerator: [10, 20, 30]:each>"
+end
+puts "array inspect bad=#{bad}"
+
+# --- the endless arm: the range, and the capture built from it ---
+
+bad = 0
+200.times do
+  en = (1..Float::INFINITY).each
+  churn
+  bad += 1 unless en.first(3) == [1, 2, 3]
+end
+puts "endless first bad=#{bad}"
+
+# a start other than 1, so a collected range is a wrong number and not just a crash
+bad = 0
+200.times do
+  en = (7..Float::INFINITY).each
+  churn
+  bad += 1 unless en.first(4) == [7, 8, 9, 10]
+end
+puts "endless first offset bad=#{bad}"
+
+bad = 0
+100.times do
+  en = (10..Float::INFINITY).each
+  churn
+  bad += 1 unless [en.next, en.next, en.next] == [10, 11, 12]
+end
+puts "endless next bad=#{bad}"
+
+bad = 0
+100.times do
+  en = (100..Float::INFINITY).each
+  churn
+  bad += 1 unless en.peek == 100 && en.next == 100 && en.peek == 101
+end
+puts "endless peek bad=#{bad}"
+
+bad = 0
+100.times do
+  en = (42..Float::INFINITY).each
+  churn
+  en.next
+  en.next
+  en.rewind
+  bad += 1 unless en.next == 42
+end
+puts "endless rewind bad=#{bad}"
+
+bad = 0
+100.times do
+  en = (1..Float::INFINITY).each
+  churn
+  bad += 1 unless en.take(2) == [1, 2]
+end
+puts "endless take bad=#{bad}"
+
+puts "keep #{KEEP.size}"

--- a/test/enum_ctor_receiver_root.rb.expected
+++ b/test/enum_ctor_receiver_root.rb.expected
@@ -1,0 +1,11 @@
+swept first bad=0
+inspect bad=0 wrong=nil
+StopIteration#result bad=0 wrong=nil
+array inspect bad=0
+endless first bad=0
+endless first offset bad=0
+endless next bad=0
+endless peek bad=0
+endless rewind bad=0
+endless take bad=0
+keep 3000


### PR DESCRIPTION
## Why

`(11..55).each` with no block does not iterate; it answers an Enumerator, and that Enumerator keeps the receiver it was built from so it can report where it came from. The receiver is almost always the caller's temporary — the expression hands it straight in and names it nowhere else — and the constructor allocates before it has finished reading it. A collection landing on that allocation frees the receiver, and the constructor then stores or reads a pointer to memory the collector has already swept.

The reason to fix this now is that it does not announce itself. There is no crash and no error; the program runs to completion and exits zero, having answered wrongly, and it does so on an ordinary `-O2` build with no GC stress switched on at all.

What it answers depends on which of the two things it lost. Lose the receiver and `(11..55).each.inspect` renders `#<Enumerator: 0..0:each>`, and an array returned from a method inspects the same way, while `StopIteration#result` — documented behaviour, not cosmetics — answers `0..0` where it should answer the range. The freed field almost always reads back as zero; occasionally — one to four times in about a hundred and fifty wrong answers — it is a surviving pointer value rendered as a number. Lose the capture that an endless range's enumerator steps through, and `(1..Float::INFINITY).each.first(3)` answers `[0, 0, 0]`: the capture held both the start and the step, so the generator yields zero forever. Lose only the receiver and the same call answers `[0, 1, 2]`, because the start is gone but the step still falls back to 1. The two wrong answers name the slot that died. Turn GC stress on and every one of those counts rises, and the collector's own `SPINEL_GC_VERIFY` aborts on the mark path, having reached an object the sweep had already freed.

This came out of a differential corpus of ~2,100 minimized programs that behave differently under CRuby 4.0.6 and Spinel, and then out of a GC review of the constructor the corpus pointed at.

## What

Two roots in `sp_Enumerator_new_from`, in `lib/spinel_rt.h`, and a test.

Nothing in `src/` changes, and the emitted C of every generated program is byte-identical: generated programs include the runtime header rather than inlining it, so a change inside it moves no program's C.

## How

The constructor has two arms and the receiver is live across an allocation in both, so the root goes on the function's first line rather than inside either arm. That one placement is the whole fix for the common case.

The materialized arm allocates the Enumerator and then reads the receiver back to store as the enumerator's source. That is the arm that answers wrongly on a plain build. The endless-range arm has the same hole one step earlier: it reads `first` and `step` out of the receiver after allocating the small capture that carries them, so a temporary `(1..Float::INFINITY)` can be gone before its own bounds are copied.

The endless arm also has a second slot, which is why this is two roots and not one. Once the capture exists it is held in nothing but a C local across the Enumerator's own allocation, and it is read later still — not on the way out of the constructor, but when the fiber first runs the generator and takes `first` out of it. Rooting the receiver alone leaves that one: with the receiver rooted and the heap held over the collection threshold so allocations keep collecting, the sanitizer reports the capture instead. Rooting the capture alone cannot help the receiver either, because the receiver dies at the capture's own allocation, which is before the capture exists to hold it.

Nothing further is needed once the constructor returns: the enumerator's scan already marks its capture, so a capture that survives construction stays reachable through the enumerator for as long as the enumerator lives. That was checked directly, by holding enumerators live across repeated `GC.start` with three thousand intervening captures allocated in between.

## Validation

The test builds the enumerator from a receiver the program never names again, allocates between building it and reading it, and checks the value it gets back rather than mere survival. The `#inspect` and `StopIteration#result` arms read the stored source and are the sharp ones; an array receiver covers the same arm from a non-Range direction; the endless-range arms cover the other arm and its capture through `#first` from 1 and from 7, `#next`, `#peek`, `#rewind` and `#take`.

The first arm exists so that each of the two roots is pinned separately on a plain run, which is what the suite performs. It sweeps the allocation phase before each construction so that some iterations land a collection inside the constructor with no GC stress at all. Deleting each root in turn and rebuilding: with both roots it answers 0 and the file passes; with the capture root deleted it answers 11; with the receiver root deleted, 6; with neither, 12 — the same counts on every run, and the file fails in each case. Neither root can be removed without CI noticing.

The file as a whole fails on master, but not every arm does the same work, and the file header records which. Measured against pristine master at the default `-O2`, ten plain runs out of ten identical: four arms are wrong — the swept one at 12 in 40000, `#inspect` at 3 in 400, the array-receiver arm at 4 in 400, and the endless `#first` at 1 in 200 — each of them a wrong answer with a zero exit status rather than a crash. That is what the file rests on, and it has held across every base it has been measured against.

Under GC stress master fails the file too, but not reproducibly in one shape: sometimes it aborts before printing anything, sometimes it finishes with every arm wrong. Those counts have moved as the collector's budget has been resized, so the body does not quote them; the invariant is that master fails and the branch matches CRuby on every run.

The array arm takes its receiver from a method rather than writing the literal inline, and that is the difference between an arm and a guard: an array literal is held by a temporary the emitter already roots, so written inline it passes on master under stress as well as plain, while the same array returned from a method has no such holder and is wrong 400 times in 400 under stress.

The strongest single piece of evidence is the sanitizer, which does reach this change: the constructor is `static` in the runtime header and so is compiled into the instrumented translation unit. Built from master with `--cc=.compat/sancc` and run with **no GC stress at all**, the test exits 134 with a `heap-use-after-free` in `sp_Enumerator_new_from` at the `first` read, in about 90 ms, three runs out of three. The same build of this branch is clean, plain and under stress.

On this branch every arm answers CRuby 4.0.6 exactly, three out of three, plain, under GC stress, and under the sanitizer in both modes. Compiled it runs in 0.37 s plain and 1.7 s under GC stress; the slowest thing it is asked to do is the sanitizer with GC stress, measured between 4 s and 17 s depending on what else the machine was running, against a 90 s watchdog.

The full gate is green on this head: 3514 tests and 61 benchmarks pass with nothing failing, optcarrot runs and reports 59662, the CRuby-extension and RBS-seed checks pass, rubyspec is 6 of 6, the differential corpus is unmoved at 905 of 2131 with nothing gained or lost, type inference reaches a fixpoint on all 3467 programs with no new non-convergence, and the new test comes back clean from the GC-stress and both sanitizer runs.

Two of those numbers deserve less weight than they look, so as not to pass them off as evidence. The generated-C sweep reporting 3529 of 3529 unchanged is true by construction: generated programs include this header rather than inlining it, so no program's emitted C could have changed. The corpus not moving is a guard against regression rather than a demonstration of the fix. What carries weight here is the suite, the stress leg's answers, and the sanitizer — which, unlike a change to a runtime `.c` file, does reach this one, because the constructor is `static` in the header and is compiled into the instrumented translation unit along with the program.

## Left alone, on purpose

`Enumerator#with_index` on a generator source, in `sp_Enumerator_with_index`, has the identical two-slot shape — the source enumerator, then the capture — and the identical two-root fix, measured the same way. It is a separate branch rather than part of this one because it lives in a runtime `.c` file rather than in this header, and it carries its own evidence.

The two meet on one program. `(1..Float::INFINITY).each.with_index` runs this constructor and that one in sequence, and needs both fixes before it answers correctly. Under GC stress the four combinations are exact: master and this change alone both crash; the other change alone answers 151 of 300 pairs wrongly; both together are correct. On a plain run the picture is shape-dependent — some programs of that form crash on master, others answer wrongly, and how many depends on where the collections fall — so it is not reduced to a single number here. Neither change is a regression against master in any other respect, and which of the two lands first is a decision for the maintainer rather than a claim made here.

The snapshot arm of `sp_Enumerator_with_index` also uses its receiver after an allocation, and nothing is rooted there by this change. No claim is made either way about it: it lives in `lib/sp_cold.c`, which the sanitizer leg never instruments, so a quiet run there would not have meant anything.

`sp_with_index_gen` stores a new fiber into the source enumerator without the write barrier its sibling `sp_enum_gen_pull` performs. It cannot bite while minor collection is off by default, and it belongs with the branch above rather than here.

`(1..4).each_slice(2).inspect` can answer `#<Enumerator: 1..4:>` with the method label missing. That is the same family but a different rule — the enumerator's scan never marks that label — so it is not widened into this one.

`sp_Enumerator_new_from_rev`, which backs a blockless `#reverse_each`, has the same shape on paper and was checked for it, including with collections forced at every allocation in the function. It could not be made to fail, because its call site roots the materialized receiver, so nothing is changed there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where `Range#each` enumerators could behave incorrectly or become invalid during garbage collection and allocation activity.
  - Materialized and endless ranges now reliably preserve their receiver and iteration state, including `next`, `peek`, `rewind`, `take`, and completion results.
- **Tests**
  - Added regression coverage for range enumerators under repeated allocation and garbage-collection pressure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->