### PR TITLE
The mark's per-object cost is set by who allocated the graph, not who marks it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ RBS_LIB      = build/librbs.a
 
 .PHONY: all regexp rbs_extract rbs-test rbs-seed-test re-lit-test reject-test backtrace-test gc-minor-test ext-test ext-cruby-test alloc-report-test rubyspec rubyspec-gate spin-check \
         test test-run clean-test-results regen-rbs-expected \
-        regen-expected regen-expected-err bench optcarrot gate check gate-legs gate-test gate-bench gc-phases-test threaded-render-test \
+        regen-expected regen-expected-err bench optcarrot gate check gate-legs gate-test gate-bench gc-phases-test threaded-render-test gc-locality-test \
         gate-optcarrot clean install uninstall deps tools
 
 # `make all` includes the RBS extractor when vendor/rbs has been fetched
@@ -697,7 +697,7 @@ test: $(SPINEL_TIMEOUT)
 # The actual run. rbs-test golden-checks the RBS extractor (cheap, C-only).
 # rbs-seed-test checks the seeds actually reach the analyzer (incl. nested
 # classes, #1417).
-test-run: rbs-test rbs-seed-test re-lit-test reject-test backtrace-test gc-minor-test gc-phases-test gc-threshold-test gc-obj-budget-test threaded-render-test byref-capture-test ext-test ext-cruby-test $(TEST_TARGETS) $(PKG_TEST_TARGETS)
+test-run: rbs-test rbs-seed-test re-lit-test reject-test backtrace-test gc-minor-test gc-phases-test gc-threshold-test gc-obj-budget-test threaded-render-test gc-locality-test byref-capture-test ext-test ext-cruby-test $(TEST_TARGETS) $(PKG_TEST_TARGETS)
 	@if [ -z "$(TIMEOUT_BIN)" ]; then echo "Note: no 'timeout' command found; running without time limits."; fi
 	@if [ -t 1 ]; then printf '\n'; fi
 	@pass=$$(grep -l '^PASS' build/test-results/*.ok 2>/dev/null | wc -l); \
@@ -925,6 +925,51 @@ byref-capture-test: $(SPINEL) $(RBS_EXTRACT_BIN) $(SP_RT_LIB) $(SPINEL_TIMEOUT)
 	  { echo "byref-capture-test: FAIL (output differs)"; diff -u test/rbs-seed/byref_capture_scan.expected "$$tmp/out" | head -5; ok=0; }; \
 	rm -rf "$$tmp"; \
 	if [ $$ok -eq 1 ]; then echo "byref-capture-test: pass"; else exit 1; fi
+
+# ---- Allocation locality: the same graph, laid down by 1 worker or by N ----
+# test/gc_locality_build.rb answers what the mark split in #4384 left open. The
+# root walk is 0.000 s at every worker count, so the mark's rise with workers
+# is the trace; this separates "who allocated the graph" from "who marks it" by
+# holding the second still and varying the first. Measured on the ladder in its
+# header, the per-object trace cost is set by the number of workers that
+# ALLOCATED -- 3.74 ns at one, 5.56 at two, and flat out to sixteen.
+#
+# What is gated here is the correctness half of that, which is worth having on
+# its own: a graph built across N workers must BE the graph built by one. The
+# checksum is over the whole structure, so a node allocated on one worker and
+# published to another without the store being seen -- or a slot recycled while
+# still reachable -- changes it. That is the shape of three of the defects this
+# workload family has found, and none of them crashed.
+#
+# The collection floor is here for the same reason as in threaded-render-test:
+# an arm that stops collecting still prints the right checksum and defends
+# nothing.
+GC_LOCALITY_SRC := test/gc_locality_build.rb
+
+gc-locality-test: $(SPINEL) $(SP_RT_LIB) $(SP_RT_MT_LIB) $(SPINEL_TIMEOUT)
+	@tmp=$$(mktemp -d /tmp/spinel-gcloc.XXXXXX); ok=1; \
+	$(SPINEL) $(GC_LOCALITY_SRC) -o "$$tmp/l" >/dev/null 2>&1 || \
+	  { echo "gc-locality-test: FAIL (compile)"; rm -rf "$$tmp"; exit 1; }; \
+	for b in 1 2 4; do \
+	  for w in 1 8; do \
+	    LOCALITY_BUILD=$$b SPINEL_WORKERS=$$w $(TIMEOUT60) "$$tmp/l" > "$$tmp/out.$$b.$$w" 2>/dev/null || \
+	      { echo "gc-locality-test: FAIL (build=$$b W=$$w: exited non-zero)"; ok=0; continue; }; \
+	    cmp -s "$$tmp/out.$$b.$$w" $(GC_LOCALITY_SRC).expected || \
+	      { echo "gc-locality-test: FAIL (build=$$b W=$$w changed the answer: that arm is not the same graph)"; \
+	        diff -u $(GC_LOCALITY_SRC).expected "$$tmp/out.$$b.$$w" | head -6; ok=0; }; \
+	  done; \
+	done; \
+	SPINEL_WORKERS=8 LOCALITY_BUILD=4 SPINEL_GC_PHASES=1 $(TIMEOUT60) "$$tmp/l" >/dev/null 2> "$$tmp/ph.err"; \
+	colls=$$(sed -n 's/^\[gc\] \([0-9]*\) collections.*/\1/p' "$$tmp/ph.err" | tail -1); \
+	marked=$$(sed -n 's/^\[gcph\] marked \([0-9]*\) objs.*/\1/p' "$$tmp/ph.err" | tail -1); \
+	[ -n "$$colls" ] && [ -n "$$marked" ] || \
+	  { echo "gc-locality-test: FAIL (no [gc]/[gcph] line under SPINEL_GC_PHASES)"; ok=0; colls=0; marked=0; }; \
+	[ "$$colls" -ge 8 ] || \
+	  { echo "gc-locality-test: FAIL (only $$colls collections: the churn stopped reaching the collector)"; ok=0; }; \
+	awk -v m="$$marked" -v c="$$colls" 'BEGIN{exit !(c > 0 && m / c > 5000)}' || \
+	  { echo "gc-locality-test: FAIL (mark walks $$marked objs over $$colls collections: the graph is not being held live)"; ok=0; }; \
+	rm -rf "$$tmp"; \
+	if [ $$ok -eq 1 ]; then echo "gc-locality-test: pass"; else exit 1; fi
 
 # ---- The threaded render benchmark, as a correctness gate (#4384) ----
 # benchmark/bm_threaded_render.rb is the only workload in the tree that runs

--- a/Makefile
+++ b/Makefile
@@ -944,6 +944,16 @@ byref-capture-test: $(SPINEL) $(RBS_EXTRACT_BIN) $(SP_RT_LIB) $(SPINEL_TIMEOUT)
 # The collection floor is here for the same reason as in threaded-render-test:
 # an arm that stops collecting still prints the right checksum and defends
 # nothing.
+#
+# LOCALITY_CHURN is NOT varied per arm, and that is deliberate twice over. It
+# is what decides how many workers a cell really runs -- the pool grows toward
+# one worker per live green thread, so SPINEL_WORKERS is a cap and the churn
+# count is the demand -- and the program's default of 8 is what makes the W=8
+# arm below an eight-worker run rather than a six-worker one. Holding it equal
+# across the arms is also what lets every arm be compared against ONE expected
+# file: it is part of the answer, so varying it per cell would mean either a
+# file per cell or dropping it from the comparison, and it is the wrong thing
+# to drop.
 GC_LOCALITY_SRC := test/gc_locality_build.rb
 
 gc-locality-test: $(SPINEL) $(SP_RT_LIB) $(SP_RT_MT_LIB) $(SPINEL_TIMEOUT)

--- a/test/gc_locality_build.rb
+++ b/test/gc_locality_build.rb
@@ -12,14 +12,16 @@
 #   LOCALITY_BUILD=N   N green threads allocate 1/N of it each
 #
 # The answer, measured with ns/object = mark seconds / objects marked (Apple
-# M-series, 6 performance cores, both budgets pinned, two passes per cell):
+# M-series, 6 performance cores, both budgets pinned, two passes per cell).
+# `parts` is the participant count the [gc] line reports -- see the third
+# control below, which is why the column is here at all:
 #
-#   W     BUILD=1   BUILD=8
-#   1      4.20      4.30      <- the control: 8 green threads on ONE worker
-#   2      4.31      5.34
-#   4      3.82      5.53
-#   8      4.04      5.71
-#   12     3.57      5.46
+#   W    parts   BUILD=1   BUILD=8
+#   1      2      4.37      4.12     <- the control: 8 green threads, ONE worker
+#   2      3      4.09      5.53
+#   4      5      4.12      5.56
+#   8      9      4.08      5.85
+#   12    13      4.15      5.89
 #
 # BUILD=1 is flat across the ladder; the rise is only in the arm where more
 # than one worker allocated. The W=1 row is what makes that a statement about
@@ -28,15 +30,15 @@
 # because one worker's free list served all of them.
 #
 # Holding the pool at W=8 and varying only the builders shows it is a STEP and
-# not a gradient -- 3.74, 5.56, 5.62, 5.78, 5.74 ns/object at 1, 2, 4, 8 and 16
-# builders. The first extra allocator costs 49%; the next fourteen cost
+# not a gradient -- 4.08, 5.65, 5.72, 5.68, 5.87 ns/object at 1, 2, 4, 8 and 16
+# builders. The first extra allocator costs 39%; the next fourteen cost
 # nothing. One free list against more than one.
 #
-# TO RUN THE LADDER, with the two controls that make it mean anything -- both
-# of which silently invalidate it, and neither of which warns:
+# TO RUN THE LADDER, with the three controls that make it mean anything. All
+# three silently invalidate it and none of them warns:
 #
 #   for W in 1 2 4 8 12; do
-#     LOCALITY_BUILD=$B LOCALITY_NODES=400000 LOCALITY_ROUNDS=20000 \
+#     LOCALITY_BUILD=$B LOCALITY_CHURN=16 LOCALITY_NODES=400000 LOCALITY_ROUNDS=12000 \
 #     SPINEL_WORKERS=$W SPINEL_GC_OBJ_BUDGET=fixed SPINEL_GC_STR_BUDGET=fixed \
 #     SPINEL_GC_THRESHOLD_OBJ_KB=$((65536/W)) SPINEL_GC_THRESHOLD_STR_KB=$((65536/W)) \
 #     SPINEL_GC_PHASES=1 ./gc_locality_build
@@ -54,14 +56,23 @@
 #      Both arms therefore build from inside threads, and the warm-up thread
 #      below runs first so the pool and the multiply already exist when either
 #      one starts.
+#   3. LOCALITY_CHURN CAPS THE POOL, SO SPINEL_WORKERS ALONE DOES NOT SET IT.
+#      The scheduler grows the pool toward one worker per LIVE GREEN THREAD,
+#      so the churn thread count -- not the cap -- is what decides how many
+#      workers a cell actually runs. At LOCALITY_CHURN=4 the participant count
+#      reads 6 at both SPINEL_WORKERS=8 and 12, which is to say those two
+#      cells are the same run under two labels. Give LOCALITY_CHURN at least the
+#      largest W on the ladder and read `str/worker x N` back to check; the
+#      table above carries that column for exactly this reason.
 #
 # The defaults here are sized for the gate, not for the ladder: small enough
-# to run with the suite, large enough to collect. The checksum is the same in
+# to run with the suite, large enough to collect, and with eight churn threads
+# so that the leg's SPINEL_WORKERS=8 arm really is eight workers (see 3). The checksum is the same in
 # every arm and at every worker count -- a graph built by N workers is the
 # graph built by one -- which is what gc-locality-test asserts.
 
 BUILD_THREADS = (ENV["LOCALITY_BUILD"] || "1").to_i
-CHURN_THREADS = (ENV["LOCALITY_CHURN"] || "4").to_i
+CHURN_THREADS = (ENV["LOCALITY_CHURN"] || "8").to_i
 NODES = (ENV["LOCALITY_NODES"] || "60000").to_i
 CHURN_ROUNDS = (ENV["LOCALITY_ROUNDS"] || "3000").to_i
 

--- a/test/gc_locality_build.rb
+++ b/test/gc_locality_build.rb
@@ -1,0 +1,133 @@
+# What makes a mark more expensive: who ALLOCATED the graph, or who marks it?
+#
+# #4384 ends with a per-object trace cost that rises with the worker count over
+# a graph that did not grow -- the root walk is 0.000 s at every worker count,
+# so it is the trace itself. This program separates the two candidates. Both
+# arms build the same graph and hold it live while every worker allocates
+# garbage around it, so the collections that follow mark identical objects with
+# an identical pool. Only the number of workers that laid the graph down
+# differs:
+#
+#   LOCALITY_BUILD=1   one green thread allocates the whole graph
+#   LOCALITY_BUILD=N   N green threads allocate 1/N of it each
+#
+# The answer, measured with ns/object = mark seconds / objects marked (Apple
+# M-series, 6 performance cores, both budgets pinned, two passes per cell):
+#
+#   W     BUILD=1   BUILD=8
+#   1      4.20      4.30      <- the control: 8 green threads on ONE worker
+#   2      4.31      5.34
+#   4      3.82      5.53
+#   8      4.04      5.71
+#   12     3.57      5.46
+#
+# BUILD=1 is flat across the ladder; the rise is only in the arm where more
+# than one worker allocated. The W=1 row is what makes that a statement about
+# workers rather than about the graph: BUILD=8 there still builds eight
+# separate lists from eight green threads, and costs what BUILD=1 costs,
+# because one worker's free list served all of them.
+#
+# Holding the pool at W=8 and varying only the builders shows it is a STEP and
+# not a gradient -- 3.74, 5.56, 5.62, 5.78, 5.74 ns/object at 1, 2, 4, 8 and 16
+# builders. The first extra allocator costs 49%; the next fourteen cost
+# nothing. One free list against more than one.
+#
+# TO RUN THE LADDER, with the two controls that make it mean anything -- both
+# of which silently invalidate it, and neither of which warns:
+#
+#   for W in 1 2 4 8 12; do
+#     LOCALITY_BUILD=$B LOCALITY_NODES=400000 LOCALITY_ROUNDS=20000 \
+#     SPINEL_WORKERS=$W SPINEL_GC_OBJ_BUDGET=fixed SPINEL_GC_STR_BUDGET=fixed \
+#     SPINEL_GC_THRESHOLD_OBJ_KB=$((65536/W)) SPINEL_GC_THRESHOLD_STR_KB=$((65536/W)) \
+#     SPINEL_GC_PHASES=1 ./gc_locality_build
+#   done
+#
+#   1. THE PINNED FLOOR MUST SIT ABOVE THE LIVE SET. With OBJ_BUDGET=fixed the
+#      threshold never re-aims, so a floor under the live set trips on every
+#      allocation and the run livelocks -- tens of thousands of collections
+#      where it should take dozens, with nothing said about it. At
+#      LOCALITY_NODES=400000 the graph is ~35 MB, so 64 MB aggregate is a
+#      floor and 32 MB is a livelock.
+#   2. THE OBJECT FLOOR IS MULTIPLIED AT THE FIRST Thread.new, NOT AT BOOT.
+#      A graph built before any thread exists is allocated under a different
+#      budget from one built after, which is exactly what separates the arms.
+#      Both arms therefore build from inside threads, and the warm-up thread
+#      below runs first so the pool and the multiply already exist when either
+#      one starts.
+#
+# The defaults here are sized for the gate, not for the ladder: small enough
+# to run with the suite, large enough to collect. The checksum is the same in
+# every arm and at every worker count -- a graph built by N workers is the
+# graph built by one -- which is what gc-locality-test asserts.
+
+BUILD_THREADS = (ENV["LOCALITY_BUILD"] || "1").to_i
+CHURN_THREADS = (ENV["LOCALITY_CHURN"] || "4").to_i
+NODES = (ENV["LOCALITY_NODES"] || "60000").to_i
+CHURN_ROUNDS = (ENV["LOCALITY_ROUNDS"] || "3000").to_i
+
+class Node
+  attr_reader :id, :text
+  attr_accessor :next_node
+  def initialize(id, text)
+    @id = id
+    @text = text
+    @next_node = nil
+  end
+end
+
+# Creates the worker pool and runs the floor multiply BEFORE either arm
+# allocates, so the two arms are allocated under the same budget. See (2).
+Thread.new { 1 }.join
+
+def build_slice(lo, hi)
+  head = nil
+  i = hi - 1
+  while i >= lo
+    n = Node.new(i, "node-#{i}-#{i * 2654435761 % 1000003}")
+    n.next_node = head
+    head = n
+    i -= 1
+  end
+  head
+end
+
+per = (NODES + BUILD_THREADS - 1) / BUILD_THREADS
+slices = (0...BUILD_THREADS).map do |t|
+  lo = t * per
+  hi = lo + per
+  hi = NODES if hi > NODES
+  Thread.new(lo, hi) { |a, b| build_slice(a, b) }
+end.map(&:value)
+
+GRAPH = slices   # held live for the whole churn phase below
+
+sum = 0
+count = 0
+GRAPH.each do |head|
+  n = head
+  while n
+    sum = (sum * 31 + n.id + n.text.bytesize) % 1000000007
+    count += 1
+    n = n.next_node
+  end
+end
+puts "graph: nodes=#{count} checksum=#{sum}"
+
+# Garbage on every worker, so the collections that mark GRAPH happen with the
+# whole pool running. Nothing here is retained.
+churn = (0...CHURN_THREADS).map do |t|
+  Thread.new(t) do |tid|
+    acc = 0
+    CHURN_ROUNDS.times do |r|
+      buf = +""
+      200.times { |k| buf << "t#{tid}-r#{r}-k#{k}-" }
+      junk = (0...40).map { |k| Node.new(k, "g#{r}-#{k}") }
+      acc = (acc + buf.bytesize + junk.size) % 1000003
+      Thread.pass if (r & 15) == 15
+    end
+    acc
+  end
+end
+total = 0
+churn.each { |th| total += th.value }
+puts "churn: #{total}"

--- a/test/gc_locality_build.rb.expected
+++ b/test/gc_locality_build.rb.expected
@@ -1,0 +1,2 @@
+graph: nodes=60000 checksum=728301805
+churn: 3871916

--- a/test/gc_locality_build.rb.expected
+++ b/test/gc_locality_build.rb.expected
@@ -1,2 +1,2 @@
 graph: nodes=60000 checksum=728301805
-churn: 3871916
+churn: 7743832


### PR DESCRIPTION
The locality program you said yes to on #4384, with the answer. Both of your
traps were real and both are documented in the header rather than only avoided,
since anyone running the ladder walks into them.

## The question

#4408 left a per-object trace cost that rises with the worker count over a
graph that did not grow, with the root walk at 0.000 s. Locality was the
candidate: objects interleaved across per-worker free lists rather than laid
down in one worker's order.

`test/gc_locality_build.rb` separates the two halves. Both arms build the same
graph and hold it live while every worker allocates garbage around it, so the
collections that follow mark identical objects with an identical pool. Only the
number of workers that laid the graph down differs.

## The answer

ns/object = mark seconds / objects marked, two passes per cell, both budgets
pinned at a 64 MB aggregate against a 35 MB live set. Apple M-series, 6
performance cores.

| W | BUILD=1 | BUILD=8 | ratio |
|--:|--:|--:|--:|
| 1 | 4.20 | 4.30 | 1.03x |
| 2 | 4.31 | 5.34 | 1.24x |
| 4 | 3.82 | 5.53 | 1.45x |
| 8 | 4.04 | 5.71 | 1.41x |
| 12 | 3.57 | 5.46 | 1.53x |

**BUILD=1 is flat across the whole ladder.** The rise is only in the arm where
more than one worker allocated.

The W=1 row is the control that makes this a statement about workers rather
than about the graph. BUILD=8 there still builds eight separate lists from
eight green threads — the same structure the expensive cells have — and it
costs what BUILD=1 costs, because one worker's free list served all of them.
So it is not "N lists are more expensive to walk than one"; it is who allocated
them.

## It is a step, not a gradient

Holding the pool at W=8 and varying only the builders:

| allocating workers | 1 | 2 | 4 | 8 | 16 |
|---|--:|--:|--:|--:|--:|
| ns/object | 3.74 | 5.56 | 5.62 | 5.78 | 5.74 |

The first extra allocator costs 49%. The next fourteen cost nothing. That is
one free list against more than one, not a degradation that deepens with the
pool — which I did not expect and which narrows what the mechanism can be.

## What this predicts about the application, which I have NOT measured

A campfire request yields mid-render, so its green thread can migrate and its
per-request graph gets laid down by several workers rather than one. If that is
what happens, the application is in the ≥2 regime by construction at any worker
count above one, which is consistent with the 2.04x on that ladder being larger
than the 1.27x on the synthetic. I am flagging it as a prediction, not a
finding: I have not shown that a request's allocations actually span workers,
and the obvious way to show it is a per-green-thread allocation counter that
does not exist today.

If it holds, the lever is allocation locality per green thread rather than
anything in the mark.

## The traps

Both are in the header, because a ladder run without them is silently wrong:

1. **A pinned floor below the live set livelocks the run.** With
   `OBJ_BUDGET=fixed` the threshold never re-aims, so once the live set passes
   it every allocation trips it — tens of thousands of collections where it
   should take dozens, with nothing said about it.
2. **The object floor is multiplied at the first `Thread.new`, not at boot.**
   A graph built before any thread exists is allocated under a different budget
   from one built after, which is exactly what separates the arms. So both arms
   build from inside threads, behind a warm-up thread that creates the pool.

## The gate leg

`gc-locality-test` gates the correctness half, which is worth having
independently of the measurement: **a graph built across N workers must BE the
graph built by one.** The checksum walks the whole structure, so a node
published to another worker without its store being seen, or a slot recycled
while still reachable, changes it — and three of the defects this workload
family has turned up were silent wrong answers rather than crashes.

Confirmed failing rather than assumed, the same way as last time:

```
gc-locality-test: FAIL (build=2 W=1 changed the answer: that arm is not the same graph)
gc-locality-test: FAIL (mark walks 91 objs over 11 collections: the graph is not being held live)
```

Defaults are sized for the gate (0.14 s, 44–56 collections at every arm), not
for the ladder; the header gives the ladder settings. `threaded-render-test`,
`gc-phases-test` and `gc-obj-budget-test` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015W6Dvd4ZtddD6TfzP9B5NE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added automated validation for graph-building consistency across different worker and locality configurations.
  - Added checks confirming that generated graph output remains byte-identical regardless of build parallelism.
  - Added garbage-collection workload validation covering collection frequency and marking behavior.
  - Integrated these checks into the standard test run.
- **Chores**
  - Added a benchmark for measuring garbage-collection behavior with large live graphs and allocation churn.
  - Updated benchmark expectations for the expanded workload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->