### PR TITLE
Parenthesise the proc cell store so the barrier post-pass sees it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -782,18 +782,26 @@ reject-test: $(SPINEL)
 # only by the map between the write and the read -- under SPINEL_GC_MINOR=1.
 # It costs a fifth of a second, and it is the leg that was missing when a
 # barrier pointed at the wrong object shipped.
+# One leg per barrier gap that shipped. A single program was what this target
+# ran when a store into a capture cell shipped with no barrier at all, so a
+# fix here adds its reproducer to the list rather than testing by hand.
+GC_MINOR_TESTS := test/gc_minor_thread_local_slot.rb \
+                  test/proc_cell_capture_marked.rb
+
 gc-minor-test: $(SPINEL) $(SP_RT_LIB) $(SP_RT_MT_LIB) $(SPINEL_TIMEOUT)
 	@tmp=$$(mktemp -d /tmp/spinel-gcminor.XXXXXX); ok=1; \
-	src=test/gc_minor_thread_local_slot.rb; \
-	$(SPINEL) "$$src" -o "$$tmp/m" >/dev/null 2>&1 || \
-	  { echo "gc-minor-test: FAIL (compile)"; rm -rf "$$tmp"; exit 1; }; \
-	for mode in 0 1; do \
-	  SPINEL_GC_MINOR=$$mode $(TIMEOUT60) "$$tmp/m" > "$$tmp/out.$$mode" 2>&1; \
-	  rc=$$?; \
-	  if [ $$rc -ne 0 ]; then echo "gc-minor-test: FAIL (SPINEL_GC_MINOR=$$mode exited $$rc)"; tail -3 "$$tmp/out.$$mode"; ok=0; \
-	  elif ! cmp -s "$$tmp/out.$$mode" "$$src.expected"; then \
-	    echo "gc-minor-test: FAIL (SPINEL_GC_MINOR=$$mode output mismatch)"; \
-	    diff -u "$$src.expected" "$$tmp/out.$$mode" | head -10; ok=0; fi; \
+	for src in $(GC_MINOR_TESTS); do \
+	  bn=$$(basename "$$src" .rb); \
+	  $(SPINEL) "$$src" -o "$$tmp/$$bn" >/dev/null 2>&1 || \
+	    { echo "gc-minor-test: FAIL ($$bn: compile)"; ok=0; continue; }; \
+	  for mode in 0 1; do \
+	    SPINEL_GC_MINOR=$$mode $(TIMEOUT60) "$$tmp/$$bn" > "$$tmp/$$bn.$$mode" 2>&1; \
+	    rc=$$?; \
+	    if [ $$rc -ne 0 ]; then echo "gc-minor-test: FAIL ($$bn: SPINEL_GC_MINOR=$$mode exited $$rc)"; tail -3 "$$tmp/$$bn.$$mode"; ok=0; \
+	    elif ! cmp -s "$$tmp/$$bn.$$mode" "$$src.expected"; then \
+	      echo "gc-minor-test: FAIL ($$bn: SPINEL_GC_MINOR=$$mode output mismatch)"; \
+	      diff -u "$$src.expected" "$$tmp/$$bn.$$mode" | head -10; ok=0; fi; \
+	  done; \
 	done; \
 	rm -rf "$$tmp"; \
 	if [ $$ok -eq 1 ]; then echo "gc-minor-test: pass"; else exit 1; fi

--- a/src/codegen_stmt.c
+++ b/src/codegen_stmt.c
@@ -942,8 +942,11 @@ static int emit_proc_cell_lvalue(Compiler *c, int scope_node, const char *nm, Bu
   if (!lv || lv->type != TY_PROC) return 0;
   int captured = g_cap_struct && g_cap_names && nameset_has(g_cap_names, nm);
   if (!lv->is_cell && !captured) return 0;
-  if (captured) buf_printf(b, "*((%s *)_cap)->c_%s", g_cap_struct, nm);
-  else buf_printf(b, "*_cell_%s", nm);
+  /* Parenthesised deref, which is what gc_wb_cells matches: a bare `*_cell_x`
+     is the one cell store shape its `(*X) =` scan does not see, so a Proc went
+     into an already-old cell with no barrier at all (see emit_assign). */
+  if (captured) buf_printf(b, "(*((%s *)_cap)->c_%s)", g_cap_struct, nm);
+  else buf_printf(b, "(*_cell_%s)", nm);
   buf_puts(b, " = (sp_int)(uintptr_t)(");
   return 1;
 }
@@ -1025,10 +1028,15 @@ void emit_assign(Compiler *c, int id, Buf *b, int indent) {
   int laundered_cell = lv && lv->type == TY_PROC;
   if (laundered_cell &&
       (lv->is_cell || (g_cap_struct && g_cap_names && nameset_has(g_cap_names, nm)))) {
+    /* Parenthesised, so gc_wb_cells sees this store: it matches `(*X) =`, and
+       the bare `*_cell_x` this used to emit was invisible to it -- the cell is
+       hoisted to scope entry, so it is old by the time a Proc is stored into
+       it, and the young Proc was on no remembered set. A minor mark does not
+       walk the old list, so it was swept while live. */
     if (g_cap_struct && g_cap_names && nameset_has(g_cap_names, nm))
-      buf_printf(b, "*((%s *)_cap)->c_%s", g_cap_struct, nm);
+      buf_printf(b, "(*((%s *)_cap)->c_%s)", g_cap_struct, nm);
     else
-      buf_printf(b, "*_cell_%s", nm);
+      buf_printf(b, "(*_cell_%s)", nm);
     buf_puts(b, " = (sp_int)(uintptr_t)(");
     const char *pvty = nt_type(c->nt, v);
     if (pvty && sp_streq(pvty, "NilNode")) buf_puts(b, "NULL");


### PR DESCRIPTION
Fixes #4375.

`gc_wb_cells` already finds `(*X) = v` where `X` names a cell the collector
scans, and wraps the store so `sp_gc_wb` lands on the cell. A captured
`TY_PROC` local is the one cell store it never matched — that path emits a
**bare** deref, `*_cell_x = (sp_int)(uintptr_t)(...)`, and the scan looks for
the parenthesised form. The generated TU carried no barrier at all.

Since codegen hoists a capture cell to scope entry, the cell promotes on the
first sweep that reaches it while the `Proc` stored into it is allocated much
later. An old cell then holds a young `Proc` on no remembered set, and a minor
mark does not walk the old list, so it is swept while live.

## Why parenthesise rather than emit the barrier at each store site

I wrote it the other way first — a `cell_needs_wb` predicate plus explicit
`sp_gc_wb` emission at the five places codegen writes a cell — and it was
worse in two ways.

`gc_wb_cells` already decides from the cell's *declaration* whether it carries
an `sp_cell_scan_` hook, which is the same question, so a second mechanism has
to re-derive it and the two can then drift apart.

More importantly, it runs the barrier **after** the store, and says why in its
own comment: the value expression allocates, and a collection between an
earlier barrier and the store clears the record that barrier just made. My
hand-placed version emitted the barrier before the store and so reintroduced a
narrower version of this very bug — narrow enough that the whole suite passed.
Reusing the existing pass gets the ordering for free.

The diff is two lines of emitted syntax as a result.

## Test

`gc-minor-test` ran one hardcoded program, which is part of why this shipped.
It takes a list now, and `test/proc_cell_capture_marked.rb` is the second leg.
I checked the leg actually discriminates: reverting `src/` and rebuilding gives

```
gc-minor-test: FAIL (proc_cell_capture_marked: SPINEL_GC_MINOR=1 output mismatch)
-90
+0
```

and it passes with the change. No new test file: the repro in #4375 is the
`a1`/`a2`/`a3` tail of that existing test, so adding it would duplicate it.

I also drafted a test for the other scanned cell kinds (celled String, Array,
Hash, poly) and **dropped it** — it passes without the fix, because those
stores already go through `gc_wb_cells`, and a test that cannot fail is not
worth the runtime.

## Gate

```
Tests:     3519 pass, 0 fail, 0 error
Benchmarks:  61 pass, 0 fail, 0 error, 0 skip
Optcarrot: OK (checksum 59662)
gc-minor-test: pass
```

`make gate` also runs `spin-check`, which fails with
`spin flags: progress leaked onto stdout`. That reproduces on unmodified
master, so it is not from this change.

## Scope

The default build is unchanged — the minor mark stays off. This only closes a
barrier gap that `SPINEL_GC_MINOR=1` exposes. Whether that default should
change is a separate question with its own measurements, and one I'd leave to
you: on a 70 MB live heap the minor mark cuts mark time 4.8x and total
collection time 3.1x, but it was enabled once and reverted, and there is a
second barrier gap behind it (#4376, fixed separately).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Proc values assigned to captured local variables could be incorrectly reclaimed during minor garbage collection.
  * Improved reliability when running minor garbage collection with Proc and thread-local variable scenarios.

* **Tests**
  * Expanded garbage-collection coverage to include multiple barrier reproduction cases.
  * Tests now continue through remaining scenarios when one compilation fails, with separate results for each case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->