### PR TITLE
An Enumerator keeps its method label alive across collection

### DIFF
--- a/lib/sp_cold.c
+++ b/lib/sp_cold.c
@@ -2310,6 +2310,7 @@ void sp_Enumerator_scan(void *p) {
   if (e->has_feed) sp_mark_rbval(e->feed);
   sp_mark_rbval(e->gen_result);
   sp_mark_rbval(e->source);
+  sp_mark_string(e->meth);
 }
 sp_Enumerator *sp_enum_with_src(sp_Enumerator *e, sp_RbVal src, const char *meth) { sp_gc_wb((void*)e);
   e->source = src;
@@ -2354,7 +2355,7 @@ sp_Enumerator *sp_enum_of_one(sp_RbVal v, const char *meth) {
 sp_Enumerator *sp_Enumerator_new_from_items(sp_PolyArray *items) {
   SP_GC_ROOT(items);
   sp_Enumerator *e = (sp_Enumerator *)sp_gc_alloc(sizeof(sp_Enumerator), NULL, sp_Enumerator_scan);
-  e->items = items; e->cursor = 0; e->gen = NULL; e->gen_cap = NULL; e->fib = NULL; e->peeked = FALSE; e->size = sp_box_nil(); e->feed = sp_box_nil(); e->has_feed = FALSE; e->gen_result = sp_box_nil(); e->source = sp_box_nil(); e->meth = "each";
+  e->items = items; e->cursor = 0; e->gen = NULL; e->gen_cap = NULL; e->fib = NULL; e->peeked = FALSE; e->size = sp_box_nil(); e->feed = sp_box_nil(); e->has_feed = FALSE; e->gen_result = sp_box_nil(); e->source = sp_box_nil(); e->meth = SPL("each");
   return e;
 }
 /* Lazy with_index over a generator-backed source (blockless Kernel#loop,
@@ -2425,7 +2426,7 @@ sp_Enumerator *sp_Enumerator_with_index(sp_Enumerator *e, sp_int off) {
 }
 sp_Enumerator *sp_Enumerator_new_gen(void (*gen)(sp_Fiber *), void *cap, sp_RbVal size) {SP_GC_ROOT_RBVAL(size);
   sp_Enumerator *e = (sp_Enumerator *)sp_gc_alloc(sizeof(sp_Enumerator), NULL, sp_Enumerator_scan);
-  e->items = NULL; e->cursor = 0; e->gen = gen; e->gen_cap = cap; e->fib = NULL; e->peeked = FALSE; e->size = size; e->feed = sp_box_nil(); e->has_feed = FALSE; e->gen_result = sp_box_nil(); e->source = sp_box_nil(); e->meth = "each";
+  e->items = NULL; e->cursor = 0; e->gen = gen; e->gen_cap = cap; e->fib = NULL; e->peeked = FALSE; e->size = size; e->feed = sp_box_nil(); e->has_feed = FALSE; e->gen_result = sp_box_nil(); e->source = sp_box_nil(); e->meth = SPL("each");
   return e;
 }
 /* Blockless Kernel#loop: an infinite Enumerator that yields nil forever (#3236).
@@ -2436,7 +2437,7 @@ static void sp_loop_gen(sp_Fiber *f) {
 }
 sp_Enumerator *sp_loop_enum(void) {
   sp_Enumerator *e = sp_Enumerator_new_gen(sp_loop_gen, NULL, sp_box_nil());
-  e->meth = "loop";
+  e->meth = SPL("loop");
   return e;
 }
 

--- a/lib/sp_enum.h
+++ b/lib/sp_enum.h
@@ -25,7 +25,8 @@ typedef struct {
   sp_bool has_src;                       /* source is set, even to nil: `nil.then`'s receiver IS
                                              nil, and #inspect must not read that as "no source"
                                              and fall back to the items (sp_gc_alloc zero-fills) */
-  const char *meth;                       /* creating method name, for #inspect ("each", ...) */
+  const char *meth;                       /* creating method name, for #inspect ("each", ...):
+                                             an SPL literal or a GC-traced heap label */
   sp_bool gen_label;                     /* #inspect as a Generator wrapper (chunk_while & co.):
                                              the items are an eager snapshot, but CRuby shows
                                              #<Enumerator: #<Enumerator::Generator:0x..>:each> */

--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -10561,13 +10561,13 @@ static sp_Enumerator *sp_Enumerator_new_from(sp_RbVal arr) {
     SP_GC_ROOT(cap);
     cap->first = r->first; cap->step = r->step ? r->step : 1;
     sp_Enumerator *e = sp_Enumerator_new_gen(sp_endless_range_gen, cap, sp_box_nil());
-    e->source = arr; e->meth = "each";
+    e->source = arr; e->meth = SPL("each");
     return e;
   }
   sp_PolyArray *items = sp_enum_items_from(arr);
   SP_GC_ROOT(items);
   sp_Enumerator *e = (sp_Enumerator *)sp_gc_alloc(sizeof(sp_Enumerator), NULL, sp_Enumerator_scan);
-  e->items = items; e->cursor = 0; e->gen = NULL; e->gen_cap = NULL; e->fib = NULL; e->peeked = FALSE; e->size = sp_box_nil(); e->feed = sp_box_nil(); e->has_feed = FALSE; e->gen_result = sp_box_nil(); e->source = arr; e->meth = "each";
+  e->items = items; e->cursor = 0; e->gen = NULL; e->gen_cap = NULL; e->fib = NULL; e->peeked = FALSE; e->size = sp_box_nil(); e->feed = sp_box_nil(); e->has_feed = FALSE; e->gen_result = sp_box_nil(); e->source = arr; e->meth = SPL("each");
   return e;
 }
 /* Stamp the iterated receiver and creating method onto a fresh Enumerator so
@@ -10616,7 +10616,7 @@ static sp_Enumerator *sp_Enumerator_new_from_rev(sp_RbVal arr) {
     }
   }
   sp_Enumerator *e = (sp_Enumerator *)sp_gc_alloc(sizeof(sp_Enumerator), NULL, sp_Enumerator_scan);
-  e->items = items; e->cursor = 0; e->gen = NULL; e->gen_cap = NULL; e->fib = NULL; e->peeked = FALSE; e->size = sp_box_nil(); e->feed = sp_box_nil(); e->has_feed = FALSE; e->gen_result = sp_box_nil(); e->source = arr; e->meth = "reverse_each";
+  e->items = items; e->cursor = 0; e->gen = NULL; e->gen_cap = NULL; e->fib = NULL; e->peeked = FALSE; e->size = sp_box_nil(); e->feed = sp_box_nil(); e->has_feed = FALSE; e->gen_result = sp_box_nil(); e->source = arr; e->meth = SPL("reverse_each");
   return e;
 }
 /* Wrap an already-built poly array as an Enumerator, taking ownership of it
@@ -10651,7 +10651,7 @@ static sp_Enumerator *sp_Enumerator_new_ewi(sp_RbVal arr, sp_int off) {
     sp_PolyArray_push(pair, sp_box_int(i + off));
     sp_PolyArray_push(pairs, sp_box_poly_array(pair));
   }
-  { sp_Enumerator *e = sp_Enumerator_new_from_items(pairs); e->source = arr; e->meth = "each_with_index"; return e; }
+  { sp_Enumerator *e = sp_Enumerator_new_from_items(pairs); e->source = arr; e->meth = SPL("each_with_index"); return e; }
 }
 /* A blockless Array#each_index enumerator: the indices 0..len-1. */
 static sp_Enumerator *sp_Enumerator_new_indices(sp_RbVal arr) {
@@ -10662,7 +10662,7 @@ static sp_Enumerator *sp_Enumerator_new_indices(sp_RbVal arr) {
   SP_GC_ROOT(idx);
   sp_int n = items ? items->len : 0;
   for (sp_int i = 0; i < n; i++) sp_PolyArray_push(idx, sp_box_int(i));
-  { sp_Enumerator *e = sp_Enumerator_new_from_items(idx); e->source = arr; e->meth = "each_index"; return e; }
+  { sp_Enumerator *e = sp_Enumerator_new_from_items(idx); e->source = arr; e->meth = SPL("each_index"); return e; }
 }
 /* Array#each_slice(n) with no block: a materialized Enumerator whose items are
    the consecutive non-overlapping slices of length n (the last may be short).
@@ -10758,7 +10758,7 @@ static sp_Enumerator *sp_Enumerator_new_slices(sp_RbVal arr, sp_int n) {
     if (len - i <= n) break;
     i += n;
   }
-  { sp_Enumerator *e = sp_Enumerator_new_from_items(out); e->source = arr; e->meth = sp_sprintf("each_slice(%lld)", (long long)n); return e; }
+  { sp_Enumerator *e = sp_Enumerator_new_from_items(out); sp_gc_wb((void*)e); e->source = arr; e->meth = sp_sprintf("each_slice(%lld)", (long long)n); return e; }
 }
 /* Array#each_cons(n) with no block: a materialized Enumerator whose items are
    the sliding windows of length n (none when len < n). */
@@ -10777,7 +10777,7 @@ static sp_Enumerator *sp_Enumerator_new_cons(sp_RbVal arr, sp_int n) {
       sp_PolyArray_push(out, sp_box_poly_array(win));
     }
   }
-  { sp_Enumerator *e = sp_Enumerator_new_from_items(out); e->source = arr; e->meth = sp_sprintf("each_cons(%lld)", (long long)n); return e; }
+  { sp_Enumerator *e = sp_Enumerator_new_from_items(out); sp_gc_wb((void*)e); e->source = arr; e->meth = sp_sprintf("each_cons(%lld)", (long long)n); return e; }
 }
 /* Blockless <enum>.with_index(off): a materialized Enumerator whose items are
    the [element, off + i] pairs of the source enumerator's items. The source is

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -13054,7 +13054,7 @@ int emit_blockless_enumerator(Compiler *c, int id, Buf *b) {
       int te = ++g_tmp;
       buf_printf(b, "({ sp_Enumerator *_t%d = sp_Enumerator_new_from(", te);
       emit_boxed(c, recv, b);
-      buf_printf(b, "); _t%d->meth = \"%s\"; _t%d; })", te,
+      buf_printf(b, "); _t%d->meth = SPL(\"%s\"); _t%d; })", te,
                  sp_streq(name, "collect") ? "map" :
                  sp_streq(name, "find_all") ? "select" : name, te);
       return 1;
@@ -13107,12 +13107,12 @@ int emit_blockless_enumerator(Compiler *c, int id, Buf *b) {
     if (sp_streq(name, "each_byte") || sp_streq(name, "each_codepoint")) {
       const char *fn = sp_streq(name, "each_byte") ? "sp_str_bytes" : "sp_str_codepoints";
       buf_printf(b, "sp_enum_with_src(sp_Enumerator_new_from(sp_box_int_array(%s(_t%d))), "
-                    "sp_box_str(_t%d), \"%s\"); })", fn, tsrc, tsrc, name);
+                    "sp_box_str(_t%d), SPL(\"%s\")); })", fn, tsrc, tsrc, name);
       return 1;
     }
     const char *itemfn = sp_streq(name, "each_char") ? "sp_str_chars_poly" : "sp_str_lines_poly";
     buf_printf(b, "sp_enum_with_src(sp_Enumerator_new_from_items(%s(_t%d)), "
-                  "sp_box_str(_t%d), \"%s\"); })", itemfn, tsrc, tsrc, name);
+                  "sp_box_str(_t%d), SPL(\"%s\")); })", itemfn, tsrc, tsrc, name);
     return 1;
   }
   /* str.each_line(sep) with no block -> an Enumerator over the sep-kept
@@ -13127,7 +13127,7 @@ int emit_blockless_enumerator(Compiler *c, int id, Buf *b) {
                   "sp_enum_with_src(sp_Enumerator_new_from(sp_box_str_array(sp_str_lines_sep(_t%d, ",
                tsrc3, tsrc3);
     emit_expr(c, argv[0], b);
-    buf_printf(b, "))), sp_box_str(_t%d), \"each_line\"); })", tsrc3);
+    buf_printf(b, "))), sp_box_str(_t%d), SPL(\"each_line\")); })", tsrc3);
     return 1;
   }
   /* str.each_line(chomp: ...) with no block -> an Enumerator over the
@@ -13144,7 +13144,7 @@ int emit_blockless_enumerator(Compiler *c, int id, Buf *b) {
     if (is_chomp < 0) emit_cond(c, chomp_v, b);
     else buf_printf(b, "%d", is_chomp);
     buf_printf(b, "; sp_enum_with_src(sp_Enumerator_new_from(sp_box_str_array(_t%d ? sp_str_lines_chomp(_t%d) : sp_str_lines(_t%d))), "
-                  "sp_box_str(_t%d), _t%d ? \"each_line(chomp: true)\" : \"each_line(chomp: false)\"); })",
+                  "sp_box_str(_t%d), _t%d ? SPL(\"each_line(chomp: true)\") : SPL(\"each_line(chomp: false)\")); })",
                tch, tsrc2, tsrc2, tsrc2, tch);
     return 1;
   }
@@ -13170,7 +13170,7 @@ int emit_blockless_enumerator(Compiler *c, int id, Buf *b) {
     int tcy = ++g_tmp;
     buf_printf(b, "({ sp_Enumerator *_t%d = sp_Enumerator_new_cycle(", tcy);
     emit_boxed(c, recv, b);
-    buf_printf(b, ", 1); _t%d->meth = \"cycle\"; _t%d; })", tcy, tcy);
+    buf_printf(b, ", 1); _t%d->meth = SPL(\"cycle\"); _t%d; })", tcy, tcy);
     return 1;
   }
   /* arr.cycle(n) with no block -> a materialized Enumerator of the elements
@@ -22188,7 +22188,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
     if (blk < 0 && nt_ref(nt, id, "arguments") < 0) {
       buf_puts(b, "sp_enum_of_one(");
       emit_boxed(c, recv, b);
-      buf_printf(b, ", \"%s\")", name);
+      buf_printf(b, ", SPL(\"%s\"))", name);
       return;
     }
     if (blk >= 0) {
@@ -25385,7 +25385,7 @@ else {
     emit_expr(c, recv, b);
     buf_printf(b, "; SP_GC_ROOT(_t%d); "
                   "sp_enum_with_src(sp_Enumerator_new_from(sp_box_str_array(sp_re_scan(sp_re_pat_%d, _t%d))), "
-                  "sp_box_str(_t%d), \"gsub\"); })", tsg, gre, tsg, tsg);
+                  "sp_box_str(_t%d), SPL(\"gsub\")); })", tsg, gre, tsg, tsg);
     return;
   }
   /* Object receivers (incl. native-bound classes like StringScanner) dispatch

--- a/test/enum_method_mark.rb
+++ b/test/enum_method_mark.rb
@@ -1,0 +1,66 @@
+# An Enumerator owns its method label, including the heap Strings used for
+# each_slice(n) and each_cons(n). Allocate after construction so collection
+# must find the label through the Enumerator, not a constructor temporary.
+# GC.start is currently a no-op in Spinel; the churn triggers real collections.
+def check_label(en)
+  10000.times { |i| "churn#{i}" }
+  puts en.inspect
+end
+
+check_label((1..4).each_slice(2))
+check_label([1, 2, 3, 4, 5].each_slice(3))
+check_label((1..4).each_cons(2))
+check_label([1, 2, 3, 4, 5].each_cons(3))
+
+# A shallow copy keeps the same label alive after its source goes away.
+def copied_slices
+  (1..4).each_slice(2).dup
+end
+check_label(copied_slices)
+
+# Repeated collections must preserve both the label and the iteration state.
+en = (1..4).each_slice(2)
+p en.next
+check_label(en)
+p en.next
+en.rewind
+check_label(en)
+p en.to_a
+
+# Static labels need the same marker-byte representation as heap labels.
+# These cover runtime constructors, direct emitted stores and source stamping.
+check_label([1, 2, 3].each)
+check_label([1, 2, 3].reverse_each)
+check_label([1, 2, 3].each_with_index)
+check_label([1, 2, 3].each_index)
+check_label([1, 2, 3].map)
+check_label([1, 2, 3].cycle)
+check_label("ab".each_char)
+check_label("ab".each_byte)
+check_label("ab".each_codepoint)
+check_label("a\nb\n".each_line)
+check_label("a\nb\n".each_line(chomp: true))
+check_label("a\nb\n".each_line(chomp: false))
+check_label(5.then)
+
+# These labels have pre-existing formatting differences from CRuby. Exercise
+# their stores and inspect readers for sanitizer coverage without pinning that
+# unrelated formatting (separator/regexp arguments and the yield_self alias).
+def check_static_label(en)
+  10000.times { |i| "churn#{i}" }
+  p en.inspect.start_with?("#<Enumerator:")
+end
+check_static_label("a:b:".each_line(":"))
+check_static_label("aba".gsub(/a/))
+check_static_label(5.yield_self)
+# The endless-range arm builds a generator-backed Enumerator: its inspect shows
+# the Generator wrapper where CRuby shows the range, and embeds a process
+# address, so assert only that its label survives collection to be read.
+check_static_label((1..).each)
+
+# Generator labels are static too; their inspect embeds a process address.
+gen = Enumerator.new { |y| y << 7 }
+loop_enum = loop
+10000.times { |i| "churn#{i}" }
+p gen.next
+p loop_enum.next

--- a/test/enum_method_mark.rb.expected
+++ b/test/enum_method_mark.rb.expected
@@ -1,0 +1,29 @@
+#<Enumerator: 1..4:each_slice(2)>
+#<Enumerator: [1, 2, 3, 4, 5]:each_slice(3)>
+#<Enumerator: 1..4:each_cons(2)>
+#<Enumerator: [1, 2, 3, 4, 5]:each_cons(3)>
+#<Enumerator: 1..4:each_slice(2)>
+[1, 2]
+#<Enumerator: 1..4:each_slice(2)>
+[3, 4]
+#<Enumerator: 1..4:each_slice(2)>
+[[1, 2], [3, 4]]
+#<Enumerator: [1, 2, 3]:each>
+#<Enumerator: [1, 2, 3]:reverse_each>
+#<Enumerator: [1, 2, 3]:each_with_index>
+#<Enumerator: [1, 2, 3]:each_index>
+#<Enumerator: [1, 2, 3]:map>
+#<Enumerator: [1, 2, 3]:cycle>
+#<Enumerator: "ab":each_char>
+#<Enumerator: "ab":each_byte>
+#<Enumerator: "ab":each_codepoint>
+#<Enumerator: "a\nb\n":each_line>
+#<Enumerator: "a\nb\n":each_line(chomp: true)>
+#<Enumerator: "a\nb\n":each_line(chomp: false)>
+#<Enumerator: 5:then>
+true
+true
+true
+true
+7
+nil


### PR DESCRIPTION
## Why

Inspecting an Enumerator should continue to show the method that created it after other code allocates. A stored `each_slice(2)` or `each_cons(2)` enumerator could instead lose its label or display unrelated text: the enumerator survived collection, but the String holding its label did not.

Concretely, build `(1..4).each_slice(2)`, allocate ten thousand short-lived interpolated Strings, and inspect it. CRuby prints `#<Enumerator: 1..4:each_slice(2)>`. On master at `d1cac2ec` the label is gone, and an ordinary build prints `#<Enumerator: 1..4:>`. The array probes read back unrelated recycled text instead: one run of `[1, 2, 3, 4, 5].each_cons(3)` inspected as `#<Enumerator: [1, 2, 3, 4, 5]:[1, 2, 3, 4, 5]>`. Which bytes surface depends on what the allocator hands back, and differs between optimization levels and between separate builds of the same commit, so the reproducible claim is that the label is wrong rather than what replaces it. Every one of the eighteen master runs is wrong and every one exits zero. ASan reports a 14-byte read of the freed label during inspection.

## What

`sp_Enumerator_scan` now marks `e->meth` with `sp_mark_string`, just as the enumerator already marks its source and other retained values. Every static label stored by a runtime constructor or emitted call uses `SPL`, the existing literal representation with a marker byte. The field comment records that contract. The two constructors that build a heap-formatted label, `each_slice(n)` and `each_cons(n)`, now take the write barrier that every other managed store into an Enumerator already takes. No root-stack slots, object fields or allocations are added.

## How

The dynamically formatted labels for `each_slice(n)` and `each_cons(n)` already have the heap String representation. The missing operation is tracing them from their owning Enumerator. Shallow copies share the label, so scanning either live copy retains it.

The literal changes are necessary for that same scan. `sp_mark_string` reads the byte immediately before the string to distinguish heap storage from static storage; a bare C literal has no such byte. Adding only the mark to master produces an ASan global-buffer-overflow immediately before the literal `each`. Using `SPL` gives static labels the marker the existing scanner expects, without allocating a heap copy or introducing another ownership flag. The audit covers direct stores and callers of `sp_enum_with_src` and `sp_enum_of_one`.

The barrier belongs to the same change. Marking `meth` makes it a traced edge, and a traced edge owes two things: a representation the marker can read, which is what `SPL` supplies, and a barrier so that a minor collection still reaches a young label stored into an older Enumerator. Every other managed store into an Enumerator already takes one; the two `sp_sprintf` labels were the only managed stores that did not. There is no failing program for that omission today, because the enumerator is unrooted where those stores happen and so cannot survive a collection to become old. That is a property of the surrounding constructor rather than of this field, and rooting the constructor later would turn the omission into a live use-after-free of the label.

## Validation

`test/enum_method_mark.rb.expected` is the output of `ruby test/enum_method_mark.rb` under CRuby 4.0.6 (revision 03b6d3f889), and it regenerates byte for byte; it is unchanged under 2.6.10 as well, so none of the expectations are version-sensitive. It covers array and range sources, slices and sliding windows, a copied enumerator whose original has returned out of scope, repeated collection between `next` and `rewind`, and every static-label construction path, including the endless-range arm. Allocation happens after construction: `GC.start` is currently a no-op in Spinel, so the test uses short-lived Strings to trigger collection.

Fresh release builds of master and this branch were compared with the test compiled at `-O0` and the default `-O2`. For each build, three ordinary runs, three GC-stress runs and three runs with GC stress plus `SPINEL_GC_VERIFY_GEN=1` were measured. Master gives wrong output in every run; the branch matches the expected file byte for byte, with exit zero and no stderr, in every run. The branch's default `-O2` ordinary runs took 9–10 ms on this machine; this is test cost, not a performance comparison.

The sanitizer check instruments both the generated translation unit and `lib/sp_cold.c`, replacing that member in a separate copy of the runtime archive so the scanner itself is covered. It does not instrument the other runtime translation units. Master reports a heap-use-after-free, the mark-only variant reports a global-buffer-overflow on an untagged literal, and the complete fix is clean and matches the expected file. Each result repeats three times in ordinary, GC-stress and generational-verification modes. The standard gate sanitizer alone does not instrument `sp_cold.c`, which is why this additional check matters.

The generated C changes for 26 existing programs; their output is unchanged, and the suite and the corpus are unchanged with it.

On `d1cac2ec` the suite is unchanged: 3542 tests and 61 benchmarks pass with no failures or errors, optcarrot is unchanged at 59662, and the 2131-program compatibility corpus holds at 906 passing, with none gained and none lost. `test/enum_method_mark.rb` is additionally clean under GC stress and under AddressSanitizer, plain and stressed.

## Left alone, on purpose

Three existing presentation differences remain identical on master and this branch: `each_line(":")` omits its separator argument from inspection, `gsub(/a/)` omits the regexp, and `yield_self` prints that spelling where CRuby prints `then`. Those paths are exercised for scanner safety without asserting their unrelated formatting. The findings and repro are preserved in the parked ledger.

The previously parked constructor-local allocation window in `sp_Enumerator_new_slices` and `sp_Enumerator_new_cons` is separate from tracing a finished enumerator's label. This change adds no constructor roots and does not narrow that window. It does make the two label stores barrier-correct in advance of a fix that would close it, for the reason given above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Enumerator method labels so they remain valid and available after garbage collection.
  * Improved reliability of Enumerator inspection and iteration across garbage-collection cycles.

* **Tests**
  * Added coverage for method-label preservation across Enumerator constructors, copying, iteration, and garbage collection.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->