### PR TITLE
Dump the allocation report on a signal, because a server never reaches atexit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1584,6 +1584,22 @@ alloc-report-test: $(SPINEL) $(SP_RT_LIB)
 	full=$$(awk '/;\(no-scan\) /{print $$NF}' "$$tmp/s.folded" | head -1); \
 	sat=$$(awk '/;\(no-scan\) /{print $$NF}' "$$tmp/sm.folded" | head -1); \
 	[ -n "$$full" ] && [ "$$full" = "$$sat" ] || { echo "alloc-report-test: FAIL (a saturated run changed a surviving row: $$full vs $$sat)"; ok=0; }; \
+	$(SPINEL) test/alloc-report/signal_dump.rb -o "$$tmp/sig" >/dev/null 2>&1 || { echo "alloc-report-test: FAIL (compile signal_dump)"; exit 1; }; \
+	SPINEL_ALLOC_REPORT="$$tmp/sig.folded" "$$tmp/sig" >/dev/null 2>&1 & \
+	sigpid=$$!; sleep 1; kill -USR1 $$sigpid 2>/dev/null; sleep 1; \
+	kill -0 $$sigpid 2>/dev/null || { echo "alloc-report-test: FAIL (the signal ended the program instead of dumping)"; ok=0; }; \
+	first=$$(awk '/^alloc;.*String /{print $$NF; exit}' "$$tmp/sig.folded" 2>/dev/null); \
+	[ -n "$$first" ] || { echo "alloc-report-test: FAIL (no report from a running program)"; ok=0; }; \
+	sleep 1; kill -USR1 $$sigpid 2>/dev/null; sleep 1; \
+	second=$$(awk '/^alloc;.*String /{print $$NF; exit}' "$$tmp/sig.folded" 2>/dev/null); \
+	kill -9 $$sigpid 2>/dev/null; wait $$sigpid 2>/dev/null; \
+	[ -n "$$second" ] && [ "$$second" -gt "$${first:-0}" ] || { echo "alloc-report-test: FAIL (the second signal did not re-dump a later table: $$first then $$second)"; ok=0; }; \
+	$(SPINEL) test/alloc-report/signal_dump_idle.rb -o "$$tmp/idle" >/dev/null 2>&1 || { echo "alloc-report-test: FAIL (compile signal_dump_idle)"; exit 1; }; \
+	SPINEL_ALLOC_REPORT="$$tmp/idle.folded" "$$tmp/idle" >/dev/null 2>&1 & \
+	idlepid=$$!; sleep 1; kill -USR1 $$idlepid 2>/dev/null; sleep 1; \
+	kill -0 $$idlepid 2>/dev/null || { echo "alloc-report-test: FAIL (the signal ended the idle program)"; ok=0; }; \
+	grep -qE '^alloc;.*String [0-9]+$$' "$$tmp/idle.folded" 2>/dev/null || { echo "alloc-report-test: FAIL (an idle program did not report when signalled: the dump is waiting for an allocation that will never come)"; ok=0; }; \
+	kill -9 $$idlepid 2>/dev/null; wait $$idlepid 2>/dev/null; \
 	rm -rf "$$tmp"; \
 	if [ $$ok -eq 1 ]; then echo "alloc-report-test: pass"; else exit 1; fi
 

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -128,6 +128,43 @@ alloc;(unattributed) 3
 Every row above that line is still exact -- the overflow is kept out of them
 rather than added to whichever row the probe happened to land on.
 
+### While it is still running: a signal
+
+`atexit` is a mode a server cannot use: it is stopped by a signal, so the
+counters it spent the whole run filling are lost at the moment they are worth
+reading. `SIGUSR1` asks for a dump in flight, and the program carries on:
+
+```
+SPINEL_ALLOC_REPORT=alloc.folded ./server &
+kill -USR1 $!          # writes alloc.folded now
+```
+
+Each dump rewrites the whole cumulative table, so a WINDOW is two dumps
+subtracted -- which is also how a server's boot is kept out of the profile:
+
+```
+kill -USR1 $pid; sleep 1; cp alloc.folded before.folded
+#   ... run the work you want to measure ...
+kill -USR1 $pid; sleep 1; cp alloc.folded after.folded
+awk 'NR==FNR{a[$1]=$2; next} /^alloc;/{print $1, $2-a[$1]}' before.folded after.folded
+```
+
+The `# bytes` lines carry their key in the third field rather than the first.
+
+`SPINEL_ALLOC_REPORT_SIGNAL` moves the signal, by number or by name
+(`USR1`, `USR2`, `URG`, `IO`, `WINCH`). Three things worth knowing:
+
+- The handler is installed only while the report is on, but while it is on it
+  replaces whatever the program had for that signal. A `Signal.trap("USR1")`
+  in the program runs later and replaces it back, at which point the dump
+  stops arriving -- move the signal rather than fight over one.
+- A threaded program parks a thread on the signal, so the dump arrives whether
+  or not anything is allocating. A single-threaded one has no such thread: the
+  handler sets a flag and the next allocation writes the report, so an idle
+  single-threaded program dumps when it next allocates.
+- A process that forked after startup has the handler in the child but not the
+  thread; the child falls back to the flag. Signal the parent.
+
 ## Which one to reach for
 
 Start with `--profile` and a sampler: it tells you which method to look at.

--- a/lib/sp_alloc.c
+++ b/lib/sp_alloc.c
@@ -4,6 +4,14 @@
    lib/*.c allocate onto one heap. sp_str_sweep is registered with the object GC
    via a constructor, so a collection triggered from any TU also reaps strings. */
 #include <time.h>
+#include <signal.h>    /* SPINEL_ALLOC_REPORT_SIGNAL: dump without exiting */
+#include <strings.h>   /* strcasecmp (that signal named rather than numbered) */
+#include <unistd.h>    /* write/read: the handler's only safe way to say "dump" */
+#include <fcntl.h>     /* the wake pipe's O_NONBLOCK and FD_CLOEXEC */
+#include <errno.h>     /* EINTR on the reader's park */
+#ifdef SP_THREADS
+#include <pthread.h>   /* the thread that does the writing */
+#endif
 #include "sp_alloc.h"
 #include "sp_dtoa.h"   /* sp_format_float for locale-independent Float#to_s */
 /* Per-site allocation attribution (SPINEL_ALLOC_SITES=1, on top of
@@ -760,11 +768,16 @@ static void *sp_alloc_site_now(void) {
    share of allocated bytes in a typical app, so leaving them off the site
    path left the biggest question the report raises unanswerable. */
 #define SP_ALLOC_STR_KEY ((void *)(uintptr_t)2)
+/* Defined below, beside the dump it calls: a signal asked for the report and
+   this is the first place after it that is allowed to write one. */
+static void sp_alloc_report_poll(void);
 void sp_alloc_report_count(void *scan, size_t bytes) {
+  sp_alloc_report_poll();
   sp_AllocStat *s = sp_alloc_stat_slot(scan ? scan : SP_ALLOC_NOSCAN_KEY, sp_alloc_site_now());
   s->count++; s->bytes += (unsigned long long)bytes;
 }
 void sp_alloc_report_str(size_t bytes) {
+  sp_alloc_report_poll();
   sp_AllocStat *s = sp_alloc_stat_slot(SP_ALLOC_STR_KEY, sp_alloc_site_now());
   s->count++; s->bytes += (unsigned long long)bytes;
 }
@@ -841,12 +854,134 @@ static void sp_alloc_report_dump(void) {
   }
   if (close_f) fclose(f);
 }
+/* ---- a dump from a program that is still running ----
+   The dump above runs from atexit, which a long-lived program never reaches:
+   a server is stopped by a signal, so the counters it spent the whole run
+   filling are lost at the moment they are worth reading. Nothing about the
+   table needed changing -- it is complete at every instant -- it just had no
+   way out before the process ended.
+
+   The handler cannot write the report: fopen, malloc and backtrace_symbols
+   are none of them async-signal-safe. What it can do is `write` one byte to a
+   pipe, which is, and a thread parked on the other end does the writing. That
+   thread is why the signal works on an IDLE server -- the first version polled
+   the flag from the counting path, and a server with no traffic allocates
+   nothing, so the dump waited for the next request instead of arriving when
+   asked.
+
+   Without threads there is no such thread to park, and a single-threaded
+   program that is idle is inside a syscall with nothing else to run: there
+   the flag and the counting path are the only mechanism available, and the
+   dump lands on the next allocation. The handler picks whichever is armed. */
+static volatile sig_atomic_t sp_alloc_report_pending = 0;
+static int sp_alloc_report_pipe[2] = { -1, -1 };
+
+static void sp_alloc_report_handler(int sig) {
+  (void)sig;
+  if (sp_alloc_report_pipe[1] >= 0) {
+    char b = 1;
+    /* Non-blocking, so a full pipe (or a fork'd child, which inherited the
+       handler but not the thread that reads it) degrades to the flag rather
+       than blocking inside a signal handler. */
+    if (write(sp_alloc_report_pipe[1], &b, 1) == 1) return;
+  }
+  sp_alloc_report_pending = 1;
+}
+
+/* A number (so real-time signals work) or a name with or without the SIG
+   prefix. SIGUSR1 by default because a program that wants it for itself can
+   move this one, and the handler is installed only while the report is on.
+   Kept as a small copy of sp_resolve_preempt_signal rather than a shared
+   helper: the allocator sits below the scheduler and should not reach up into
+   it for a dozen lines. */
+static int sp_resolve_report_signal(void) {
+  const char *e = getenv("SPINEL_ALLOC_REPORT_SIGNAL");
+  if (!e || !*e) return SIGUSR1;
+  char *end;
+  long n = strtol(e, &end, 10);
+  if (*end == '\0') { if (n > 0 && n < 65) return (int)n; }
+  else {
+    const char *name = e;
+    if (strncasecmp(name, "SIG", 3) == 0) name += 3;
+    static const struct { const char *n; int s; } tab[] = {
+      { "USR1", SIGUSR1 }, { "USR2", SIGUSR2 }, { "URG", SIGURG },
+      { "IO", SIGIO }, { "WINCH", SIGWINCH },
+    };
+    for (size_t i = 0; i < sizeof tab / sizeof tab[0]; i++)
+      if (strcasecmp(name, tab[i].n) == 0) return tab[i].s;
+  }
+  fprintf(stderr, "spinel: ignoring unrecognized SPINEL_ALLOC_REPORT_SIGNAL=%s;"
+                  " using SIGUSR1\n", e);
+  return SIGUSR1;
+}
+
+/* The flag path: the next counted allocation writes the report. Claimed with
+   an exchange so that however many threads are allocating, one dump happens
+   and the losers carry straight on. */
+static void sp_alloc_report_poll(void) {
+  if (!sp_alloc_report_pending) return;
+#ifdef SP_THREADS
+  if (!__atomic_exchange_n(&sp_alloc_report_pending, 0, __ATOMIC_SEQ_CST)) return;
+#else
+  sp_alloc_report_pending = 0;
+#endif
+  sp_alloc_report_dump();
+}
+
+#ifdef SP_THREADS
+/* Parked on the pipe for the life of the process. Every dump rewrites the
+   whole cumulative table, the same one atexit writes, so a window is two
+   dumps subtracted rather than a mode of its own -- which is also what
+   excludes a server's boot from the profile. Two signals in quick succession
+   write it twice; the second overwrites the first, which is harmless. */
+static void *sp_alloc_report_reader(void *arg) {
+  (void)arg;
+  for (;;) {
+    char b;
+    ssize_t n = read(sp_alloc_report_pipe[0], &b, 1);
+    if (n == 0) return NULL;
+    if (n < 0) { if (errno == EINTR) continue; return NULL; }
+    sp_alloc_report_dump();
+  }
+}
+
+/* The read end stays blocking, which is how the thread parks for the life of
+   the process at no cost; only the WRITE end is non-blocking, because that is
+   the one a signal handler touches and it must never block. Both are
+   close-on-exec, so an exec'd child does not inherit a pipe nobody reads.
+   Failure here is not fatal: the handler falls back to the flag. */
+static void sp_alloc_report_start_reader(void) {
+  if (pipe(sp_alloc_report_pipe) != 0) { sp_alloc_report_pipe[0] = sp_alloc_report_pipe[1] = -1; return; }
+  fcntl(sp_alloc_report_pipe[0], F_SETFD, FD_CLOEXEC);
+  fcntl(sp_alloc_report_pipe[1], F_SETFD, FD_CLOEXEC);
+  fcntl(sp_alloc_report_pipe[1], F_SETFL,
+        fcntl(sp_alloc_report_pipe[1], F_GETFL, 0) | O_NONBLOCK);
+  pthread_t tid;
+  if (pthread_create(&tid, NULL, sp_alloc_report_reader, NULL) != 0) {
+    close(sp_alloc_report_pipe[0]); close(sp_alloc_report_pipe[1]);
+    sp_alloc_report_pipe[0] = sp_alloc_report_pipe[1] = -1;
+    return;
+  }
+  pthread_detach(tid);
+}
+#endif
+
 __attribute__((constructor)) static void sp_alloc_report_boot(void) {
   const char *e = getenv("SPINEL_ALLOC_REPORT");
   if (e && *e && strcmp(e, "0") != 0) {
     sp_alloc_report_on = 1;
     { const char *sv = getenv("SPINEL_ALLOC_SITES");
       sp_alloc_sites_on = (sv && *sv && strcmp(sv, "0") != 0) ? 1 : 0; }
+#ifdef SP_THREADS
+    sp_alloc_report_start_reader();
+#endif
+    /* SA_RESTART: asking for a report must not turn an in-flight read(2) into
+       an EINTR the program never expected to handle. */
+    { struct sigaction sa; memset(&sa, 0, sizeof sa);
+      sa.sa_handler = sp_alloc_report_handler;
+      sigemptyset(&sa.sa_mask);
+      sa.sa_flags = SA_RESTART;
+      sigaction(sp_resolve_report_signal(), &sa, NULL); }
     atexit(sp_alloc_report_dump);
   }
 }

--- a/test/alloc-report/signal_dump.rb
+++ b/test/alloc-report/signal_dump.rb
@@ -1,0 +1,12 @@
+# A program that never exits, which is the case the atexit dump cannot serve:
+# a server is killed rather than returned from. The Makefile signals this one
+# twice and then kills it with SIGKILL, so a report that exists at the end can
+# only have come from a signal -- atexit never ran.
+i = 0
+total = 0
+while true
+  s = "item-#{i}"
+  a = [s, s]
+  total += s.length + a.length
+  i += 1
+end

--- a/test/alloc-report/signal_dump_idle.rb
+++ b/test/alloc-report/signal_dump_idle.rb
@@ -1,0 +1,15 @@
+# The idle case, which is the shape of every server this report exists for: a
+# program that has allocated, is now parked with nothing to do, and is asked
+# for its numbers. The dump must arrive when asked rather than waiting for the
+# next allocation -- an idle server has none.
+worker = Thread.new do
+  s = "warm-up"
+  i = 0
+  while i < 100
+    s = "item-#{i}"
+    i += 1
+  end
+  puts s.length
+  sleep 300
+end
+worker.join


### PR DESCRIPTION
`SPINEL_ALLOC_REPORT` is written from `atexit`, which is a mode a long-lived
program cannot use: a server is stopped by a signal, so the counters it spent
the whole run filling are lost at exactly the moment they are worth reading.
Nothing about the table needed changing — it is complete at every instant — it
just had no way out before the process ended.

`SIGUSR1` now asks for a dump in flight, and the program carries on.
`SPINEL_ALLOC_REPORT_SIGNAL` moves it, by number or by name.

## Shape

The handler cannot write the report: `fopen`, `malloc` and
`backtrace_symbols` are none of them async-signal-safe. What it *can* do is
`write` one byte to a pipe, and a thread parked on the other end does the
writing. **Cost when the report is off: nothing at all — no branch anywhere.**
The thread, the pipe and the handler are installed only when it is on.

Every dump rewrites the whole cumulative table, the same one `atexit` writes,
so a window is two dumps subtracted rather than a mode of its own — which is
also what keeps a server's boot out of the profile. `docs/profiling.md` carries
the recipe.

**The thread is the difference between working and nearly working.** The first
version set a flag and let the next counted allocation write the file. That is
fine on a busy server and useless on an idle one: I signalled a warm Campfire
server between load runs and the dump waited for the next request. A
single-threaded build still uses that path, because a single-threaded program
that is idle is inside a syscall with nothing else to run — that limit is
documented rather than papered over.

## Tests

`alloc-report-test` gains two programs that never exit, and each was checked
against the version it is meant to catch:

- **busy**: signal, assert it is still running and has written a table, signal
  again, assert the second table is later than the first, then `SIGKILL` — so a
  report that exists at the end can only have come from a signal. Against
  master's runtime that program dies at the first signal (`SIGUSR1`'s default
  disposition is terminate) and writes nothing.
- **idle**: a threaded program that allocates a little, then parks. Against the
  flag-only version above it reports nothing at all.

`make gate`: 3536 tests pass, 0 fail, 0 error. One unrelated step fails,
`spin-e2e FAIL: spin flags: progress leaked onto stdout` — it fails identically
on master at `2d160ed2` here, so it is not from this change; happy to file it
separately if it is not already known.

## What it was built for, and what it found immediately

Campfire, warm, `/rooms/1`: dump, 100 requests, dump, subtract. Boot excluded
because it is in both dumps. 1,408 rows, no `(unattributed)` row, so the
8,192-entry table held.

```
TOTAL per request: 11,530 KB in 10,094 allocations
  KB/req  allocs/req  share  site
  9591.3        2608  83.2%  sp_str_concat
   774.4           6   6.7%  sp_str_append_grow
   386.8           7   3.4%  sp_Views__Rooms_s_show
   383.9           9   3.3%  _proc_38
```

83% of the bytes a request allocates are 2,608 calls to `sp_str_concat`
averaging 3.7 KB each, building a 423 KB page — an accumulation that copies
what it has so far, which is ours to fix in the emitter, and which is the kind
of thing that was simply not observable before: the process it happens in never
exits.

One thing that surfaced with it, not part of this PR: an allocation made
*inside* a runtime helper attributes to the helper, since the captured frame is
the allocator's caller. `sp_str_concat` is the answer to "what allocates" but
not to "which Ruby code asked". The doc already warns that one frame is not
always the frame you want; worth knowing that runtime helpers are the case
where it always bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vQWvnWEJ6qSqtFKaLHvFX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added on-demand allocation report generation triggered by a configurable signal, with `SIGUSR1` used by default.
  - Reports can be captured while applications are active or idle, including cumulative snapshots for comparing allocation changes.
  - Supports both threaded and single-threaded applications, as well as forked processes.

- **Documentation**
  - Added guidance for configuring signals and interpreting live allocation reports.

- **Tests**
  - Added coverage for repeated signal requests and idle-process reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->