### PR TITLE
A blockless String fold roots the array it walks

### DIFF
--- a/src/codegen_fold.c
+++ b/src/codegen_fold.c
@@ -3234,6 +3234,15 @@ int emit_inject_expr(Compiler *c, int id, Buf *b) {
 
   int ta = ++g_tmp, tacc = ++g_tmp, ti = ++g_tmp, tn = ++g_tmp;
   buf_printf(b, "({ sp_%sArray *_t%d = ", k, ta); emit_expr(c, recv, b);
+  /* The String arm is the one of the three that allocates between turns:
+     every sp_str_concat below builds a fresh String, and the loop takes the
+     next element out of this temp after it. An array a method call returned
+     has no other holder, so a collection landing in the concat freed it
+     mid-walk. Nothing the Integer and Float arms' walk continues past
+     allocates, so they keep the bare hoist. The accumulator needs no root of
+     its own: sp_str_concat roots its arguments on entry, and nothing runs
+     between one turn's answer and the next turn's call. */
+  if (str_op) buf_printf(b, "; SP_GC_ROOT(_t%d)", ta);
   buf_printf(b, "; sp_int _t%d = sp_%sArray_length(_t%d); ", tn, k, ta);
   emit_ctype(c, et, b); buf_printf(b, " _t%d = ", tacc);
   int start;

--- a/test/inject_symbol_root.rb
+++ b/test/inject_symbol_root.rb
@@ -1,0 +1,76 @@
+# The blockless symbol fold, `inject(:+)` over an array of Strings, copies its
+# receiver into a C temporary and reads the next element out of it on every
+# turn, while the concatenation between two turns allocates a fresh String.
+# Every receiver here is a method's answer, so nothing but that temporary holds
+# it; the accumulator is likewise reassigned from each fresh String and read
+# back by the next turn. Either one collected mid-walk shows up as a short
+# answer, a different tail or a crash, never as a passing test. The
+# local-receiver arm is the control: a local is itself a root. The Integer and
+# Float folds allocate nothing between turns and are here to show that arm's
+# answers are unchanged.
+
+ENTRIES = 40
+BIG = 3000
+
+def make_array
+  (1..ENTRIES).map { |i| "a#{i}" }
+end
+
+def make_big
+  (1..BIG).map { |i| "s#{i}-" }
+end
+
+def make_ints
+  (1..ENTRIES).map { |i| i * 3 }
+end
+
+def make_floats
+  (1..ENTRIES).map { |i| i * 0.5 }
+end
+
+def make_empty
+  [].map { |i| "x#{i}" }
+end
+
+def show(label, s)
+  if s.nil?
+    puts "#{label} nil"
+  else
+    puts "#{label} len=#{s.length} head=#{s[0, 6]} tail=#{s[-6, 6]}"
+  end
+end
+
+# --- the four spellings of the symbol fold over a method's answer ---
+
+show("inject sym", make_array.inject(:+))
+show("reduce sym", make_array.reduce(:+))
+show("inject block-sym", make_array.inject(&:+))
+show("reduce block-sym", make_array.reduce(&:+))
+
+# --- seeded folds: the seed is the first accumulator ---
+
+show("inject seed sym", make_array.inject("z", :+))
+show("reduce seed block-sym", make_array.reduce("z", &:+))
+
+# --- a long walk, so the concatenations reach a collection on a plain build ---
+
+show("inject big", make_big.inject(:+))
+show("inject big seed", make_big.inject("Z", :+))
+
+# --- edge shapes: empty and single-element receivers ---
+
+show("inject empty", make_empty.inject(:+))
+show("inject empty seed", make_empty.inject("e", :+))
+show("inject one", make_array.first(1).inject(:+))
+
+# --- the arms this fold shares: Integer and Float folds, unchanged ---
+
+puts "inject ints #{make_ints.inject(:+)} #{make_ints.reduce(:-)}"
+puts "inject floats #{make_floats.inject(:+)} #{make_floats.reduce(2.0, :+)}"
+
+# --- control: the same fold over a receiver held in a local ---
+
+held = make_array
+show("control inject sym", held.inject(:+))
+held = make_big
+show("control inject big", held.inject(:+))

--- a/test/inject_symbol_root.rb.expected
+++ b/test/inject_symbol_root.rb.expected
@@ -1,0 +1,15 @@
+inject sym len=111 head=a1a2a3 tail=a39a40
+reduce sym len=111 head=a1a2a3 tail=a39a40
+inject block-sym len=111 head=a1a2a3 tail=a39a40
+reduce block-sym len=111 head=a1a2a3 tail=a39a40
+inject seed sym len=112 head=za1a2a tail=a39a40
+reduce seed block-sym len=112 head=za1a2a tail=a39a40
+inject big len=16893 head=s1-s2- tail=s3000-
+inject big seed len=16894 head=Zs1-s2 tail=s3000-
+inject empty nil
+inject empty seed len=1 head=e tail=
+inject one len=2 head=a1 tail=
+inject ints 2460 -2454
+inject floats 410.0 412.0
+control inject sym len=111 head=a1a2a3 tail=a39a40
+control inject big len=16893 head=s1-s2- tail=s3000-


### PR DESCRIPTION
## Why

`arr.inject(:+)` over an array of Strings should answer the concatenation of every element, however large the array. In Spinel it did not always. The typed arm of the blockless symbol fold copies the receiver into a C temporary and takes the next element out of that temporary on every turn, and the concatenation between two turns allocates the fresh String that becomes the accumulator. An array a method call returned has no other holder, so a collection landing inside the concatenation freed the array mid-walk.

Concretely, on an ordinary release build of master at `d1cac2ec`, with no GC stress: in the test program, `inject(:+)` over 3000 Strings a method returned answers 872 characters ending in `-s196-` where CRuby answers 16893 ending in `s3000-`, and the seeded `inject("Z", :+)` over another array of the same shape answers 3893 where CRuby answers 16894, in three of three runs. AddressSanitizer over the generated C reports a heap-use-after-free: the read is the element fetch in `sp_StrArray_get` on that line, and the free is the collection inside `sp_str_concat` on the same line. The forty-element folds in the same program answer correctly on a plain run of that build and fail under `SPINEL_GC_STRESS=1`, where a three-line probe over forty Strings prints a twelve-character fragment or dies. Which turn the collection lands on belongs to the binary; the invariant is that the walk reads an array nothing holds.

This is the rule #4369 applied at one more site. Two of the three arms above it in the same function, the ones that fold over boxed values, already root their receiver. The typed arm, which serves an array of Integers, Floats or Strings folded with a symbol, was the one left bare. #4371 later rooted the fold with a block, receiver and accumulator together, and its body records that #4369 had left the block fold out because rooting its receiver alone moved the fault. That warning was about the block fold, whose block allocates before it reads the accumulator. The fold without a block has no such step, and the measurement below is what says so.

## What

In the typed arm of `emit_inject_expr`, the hoisted receiver gains an `SP_GC_ROOT` immediately after the hoist, only when the operator is `+` over Strings. The root is guarded on that case, so the generated C of the Integer and Float folds is unchanged; nothing their walk continues past allocates. One root statement per String fold in the generated C, held for the duration of that fold: the test's own generated C gains thirteen. No change to the runtime library and no new allocation.

The accumulator gets no root of its own here, and that was measured, not assumed: a version of this change that rooted it too was built, and with that root removed and the receiver root kept the test matched CRuby in three plain runs and one AddressSanitizer run. `sp_str_concat` roots both its arguments on entry, and nothing runs between one turn's answer and the next turn's call, so the accumulator is never bare across an allocation. The fold with a block is different, because its block allocates before it reads the accumulator, and that is why #4371 roots it there.

## How

The pins were run on the two-root version. With the receiver root removed and the accumulator root kept, rebuilding the compiler and running the test on a plain build, the two 3000-element arms come back short in three of three runs, and under AddressSanitizer the element read in `sp_StrArray_get` follows the free inside `sp_str_concat`'s collection, on the same line of the test. With the accumulator root removed and the receiver root kept, the test matches CRuby, plain and under AddressSanitizer, and that is the version here. With the receiver root in place the test matches CRuby in every run.

## Validation

`test/inject_symbol_root.rb.expected` is the output of `ruby test/inject_symbol_root.rb` under CRuby 4.0.6, and it regenerates byte for byte. Every receiver under test is a method's answer, the two controls hold theirs in a local, and every String arm that answers a String prints its length with its head and tail, so an array lost mid-walk shows up as a changed line rather than a passing test. Fifteen arms cover the four spellings `inject(:+)`, `reduce(:+)`, `inject(&:+)` and `reduce(&:+)`, the seeded `inject("z", :+)` and `reduce("z", &:+)`, the two 3000-element walks, an empty receiver with and without a seed, a one-element receiver, the Integer and Float folds through the same arm, and the two local-receiver controls. Compiled with this branch's release build, it runs in 0.007 seconds.

Master fails it in every run: on a plain build the two long arms, three of three, and under `SPINEL_GC_STRESS=1` eight of the String arms, with one run of three dying before it printed anything. This branch matches the expected file in every run, plain and stressed, three of three each, and is clean under AddressSanitizer over its generated C, plain and stressed.

On `d1cac2ec` the 3542-test suite and the 61 benchmarks pass, optcarrot is unchanged at 59662, and the generated C of no existing program changes: across the 3554 programs of the sweep the only file whose C differs is this test's own; there is no new inference non-convergence, and the one program whose fixpoint round count differs is the one the gate marks noise-prone and that moves on master against itself; the 2131-program compatibility corpus holds at 906 passing, with none gained and none lost.

## Left alone, on purpose

The Integer and Float arms of the same emitter keep their bare hoist. Nothing their walk continues past allocates, and rooting them would put a push and a pop into every integer fold for no casualty. The first arm of the function, which folds a literal of Integer arrays with a set operation, does not root its receiver either. That receiver is always a literal the statement has already spilled into a rooted temporary, and a 300-element fold through it matches CRuby on master, plain and stressed. The blockless `sum("")`, `join`, and the fold with a block over a 3000-element array of the same shape answer correctly on master. The fold with a block was rooted by #4371, and `sum("")` with a block, whose typed arm hoists the same way and fails the same way under GC stress, is rooted by #4402. A fold over a Hash value, `h["k"].inject(:+)`, goes through the runtime's `sp_poly_inject_sym` instead of this emitter and answers 12 characters where CRuby answers 111 under GC stress on master and this branch alike. That is a root in the runtime library, a separate change. `reduce(:*)` over forty small Integers raises `integer overflow in *` where CRuby promotes to a Bignum, so the test folds with `:-` instead. That is the integer overflow policy, not a rooting question. `inject(:-)`, `inject(:*)` and `inject(:<<)` over Strings are NoMethodError on `inject` itself where CRuby raises on the operator or, for `:<<`, mutates the first element, and `inject(:concat)` answers correctly without mutating it. All of it is identical on master and this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `inject` and `reduce` operations on String arrays returned by methods, preventing failures when processing larger or edge-case inputs.
  * Preserved existing behavior for Integer and Float reductions.
  * Improved reliability for seeded, unseeded, and block-symbol forms, including empty and single-element arrays.

* **Tests**
  * Added regression coverage for String, Integer, and Float fold operations across typical and boundary-sized inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->