### PR TITLE
A spawn opens its input file read-only and closes the files it opened

### DIFF
--- a/lib/sp_process.c
+++ b/lib/sp_process.c
@@ -2,8 +2,8 @@
  *
  * Lives in its own TU because the codegen calls sp_process_spawn
  * with pre-resolved positional args (in_fd, out_fd, err_fd, pgroup,
- * rlimit_cpu, rlimit_as, chdir). All opts-hash unpacking happens at
- * compile time in the codegen; the runtime just needs primitive int
+ * rlimit_cpu, rlimit_as, chdir, owned). All opts-hash unpacking happens
+ * at compile time in the codegen; the runtime just needs primitive int
  * / int-fd / int-pgroup / int-rlimit values. The cmd is either a
  * String or an Array (boxed as a PolyArray). args is a PolyArray of
  * extra String args appended after cmd.
@@ -18,21 +18,29 @@
  * Process.spawn(cmd, *args, opts) -> child pid
  * Process.waitpid2(pid) -> [pid, raw_status]
  *
- * opts is a PolyArray of 7 elements in this order:
- *   [0] in_fd        - Integer fd (>= 0), -1 for false/nil, IO was
- *                      resolved to its fd by the codegen, String path
- *                      was opened by the codegen
+ * opts is a PolyArray of 8 elements in this order:
+ *   [0] in_fd        - Integer fd (>= 0), -1 for false/nil/absent. An IO
+ *                      was resolved to its fd by the codegen; a String
+ *                      path was opened here, by sp_process_open_redirect,
+ *                      which the generated program calls before this
  *   [1] out_fd       - same conventions
  *   [2] err_fd       - same conventions
  *   [3] pgroup       - Integer (0=inherit, 1=new, >1=specific pgid)
  *   [4] rlimit_cpu   - Integer (seconds), nil = no limit
  *   [5] rlimit_as    - Integer (bytes), nil = no limit
  *   [6] chdir        - String path or nil
+ *   [7] owned        - Integer bit mask, bit 0/1/2 set when [0]/[1]/[2]
+ *                      is an fd sp_process_open_redirect opened for this
+ *                      spawn; those are closed here once the child has
+ *                      its copies, and on every raise this file makes
+ *                      before the fork.
+ *                      A caller's IO or Integer fd is never in the mask.
  *
- * IO and String values in opts[0..2] are resolved to fds by the
- * codegen (which has access to sp_File_fileno and open(2)). The
- * [:child, :out|:err|Integer] form is also resolved by the codegen
- * (it sees the literal array at parse time).
+ * An IO value in opts[0..2] is resolved to its fd by the codegen (which
+ * has access to sp_File_fileno); a String value reaches the runtime
+ * through sp_process_open_redirect. The [:child, :out|:err|Integer]
+ * form is resolved by the codegen (it sees the literal array at parse
+ * time).
  */
 
 #include <fcntl.h>
@@ -47,6 +55,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <errno.h>
+#include <limits.h>
 
 #include "sp_alloc.h"   /* sp_PolyArray, sp_RbVal, sp_box_*, sp_raise_cls */
 #include "sp_process_status.h"   /* sp_ProcessStatus, sp_box_process_status */
@@ -89,9 +98,64 @@ static void close_redirect_srcs(int in_fd, int out_fd, int err_fd) {
   }
 }
 
+/* The fds this spawn opened itself, one slot each for in/out/err and -1
+   where the slot came from the caller (an IO, an Integer, nothing). Only
+   these are the spawn's to close: the child closes its copies after the
+   dup2s above, and the parent closes its own once the child has them. */
+static void close_owned(const int *owned) {
+  for (int i = 0; i < 3; i++) if (owned[i] >= 0) close(owned[i]);
+}
+
+/* Raise on the spawn's behalf: the fds it opened are released first, so a
+   spawn that never forks does not leave them behind. errno survives the
+   closes for the Errno class the raise builds. */
+SP_NORETURN void sp_process_spawn_fail(int *owned, const char *cls, const char *msg) {
+  int e = errno;
+  close_owned(owned);
+  errno = e;
+  sp_raise_cls(cls, msg);
+}
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+/* A filename redirection, opened here rather than by the generated program:
+   read-only for slot 0 (:in), created and truncated for :out and :err. The
+   fd is recorded in owned[slot]. A failed open raises the Errno class CRuby
+   raises, with CRuby's message, after releasing the fds already opened for
+   this spawn. The ladder is sp_file_open_raise's four (sp_cold.c) plus the
+   six more errnos open(2) answers for a path; anything else is a bare
+   SystemCallError. The message is built in a buffer sized for a path, and
+   sp_raise_cls copies it before it can allocate, so a local is enough. */
+int sp_process_open_redirect(const char *path, int slot, int *owned) {
+  int flags = slot == 0 ? O_RDONLY : O_WRONLY | O_CREAT | O_TRUNC;
+  int fd = open(path, flags, 0644);
+  if (fd < 0) {
+    int e = errno;
+    const char *cls = e == ENOENT ? "Errno::ENOENT" :
+                      e == EACCES ? "Errno::EACCES" :
+                      e == EEXIST ? "Errno::EEXIST" :
+                      e == EISDIR ? "Errno::EISDIR" :
+                      e == ENOTDIR ? "Errno::ENOTDIR" :
+                      e == ENAMETOOLONG ? "Errno::ENAMETOOLONG" :
+                      e == ELOOP ? "Errno::ELOOP" :
+                      e == EROFS ? "Errno::EROFS" :
+                      e == EMFILE ? "Errno::EMFILE" :
+                      e == ENFILE ? "Errno::ENFILE" : "SystemCallError";
+    char msg[PATH_MAX + 64];
+    snprintf(msg, sizeof msg, "%s - %s", strerror(e), path);
+    errno = e;
+    sp_process_spawn_fail(owned, cls, msg);
+  }
+  owned[slot] = fd;
+  return fd;
+}
+
 /* Extract a resolved Integer fd from a pre-resolved opts slot. The
-   codegen turns IO/String/false into Integer before passing; we
-   just unbox. -1 means "not set" (/dev/null). */
+   codegen turns IO/false into Integer before passing, and a String
+   path arrives as the fd sp_process_open_redirect returned; we just
+   unbox. -1 means "not set": inherit the parent's, per apply_redirect. */
 static int slot_to_fd(sp_RbVal v) {
   if (v.tag == SP_TAG_NIL) return -1;
   if (v.tag == SP_TAG_BOOL && v.v.i == 0) return -1;
@@ -106,41 +170,47 @@ sp_int sp_process_spawn(sp_RbVal cmd, sp_RbVal args_box,
   SP_GC_ROOT_RBVAL(args_box);
   SP_GC_ROOT_RBVAL(opts_box);
 
-  /* opts_box must be a PolyArray of 7 elements. */
+  /* opts_box must be a PolyArray of 8 elements. */
   if (opts_box.tag != SP_TAG_OBJ ||
       opts_box.cls_id != SP_BUILTIN_POLY_ARRAY) {
     sp_raise_cls("TypeError", "opts must be a PolyArray (codegen bug)");
   }
   sp_PolyArray *opts = (sp_PolyArray *)opts_box.v.p;
-  if (opts->len < 7) {
+  if (opts->len < 8) {
     sp_raise_cls("ArgumentError", "opts array too short (codegen bug)");
   }
   int in_fd  = slot_to_fd(opts->data[0]);
   int out_fd = slot_to_fd(opts->data[1]);
   int err_fd = slot_to_fd(opts->data[2]);
+  /* Slot 7: a bit per slot the generated program had this file open for
+     it, so those fds are the spawn's to close; a caller's IO stays open. */
+  int owned_mask = opts->data[7].tag == SP_TAG_INT ? (int)opts->data[7].v.i : 0;
+  int owned[3] = { owned_mask & 1 ? in_fd : -1,
+                   owned_mask & 2 ? out_fd : -1,
+                   owned_mask & 4 ? err_fd : -1 };
 
   int pgroup = 0;
   if (opts->data[3].tag == SP_TAG_NIL) pgroup = 0;
   else if (opts->data[3].tag == SP_TAG_BOOL && opts->data[3].v.i == 1) pgroup = 1;
   else if (opts->data[3].tag == SP_TAG_INT) pgroup = (int)opts->data[3].v.i;
-  else sp_raise_cls("TypeError", "pgroup must be true, 0, or Integer");
+  else sp_process_spawn_fail(owned, "TypeError", "pgroup must be true, 0, or Integer");
 
   int rlimit_cpu_set = 0;
   rlim_t rlimit_cpu_val = 0;
   if (opts->data[4].tag == SP_TAG_INT) { rlimit_cpu_set = 1; rlimit_cpu_val = (rlim_t)opts->data[4].v.i; }
   else if (opts->data[4].tag != SP_TAG_NIL)
-    sp_raise_cls("TypeError", "rlimit_cpu must be Integer");
+    sp_process_spawn_fail(owned, "TypeError", "rlimit_cpu must be Integer");
 
   int rlimit_as_set = 0;
   rlim_t rlimit_as_val = 0;
   if (opts->data[5].tag == SP_TAG_INT) { rlimit_as_set = 1; rlimit_as_val = (rlim_t)opts->data[5].v.i; }
   else if (opts->data[5].tag != SP_TAG_NIL)
-    sp_raise_cls("TypeError", "rlimit_as must be Integer");
+    sp_process_spawn_fail(owned, "TypeError", "rlimit_as must be Integer");
 
   const char *chdir_to = NULL;
   if (opts->data[6].tag == SP_TAG_STR) chdir_to = opts->data[6].v.s;
   else if (opts->data[6].tag != SP_TAG_NIL)
-    sp_raise_cls("TypeError", "chdir must be a String");
+    sp_process_spawn_fail(owned, "TypeError", "chdir must be a String");
 
   /* Resolve cmd + args into argv. */
   const char *prog = NULL;
@@ -156,14 +226,14 @@ sp_int sp_process_spawn(sp_RbVal cmd, sp_RbVal args_box,
         args_box.cls_id == SP_BUILTIN_POLY_ARRAY) {
       args_arr = (sp_PolyArray *)args_box.v.p;
     } else if (args_box.tag != SP_TAG_NIL) {
-      sp_raise_cls("TypeError", "args must be a PolyArray of extra args");
+      sp_process_spawn_fail(owned, "TypeError", "args must be a PolyArray of extra args");
     }
   } else if (cmd.tag == SP_TAG_OBJ &&
              cmd.cls_id == SP_BUILTIN_POLY_ARRAY) {
     cmd_arr = (sp_PolyArray *)cmd.v.p;
-    if (cmd_arr->len < 1) sp_raise_cls("ArgumentError", "empty command array");
+    if (cmd_arr->len < 1) sp_process_spawn_fail(owned, "ArgumentError", "empty command array");
     if (cmd_arr->data[0].tag != SP_TAG_STR)
-      sp_raise_cls("ArgumentError", "command[0] must be a String");
+      sp_process_spawn_fail(owned, "ArgumentError", "command[0] must be a String");
     prog = cmd_arr->data[0].v.s;
     extra_from_cmd = cmd_arr->len - 1;
     if (args_box.tag == SP_TAG_OBJ &&
@@ -171,27 +241,27 @@ sp_int sp_process_spawn(sp_RbVal cmd, sp_RbVal args_box,
       args_arr = (sp_PolyArray *)args_box.v.p;
     }
   } else {
-    sp_raise_cls("TypeError",
-                 "wrong first argument type (expected String or Array)");
+    sp_process_spawn_fail(owned, "TypeError",
+                          "wrong first argument type (expected String or Array)");
   }
   if (args_arr) extra_from_args = (int)args_arr->len;
 
   int total = 1 + extra_from_cmd + extra_from_args;
   argv = (char **)malloc(sizeof(char *) * (size_t)(total + 1));
-  if (!argv) sp_raise_cls("NoMemoryError", "out of memory");
+  if (!argv) sp_process_spawn_fail(owned, "NoMemoryError", "out of memory");
   argv[0] = (char *)prog;
   int ai = 1;
   if (cmd_arr) {
     for (int i = 1; i < cmd_arr->len; i++) {
       if (cmd_arr->data[i].tag != SP_TAG_STR)
-        sp_raise_cls("ArgumentError", "command array element must be a String");
+        sp_process_spawn_fail(owned, "ArgumentError", "command array element must be a String");
       argv[ai++] = (char *)cmd_arr->data[i].v.s;
     }
   }
   if (args_arr) {
     for (int i = 0; i < args_arr->len; i++) {
       if (args_arr->data[i].tag != SP_TAG_STR)
-        sp_raise_cls("ArgumentError", "spawn args must be Strings");
+        sp_process_spawn_fail(owned, "ArgumentError", "spawn args must be Strings");
       argv[ai++] = (char *)args_arr->data[i].v.s;
     }
   }
@@ -205,13 +275,13 @@ sp_int sp_process_spawn(sp_RbVal cmd, sp_RbVal args_box,
   int err_pipe[2];
   if (pipe(err_pipe) < 0) {
     free(argv);
-    sp_raise_cls("SystemCallError", sp_errf_errno("pipe failed", errno));
+    sp_process_spawn_fail(owned, "SystemCallError", sp_errf_errno("pipe failed", errno));
   }
 
   pid_t pid = fork();
   if (pid < 0) {
     free(argv);
-    sp_raise_cls("SystemCallError", sp_errf_errno("fork failed", errno));
+    sp_process_spawn_fail(owned, "SystemCallError", sp_errf_errno("fork failed", errno));
   }
   if (pid == 0) {
     /* CHILD. If execve fails, write the errno to the parent's pipe
@@ -252,8 +322,11 @@ sp_int sp_process_spawn(sp_RbVal cmd, sp_RbVal args_box,
     (void)!write(err_pipe[1], &e, sizeof e);
     _exit(127);
   }
-  /* PARENT. Close the child's write end, read the errno if any. */
+  /* PARENT. The child has its own copies of the redirections now, so the
+     ones this spawn opened are closed here, on the exec-failure path too;
+     then close the child's write end and read the errno if any. */
   close(err_pipe[1]);
+  close_owned(owned);
   int exec_errno = 0;
   ssize_t got = read(err_pipe[0], &exec_errno, sizeof exec_errno);
   close(err_pipe[0]);

--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -401,6 +401,8 @@ static inline sp_float sp_math_gamma(sp_float x){if(x<0.0&&x==floor(x))sp_raise_
    so an implicit declaration mistypes the result, and a program that never
    spawns should not carry two lines about it. */
 sp_int sp_process_spawn(sp_RbVal cmd, sp_RbVal args, sp_RbVal opts);
+int sp_process_open_redirect(const char *path, int slot, int *owned);
+SP_NORETURN void sp_process_spawn_fail(int *owned, const char *cls, const char *msg);
 sp_PolyArray *sp_process_waitpid2(sp_int pid);
 
 

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -23300,7 +23300,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
        emit a sp_poly_hash_get_pair_val call, resolve the value to a
        primitive (Integer fd, true, Integer, String), and push it into
        a flat PolyArray. The runtime (sp_process_spawn) takes the
-       7-element flat array positionally -- this keeps the runtime
+       8-element flat array positionally -- this keeps the runtime
        TU out of spinel_rt.h's static-inline family entirely. The
        [:child, :out|:err|Integer] redirect is recognized inline. */
     if (tcn && sp_streq(tcn, "Process") && sp_streq(name, "spawn") && argc >= 1) {
@@ -23333,11 +23333,13 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
         emit_boxed(c, argv[k], b);
         buf_puts(b, ");");
       }
-      /* opts: build a 7-element flat PolyArray
-         [in_fd, out_fd, err_fd, pgroup, rlimit_cpu, rlimit_as, chdir].
+      /* opts: build an 8-element flat PolyArray
+         [in_fd, out_fd, err_fd, pgroup, rlimit_cpu, rlimit_as, chdir, owned].
          If last_is_opts, each entry is a hash lookup result resolved
          to a primitive. If not, all entries are nil/0. */
       buf_printf(b, " sp_PolyArray *_t%d = sp_PolyArray_new(); SP_GC_ROOT(_t%d);", topts, topts);
+      int town = ++g_tmp;
+      buf_printf(b, " int _t%d[3] = { -1, -1, -1 };", town);
       if (last_is_opts) {
         int tth = ++g_tmp;
         int tkv = ++g_tmp;
@@ -23349,7 +23351,11 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
            resolve it. The C block is emitted three times with the
            key name changed -- a top-level static helper would be
            cleaner but cannot be declared inside a statement
-           expression. */
+           expression. A filename is opened by the runtime, read-only
+           for :in and write-truncate for :out and :err, and the fds
+           it opened are recorded in _town so the runtime can close
+           the parent's copies once the child has its own; a caller's
+           IO is never closed. */
         const char *fd_keys[] = { "in", "out", "err" };
         for (int i = 0; i < 3; i++) {
           buf_printf(b,
@@ -23367,9 +23373,7 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
             "  } else if (_v.tag == SP_TAG_OBJ && _v.cls_id == SP_BUILTIN_IO && _v.v.p) { "
             "    sp_PolyArray_push(_t%d, sp_box_int(sp_File_fileno((sp_File*)_v.v.p))); "
             "  } else if (_v.tag == SP_TAG_STR) { "
-            "    int _fd = open(_v.v.s, O_WRONLY|O_CREAT|O_TRUNC, 0644); "
-            "    if (_fd < 0) sp_raise_cls(\"Errno::ENOENT\", _v.v.s); "
-            "    sp_PolyArray_push(_t%d, sp_box_int(_fd)); "
+            "    sp_PolyArray_push(_t%d, sp_box_int(sp_process_open_redirect(_v.v.s, %d, _t%d))); "
             "  } else if (_v.tag == SP_TAG_OBJ && _v.cls_id == SP_BUILTIN_POLY_ARRAY) { "
             "    sp_PolyArray *_a = (sp_PolyArray*)_v.v.p; "
             "    if (_a->len >= 2 && _a->data[0].tag == SP_TAG_SYM "
@@ -23381,18 +23385,18 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
             "        } else if (_fdv.v.i == sp_sym_intern(\"err\")) { "
             "          sp_PolyArray_push(_t%d, sp_box_int(2)); "
             "        } else { "
-            "          sp_raise_cls(\"ArgumentError\", \"bad redirect value\"); "
+            "          sp_process_spawn_fail(_t%d, \"ArgumentError\", \"bad redirect value\"); "
             "        } "
             "      } else if (_fdv.tag == SP_TAG_INT) { "
             "        sp_PolyArray_push(_t%d, sp_box_int((int)_fdv.v.i)); "
             "      } else { "
-            "        sp_raise_cls(\"ArgumentError\", \"bad redirect value\"); "
+            "        sp_process_spawn_fail(_t%d, \"ArgumentError\", \"bad redirect value\"); "
             "      } "
             "    } else { "
-            "      sp_raise_cls(\"ArgumentError\", \"bad child-array shape\"); "
+            "      sp_process_spawn_fail(_t%d, \"ArgumentError\", \"bad child-array shape\"); "
             "    } "
             "  } else { "
-            "    sp_raise_cls(\"ArgumentError\", \"bad redirect type\"); "
+            "    sp_process_spawn_fail(_t%d, \"ArgumentError\", \"bad redirect type\"); "
             "  } "
             "} else { sp_PolyArray_push(_t%d, sp_box_int(-1)); } }",
             tkv, tfd, tkv, tth, fd_keys[i], tfd,
@@ -23401,10 +23405,14 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
             topts,
             topts,
             topts,
+            topts, i, town,
             topts,
             topts,
+            town,
             topts,
-            topts,
+            town,
+            town,
+            town,
             topts);
         }
         /* pgroup: look up, accept true / 0 / Integer, or 0. */
@@ -23455,13 +23463,17 @@ else { memcpy(dir, sf, n); dir[n] = 0; } }
         buf_printf(b, " sp_PolyArray_push(_t%d, sp_box_nil());", topts);
         buf_printf(b, " sp_PolyArray_push(_t%d, sp_box_nil());", topts);
       }
+      /* Slot 7: which of in/out/err the runtime opened itself, a bit per
+         slot, so it closes the parent's copies and never a caller's IO. */
+      buf_printf(b, " sp_PolyArray_push(_t%d, sp_box_int((_t%d[0] >= 0) | ((_t%d[1] >= 0) << 1) | ((_t%d[2] >= 0) << 2)));",
+                 topts, town, town, town);
       /* If cmd is an Array, fold its elements into args (prefix). */
       buf_printf(b, " sp_PolyArray *_t%d = _t%d;", tmerged, targs);
       buf_printf(b, " if (_t%d.tag == SP_TAG_OBJ && _t%d.cls_id == SP_BUILTIN_POLY_ARRAY) {", tcmd, tcmd);
       buf_printf(b, "   sp_PolyArray *_cmd = (sp_PolyArray *)_t%d.v.p;", tcmd);
       buf_printf(b, "   _t%d = sp_PolyArray_new(); SP_GC_ROOT(_t%d);", tmerged, tmerged);
       buf_printf(b, "   for (sp_int _i = 0; _i < _cmd->len - 1; _i++) {");
-      buf_printf(b, "     if (_cmd->data[_i].tag != SP_TAG_STR) sp_raise_cls(\"ArgumentError\", \"command array element must be a String\");");
+      buf_printf(b, "     if (_cmd->data[_i].tag != SP_TAG_STR) sp_process_spawn_fail(_t%d, \"ArgumentError\", \"command array element must be a String\");", town);
       buf_printf(b, "     sp_PolyArray_push(_t%d, _cmd->data[_i]);", tmerged);
       buf_printf(b, "   }");
       buf_printf(b, "   for (sp_int _i = 0; _i < _t%d->len; _i++) sp_PolyArray_push(_t%d, _t%d->data[_i]);", targs, tmerged, targs);

--- a/test/process_spawn_file_redirect.rb
+++ b/test/process_spawn_file_redirect.rb
@@ -1,0 +1,145 @@
+# Process.spawn with a filename redirection. The file named by `in:` is
+# opened read-only, so the child reads it and its contents survive; `out:`
+# and `err:` are created and truncated as before. The descriptors a spawn
+# opens for those names are its own to close: the parent's copies go once the
+# child has them, and on every raise the runtime makes, while an IO the
+# caller handed in stays open. Every count below is /dev/fd after minus before, so the expected
+# value is 0 on any machine.
+
+require "tmpdir"
+
+def fds
+  Dir.children("/dev/fd").size
+end
+
+Dir.mktmpdir do |dir|
+  input = File.join(dir, "input.txt")
+  output = File.join(dir, "output.txt")
+  errout = File.join(dir, "err.txt")
+  missing = File.join(dir, "absent.txt")
+  nodir = File.join(dir, "nodir", "x.txt")
+
+  # 1) in: a filename -- the child reads it, and it is unchanged afterwards.
+  File.write(input, "valuable input\n")
+  File.write(output, "stale output that must go\n")
+  pid = Process.spawn("/bin/cat", in: input, out: output)
+  _, status = Process.waitpid2(pid)
+  p status.exitstatus
+  p File.read(input)
+  p File.read(output)
+
+  # 2) err: a filename is created and truncated, as out: is.
+  File.write(errout, "stale\n")
+  pid = Process.spawn("/bin/sh", "-c", "echo oops >&2", err: errout)
+  _, status = Process.waitpid2(pid)
+  p status.exitstatus
+  p File.read(errout)
+
+  # 3) A missing input path raises the Errno CRuby raises and creates nothing.
+  begin
+    Process.spawn("/bin/cat", in: missing)
+    puts "no raise"
+  rescue SystemCallError => e
+    puts e.class
+    puts e.message.sub(dir, "DIR")
+  end
+  p File.exist?(missing)
+
+  # 4) An output path in a missing directory raises the same way.
+  begin
+    Process.spawn("/usr/bin/true", out: nodir)
+    puts "no raise"
+  rescue SystemCallError => e
+    puts e.class
+    puts e.message.sub(dir, "DIR")
+  end
+
+  # 5) Twenty spawns with filename redirections leave the fd table as it was.
+  before = fds
+  20.times do
+    pid = Process.spawn("/bin/cat", in: input, out: output)
+    Process.waitpid2(pid)
+  end
+  p fds - before
+
+  # 6) So does a spawn whose exec fails after the redirections were opened.
+  before = fds
+  20.times do
+    begin
+      pid = Process.spawn("/no/such/command", in: input, out: output)
+      Process.waitpid2(pid)
+    rescue Errno::ENOENT
+    end
+  end
+  p fds - before
+
+  # 7) And one whose second redirection fails to open after the first did.
+  before = fds
+  20.times do
+    begin
+      Process.spawn("/bin/cat", in: input, out: nodir)
+    rescue Errno::ENOENT
+    end
+  end
+  p fds - before
+
+  # 8) An IO the caller opened is still open and writable after the spawn.
+  f = File.open(output, "w")
+  pid = Process.spawn("/bin/echo", "from child", out: f)
+  Process.waitpid2(pid)
+  p f.closed?
+  f.puts "from parent"
+  f.close
+  p File.read(output)
+
+  # 9) out: and err: both filenames in one spawn: two owned descriptors.
+  pid = Process.spawn("/bin/sh", "-c", "echo to-out; echo to-err >&2", out: output, err: errout)
+  Process.waitpid2(pid)
+  p File.read(output)
+  p File.read(errout)
+
+  # 10) A caller's IO in one slot and a filename in another: only the
+  # filename's descriptor is the spawn's to close.
+  f = File.open(output, "w")
+  pid = Process.spawn("/bin/sh", "-c", "echo to-io; echo to-file >&2", out: f, err: errout)
+  Process.waitpid2(pid)
+  p f.closed?
+  f.close
+  p File.read(output)
+  p File.read(errout)
+
+  # 11) A spawn with no options at all.
+  pid = Process.spawn("/usr/bin/true")
+  _, status = Process.waitpid2(pid)
+  p status.exitstatus
+
+  # 12) A path through a regular file raises Errno::ENOTDIR, for in: and out:.
+  notdir = File.join(dir, "notdir")
+  File.write(notdir, "x")
+  [[:in, { in: File.join(notdir, "x") }], [:out, { out: File.join(notdir, "x") }]].each do |label, opts|
+    begin
+      Process.spawn("/bin/cat", **opts)
+      puts "#{label} no raise"
+    rescue SystemCallError => e
+      puts "#{label} #{e.class} #{e.message.sub(dir, "DIR")}"
+    end
+  end
+
+  # 13) A name longer than the filesystem allows raises Errno::ENAMETOOLONG.
+  begin
+    Process.spawn("/bin/cat", in: File.join(dir, "z" * 600))
+    puts "no raise"
+  rescue SystemCallError => e
+    puts "#{e.class} #{e.message.sub(dir, "DIR").length}"
+  end
+
+  # 14) The message carries the whole path, however long.
+  begin
+    Process.spawn("/bin/cat", in: File.join(dir, "a" * 200, "b" * 200, "c" * 200))
+    puts "no raise"
+  rescue SystemCallError => e
+    puts "#{e.class} #{e.message.sub(dir, "DIR").length} #{e.message[-12..]}"
+  end
+
+  File.delete(input, output, errout, notdir)
+end

--- a/test/process_spawn_file_redirect.rb.expected
+++ b/test/process_spawn_file_redirect.rb.expected
@@ -1,0 +1,25 @@
+0
+"valuable input\n"
+"valuable input\n"
+0
+"oops\n"
+Errno::ENOENT
+No such file or directory - DIR/absent.txt
+false
+Errno::ENOENT
+No such file or directory - DIR/nodir/x.txt
+0
+0
+0
+false
+"from child\nfrom parent\n"
+"to-out\n"
+"to-err\n"
+false
+"to-io\n"
+"to-file\n"
+0
+in Errno::ENOTDIR Not a directory - DIR/notdir/x
+out Errno::ENOTDIR Not a directory - DIR/notdir/x
+Errno::ENAMETOOLONG 625
+Errno::ENOENT 634 cccccccccccc


### PR DESCRIPTION
## Why

`Process.spawn("/bin/cat", in: "input.txt", out: "output.txt")` should hand the child the input file to read and leave that file as it was. On master it empties the input file before the child starts, then gives the child a write-only descriptor as its standard input. In the test program, with `input.txt` holding `"valuable input\n"`, the spawn exits 1, `cat` prints `stdin: Bad file descriptor`, and both files read `""` afterwards. CRuby exits 0 and both files read the input. A program that uses the documented filename form of `in:` loses the file it meant to read.

The same spawn also keeps the descriptor it opened. The child closes its copy after the `dup2`, but nothing closes the parent's, so a program that spawns and waits in a loop grows its descriptor table by one per filename redirection. In the test program, twenty spawn-and-wait turns with `in:` and `out:` filenames grow `/dev/fd` by 40 on master and by 0 under CRuby. In a probe that runs twenty turns over one shape at a time, master grows `/dev/fd` by 20 for `out:` alone, 20 for `err:` alone, 40 for `out:` with `err:`, 60 for all three, 20 for a failed exec with `out:` a filename and 40 with `in:` and `out:`, every one of them 0 under CRuby and on this branch. A spawn that raised before forking, because a later redirection failed to open, kept the descriptor too: twenty such turns grow `/dev/fd` by 20 on master in the test program.

Both come from one line of the emitter, repeated for `in:`, `out:` and `err:`: every filename was opened with `O_WRONLY|O_CREAT|O_TRUNC` in the parent, with no record of which descriptors the spawn had opened itself. A third face of that line: a missing `in:` path was created empty instead of raising, so the spawn went on to run `cat` on a write-only descriptor to the empty file it had just made.

## What

The open moves out of the generated program into the runtime, next to the code that already closes the child's copies. `sp_process_open_redirect` in `lib/sp_process.c` opens an `in:` path `O_RDONLY`, an `out:` or `err:` path created and truncated as before, and records the descriptor in a three-slot array the generated program keeps for the duration of the call, one slot per redirection, `-1` wherever the spawn did not open the file itself. A failed open raises after closing the descriptors already opened for that spawn, with CRuby's message, `strerror - path`, built in a buffer sized for a path, and with the Errno class CRuby raises when the errno is one of `ENOENT`, `EACCES`, `EEXIST`, `EISDIR`, `ENOTDIR`, `ENAMETOOLONG`, `ELOOP`, `EROFS`, `EMFILE` or `ENFILE`, the four `sp_file_open_raise` maps plus six more that `open(2)` can answer for a path. Any other errno is a `SystemCallError`.

The flat options array `sp_process_spawn` reads gains an eighth slot: a bit per redirection the spawn owns. Once the fork has given the child its copies, the parent closes its own, before it reads the exec-failure pipe, so the descriptors go on the failure path too. Every raise in the runtime after the owned descriptors are known and before the fork goes through `sp_process_spawn_fail`, which closes the owned descriptors and then raises with errno intact, and the generated program's own argument-shape raises inside the spawn call go through the same function. A descriptor that came from a caller's IO is never recorded, so it is never closed. The file's header comment documents the eight-slot contract and the runtime-side open.

## How

Each face of the line has its own test arm, and each fails on master in its own way. `in:` a file holding `"valuable input\n"` with `out:` a file holding stale text: master answers exit 1 and `""` for both files, this branch exit 0 and the input text for both, as CRuby does. `in:` a missing path: master prints `no raise` and the path now exists, this branch raises `Errno::ENOENT` with `No such file or directory - DIR/absent.txt` and the path does not exist. Twenty spawn-and-wait turns with `in:` and `out:` filenames: master grows `/dev/fd` by 40, this branch by 0. Twenty spawns of a missing command with both redirections, each rescued: master 40, this branch 0. Twenty spawns whose `out:` path is in a missing directory, so the raise comes after `in:` was opened: master 20, this branch 0. A path through a regular file: master raises `Errno::ENOENT` with the bare path for `in:` and for `out:`, this branch `Errno::ENOTDIR` with `Not a directory - DIR/notdir/x`. A 600-character name: master `Errno::ENOENT`, this branch `Errno::ENAMETOOLONG`. A message of 634 characters once the temporary directory's name is replaced: this branch carries it whole, and prints its last twelve characters as CRuby does. A `File` the caller opened and handed as `out:`, written to by the child and then by the caller: `closed?` is false on both trees, and the file holds both lines. `out:` and `err:` both filenames, a caller's IO for `out:` with a filename for `err:`, and a spawn with no options answer the same on master, this branch and CRuby. They are there because those are the shapes where two owned descriptors close in one call, where the mask has a single high bit, and where every spawning program's generated C changes.

## Validation

`test/process_spawn_file_redirect.rb.expected` is the output of `ruby test/process_spawn_file_redirect.rb` under CRuby 4.0.6, and it regenerates byte for byte. Every count in the test is `/dev/fd` after minus before, so the expected value is 0 on any machine and the arm is portable to Linux, where `/dev/fd` is the same view. Compiled, the test runs in under a tenth of a second on this branch, and matches the expected file in three of three plain runs and in two of two under `SPINEL_GC_STRESS=1`, with nothing on stderr. On master it compiles and runs to the end in three identical runs. The `err:` arm, the caller's-IO arm and the three added shapes match CRuby, and every other arm answers differently. The existing `test/process_spawn.rb`, `test/file_null_constant.rb` and `test/waitpid_thread_drains_pipe.rb`, which redirect to IOs, to `File::NULL` by name and to a pipe end, match their expected output on this branch.

On `d1cac2ec` the 3542-test suite and the 61 benchmarks pass, optcarrot is unchanged at 59662, the 2131-program compatibility corpus holds at 906 passing with none gained and none lost, and the generated C changes only for the three existing programs that call `Process.spawn` and for this test, by the owned-descriptor array, the runtime open and the eighth options element. The test is clean under GC stress and under AddressSanitizer over its generated C.

## Left alone, on purpose

The three redirections are opened in `in:`, `out:`, `err:` order whatever order the caller wrote them, so `out: created, in: absent` raises with the output file not created here and created under CRuby. The order predates this change and master never raised on `in:` at all. Three raises in the runtime before the descriptors are known, two on a malformed options array and one on a non-Integer slot, stay bare. None is reachable from Ruby. A spawn whose exec fails still raises without reaping the child, and its message says `cannot execute` where CRuby names the command. `[:out, :err] => path` is ignored, `out: [path, "a"]` and `out: [path, "w", 0600]` raise, Integer keys such as `1 => path` are read as arguments, `in: nil` and `in: false` are ignored where CRuby raises, and `in: :foo` reports `bad redirect type`. All the same on master. The `[executable, argv0]` command form still raises `TypeError`. A non-String `chdir:` is swallowed by the emitter, so the runtime's `TypeError` never fires. `File.open` on a path through a regular file raises a bare `SystemCallError`, because `sp_file_open_raise` maps four errnos. This change does not touch it, and a spawn whose open fails with an errno outside its own ten raises a bare `SystemCallError` the same way, where CRuby names an Errno class for every errno. A closed IO in a later slot raises from the generated program before the runtime is entered, so a filename opened for an earlier slot is still leaked, as before: twenty turns of `out:` a filename with `err:` a closed IO grow `/dev/fd` by 20 on master and on this branch, and by 0 under CRuby. The two element-type raises after the argument vector is allocated still leak that vector, as before. The options hash is read through an unrooted temporary across three pushes, as before, and this change adds no allocation to that window. The redirection descriptors are opened without `O_CLOEXEC`, as before. `Dir.mktmpdir` leaves a non-empty directory behind on Spinel, which is why the test deletes its own files before the block ends.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `Process.spawn` now supports redirecting standard input, output, and error streams directly to filenames.
  * Input files are opened for reading, while output and error files are created or truncated as needed.
  * Existing file handles remain open and can be mixed with filename-based redirects.

* **Bug Fixes**
  * Improved error reporting for missing, invalid, and excessively long redirect paths.
  * Prevented file descriptor leaks when process launching or redirection fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->