### PR TITLE
Nine more fold hoists keep their array alive, and one its accumulator

### DIFF
--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -2112,7 +2112,10 @@ int emit_sum_block_expr(Compiler *c, int id, Buf *b) {
   int tc = -1, tx = -1, tt = -1;
   if (acct == TY_FLOAT) { tc = ++g_tmp; tx = ++g_tmp; tt = ++g_tmp; }
   buf_printf(b, "({ sp_%sArray *_t%d = ", k, ta); emit_expr(c, recv, b);
-  buf_printf(b, "; sp_int _t%d = sp_%sArray_length(_t%d); ", tn, k, ta);
+  /* rooted the way the poly-accumulator arm above roots its receiver: the
+     element is taken out of this temp on every turn and the block allocates
+     in between */
+  buf_printf(b, "; SP_GC_ROOT(_t%d); sp_int _t%d = sp_%sArray_length(_t%d); ", ta, tn, k, ta);
   emit_ctype(c, acct, b); buf_printf(b, " _t%d = ", tacc);
   if (argc == 1) {
     TyKind init_t = comp_ntype(c, argv[0]);
@@ -2257,6 +2260,9 @@ int emit_slice_when_chunk_inspect_expr(Compiler *c, int id, Buf *b) {
     Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, pr, &rb);
     emit_indent(g_pre, g_indent);
     buf_printf(g_pre, "sp_IntArray *_t%d = %s;\n", ta, rb.p ? rb.p : ""); free(rb.p);
+    /* rooted like the two arrays built below it: the length is the loop
+       bound, re-read every turn, and the block runs between two reads */
+    emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", ta);
     emit_indent(g_pre, g_indent);
     buf_printf(g_pre, "sp_PtrArray *_t%d = sp_PtrArray_new(); SP_GC_ROOT(_t%d);\n", tout, tout);
     emit_indent(g_pre, g_indent);
@@ -2306,6 +2312,8 @@ int emit_slice_when_chunk_inspect_expr(Compiler *c, int id, Buf *b) {
   Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, pr, &rb);
   emit_indent(g_pre, g_indent);
   buf_printf(g_pre, "sp_IntArray *_t%d = %s;\n", ta, rb.p ? rb.p : ""); free(rb.p);
+  /* rooted for the walk, as the slice_when arm above roots its receiver */
+  emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", ta);
   emit_indent(g_pre, g_indent);
   buf_printf(g_pre, "sp_IntArray *_t%d = sp_IntArray_new(); SP_GC_ROOT(_t%d);\n", tkeys, tkeys);
   emit_indent(g_pre, g_indent);
@@ -3719,9 +3727,20 @@ int emit_each_with_index_chain(Compiler *c, int id, Buf *b) {
   int ta = ++g_tmp, tacc = ++g_tmp, ti = ++g_tmp, tidx = ++g_tmp;
   buf_puts(b, "({ ");
   emit_ctype(c, rt, b); buf_printf(b, " _t%d = ", ta); emit_expr(c, arr, b); buf_puts(b, "; ");
+  /* rooted the way emit_reduce_block_expr roots its own hoist: the loop below
+     re-reads this temp's length as its bound and takes the element out of it
+     every turn, with the block running in between */
+  emit_gc_root_tmp(c, rt, ta, b); buf_puts(b, " ");
   emit_ctype(c, acc_ty, b); buf_printf(b, " _t%d = ", tacc);
   if (init >= 0) emit_expr(c, init, b); else buf_puts(b, "0");
   buf_puts(b, "; ");
+  /* and the accumulator, for the reason emit_reduce_block_expr gives: it is
+     rebound to the block's fresh answer every turn, and the next block body
+     allocates before it reads it. With only the receiver rooted, a String seed
+     came back 3 characters of 112 under GC stress. Same guard as there. */
+  if (needs_root(acc_ty) && !comp_ty_value_obj(c, acc_ty)) {
+    emit_gc_root_tmp(c, acc_ty, tacc, b); buf_puts(b, " ");
+  }
   buf_printf(b, "sp_int _t%d = ", tidx);
   if (off >= 0) emit_expr(c, off, b); else buf_puts(b, "0");
   buf_puts(b, "; ");
@@ -4182,6 +4201,10 @@ int emit_sort_cmp_expr(Compiler *c, int id, Buf *b) {
 else {
     emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre);
     buf_printf(g_pre, " _t%d = _t%d;\n", tr, trv);  /* sort! operates on self */
+    /* rooted like the copy the non-bang arm sorts: the comparator below is
+       user code, and the array it sorts in place has no other holder when
+       the receiver was a temporary */
+    emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", tr);
   }
   /* Bottom-up merge sort: stable, and O(n log n) comparisons. (A bubble sort
      with the comparator inlined was quadratic -- a 40K-element sort took five
@@ -4353,6 +4376,11 @@ int emit_minmax_cmp_expr(Compiler *c, int id, Buf *b) {
   int trv = ++g_tmp, tn = ++g_tmp, tmin = ++g_tmp, tmax = ++g_tmp, ti = ++g_tmp, te = ++g_tmp, tres = ++g_tmp;
   Buf rb; memset(&rb, 0, sizeof rb); emit_expr(c, recv, &rb);
   emit_indent(g_pre, g_indent); emit_ctype(c, rt, g_pre); buf_printf(g_pre, " _t%d = ", trv); buf_puts(g_pre, rb.p ? rb.p : ""); buf_puts(g_pre, ";\n"); free(rb.p);
+  /* the length is hoisted once, but every turn takes its element out of this
+     temp after the comparator has run, and the comparator is user code that
+     allocates: rooted. A range or hash receiver arrives here already rooted
+     by the arm above that materialized it, and takes a second slot. */
+  emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", trv);
   emit_indent(g_pre, g_indent); buf_printf(g_pre, "sp_int _t%d = sp_%sArray_length(_t%d);\n", tn, k, trv);
   emit_indent(g_pre, g_indent); emit_ctype(c, et, g_pre);
   /* An empty comparator reduction returns nil, so use the carrier's nil
@@ -4673,6 +4701,9 @@ int emit_collect_expr(Compiler *c, int id, Buf *b) {
             Buf rb_es; memset(&rb_es, 0, sizeof rb_es); emit_expr(c, es_recv, &rb_es);
             emit_indent(g_pre, g_indent); emit_ctype(c, arr_rt, g_pre);
             buf_printf(g_pre, " _t%d = %s;\n", ta_es, rb_es.p ? rb_es.p : ""); free(rb_es.p);
+            /* rooted like the result array below: the length is the loop
+               bound and the block runs between two reads of it */
+            emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", ta_es);
             emit_indent(g_pre, g_indent);
             buf_printf(g_pre, "sp_int _t%d = ", ts_es); emit_int_expr(c, es_argv[0], g_pre); buf_puts(g_pre, ";\n");
             emit_indent(g_pre, g_indent);
@@ -4749,6 +4780,9 @@ int emit_collect_expr(Compiler *c, int id, Buf *b) {
             Buf rb_ec; memset(&rb_ec, 0, sizeof rb_ec); emit_expr(c, ec_recv, &rb_ec);
             emit_indent(g_pre, g_indent); emit_ctype(c, arr_ec, g_pre);
             buf_printf(g_pre, " _t%d = %s;\n", ta_ec, rb_ec.p ? rb_ec.p : ""); free(rb_ec.p);
+            /* rooted like the result array below, for the same reason as the
+               each_slice chain above */
+            emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", ta_ec);
             emit_indent(g_pre, g_indent);
             buf_printf(g_pre, "sp_int _t%d = ", tn_ec); emit_int_expr(c, ec_argv[0], g_pre); buf_puts(g_pre, ";\n");
             emit_indent(g_pre, g_indent);
@@ -4849,6 +4883,8 @@ int emit_collect_expr(Compiler *c, int id, Buf *b) {
               Buf rb_wi; memset(&rb_wi, 0, sizeof rb_wi); emit_expr(c, ec_recv2, &rb_wi);
               emit_indent(g_pre, g_indent); emit_ctype(c, arr_wi, g_pre);
               buf_printf(g_pre, " _t%d = %s;\n", ta_wi, rb_wi.p ? rb_wi.p : ""); free(rb_wi.p);
+              /* rooted like the result array below, as the each_cons chain is */
+              emit_indent(g_pre, g_indent); buf_printf(g_pre, "SP_GC_ROOT(_t%d);\n", ta_wi);
               emit_indent(g_pre, g_indent);
               buf_printf(g_pre, "sp_int _t%d = ", tn_wi); emit_int_expr(c, ec_argv2[0], g_pre); buf_puts(g_pre, ";\n");
               emit_indent(g_pre, g_indent);

--- a/test/fold_hoist_root.rb
+++ b/test/fold_hoist_root.rb
@@ -1,0 +1,129 @@
+# Nine more hoists in the fold file copy their receiver into a C temporary
+# and read it again on every turn -- as the loop bound, or as the container the
+# element comes out of -- while the block between two turns allocates. Every
+# receiver here is a method's answer, so nothing but that temporary holds it,
+# and every block allocates before it looks at what it was given: a receiver
+# collected mid-walk shows up as a short count, an empty answer or a crash,
+# never as a passing test. The local-receiver arms are the control: a local is
+# itself a root, so those were always safe. The with_index chain also rebinds
+# its accumulator to a fresh answer every turn, and that slot is rooted here
+# as the reduce emitter's already is.
+
+ENTRIES = 40
+CHURN = 100
+
+def churn
+  CHURN.times { "q" * 64 }
+end
+
+def make_array
+  (1..ENTRIES).map { |i| "a#{i}" }
+end
+
+def make_ints
+  (1..ENTRIES).map { |i| i.odd? ? i : i + 100 }
+end
+
+# --- each_slice(n).map, each_cons(n).map, each_cons(n).with_index.map ---
+
+n = 0
+r = make_array.each_slice(2).map { |w| churn; n += 1; w.size }
+puts "each_slice map n=#{n} out=#{r.size}"
+
+n = 0
+r = make_array.each_slice(3).map { |a, b, c| churn; n += 1; "#{a}#{b}#{c}" }
+puts "each_slice map params n=#{n} out=#{r.size} last=#{r.last}"
+
+n = 0
+r = make_array.each_cons(2).map { |w| churn; n += 1; w.size }
+puts "each_cons map n=#{n} out=#{r.size}"
+
+n = 0
+r = make_array.each_cons(2).map { |a, b| churn; n += 1; a + b }
+puts "each_cons map params n=#{n} out=#{r.size} last=#{r.last}"
+
+n = 0
+r = make_array.each_cons(2).with_index.map { |w, i| churn; n += 1; w.size + i }
+puts "each_cons with_index map n=#{n} out=#{r.size} last=#{r.last}"
+
+n = 0
+r = make_array.each_cons(2).with_index(1).map { |(a, b), i| churn; n += 1; "#{a}#{b}#{i}" }
+puts "each_cons with_index offset map n=#{n} out=#{r.size} last=#{r.last}"
+
+# --- slice_when, chunk ---
+
+n = 0
+r = make_ints.slice_when { |a, b| churn; n += 1; b != a + 1 }.to_a.inspect
+puts "slice_when n=#{n} len=#{r.length}"
+
+n = 0
+r = make_ints.chunk { |x| churn; n += 1; x % 2 }.to_a.inspect
+puts "chunk n=#{n} len=#{r.length}"
+
+# --- max / min / minmax with a comparator block ---
+
+n = 0
+r = make_array.max { |x, y| churn; n += 1; x <=> y }
+puts "max n=#{n} r=#{r.inspect}"
+
+n = 0
+r = make_array.min { |x, y| churn; n += 1; x <=> y }
+puts "min n=#{n} r=#{r.inspect}"
+
+r = make_ints.minmax { |x, y| churn; x <=> y }
+puts "minmax r=#{r.inspect}"
+
+# --- sort! with a comparator block ---
+
+n = 0
+r = make_array.sort! { |x, y| churn; n += 1; x <=> y }
+puts "sort! size=#{r.size} first=#{r.first.inspect} last=#{r.last.inspect}"
+
+n = 0
+r = make_ints.sort! { |x, y| churn; n += 1; y <=> x }
+puts "sort! ints size=#{r.size} first=#{r.first} last=#{r.last}"
+
+# --- sum(seed) with a block on the String, Integer and Float accumulators ---
+
+n = 0
+r = make_array.sum("") { |x| churn; n += 1; x }
+puts "sum string n=#{n} len=#{r.length}"
+
+n = 0
+r = make_ints.sum(0) { |x| churn; n += 1; x }
+puts "sum int n=#{n} r=#{r}"
+
+n = 0
+r = make_ints.sum(0.5) { |x| churn; n += 1; x }
+puts "sum float n=#{n} r=#{r}"
+
+# --- each.with_index(off).inject: the receiver, then the accumulator ---
+
+n = 0
+r = make_array.each.with_index(1).inject("z") { |acc, (x, i)| churn; n += 1; acc }
+puts "with_index inject n=#{n} r=#{r.inspect}"
+
+n = 0
+r = make_array.each.with_index(1).inject("z") { |acc, (x, i)| churn; n += 1; acc + x }
+puts "with_index inject string acc n=#{n} len=#{r.length}"
+
+n = 0
+ri = make_ints.each.with_index(1).inject(0) { |acc, (v, j)| churn; n += 1; acc + v + j }
+puts "with_index inject int acc n=#{n} r=#{ri}"
+
+# --- controls: the same walks over a receiver held in a local ---
+
+held = make_array
+n = 0
+r = held.each_cons(2).map { |w| churn; n += 1; w.size }
+puts "control each_cons map n=#{n} out=#{r.size}"
+
+held = make_array
+n = 0
+r = held.max { |x, y| churn; n += 1; x <=> y }
+puts "control max n=#{n} r=#{r.inspect}"
+
+held = make_array
+n = 0
+r = held.sort! { |x, y| churn; n += 1; x <=> y }
+puts "control sort! size=#{r.size} first=#{r.first.inspect}"

--- a/test/fold_hoist_root.rb.expected
+++ b/test/fold_hoist_root.rb.expected
@@ -1,0 +1,22 @@
+each_slice map n=20 out=20
+each_slice map params n=14 out=14 last=a40
+each_cons map n=39 out=39
+each_cons map params n=39 out=39 last=a39a40
+each_cons with_index map n=39 out=39 last=40
+each_cons with_index offset map n=39 out=39 last=a39a4039
+slice_when n=39 len=255
+chunk n=40 len=455
+max n=39 r="a9"
+min n=39 r="a1"
+minmax r=[1, 140]
+sort! size=40 first="a1" last="a9"
+sort! ints size=40 first=140 last=1
+sum string n=40 len=111
+sum int n=40 r=2820
+sum float n=40 r=2820.5
+with_index inject n=40 r="z"
+with_index inject string acc n=40 len=112
+with_index inject int acc n=40 r=3640
+control each_cons map n=39 out=39
+control max n=39 r="a9"
+control sort! size=40 first="a1"


### PR DESCRIPTION
## Why

A fold over an array a method just returned should visit every element, however much the block allocates. In Spinel, nine hoists in six emitters of the fold file did not guarantee that. They copy the receiver into a C temporary and read that temporary again on every turn, as the loop bound or as the container the element comes out of, and nothing else holds the array while the block runs. A collection landing inside the block freed the array mid-walk.

Concretely, on an ordinary release build of master at `d1cac2ec`. These are counts from two programs, and which turn a collection lands on belongs to the binary; the invariant is that the walk is short or the answer wrong. In a probe over forty-element arrays of Strings and of Integers that a method returned: `each_cons(2).map` ran 29 of 39 turns, and so did `each_cons(2).with_index.map`; `slice_when { }.to_a.inspect` answered 53 characters where CRuby answers 255; `max { |a, b| }` and `min { |a, b| }` answered `""` where CRuby answers `"a9"` and `"a1"`; `sort! { |a, b| }` put nil at both ends of the array; `each.with_index(1).inject { }` ran 14 of 40 turns. In the test program, `sum("") { }` answered 78 characters where CRuby answers 111, `sum(0) { }` over Integers raised `nil can't be coerced into Integer`, and `slice_when` answered 183 characters; `sum("") { }` died outright when that arm ran on its own. Under `SPINEL_GC_STRESS=1` the same walks run a turn or two, answer wrongly, or die, and which of the three varies run to run. A receiver held in a local was always safe, because the local is a root; that is what made these easy to miss.

This is the rule #4369 applied to ten hoists in this file, at nine more of its sites. The comparator emitters, `max`, `min` and `sort!`, and the typed `sum` arm hoist the length once, so nothing re-reads the temporary as a loop bound and the scan that found the first ten, which looked only for that, could not see them; the rest were simply not in the programs whose C that scan read. Run on this test's generated C, the same scan flags seven of the nine on master and none on this branch. Every turn still takes its element out of the temporary after the block has run.

## What

Each hoisted receiver gains the same `SP_GC_ROOT` the rooted emitters in this file already emit, immediately after the hoist: the `each_slice(n).map`, `each_cons(n).map` and `each_cons(n).with_index(off).map` chains in `emit_collect_expr`; the `slice_when` and `chunk` arms of `emit_slice_when_chunk_inspect_expr`; `emit_minmax_cmp_expr`, which serves `max`, `min` and `minmax` with a comparator block; the `sort!` arm of `emit_sort_cmp_expr`, whose non-bang arm already rooted the copy it sorts; the Integer, Float and String accumulator arm of `emit_sum_block_expr`, whose poly-accumulator arm already rooted its receiver; and `emit_each_with_index_chain`, through `emit_gc_root_tmp` as `emit_reduce_block_expr` does.

The with_index chain also rebinds its accumulator to the block's fresh answer on every turn, and the next block body allocates before it reads it. With only the receiver rooted, `inject("z") { |acc, (x, i)| acc + x }` came back three characters long under GC stress and 36 on a plain build, where CRuby answers 112. The accumulator is rooted the way `emit_reduce_block_expr` roots its own, under the same guard, so a value-type object is not handed to the root stack as a pointer.

One root statement per fold in the generated C, held for the duration of that fold, and two for the with_index chain: the test's own generated C gains twenty-four. A `max`, `min` or `minmax` over a Range or a Hash arrives at the comparator emitter already rooted by the arm that materialized it into an array, and takes a second slot there. No change to the runtime library and no new allocation: a root is a push and a pop around the fold.

## How

Each root removes exactly its own casualty. Removing the ten roots one at a time, rebuilding the compiler and running the test on a plain build three times each, every build fails on the arm that root serves, seven of them by printing a different line and three by dying at that arm before the later arms run, and no build fails on an arm another root serves: without the `each_slice` root the three-parameter slice walk runs 9 of 14 turns; without the `each_cons` root the pair walk runs 24 of 39; without the `each_cons` with_index chain's root it runs 4 of 39; without the `slice_when` root its walk runs 13 of 39 and answers 79 characters; without the `chunk` root, 2 of 40 and 22 characters; without the comparator root `max` answers `""`, or the run dies; without the `sort!` root the array comes back with nil at both ends, or the run dies; without the typed `sum` root the run dies; without the with_index inject's receiver root it runs 25 of 40 turns, and without its accumulator root every turn runs and the String comes back 81 characters long where CRuby answers 112. With all ten in place the test matches CRuby in every run.

## Validation

`test/fold_hoist_root.rb.expected` is the output of `ruby test/fold_hoist_root.rb` under CRuby 4.0.6, and it regenerates byte for byte. Every receiver under test is a method's answer, the three controls deliberately hold theirs in a local, every block allocates before it looks at what it was given, and every arm prints its answer, all but the `minmax` and `sort!` arms with their turn count, so a receiver or accumulator lost mid-walk shows up as a changed line rather than a passing test. Twenty-two arms cover the three `map` chains in their block-parameter forms, `slice_when` and `chunk`, `max`, `min` and `minmax`, `sort!` over Strings and Integers, `sum` with a String, Integer and Float seed, the with_index chain with a String accumulator the block hands back unchanged, a String accumulator it appends to, and an Integer one, and three local-receiver controls. Compiled, it runs in well under a tenth of a second.

Master fails it in every run. The plain runs print up to fourteen lines, thirteen of which differ from CRuby, and then die on the coerced nil in the `sum` arms; the stress runs segfault, normally before any output is flushed. This branch matches the expected file in every run, plain and stressed, three of three each.

On `d1cac2ec` the 3542-test suite and the 61 benchmarks pass, optcarrot is unchanged at 59662, the generated C of 49 existing programs changes, and after removing the added root statements from both sides the residual diff is zero lines in all 49, with their output unchanged; there is no new inference non-convergence, and the one program whose fixpoint round count differs is the one the gate marks noise-prone and that moves on master against itself; the 2131-program compatibility corpus holds at 906 passing, with none gained and none lost. `test/fold_hoist_root.rb` is additionally clean under GC stress and under AddressSanitizer over its generated C, plain and stressed.

## Left alone, on purpose

The `minmax` arm pins its answer and not its comparison count: CRuby hands `minmax` its elements in pairs, which the emitter's own comment records, and so makes 58 comparisons over forty elements where Spinel makes 78. The boxed-poly arm of `uniq { }` hoists the same way and is not touched here: its result is discarded on both trees, it answers nil, so no program can observe a wrong answer from it, only a short walk in a counter the block keeps. Making that arm answer at all is a separate rule. The blockless symbol fold, `inject(:+)`, is a different emitter again, and it still holds its receiver and its String accumulator bare: `(1..40).map { |i| "a#{i}" }.inject(:+)` answers an empty or truncated String under GC stress on master and on this branch alike, and it is the next site. Two shapes around the with_index chain misbehave on master and this branch alike, neither a rooting question: an Array seed with `acc + [x]` refuses the C build, and the `|acc, pair|` form with an Integer accumulator reads its element as nil.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for enumerable operations such as slicing, grouping, sorting, indexing, summation, and aggregation when garbage collection occurs during iteration.
  - Fixed issues that could affect temporary receivers and accumulated results in chained enumerable workflows, including comparator-based operations and block-driven reductions.
  - Added coverage for method-returned receivers, mutable accumulators, and allocation-heavy iteration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->