### PR TITLE
Enumerator#with_index roots the source it wraps and the capture it builds

### DIFF
--- a/lib/sp_cold.c
+++ b/lib/sp_cold.c
@@ -2390,7 +2390,17 @@ static void sp_with_index_gen(sp_Fiber *f) {
 }
 sp_Enumerator *sp_Enumerator_with_index(sp_Enumerator *e, sp_int off) {
   if (e && e->gen) {
+    /* Two allocations, and two things held in nothing but a C local across
+       them. The source enumerator dies at the sp_WiCap allocation below --
+       which is before the cap exists, so rooting the cap cannot cover it --
+       and both `e->size` and `e->source` are then read out of freed memory.
+       The cap dies at the enumerator's own allocation and is not a dead local
+       at that point: it is parked in r->gen_cap, which sp_with_index_gen reads
+       when the fiber first runs and sp_Enumerator_scan walks on every later
+       collection. Rooting either one alone leaves the other. */
+    SP_GC_ROOT(e);
     sp_WiCap *cap = (sp_WiCap *)sp_gc_alloc(sizeof(sp_WiCap), NULL, sp_wi_cap_scan);
+    SP_GC_ROOT(cap);
     cap->src = e; cap->off = off;
     sp_Enumerator *r = sp_Enumerator_new_gen(sp_with_index_gen, cap, e->size);
     r->source = e->source;

--- a/test/enum_with_index_source_root.rb
+++ b/test/enum_with_index_source_root.rb
@@ -1,0 +1,84 @@
+# Enumerator#with_index over a generator source -- a blockless Kernel#loop, or
+# any enumerator that steps through a fiber -- builds a second enumerator that
+# wraps the first. Building it allocates twice, and until now neither the source
+# it wraps nor the small capture that carries the source and the running index
+# was held in anything but a C local across those allocations.
+#
+# Both slots are real and neither root covers the other. The source dies at the
+# capture's allocation, which is before the capture exists to hold it, and its
+# `size` is then read out of freed memory. The capture dies at the wrapping
+# enumerator's own allocation, and it is not a dead local at that point: it is
+# stored in the new enumerator, which the collector walks on every later pass
+# and whose generator reads it when the fiber first runs.
+#
+# Every arm builds from a source the program never names again and checks the
+# pairs it yields. Measured against pristine master at the default -O2, three
+# runs out of three: on a plain run the swept arm below answers 27 wrong pairs
+# in twenty thousand while the other arms are clean, and under GC stress master
+# segfaults outright before printing anything. So the swept arm is what carries
+# this file on the plain run the suite performs; the rest are coverage for the
+# stressed run and guards against the shapes coming back.
+
+# The first arm pins both roots on a PLAIN run, which is what the suite
+# performs. It sweeps the allocation phase before each construction so that some
+# iterations land a collection inside the constructor with no GC stress at all.
+# With both roots it answers zero; with only the capture rooted, or with neither
+# root, it answers 27; with only the source rooted it segfaults. Every deletion
+# fails the file, which is the point. The counts are layout-sensitive and have
+# moved with the collector's budget before; which variants fail has not.
+#
+# It comes first, before anything is held live, because a large live set makes
+# every collection walk it.
+
+bad = 0
+20000.times do |k|
+  (k % 37).times { [1, 2] }
+  en = loop.with_index
+  bad += 1 unless en.first(2) == [[nil, 0], [nil, 1]]
+end
+puts "swept with_index bad=#{bad}"
+
+bad = 0
+100.times do
+  en = loop.with_index
+  20.times { [1, 2, 3] }
+  expected = [[nil, 0], [nil, 1], [nil, 2]]
+  got = en.first(3)
+  bad += 1 unless got == expected
+end
+puts "loop.with_index live-expected bad=#{bad}"
+
+bad = 0
+100.times do
+  en = loop.with_index
+  120.times { [1, 2, 3, 4] }
+  bad += 1 unless en.first(3) == [[nil, 0], [nil, 1], [nil, 2]]
+end
+puts "loop.with_index bad=#{bad}"
+
+bad = 0
+100.times do
+  en = loop.with_index(5)
+  120.times { [1, 2, 3, 4] }
+  bad += 1 unless en.first(2) == [[nil, 5], [nil, 6]]
+end
+puts "loop.with_index(5) bad=#{bad}"
+
+# driven one pair at a time through #next rather than through a fresh fiber
+bad = 0
+100.times do
+  en = loop.with_index(2)
+  120.times { [1, 2, 3, 4] }
+  bad += 1 unless [en.next, en.next] == [[nil, 2], [nil, 3]]
+end
+puts "loop.with_index(2) next bad=#{bad}"
+
+# the wrapping enumerator outlives the collection that follows it
+bad = 0
+100.times do
+  en = loop.with_index
+  first = en.first(1)
+  120.times { [1, 2, 3, 4] }
+  bad += 1 unless first == [[nil, 0]] && en.first(2) == [[nil, 0], [nil, 1]]
+end
+puts "loop.with_index reread bad=#{bad}"

--- a/test/enum_with_index_source_root.rb.expected
+++ b/test/enum_with_index_source_root.rb.expected
@@ -1,0 +1,6 @@
+swept with_index bad=0
+loop.with_index live-expected bad=0
+loop.with_index bad=0
+loop.with_index(5) bad=0
+loop.with_index(2) next bad=0
+loop.with_index reread bad=0


### PR DESCRIPTION
## Why

`loop.with_index` wraps one enumerator in another. The inner one is the caller's temporary — `loop` hands it straight in and the program names it nowhere else — and building the wrapper allocates twice before it has finished with it: once for a small capture holding the source and the running index, and once for the wrapping enumerator itself. Neither the source nor the capture was held in anything but a C local across those allocations, so a collection landing on either one frees something the constructor is still using.

On an ordinary `-O2` build with no GC stress at all, `100.times { en = loop.with_index; 20.times { [1,2,3] }; en.first(3) == [[nil,0],[nil,1],[nil,2]] }` segfaults, three runs out of three. The threshold is sharp and repeatable: thirty-two, sixty, sixty-three and sixty-four iterations are clean, sixty-five and above segfault. Sweeping the allocation phase instead of leaving it where it falls turns the same construction into a quiet wrong answer rather than a crash — 27 wrong pairs in twenty thousand, still with no GC stress and a zero exit status. Under GC stress it segfaults before printing anything.

This came out of a differential corpus of ~2,100 minimized programs that behave differently under CRuby 4.0.6 and Spinel.

## What

Two roots in `sp_Enumerator_with_index`, in `lib/sp_cold.c`, and a test. Nothing in `src/` changes and no generated program's C changes; this is inside the runtime archive.

This is a rule the compiler already follows on the other side of the same call. When codegen builds a generator capture it emits `SP_GC_ROOT` on the capture struct before handing it over, and says why in `src/codegen.c:4149-4176`: "for a generator it goes straight into `sp_Enumerator_new_gen`, whose enumerator allocation can trigger a GC while the struct is reachable only through this unrooted C local". The emitted code has been obeying that rule; the hand-written caller in the runtime was not.

## How

The two slots fail differently, which is how they were told apart rather than guessed at.

The source dies first, at the capture's own allocation. That point is before the capture exists, so no amount of rooting the capture reaches it, and the next lines read `e->size` and `e->source` out of freed memory. Leave the source unrooted — root neither, or only the capture — and the swept loop answers 27 wrong pairs in twenty thousand on a plain build, with a zero exit status. Under GC stress the two part company: with neither root the program segfaults, while with the capture rooted it raises `FiberError`, from resuming the fiber of a source enumerator that has been collected.

The capture dies at the wrapping enumerator's allocation. It is not a dead local at that moment: it has been stored in the wrapper, whose scan hook walks it on every later collection and whose generator reads it when the fiber first runs. Root only the source, leaving the capture unrooted, and the program segfaults instead, three runs out of three, plain and under GC stress alike. A crash and a quiet wrong answer, from the same function, depending on which of the two is missing.

Both rooted, the constructor is correct on every probe, plain and under stress, and at 65, 100, 200, 500 and 1000 iterations alike — the last point mattering because the fault has a sharp threshold at 65 and it was worth showing the fix is not simply moving it.

## Validation

The test's first arm pins each root separately on a plain run, which is what the suite performs, by sweeping the allocation phase before each construction. Deleting each root in turn and rebuilding: both roots, it passes; capture root deleted — leaving the source unrooted — it answers 27 and fails; source root deleted, it segfaults and fails; neither, it answers 27 and fails. Each of those repeated three runs out of three, so neither root can be removed without CI noticing.

The remaining arms cover an offset index, stepping through `#next` rather than a fresh fiber, and re-reading the wrapper after a collection. On a plain run they are clean on master, because the sweep ahead of them has already moved the allocation phase; they carry their coverage under GC stress, where master segfaults before printing anything.

On master the file fails three runs out of three at the default `-O2`, on a plain run through the swept arm and under GC stress by segfaulting outright. On this branch it answers CRuby 4.0.6 exactly, three out of three, plain and stressed. Compiled it runs in 0.18 s plain.

A word on what the sanitizer does and does not show here. `lib/sp_cold.c` is compiled into the prebuilt runtime archive, and the gate's sanitizer leg instruments only the generated translation unit and the headers it includes — so it does not reach this file, and a clean run of that leg is no evidence either way for this change. To get evidence, the runtime archive itself was rebuilt with the sanitizer, in four variants. With both roots it is clean, plain and stressed. Under GC stress each broken variant reports a heap-use-after-free that names its own slot: with the source unrooted, a 208-byte region allocated in the blockless-loop constructor, freed at the capture's allocation and read two lines later; with the capture unrooted, a 64-byte region allocated at the capture's allocation, freed inside the enumerator's, and read afterwards by the collector's own scan of the capture. Those are the three reads the code comment names.

The full gate is green on this head: 3514 tests and 61 benchmarks pass with nothing failing, optcarrot runs and reports 59662, the CRuby-extension and RBS-seed checks pass, rubyspec is 6 of 6, the differential corpus is unmoved at 905 of 2131 with nothing gained or lost, type inference reaches a fixpoint on all 3467 programs with no new non-convergence, and the new test comes back clean from the GC-stress run.

Three of those legs deserve less weight than they look here. The generated-C sweep reporting 3529 of 3529 unchanged is true by construction, since a runtime `.c` file cannot alter any program's emitted C. The corpus not moving is a guard rather than a demonstration. And the gate's sanitizer runs on the new test are clean but prove nothing either way about this change, for the reason above — they cannot see `lib/sp_cold.c`. What carries weight is the suite, the GC-stress answers, and the instrumented-archive runs described above.

## Left alone, on purpose

`(1..Float::INFINITY).each.with_index` chains this constructor onto the endless-range one, and it needs both this change and the separate fix to `sp_Enumerator_new_from`'s receiver and capture before it answers correctly. That is a defect in the other constructor, not in this one, so it is tested where it is fixed rather than here.

It is worth being explicit about how the two interact, because it bears on which lands first. Under GC stress the four combinations are exact: master crashes, the other change alone crashes, this change alone answers 151 of 300 pairs wrongly, and both together are correct. On a plain run the picture depends on the shape of the program — some forms of that chain crash on master and others answer wrongly, and the count varies with where the collections land — so it is described rather than reduced to one number. What is consistent is the direction: this change on its own converts a crash into a quiet wrong answer on that chain, and the other change is what makes it correct. So this change on its own trades a loud failure for a quiet one on that particular chain, until the other lands; both together are correct, and neither is a regression against master in any other respect.
