### PR TITLE
An --rbs seed on a mutated String parameter must not change what the program does

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -993,6 +993,12 @@ rbs-seed-test: $(SPINEL) $(RBS_EXTRACT_BIN) $(SP_RT_LIB) $(SPINEL_TIMEOUT)
 	  "$$tmp/nr" > "$$tmp/nr.out" 2>/dev/null; \
 	  cmp -s "$$tmp/nr.out" test/rbs-seed/nilable_return.expected || { echo "rbs-seed-test: FAIL (#4250 nilable seed erased the nil arm)"; diff -u test/rbs-seed/nilable_return.expected "$$tmp/nr.out" || true; ok=0; }; \
 	else echo "rbs-seed-test: FAIL (#4250 nilable_return C did not compile)"; ok=0; fi; \
+	$(SPINEL) test/rbs-seed/byref_string_param.rb --rbs test/rbs-seed/sig \
+	  -c --no-line-map -o "$$tmp/br.c" 2>/dev/null; \
+	if $(CC) -O0 -Ilib $(RBS_SEED_STRICT) "$$tmp/br.c" $(SP_RT_LIB) $(LDFLAGS) -lm -o "$$tmp/br" 2>"$$tmp/br.err"; then \
+	  "$$tmp/br" > "$$tmp/br.out" 2>/dev/null; \
+	  cmp -s "$$tmp/br.out" test/rbs-seed/byref_string_param.expected || { echo "rbs-seed-test: FAIL (a String seed on a mutated param dropped the caller's appends)"; diff -u test/rbs-seed/byref_string_param.expected "$$tmp/br.out" || true; ok=0; }; \
+	else echo "rbs-seed-test: FAIL (byref_string_param C did not compile)"; ok=0; fi; \
 	$(SPINEL) test/rbs-seed/colliding_class_pin.rb --rbs test/rbs-seed/sig \
 	  -c --no-line-map -o "$$tmp/cp.c" 2>/dev/null; \
 	grep -Eq 'const char[[:space:]]*\*[[:space:]]*iv_rtag' "$$tmp/cp.c" || { echo "rbs-seed-test: FAIL (collision-renamed class seed not applied)"; ok=0; }; \

--- a/src/analyze.c
+++ b/src/analyze.c
@@ -9119,7 +9119,7 @@ static void compute_byref_out_params(Compiler *c) {
         if (pi >= 0 && pi < 32 && !(blocked[si] & (1u << pi))) {
           LocalVar *p = scope_local(s, vn);
           if (p && p->is_param && p->type == TY_STRING && !p->is_cell &&
-              !p->rbs_seeded && !p->is_block_param && !p->byref_out) {
+              !p->is_block_param && !p->byref_out) {
             p->byref_out = 1;
             p->is_cell = 1;   /* body reads/writes ride the cell deref forms */
             changed = 1;
@@ -9145,7 +9145,7 @@ static void compute_byref_out_params(Compiler *c) {
           if (pi < 0 || pi >= 32 || (blocked[si] & (1u << pi))) continue;
           LocalVar *p = scope_local(s, vn);
           if (p && p->is_param && p->type == TY_STRING && !p->is_cell &&
-              !p->rbs_seeded && !p->is_block_param && !p->byref_out) {
+              !p->is_block_param && !p->byref_out) {
             p->byref_out = 1;
             p->is_cell = 1;
             changed = 1;

--- a/test/rbs-seed/byref_string_param.expected
+++ b/test/rbs-seed/byref_string_param.expected
@@ -1,0 +1,1 @@
+<html>part1;part2;</html>

--- a/test/rbs-seed/byref_string_param.rb
+++ b/test/rbs-seed/byref_string_param.rb
@@ -13,12 +13,24 @@ module Views
   end
 end
 
+# Forwards its buffer and never appends to it itself, so its parameter can
+# only reach byref through the TRANSITIVE arm -- the second site the seed
+# exclusion sat on.
+module Views
+  module Body
+    def self.frags_into(io)
+      Views::Parts.frag_into(io, 1)
+      Views::Parts.frag_into(io, 2)
+      nil
+    end
+  end
+end
+
 module Views
   module Page
     def self.show_into(io)
       io << "<html>"
-      Views::Parts.frag_into(io, 1)
-      Views::Parts.frag_into(io, 2)
+      Views::Body.frags_into(io)
       io << "</html>"
       nil
     end

--- a/test/rbs-seed/byref_string_param.rb
+++ b/test/rbs-seed/byref_string_param.rb
@@ -1,0 +1,34 @@
+# A seed must not change what the program DOES. The output-buffer pattern
+# (`def render_into(io, ...); io << ...; end`) relies on the caller seeing
+# the callee's appends, which spinel gives it by passing eligible String
+# params by reference. A truthful `(String io)` seed used to disqualify the
+# parameter from that ABI, so every append landed in a copy and the caller
+# got an empty buffer -- silently, and only when a sidecar was present.
+module Views
+  module Parts
+    def self.frag_into(io, n)
+      io << "part#{n};"
+      nil
+    end
+  end
+end
+
+module Views
+  module Page
+    def self.show_into(io)
+      io << "<html>"
+      Views::Parts.frag_into(io, 1)
+      Views::Parts.frag_into(io, 2)
+      io << "</html>"
+      nil
+    end
+
+    def self.show
+      io = String.new
+      Views::Page.show_into(io)
+      io
+    end
+  end
+end
+
+puts Views::Page.show

--- a/test/rbs-seed/sig/byref_string_param.rbs
+++ b/test/rbs-seed/sig/byref_string_param.rbs
@@ -5,6 +5,12 @@ module Views
 end
 
 module Views
+  module Body
+    def self.frags_into: (String io) -> nil
+  end
+end
+
+module Views
   module Page
     def self.show_into: (String io) -> nil
     def self.show: () -> String

--- a/test/rbs-seed/sig/byref_string_param.rbs
+++ b/test/rbs-seed/sig/byref_string_param.rbs
@@ -1,0 +1,12 @@
+module Views
+  module Parts
+    def self.frag_into: (String io, Integer n) -> nil
+  end
+end
+
+module Views
+  module Page
+    def self.show_into: (String io) -> nil
+    def self.show: () -> String
+  end
+end


### PR DESCRIPTION
`compute_byref_out_params` (da38f96fa) gives a mutated String parameter the
by-reference ABI so that a callee's `io << "x"` reaches the caller — the
output-buffer pattern, and what CRuby does. Its eligibility list excluded
`rbs_seeded` parameters, so writing a **truthful** sidecar changed what the
program did.

## The reduction

`test/rbs-seed/byref_string_param.rb` — two module methods, one passing its
buffer to the other:

```ruby
def self.show_into(io)
  io << "<html>"
  Views::Parts.frag_into(io, 1)
  Views::Parts.frag_into(io, 2)
  io << "</html>"
  nil
end
```

| | output |
|---|---|
| CRuby | `<html>part1;part2;</html>` |
| spinel, no sidecar | `<html>part1;part2;</html>` |
| spinel, `def self.show_into: (String io) -> nil` | *(empty)* |

The seed states the type the analyzer already infers. Nothing else about the
program changes. Every append lands in a copy and the caller's buffer stays
empty — silently, which is the same divergence da38f96fa set out to close
("the mutation silently stopped at the callee … diverging from CRuby with no
diagnostic").

`untyped io` behaves the same way and correctly so — that parameter really is
poly, and byref wants `TY_STRING`. It is the *accurate* `String` seed that
surprises.

## The change

Two tokens: `!p->rbs_seeded &&` comes off the direct and the transitive arm.
Every other guard stays exactly as it was — unique name, never aliased, never
spelled as a symbol or string, all parameters required positional, no plain
rebind of the parameter.

I could not find a reason for the exclusion in da38f96fa's message or around
the code, and the gate does not appear to have covered it, so it may simply
have been conservatism while the ABI was new. **If it is load-bearing for
something I have not found — a seeded method whose implementation is not the
one the seed describes, say — then the right shape is probably a diagnostic
rather than silence, and I will happily write that instead.** I tried a
warning first and withdrew it: "mutates a String param and is not byref" is
not the same claim as "the mutation is lost", because the inliner rescues some
of those calls, and a warning that cries wolf on a shape this ordinary is
worse than none.

## Where it came from

Roundhouse's view layer builds each page with `io = String.new; io << …; io`.
Nested views therefore return a finished string that the parent appends into
its own buffer — one full copy of every fragment per nesting level, which on
the campfire port is 9.6 MB of the 11.5 MB a `/rooms/1` request allocates
(measured with `SPINEL_ALLOC_REPORT` and the signal dump from #4388). Passing
the buffer down instead removes those copies, and the emitted views ship with
`.rbs` sidecars — so every one of them took this path and the pages came out
empty, with nothing in the build to say why.

## Testing

`test/rbs-seed/byref_string_param.rb` + sidecar + `.expected`, wired into
`rbs-seed-test`, which compiles with the seed, links, runs and compares —
the same shape the other cases in that target use. Before the change it prints
nothing; after it matches CRuby.

`make gate`: 3537 tests pass, 0 fail, 0 error. The one failing step is
`spin-e2e FAIL: spin flags: progress leaked onto stdout`, which fails
identically on master here and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vQWvnWEJ6qSqtFKaLHvFX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed RBS-seeded rendering so caller-provided string buffers retain appended content.
  - Corrected generated behavior for methods that mutate string parameters by reference, including through delegated calls.

- **Tests**
  - Added coverage for rendering HTML fragments into a shared string buffer.
  - Added compilation and runtime validation to ensure generated output matches the expected HTML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->