### PR TITLE
spin pack carries a dependency's native C, not only a bundled package's

### DIFF
--- a/docs/spin.md
+++ b/docs/spin.md
@@ -411,8 +411,10 @@ pack demo -> /path/to/demo/build/pack/demo
 ```
 
 It contains the generated C, the runtime sources, the sources of every native
-package the build links, and a Makefile. `--out DIR` puts it somewhere else.
-One executable at a time; name it when the project has several.
+package the build links -- bundled or a dependency, whose objects live in the
+shared cache rather than beside their source -- and a Makefile. `--out DIR`
+puts it somewhere else. One executable at a time; name it when the project has
+several.
 
 **The Makefile is derived, not written.** `spinel --print-build` reports the
 ingredients the program requires -- its defines, include paths, libraries and

--- a/tools/spin.rb
+++ b/tools/spin.rb
@@ -1141,6 +1141,32 @@ class Project
     end
   end
 
+  # The source a carried-C object was compiled from, or "" when there is no
+  # telling. A bundled package (the compiler's own packages/) compiles beside
+  # its source. A dependency compiles into the shared object cache, one
+  # directory per (package, version, compiler) whose layout mirrors the
+  # package tree -- so the object's path below that directory names its source
+  # within the package. `_mt` marks the threaded variant of one source file.
+  def native_source_for(obj)
+    base = File.basename(obj)
+    stem = base[0, base.length - 2]
+    stem = stem[0, stem.length - 3] if stem.length > 3 && stem[stem.length - 3, 3] == "_mt"
+    beside = File.join(File.dirname(obj), stem + ".c")
+    return beside if File.exist?(beside)
+    @dep_srcs.split("\n").each do |s|
+      f = s.split("\t")
+      key = "/" + f[0] + "-" + f[2] + "-" + cc_cache_key + "/"
+      at = obj.index(key)
+      next if at.nil?
+      rel = obj[(at + key.length)..-1].to_s
+      rel = rel[0, rel.length - 2]
+      rel = rel[0, rel.length - 3] if rel.length > 3 && rel[rel.length - 3, 3] == "_mt"
+      src = File.join(f[1], rel + ".c")
+      return src if File.exist?(src)
+    end
+    ""
+  end
+
   # carried native C across the root package and every resolved dep (M2)
   def native_objs
     objs = []
@@ -1440,18 +1466,17 @@ def cmd_pack(prj, targets, outdir)
       # a package's native object. Its SOURCE is what travels; the object was
       # built for the packer's platform and the pack exists to leave that
       # behind. A `_mt` object is the threaded variant of one source file.
-      base = File.basename(val)
-      stem = base[0, base.length - 2]
-      stem = stem[0, stem.length - 3] if stem.length > 3 && stem[stem.length - 3, 3] == "_mt"
-      src = File.join(File.dirname(val), stem + ".c")
-      if File.exist?(src)
+      src = prj.native_source_for(val)
+      if src != ""
+        stem = File.basename(src)
+        stem = stem[0, stem.length - 2]
         pack_copy(src, File.join(outdir, "native", stem + ".c"))
         natives += " native/" + stem + ".o"
-        Dir.glob(File.join(File.dirname(val), "*.h")).each do |hf|
+        Dir.glob(File.join(File.dirname(src), "*.h")).each do |hf|
           pack_copy(hf, File.join(outdir, "native", File.basename(hf)))
         end
       else
-        puts "pack: warning: no source beside #{base}; the pack will not build without it"
+        puts "pack: warning: no source for #{File.basename(val)}; the pack will not build without it"
       end
     end
   end

--- a/tools/spin_e2e.sh
+++ b/tools/spin_e2e.sh
@@ -888,15 +888,20 @@ fi
 # package on purpose: those are what make the pack more than a copy, since the
 # threaded runtime needs -DSP_THREADS to reach the runtime sources as well as
 # the generated TU, and a package travels as source rather than as the object
-# built for the packer's platform.
+# built for the packer's platform. The dependency with carried C (spinel-fast,
+# from the M2 case above) is the other kind of native package: a bundled one
+# compiles beside its source, a dependency compiles into the shared cache, and
+# the pack has to find the source of each.
 cd "$WORK"
 "$SPIN" new packer >/dev/null || fail "pack: new"
 cd packer
+printf '[package]\nname = "packer"\n\n[dependencies]\nfast = { path = "../spinel-fast" }\n' > spin.toml
 cat > bin/packer.rb <<'RBEOF'
 require "json"
+require "fast"
 ths = (0...4).map { |i| Thread.new(i) { |n| n * 10 } }
 puts "threads #{ths.map(&:value).inspect}"
-puts "json #{JSON.generate({ "a" => 1, "b" => [2, 3] })}"
+puts "json #{JSON.generate({ "a" => 1, "b" => [2, 3] })} fast #{Fast.fast_quad(10)}"
 RBEOF
 REF=$("$SPIN" run 2>&1 | tail -2 | tr '\n' '|')
 "$SPIN" pack >/dev/null 2>&1 || fail "pack: spin pack"
@@ -905,6 +910,7 @@ REF=$("$SPIN" run 2>&1 | tail -2 | tr '\n' '|')
 [ -f build/pack/packer/lib/sp_gc.c ] || fail "pack: no runtime source"
 [ -f build/pack/packer/lib/spinel/runtime.h ] || fail "pack: no package ABI header"
 [ -f build/pack/packer/native/sp_json.c ] || fail "pack: native package not carried as source"
+[ -f build/pack/packer/native/fast_ext.c ] || fail "pack: dependency's native C not carried as source"
 grep -q -- "-DSP_THREADS" build/pack/packer/Makefile || fail "pack: threaded program without -DSP_THREADS"
 grep -q -- "-lpthread" build/pack/packer/Makefile || fail "pack: threaded program without -lpthread"
 # What the pack must NOT carry: how THIS build was run. The compiler reports


### PR DESCRIPTION
`spin pack` (32ad55a6) looks for each linked object's source beside the object. That holds for the compiler's own `packages/`, which compile in place, and for nothing else: a `[dependencies]` package's carried C compiles into the shared cache (`~/.cache/spin/native/<name>-<version>-<cc>/`) while its source stays in the package tree. The pack warns and writes a Makefile that cannot link — on the recipient's machine, which is the person the warning did not reach.

## Reproduction

Any project with a dependency that carries C. The e2e's own `spinel-fast` (a path dependency with `sources = ["*.c"]`) is enough:

```
$ spin new packer && cd packer
$ printf '[package]\nname = "packer"\n\n[dependencies]\nfast = { path = "../spinel-fast" }\n' > spin.toml
$ printf 'require "fast"\nputs Fast.fast_quad(10)\n' > bin/packer.rb
$ spin pack
pack: warning: no source beside fast_ext_mt.o; the pack will not build without it
pack packer -> .../build/pack/packer
$ ls build/pack/packer/native
(empty)
```

Found packing ONCE Campfire (rubys/roundhouse), whose `spin.toml` depends on `rubys/spinel-bcrypt` by git: `crypt_blowfish_mt.o` and `sp_bcrypt_mt.o` both warned, and `make` in the pack stopped at undefined bcrypt symbols.

## Change

The cache mirrors the package tree under one directory per (package, version, compiler), so an object's path below that directory names its source within the package. `Project#native_source_for` resolves it that way — beside first, then through the project's dependency records — and `cmd_pack` asks it instead of assuming. Headers are copied from beside the *source*, which is the same place for a bundled package.

## Test

The e2e pack case gains the `fast` dependency beside the bundled `json` package, asserts `native/fast_ext.c` is in the pack, and still builds the pack with `make` and compares answers to `spin run`. Confirmed discriminating: the new assertion fails on the previous `bin/spin`, passes on this one. Campfire repacked with zero warnings and its pack built and served from a `debian:trixie-slim` image.

(Aside, not in this PR: on macOS `tools/spin_e2e.sh` fails earlier at "spin flags: progress leaked onto stdout" because BSD `wc -l` pads its output — `[ "       0" = "0" ]`. A `tr -d ' '` fixes it; I ran a copy with that change to reach the pack case.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5CqTWStgx9F3iqeYoTNRD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Packed projects now include native source files for linked dependencies, including bundled and path-based dependencies.
  * Native headers are collected from their source locations.
  * Packed programs can verify native functionality from included path dependencies.

* **Documentation**
  * Clarified which native sources and compiled objects are included in packed output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->