### PR TITLE
Clear the dirty bits the barrier set, not every bit in the old heap

### DIFF
--- a/lib/sp_gc.c
+++ b/lib/sp_gc.c
@@ -237,6 +237,12 @@ void sp_gc_wb_slow(void *obj) {
         pm == 0xfe || pm == 0xfc || pm == 0xfb) return; }
   sp_gc_hdr *h = (sp_gc_hdr *)obj - 1;
   if (!h->old || h->dirty) return;
+  /* The bit goes up before the entry goes in, so between here and the push an
+     object carries it with nothing naming it. The collector's clear reads the
+     array and so depends on never observing that: nothing below allocates or
+     polls a safepoint, so a worker cannot park inside this function, and a
+     collection waits for every worker to park. Add an allocation or a poll
+     below and that clear has to go back to walking the old list. */
   h->dirty = 1;
 #ifdef SP_THREADS
   /* Mutators run this concurrently, so the slot has to be claimed atomically:
@@ -535,21 +541,25 @@ void sp_gc_collect(void){
     /* the old sweep above cleared every survivor; the array may name objects it
        just freed, so it must not be walked here */
   }
-#ifdef SP_THREADS
-  /* A worker can be preempted between sp_gc_wb's `h->dirty = 1` and its push,
-     so an object can carry the bit without an entry -- and clearing only what
-     the array holds would leave it dirty forever, which is the one state that
-     turns off its barrier for good. Single-threaded, no collection can start
-     inside sp_gc_wb, so the array is exact and the cheap clear is correct. */
-  else{ for(sp_gc_hdr*h=sp_gc_old_heap;h;h=h->next)h->dirty=0; }
-#else
+  /* Clear the bits the barrier set, not every bit in the old heap. An object can
+     carry the bit with no entry naming it in exactly one case -- sp_gc_wb was
+     refused a slot -- and it sets sp_gc_rem_overflow when it is, so the overflow
+     branch covers precisely the state the array cannot describe. Same reasoning
+     in both builds.
+
+     This reads the array, so it needs the array consistent: see the note in
+     sp_gc_wb_slow on why no collection can observe it mid-update.
+
+     The threaded path walked the whole old list here instead, on every non-full
+     cycle -- O(live) per collection for work proportional to the stores. On a
+     server it was the largest phase of the stopped window (5.7s of 13.1s of
+     collector time, collector at 65% of wall; campfire from matz/spinel#4352). */
   else if(sp_gc_rem_overflow){
     for(sp_gc_hdr*h=sp_gc_old_heap;h;h=h->next)h->dirty=0;
   }
   else{
     for(int ri=0;ri<sp_gc_nremembered;ri++)((sp_gc_hdr*)sp_gc_remembered[ri]-1)->dirty=0;
   }
-#endif
   sp_gc_nremembered=0; sp_gc_rem_overflow=0;
   /* Sweep the string heap only when IT is over its trigger: the sweep is a
      full walk of the live string list, and running it on every OBJECT-heap


### PR DESCRIPTION
Under `SP_THREADS` the remembered-set clear walks the **whole old list on every
non-full cycle** — O(live) per collection, for work that is proportional to the
stores. The single-threaded path already clears only what the remembered array
names. This lets the threaded path do the same.

Four lines of code leave: the `#ifdef SP_THREADS`, the walk, and its two
delimiters. The barrier itself is untouched.

## Why it is safe

An object can carry the dirty bit with **no entry naming it** in exactly one
case: `sp_gc_wb` was refused a slot. It sets `sp_gc_rem_overflow` when it is,
and the overflow branch already falls back to the whole-heap walk — so that
branch covers precisely the state the array cannot describe.

### The comment I removed reads the situation right and draws the wrong conclusion

> A worker can be preempted between `sp_gc_wb`'s `h->dirty = 1` and its push, so
> an object can carry the bit without an entry — and clearing only what the array
> holds would leave it dirty forever, which is the one state that turns off its
> barrier for good.

The **premise is true**: the OS can deschedule a worker between those two
writes, and in that window the object does carry the bit with nothing naming it.

The **conclusion does not follow**, because preemption is not the hazard. The
hazard is a *collection observing* that intermediate state, and none can:

1. Nothing in `sp_gc_wb_slow` allocates or polls a safepoint — it is a tag-byte
   test, a field test, an atomic add and a store. So a worker cannot park inside
   it.
2. A collection waits for `g_nparked >= sp_active_workers - 1` before it touches
   the heap, so it cannot proceed while any worker is mid-barrier.
3. The runtime creates exactly two kinds of thread — `sp_worker_main` (counted
   in `sp_active_workers`, parks) and `sp_sysmon_main` (the monitor, which does
   not). The monitor's entire call graph is `sp_ev_drop`, `sp_ev_arm_fd`,
   `sp_ev_dispatch`, `sp_ev_home_of`, `sp_sched_wake_for`,
   `sp_recompute_safepoint_flag`, `sp_monotonic_now`; none of them reaches
   `sp_gc_wb`. So there is no thread that can be mid-barrier while a collection
   runs.

What the old comment *did* miss is the refused-slot case — the real source of a
bit with no entry, and one it already flagged via `sp_gc_rem_overflow`.

Because this makes the clear **read the array**, where the whole-heap walk did
not, the invariant is now stated at `sp_gc_wb_slow` — where a future allocation
or safepoint poll would break it — and not only at the clear that relies on it.

## This is the part worth your scrutiny

The diff is four lines but it rests on that reachability argument, and I would
rather have it checked than trusted. Specifically: **is there a path onto
`sp_gc_wb` from a thread that does not park at the stop-the-world barrier, or a
way for a collection to begin while a worker is inside it, that I have missed?**
If there is, the clear has to keep walking the old list under `SP_THREADS` and
this should be closed.

I also considered reordering the barrier's two writes so the array would be a
superset of the dirty set, and **rejected it**: it is unnecessary given the
above, and strictly worse if the above were ever false. Setting the bit first
self-heals — the push that follows lands in the next epoch's array and the clear
after that finds it. Pushing first does not: the entry is cleared before the bit
is set, and the object stays dirty with nothing naming it, which is exactly the
state the old comment feared.

## Measurements

Harness and application from #4352 — the roundhouse campfire port, jemalloc,
`wrk -t4 -d20s` against `/rooms/1`. Nothing in `benchmark/` exercises the
collector under concurrency, so this is the only threaded-GC workload I could
find. Response asserted byte-identical (434,443 B) across arms, and the process
owning port 3000 asserted to be the one under test.

| | master | this branch | |
|---|--:|--:|--:|
| c=8 | 1081.8 req/s | **1567.8 req/s** | **+44.9%** |
| c=64 | 582.5 req/s | **972.9 req/s** | **+67.0%** |

Medians of 5 interleaved rounds each. Ranges: c=8 master 898–1097, branch
1009–1582 (they overlap by one sample each way); c=64 master 550–738, branch
765–1003 (no overlap).

**Peak RSS does not rise — it falls:**

| | master | this branch |
|---|--:|--:|
| c=8 | 207.6, 219.1 MB | 204.6, 217.5 MB |
| c=64 | 739.2, 737.1 MB | **437.8, 607.8 MB** |

Shorter pauses mean fewer 434 KB renders are in flight at once: the live object
heap at c=64 is 25.7 MB on master against 15.8 MB here.

Where the time went, from local instrumentation (see below):

| | collections | collector share of wall | avg pause | the clear |
|---|--:|--:|--:|--:|
| master, c=8 | 14,407 | 65.4% | 0.91 ms | **5.72s of 13.09s** |
| this branch, c=8 | 20,446 | 51.4% | 0.50 ms | 0.002s |

GC per request falls from 0.62 ms to 0.34 ms at c=8.

### It may also explain the dead end in #4352

That report lists five synthetic programs that should have reproduced the
collapse and did not, and calls that the most useful part of it. **All five have
small live sets**, and this cost — like the mark and the sweep — is O(live) paid
per collection. campfire retains a large old heap and collects ~14k times in
20s; the reproducers did neither.

It is also the mechanism behind the arithmetic in that report ("what moved is
the cost of a collection, not the number of them"): from c=8 to c=64 collections
per second *fall* 4.6x while cost per collection *rises* 4.7x, because the live
set grows 11x with in-flight renders.

## Verification

- `SPINEL_GC_VERIFY_GEN=1` across all 61 benchmarks: **no barrier gaps**. This
  is the oracle for what the change actually risks — an object left dirty has
  its barrier off, and the verifier names the holder of anything a barrier
  missed.
- `SPINEL_GC_MINOR=1 make test`: **3521 pass, 0 fail, 0 error**.
- `make gate`: 3521 pass, 61 benchmarks, optcarrot OK (checksum 59662),
  `gc-minor-test` pass.
- `make gate` also runs `spin-check`, which fails with
  `spin flags: progress leaked onto stdout` on unmodified master too —
  pre-existing, not from this change.

Caveats: macOS, jemalloc, 14 cores, where #4352 was Linux/glibc on 6c/12t —
direction should hold, magnitudes will not. Also, `make seed` in the published
campfire tarball is schema-only (zero INSERTs), so the "50 users, 5 rooms, 100
messages/room" the issue describes has to be generated separately; 100 messages
per room with ActionText bodies reproduces the 434 KB page.

## An offer, @matz — instrumentation

Every phase figure above comes from a local patch that splits
`sp_gc_stat_seconds` into mark / old sweep / slot sweep / remembered-set clear /
string sweep / trim behind `SPINEL_GC_PHASES=1`. I did not include it here
because this PR should stand on its own, but it is what found this: the totals
said "the collector is 65% of wall" and gave no way to choose between attacking
the mark and attacking the sweep.

It is ~30 lines, off by default (one not-taken branch per phase boundary, six
per collection), and comes with a test leg holding its contract — the flag must
not change what a program computes and must be silent when unset. It would also
have answered #4352's "spinel exposes no counter I could find" directly.

**Would that be worth a PR of its own?** Happy either way — if you would rather
not carry it, we will keep it local for our own work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved garbage-collection performance in threaded builds by avoiding unnecessary full-heap scans during typical non-full collections.
  * Retains full-heap scanning when required to ensure collection correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->