### PR TITLE
A request header value carrying CR or LF is refused, not written

### DIFF
--- a/packages/net/net/http.rb
+++ b/packages/net/net/http.rb
@@ -123,7 +123,21 @@ module Net
       @headers = {}
       @header_names = {}
       @body = ""
-      initheader.each { |k, v| self[k] = v } unless initheader.nil?
+      # CRuby's initheader half strips the value before it looks at it, and
+      # so raises NoMethodError for anything without `strip`; this package
+      # strips a String and lets the other shapes through to `#[]=`, as it
+      # already did. So a trailing newline here is whitespace, and the
+      # message names the header where `#[]=`'s does not. Both are kept, so a
+      # caller rescuing on the message sees the one CRuby raises.
+      unless initheader.nil?
+        initheader.each do |k, v|
+          v = v.strip if v.is_a?(String)
+          if v.is_a?(String) && crlf?(v)
+            raise ArgumentError, "header #{k} has field value #{v.inspect}, this cannot include CR/LF"
+          end
+          self[k] = v
+        end
+      end
     end
 
     # Header names are case-insensitive on the wire, and CRuby's
@@ -146,10 +160,15 @@ module Net
       #
       # CRuby only reaches that path through `#[]=`; its initheader half calls
       # `value.strip` per value and so raises NoMethodError for an Array. This
-      # package routes initheader through `#[]=` and therefore accepts one -- a
-      # deliberate divergence, in the permissive direction, and one rule for one
-      # value shape rather than two.
-      @headers[k] = value.is_a?(Array) ? value.map { |v| v.to_s }.join(", ") : value.to_s
+      # package routes initheader through `#[]=` and therefore accepts one whose
+      # elements are clean -- a deliberate divergence, in the permissive
+      # direction, and one rule for one value shape rather than two. An element
+      # carrying a break is refused below, like any other value.
+      text = value.is_a?(Array) ? value.map { |v| v.to_s }.join(", ") : value.to_s
+      # The joined text carries every element's bytes, so one check covers a
+      # break in any element as well as in a scalar.
+      raise ArgumentError, "header field value cannot include CR/LF" if crlf?(text)
+      @headers[k] = text
       @header_names[k] = name.to_s
       value
     end
@@ -180,6 +199,14 @@ module Net
       @body = URI.encode_www_form(hash)
       self["Content-Type"] = "application/x-www-form-urlencoded"
       @body
+    end
+
+    private
+
+    # A carriage return or a line feed in a header value would end the
+    # header on the wire and make whatever follows it a header of its own.
+    def crlf?(text)
+      text.include?("\r") || text.include?("\n")
     end
   end
 

--- a/packages/net/test/net_http_header_crlf.rb
+++ b/packages/net/test/net_http_header_crlf.rb
@@ -1,0 +1,58 @@
+# A request header value that carries a carriage return or a line feed is
+# refused with ArgumentError, the way CRuby's Net::HTTPHeader refuses it,
+# instead of being stored and written between the header name and its CRLF
+# on the wire, where the text after the break becomes a header of its own.
+# Every line here is diffed against CRuby's own net/http; nothing touches the
+# network. The two entry points have different messages in CRuby and both
+# are pinned: `[]=` names no header, the initheader form names the header and
+# inspects the value, and it strips the value first, so a trailing newline
+# there is whitespace, not an injection.
+require "net/http"
+
+def try(label)
+  yield
+  puts "#{label}: accepted"
+rescue ArgumentError => e
+  puts "#{label}: ArgumentError: #{e.message}"
+end
+
+req = Net::HTTP::Get.new("/")
+
+try("cr") { req["X-Note"] = "hello\rX-Injected: yes" }
+try("lf") { req["X-Note"] = "hello\nX-Injected: yes" }
+try("crlf") { req["X-Note"] = "hello\r\nX-Injected: yes" }
+try("trailing lf") { req["X-Note"] = "hello\n" }
+try("array element") { req["X-Multi"] = ["one", "two\nX-Injected: yes"] }
+try("array element cr") { req["X-Multi"] = ["one\r", "two"] }
+puts "after refusals key? #{req.key?("X-Note")} #{req.key?("X-Multi")}"
+
+try("plain") { req["X-Note"] = "hello" }
+try("spaces kept") { req["X-Pad"] = " padded " }
+try("array") { req["X-Multi"] = ["one", "two"] }
+try("integer") { req["X-Num"] = 7 }
+puts "stored #{req["X-Note"].inspect} #{req["X-Pad"].inspect} #{req["X-Multi"].inspect} #{req["X-Num"].inspect}"
+
+try("initheader lf") { Net::HTTP::Get.new("/", "X-Note" => "hello\nX-Injected: yes") }
+try("initheader cr") { Net::HTTP::Post.new("/", "X-Note" => "a\rb") }
+try("initheader crlf") { Net::HTTP::Get.new("/", "Content-Type" => "text/plain\r\nX-Injected: yes") }
+try("initheader second key") { Net::HTTP::Get.new("/", "X-A" => "ok", "X-B" => "bad\n") }
+# CRuby strips the value before it checks it and so raises NoMethodError for an
+# Array there; this package joins the Array and refuses the break with
+# ArgumentError. Both refuse, which is what a caller can rely on.
+begin
+  Net::HTTP::Get.new("/", "X-Multi" => ["one", "two\nX-Injected: yes"])
+  puts "initheader array element: accepted"
+rescue StandardError
+  puts "initheader array element: refused"
+end
+
+r = Net::HTTP::Get.new("/", "X-Note" => "hello\n", "X-Pad" => " padded ")
+puts "initheader stripped #{r["X-Note"].inspect} #{r["X-Pad"].inspect}"
+r = Net::HTTP::Post.new("/", "Content-Type" => "text/plain")
+puts "initheader plain #{r["Content-Type"].inspect}"
+
+# Appending to what `[]` answers does not raise, and reads back the same.
+q = Net::HTTP::Get.new("/")
+q["Y"] = "vv"
+q["Y"] << "!"
+puts "append to stored #{q["Y"].inspect}"

--- a/packages/net/test/net_http_header_crlf.rb.expected
+++ b/packages/net/test/net_http_header_crlf.rb.expected
@@ -1,0 +1,20 @@
+cr: ArgumentError: header field value cannot include CR/LF
+lf: ArgumentError: header field value cannot include CR/LF
+crlf: ArgumentError: header field value cannot include CR/LF
+trailing lf: ArgumentError: header field value cannot include CR/LF
+array element: ArgumentError: header field value cannot include CR/LF
+array element cr: ArgumentError: header field value cannot include CR/LF
+after refusals key? false false
+plain: accepted
+spaces kept: accepted
+array: accepted
+integer: accepted
+stored "hello" " padded " "one, two" "7"
+initheader lf: ArgumentError: header X-Note has field value "hello\nX-Injected: yes", this cannot include CR/LF
+initheader cr: ArgumentError: header X-Note has field value "a\rb", this cannot include CR/LF
+initheader crlf: ArgumentError: header Content-Type has field value "text/plain\r\nX-Injected: yes", this cannot include CR/LF
+initheader second key: accepted
+initheader array element: refused
+initheader stripped "hello" "padded"
+initheader plain "text/plain"
+append to stored "vv"


### PR DESCRIPTION
## Why

A header value is one line on the wire. If the text a caller hands `Net::HTTPRequest#[]=` contains a carriage return or a line feed, the bytes after the break become a header of their own when the request is written, or end the header section early. CRuby's Net::HTTPHeader refuses such a value with ArgumentError before it is stored, through `[]=`, through an Array element, and through the initheader hash a request is constructed with, where it strips the value first and so accepts a newline that is only trailing whitespace. On master all three accept the break: `req["X-Note"] = "hello\r\nX-Injected: yes"` reads back verbatim, and a loopback server sees `X-Note: hello` followed by an `X-Injected: yes` header the caller never wrote. An application that puts untrusted text into a header is exposed exactly there. The external review pass filed this as its one request-integrity finding; it reproduces with no network at all.

## What

`[]=` builds the text it is about to store, the `to_s` of a scalar or the `", "` join of an Array, and raises CRuby's `header field value cannot include CR/LF` if that text contains either byte. Checking the joined text is one check for both shapes: a break in any element is in the join. The initheader path, which routed straight through `[]=`, now does what CRuby's does first: it strips each String value and raises CRuby's other message, the one that names the header and inspects the value, so a caller rescuing on the message sees the one CRuby raises, and a trailing newline in an initheader value is whitespace rather than an injection. The check itself is one private predicate on the request class, used by both paths. Values without a break are stored as they were, and `[]=` still keeps surrounding spaces as CRuby's does. An Array or an Integer in initheader is still accepted where CRuby raises NoMethodError, the package's documented permissive divergence; the one change on that path is that an Array element carrying a break is now refused too, with the `[]=` message, so both implementations refuse it, by different classes.

Two other things move, both stated here because the oracle cannot pin the first. `content_type=` goes through `[]=` in this package, and CRuby's writes its header table directly, so CRuby and master both accept `req.content_type = "text/plain\r\nX-Injected: yes"` and put the extra header on the wire, where this branch raises. That is the one place this branch is stricter than CRuby, kept on purpose, and it has no test line because CRuby accepts it. And appending to what `[]` answers no longer raises: `q["Y"] << "!"` after `q["Y"] = "vv"` raised FrozenError on master and now leaves the stored value at `"vv"`, which is what CRuby answers.

## How

The check belongs at `[]=` because nothing can change a value after it is stored. On master and on this branch alike, appending to the argument after `[]=` leaves the stored value and the wire header at `X-Note: hello`. CRuby differs there in the permissive direction: it stores the caller's String, so appending to it after `[]=` does change what CRuby sends. A check at write time in `write_request` was tried and removed, because nothing that goes through the class's own methods can reach it: every store is the one in `[]=`, `content_type=` and `set_form_data` call `[]=`, and the initheader loop calls it after its own check.

## Validation

`packages/net/test/net_http_header_crlf.rb.expected` is the output of `ruby` on that file under CRuby 4.0.6 and regenerates byte for byte. The program touches no network. It pins, through `[]=`: CR, LF, CRLF, a trailing LF, an LF in an Array element and a CR in one, all refused with CRuby's message, and `key?` false for both refused names afterwards; then a plain value, a value with surrounding spaces kept, an Array joined with `", "` and an Integer, all accepted and read back as CRuby reads them. Through initheader: LF, CR and CRLF, on `Get` and `Post`, each refused with the message that names the header and inspects the value; a second key whose value carries only a trailing newline accepted, since CRuby strips it; an Array element carrying a break refused, printed as `refused` from a rescue of StandardError because CRuby raises NoMethodError there and this package ArgumentError; and the stripped read-back of `"hello\n"` and `" padded "`. The last line appends to what `[]` answers and prints the stored value. Master fails 13 of its 20 lines: every injection is accepted, `key?` reads true, the initheader values read back unstripped, and the last line dies with FrozenError. This branch matches CRuby in three of three runs. Compiling the test on this machine's -O2 build of the branch takes between one and two seconds and the compiled program runs in under a hundredth of a second, so it is nowhere near the 10 second CI limit.

The existing package tests still match their expected output on this branch: `net_http_client.rb`, which serialises an Array header, a content type and Host through a loopback server, and `net_http_timeouts.rb`. The issue's own repro answers `ArgumentError`, as CRuby does, and the loopback program that captured the injected header on master raises before it sends on this branch.

## Left alone, on purpose

CRuby does not check header names for CR or LF, and neither does this change. CRuby checks the request line, method and path, at write time with its own message, `A Request-Line must not contain CR or LF`; Spinel's `write_request` interpolates the path unchecked, which is a rule about the request line, not a header value. Two `Net::HTTPRequest` subclasses used inside blocks in one program make `req[name]` answer nil on master and on this branch alike, a miscompile in the package's `[]` and not a header rule. A `100 Continue` interim response is still taken as the final one, which the same review pass reported separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP header validation to reject values containing carriage returns or line feeds, helping prevent header injection.
  * Header values provided during initialization now have trailing newline characters removed before storage.
  * Array-based header values remain supported, with validation applied to each value.
  * Invalid initialized headers now report the affected header name in the error message.
  * Valid scalar, array, padded, and integer header values continue to be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->