### PR TITLE
Say which phase of a collection the time went to

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ RBS_LIB      = build/librbs.a
 
 .PHONY: all regexp rbs_extract rbs-test rbs-seed-test re-lit-test reject-test backtrace-test gc-minor-test ext-test ext-cruby-test alloc-report-test rubyspec rubyspec-gate spin-check \
         test test-run clean-test-results regen-rbs-expected \
-        regen-expected regen-expected-err bench optcarrot gate check gate-legs gate-test gate-bench \
+        regen-expected regen-expected-err bench optcarrot gate check gate-legs gate-test gate-bench gc-phases-test \
         gate-optcarrot clean install uninstall deps tools
 
 # `make all` includes the RBS extractor when vendor/rbs has been fetched
@@ -671,7 +671,7 @@ test: $(SPINEL_TIMEOUT)
 # The actual run. rbs-test golden-checks the RBS extractor (cheap, C-only).
 # rbs-seed-test checks the seeds actually reach the analyzer (incl. nested
 # classes, #1417).
-test-run: rbs-test rbs-seed-test re-lit-test reject-test backtrace-test gc-minor-test ext-test ext-cruby-test $(TEST_TARGETS) $(PKG_TEST_TARGETS)
+test-run: rbs-test rbs-seed-test re-lit-test reject-test backtrace-test gc-minor-test gc-phases-test ext-test ext-cruby-test $(TEST_TARGETS) $(PKG_TEST_TARGETS)
 	@if [ -z "$(TIMEOUT_BIN)" ]; then echo "Note: no 'timeout' command found; running without time limits."; fi
 	@if [ -t 1 ]; then printf '\n'; fi
 	@pass=$$(grep -l '^PASS' build/test-results/*.ok 2>/dev/null | wc -l); \
@@ -785,6 +785,28 @@ reject-test: $(SPINEL)
 # One leg per barrier gap that shipped. A single program was what this target
 # ran when a store into a capture cell shipped with no barrier at all, so a
 # fix here adds its reproducer to the list rather than testing by hand.
+# SPINEL_GC_PHASES only reports; it must not change what a program computes, and
+# it must say nothing at all when it is off. Both halves are the contract, and
+# neither is visible to the ordinary harness, which cannot vary the environment
+# per test.
+gc-phases-test: $(SPINEL) $(SP_RT_LIB) $(SP_RT_MT_LIB) $(SPINEL_TIMEOUT)
+	@tmp=$$(mktemp -d /tmp/spinel-gcph.XXXXXX); ok=1; \
+	src=test/gc_minor_thread_local_slot.rb; \
+	$(SPINEL) "$$src" -o "$$tmp/m" >/dev/null 2>&1 || \
+	  { echo "gc-phases-test: FAIL (compile)"; rm -rf "$$tmp"; exit 1; }; \
+	$(TIMEOUT60) "$$tmp/m" > "$$tmp/off.out" 2> "$$tmp/off.err"; \
+	SPINEL_GC_PHASES=1 $(TIMEOUT60) "$$tmp/m" > "$$tmp/on.out" 2> "$$tmp/on.err"; \
+	if ! cmp -s "$$tmp/off.out" "$$tmp/on.out"; then \
+	  echo "gc-phases-test: FAIL (stdout differs with the flag set)"; \
+	  diff -u "$$tmp/off.out" "$$tmp/on.out" | head -10; ok=0; fi; \
+	if [ -s "$$tmp/off.err" ]; then \
+	  echo "gc-phases-test: FAIL (wrote to stderr with the flag unset)"; \
+	  head -3 "$$tmp/off.err"; ok=0; fi; \
+	if ! grep -q '^\[gcph\]' "$$tmp/on.err"; then \
+	  echo "gc-phases-test: FAIL (no [gcph] line with the flag set)"; ok=0; fi; \
+	rm -rf "$$tmp"; \
+	if [ $$ok -eq 1 ]; then echo "gc-phases-test: pass"; else exit 1; fi
+
 GC_MINOR_TESTS := test/gc_minor_thread_local_slot.rb \
                   test/gc_minor_thread_retval.rb \
                   test/gc_minor_thread_tls_first_write.rb \

--- a/docs/internals/gc.md
+++ b/docs/internals/gc.md
@@ -192,6 +192,7 @@ Environment variables:
 |-----------------------|------------------------------------------------------------------------|
 | `SPINEL_GC_STRESS`    | drops the thresholds to 2048 B, so nearly every allocation collects     |
 | `SPINEL_GC_VERIFY`    | registry check on every mark, plus a SIGSEGV/SIGBUS reporter naming the phase and object |
+| `SPINEL_GC_PHASES`    | adds a `[gcph]` line splitting collector time into mark / old sweep / slot sweep / remembered clear / string sweep / trim, named as the collector's own comments name them; arms the reporter on its own |
 | `SPINEL_MAX_HEAP_MB`  | RSS ceiling, checked at GC trigger points against `/proc/self/statm`; Linux only, off by default |
 
 ## Limits, and where the next work is

--- a/lib/sp_alloc.c
+++ b/lib/sp_alloc.c
@@ -168,6 +168,9 @@ static void sp_gc_stats_report(void) {
   static double last = 0;
   if (on < 0) {
     const char *e = getenv("SPINEL_GC_STATS"); on = (e && *e && *e != '0') ? 1 : 0;
+    /* SPINEL_GC_PHASES arms the same reporter on its own, so the breakdown does
+       not also require SPINEL_GC_STATS to be set. */
+    if (sp_gc_ph_on) on = 1;
     /* A program that exits before the next tick would otherwise report nothing
        but its first collection, so the totals are also printed on the way out.
        A server is killed rather than returning from main, which is why the
@@ -206,6 +209,18 @@ static void sp_gc_stats_emit(void) {
           (double)SP_GC_CTR_GET(sp_gc_bytes) / 1048576.0, (double)sbytes / 1048576.0,
           (double)SP_GC_CTR_GET(sp_gc_threshold) / 1048576.0,
           (double)SP_GC_CTR_GET(sp_str_threshold) / 1048576.0, nw);
+  if (!sp_gc_ph_on) return;
+  /* Which part of a collection cost that time. The names are the ones the
+     collector's own comments use, so a number leads to the code that spent it.
+     Under SP_THREADS the per-worker string sweep runs inside the slot sweep
+     (sp_sweep_one_slot), so `string sweep` is the serial path's figure and
+     reads zero on the threaded one. */
+  fprintf(stderr,
+          "[gcph] mark %.3fs  old sweep %.3fs  slot sweep %.3fs  "
+          "remembered clear %.3fs  string sweep %.3fs  trim %.3fs  of %.3fs total\n",
+          sp_gc_ph_mark, sp_gc_ph_oldsweep, sp_gc_ph_slotsweep,
+          sp_gc_ph_rembclear, sp_gc_ph_strsweep, sp_gc_ph_trim,
+          sp_gc_stat_seconds);
 }
 
 void sp_gc_retune_object(size_t before) {

--- a/lib/sp_gc.c
+++ b/lib/sp_gc.c
@@ -178,6 +178,7 @@ static void sp_gc_fault_report(int sig) {
 }
 __attribute__((constructor)) static void sp_gc_debug_env(void){
   const char *v=getenv("SPINEL_GC_VERIFY"); sp_gc_verify=(v&&*v&&*v!='0');
+  { const char *ph=getenv("SPINEL_GC_PHASES"); sp_gc_ph_on=(ph&&*ph&&*ph!='0'); }
   { const char *fi=getenv("SPINEL_GC_FULL_INTERVAL");
     if(fi&&*fi){ int n=atoi(fi); if(n>0&&n<=4096){ sp_gc_full_interval=n; sp_gc_full_interval_fixed=1; } } }
   { const char *g=getenv("SPINEL_GC_VERIFY_GEN"); sp_gc_verify_gen=(g&&*g&&*g!='0');
@@ -419,6 +420,20 @@ static SP_NOINLINE void sp_gc_verify_gen_run(void) {
     free(cand);
 }
 
+/* Phase accounting (SPINEL_GC_PHASES=1). sp_gc_stat_seconds says how much time
+   a collection cost; it never said which part of one, so "GC is half of wall"
+   gave no way to choose between the mark and the sweep. Every phase figure in
+   docs/internals/gc-threaded-pause-plan.md was measured by patching this file
+   by hand, three times over; these are the same measurements, kept.
+
+   The remembered-set clear gets a bucket of its own rather than being folded
+   into a sweep: under SP_THREADS it walks the WHOLE old heap on every non-full
+   cycle, so on a large live set it is O(live) per collection, and nothing
+   attributed it. It is 8% of the stopped window on the threaded large-heap
+   shape in the plan doc. */
+double sp_gc_ph_mark = 0, sp_gc_ph_oldsweep = 0, sp_gc_ph_slotsweep = 0,
+       sp_gc_ph_rembclear = 0, sp_gc_ph_strsweep = 0, sp_gc_ph_trim = 0;
+int sp_gc_ph_on = 0;
 unsigned long long sp_gc_stat_collections=0;
 unsigned long long sp_gc_stat_fulls=0;
 double sp_gc_stat_seconds=0;
@@ -430,10 +445,17 @@ static double sp_gc_stat_now(void){
   return 0.0;
 #endif
 }
+/* Close the phase that ended here. Off by default, so a build that does not ask
+   for the breakdown pays one not-taken branch per boundary, against a
+   collection measured in microseconds. */
+#define SP_GC_PH(bucket) \
+  do { if (sp_gc_ph_on) { double _t = sp_gc_stat_now(); (bucket) += _t - ph_t; ph_t = _t; } } while (0)
+
 
 void sp_gc_collect(void){
   size_t ob_before = sp_gc_bytes;
   double stat_t0 = sp_gc_stat_now();
+  double ph_t = stat_t0;
   int full=(sp_gc_cycle%sp_gc_full_interval==0);sp_gc_cycle++;
   /* Forced by growth rather than by the schedule: the old generation has
      outgrown what the last full found live in it. */
@@ -477,6 +499,7 @@ void sp_gc_collect(void){
      record -- the one failure mode of this design, silent until it is a use
      after free. Off unless SPINEL_GC_VERIFY_GEN is set. */
   if(!full && sp_gc_verify_gen) sp_gc_verify_gen_run();
+  SP_GC_PH(sp_gc_ph_mark);
   if(full){
     size_t old_before=sp_gc_old_bytes;
     sp_gc_hdr**pp=&sp_gc_old_heap;sp_gc_old_bytes=0;
@@ -516,6 +539,7 @@ void sp_gc_collect(void){
      string heap from inside it (each worker takes its own slot) and would
      otherwise read this flag while it was still 0 -- and then sweep the old
      string list on a minor cycle, freeing strings only an old object holds. */
+  SP_GC_PH(sp_gc_ph_oldsweep);
   sp_gc_str_minor_only = (sp_gc_str_sweep_hook && !full && sp_gc_minor_on);
 #ifdef SP_THREADS
   { int n=sp_active_workers; if(n<1)n=1; if(n>SP_MAX_WORKERS)n=SP_MAX_WORKERS;
@@ -538,6 +562,7 @@ void sp_gc_collect(void){
      the live set those bytes were never there. Churning large arrays walked the
      counter below zero; the retune read the wrapped value and set a threshold
      near SIZE_MAX, which never fires again (#4073). */
+  SP_GC_PH(sp_gc_ph_slotsweep);
   sp_gc_bytes=sp_gc_old_bytes;
   /* The remembered set has done its job and starts over after EVERY cycle, not
      only a full one. Every young object it led the mark to has just been
@@ -576,6 +601,7 @@ void sp_gc_collect(void){
     for(int ri=0;ri<sp_gc_nremembered;ri++)((sp_gc_hdr*)sp_gc_remembered[ri]-1)->dirty=0;
   }
   sp_gc_nremembered=0; sp_gc_rem_overflow=0;
+  SP_GC_PH(sp_gc_ph_rembclear);
   /* Sweep the string heap only when IT is over its trigger: the sweep is a
      full walk of the live string list, and running it on every OBJECT-heap
      collection made each collection O(live strings) -- the dominant cost of
@@ -600,11 +626,13 @@ void sp_gc_collect(void){
   if(sp_gc_str_sweep_hook){
     sp_gc_str_sweep_hook();
   }
+  SP_GC_PH(sp_gc_ph_strsweep);
   sp_gc_str_minor_only = 0;
   /* malloc_trim walks the allocator arena; once per full cycle was ~10% of
      collection time on allocation-heavy runs. Every 4th full keeps the RSS
      benefit at a fraction of the cost. */
   if(full&&(sp_gc_full_runs%4)==1)malloc_trim(0);
+  SP_GC_PH(sp_gc_ph_trim);
   /* Bump BEFORE the retune hook: the hook is where the stats line is printed
      (sp_alloc.c sees both thresholds and the string heap), and it must read
      this collection, not the previous one. */

--- a/lib/sp_gc.h
+++ b/lib/sp_gc.h
@@ -291,6 +291,12 @@ extern int sp_gc_verify_gen;
 extern int sp_gc_verify_gen_fail;
 extern int sp_gc_verify_probe_on, sp_gc_verify_probe_hit;
 extern unsigned sp_gc_verify_probe;
+/* Per-phase collector time, in seconds, cumulative (SPINEL_GC_PHASES=1; all
+   zero when it is off). sp_gc_stat_seconds is their sum plus the bookkeeping
+   between them. Reported by sp_alloc.c, which is where the stats line lives. */
+extern double sp_gc_ph_mark, sp_gc_ph_oldsweep, sp_gc_ph_slotsweep,
+              sp_gc_ph_rembclear, sp_gc_ph_strsweep, sp_gc_ph_trim;
+extern int sp_gc_ph_on;
 void sp_gc_collect(void);
 #ifdef SP_THREADS
 /* Sweep one worker's young list on that worker (see sp_gc.c). Survivors come


### PR DESCRIPTION
As offered on #4380. `sp_gc_stat_seconds` says how much a collection cost and
never which part of one, so "the collector is half of wall time" gives no way to
choose between attacking the mark and attacking the sweep.

```
[gcph] mark 0.178s  old sweep 0.006s  slot sweep 0.560s  remembered clear 0.000s  string sweep 0.001s  trim 0.000s  of 0.745s total
```

Phases named as the collector's own comments name them, per your request — a
number leads to the code that spent it without a translation step. The doc table
in `docs/internals/gc.md` uses the same words.

## What it is for

It is what found #4380. Before that landed, `remembered clear` was **5.7s of
13.1s** of collector time on the campfire server — the largest single phase of
the stopped window, and completely invisible in a total. On current master it
reads `0.000s`.

It also answers a question a total cannot, because the answer is not the same
everywhere:

| workload | mark | sweep |
|---|--:|--:|
| threaded churn, small live set | 1% | 99% |
| large live heap, c=8 | 39% | 61% |
| large live heap, c=64 | **54%** | 46% |

Which half is worth attacking depends on the workload and inverts with
concurrency. #4352 had to reason about "the cost of a collection" from totals
and noted that spinel exposed no counter for it; this is that counter. Running
it against that application, collections per second *fall* 4.6x from c=8 to c=64
while cost per collection *rises* 4.7x — which is what that report deduced and
could not check.

The remembered clear gets a bucket of its own rather than being folded into a
sweep, and earned it: nothing attributed a whole-old-heap walk that ran on every
non-full cycle.

## Cost when off

One not-taken branch per phase boundary — six per collection, against a
collection measured in microseconds. optcarrot is 0.11s CPU either way, which is
arithmetic rather than a measurement: nine collections make 54 branches.

`SPINEL_GC_PHASES` arms the reporter on its own, so the breakdown does not also
require `SPINEL_GC_STATS`.

## Test

`gc-phases-test` holds the two halves of the contract that the ordinary harness
cannot reach, since it cannot vary the environment per test: the flag must not
change what a program computes, and must say nothing at all when unset. I
checked it discriminates — forcing the flag on unconditionally makes it fail
with `wrote to stderr with the flag unset`.

## Gate

```
Tests:     3523 pass, 0 fail, 0 error
Benchmarks:  61 pass, 0 fail, 0 error, 0 skip
Optcarrot: OK (checksum 59662)
gc-minor-test: pass
gc-phases-test: pass
```

Two notes on the gate, both unrelated to this change:

- One `make gate` run showed `catch_throw_tags_values` and
  `catch_throw_through_loop` failing with **no output at all**, on a machine at
  ~10 load average. Both pass standalone on this branch and on master, and a
  clean `make test` re-run is 3523/0/0. I read it as those two hitting the
  harness timeout under load rather than anything here, but flagging it in case
  it is a known flake worth a longer timeout.
- `spin-check` fails with `spin flags: progress leaked onto stdout`, which
  reproduces on unmodified master.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `SPINEL_GC_PHASES=1` option to report garbage-collection timing by phase, including marking, sweeping, remembered-set clearing, string sweeping, trimming, and total collection time.

- **Documentation**
  - Documented the new garbage-collection phase timing option and its diagnostic output.

- **Tests**
  - Added automated coverage to verify output remains consistent while phase timing diagnostics appear only when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->