### PR TITLE
spin pack leaves -lcrypt to the recipient's platform

### DIFF
--- a/docs/spin.md
+++ b/docs/spin.md
@@ -411,8 +411,10 @@ pack demo -> /path/to/demo/build/pack/demo
 ```
 
 It contains the generated C, the runtime sources, the sources of every native
-package the build links, and a Makefile. `--out DIR` puts it somewhere else.
-One executable at a time; name it when the project has several.
+package the build links -- bundled or a dependency, whose objects live in the
+shared cache rather than beside their source -- and a Makefile. `--out DIR`
+puts it somewhere else. One executable at a time; name it when the project has
+several.
 
 **The Makefile is derived, not written.** `spinel --print-build` reports the
 ingredients the program requires -- its defines, include paths, libraries and

--- a/docs/spin.md
+++ b/docs/spin.md
@@ -452,7 +452,11 @@ described above.
 
 **What a pack cannot carry.** A package that binds a system library -- openssl,
 sqlite -- names it with `-l` in the Makefile and expects it on the recipient's
-machine. Those packs need a C compiler, `make`, and that library.
+machine. Those packs need a C compiler, `make`, and that library. One library
+is the recipient's platform's to name rather than the packer's: `String#crypt`
+is libc `crypt(3)`, a separate `-lcrypt` on glibc and part of libSystem on
+Darwin, and the Makefile decides that from `uname` where it runs, so a pack
+made on a Mac links on Linux and the other way round.
 
 ## Rebuilds
 

--- a/tools/spin.rb
+++ b/tools/spin.rb
@@ -1141,6 +1141,32 @@ class Project
     end
   end
 
+  # The source a carried-C object was compiled from, or "" when there is no
+  # telling. A bundled package (the compiler's own packages/) compiles beside
+  # its source. A dependency compiles into the shared object cache, one
+  # directory per (package, version, compiler) whose layout mirrors the
+  # package tree -- so the object's path below that directory names its source
+  # within the package. `_mt` marks the threaded variant of one source file.
+  def native_source_for(obj)
+    base = File.basename(obj)
+    stem = base[0, base.length - 2]
+    stem = stem[0, stem.length - 3] if stem.length > 3 && stem[stem.length - 3, 3] == "_mt"
+    beside = File.join(File.dirname(obj), stem + ".c")
+    return beside if File.exist?(beside)
+    @dep_srcs.split("\n").each do |s|
+      f = s.split("\t")
+      key = "/" + f[0] + "-" + f[2] + "-" + cc_cache_key + "/"
+      at = obj.index(key)
+      next if at.nil?
+      rel = obj[(at + key.length)..-1].to_s
+      rel = rel[0, rel.length - 2]
+      rel = rel[0, rel.length - 3] if rel.length > 3 && rel[rel.length - 3, 3] == "_mt"
+      src = File.join(f[1], rel + ".c")
+      return src if File.exist?(src)
+    end
+    ""
+  end
+
   # carried native C across the root package and every resolved dep (M2)
   def native_objs
     objs = []
@@ -1440,18 +1466,17 @@ def cmd_pack(prj, targets, outdir)
       # a package's native object. Its SOURCE is what travels; the object was
       # built for the packer's platform and the pack exists to leave that
       # behind. A `_mt` object is the threaded variant of one source file.
-      base = File.basename(val)
-      stem = base[0, base.length - 2]
-      stem = stem[0, stem.length - 3] if stem.length > 3 && stem[stem.length - 3, 3] == "_mt"
-      src = File.join(File.dirname(val), stem + ".c")
-      if File.exist?(src)
+      src = prj.native_source_for(val)
+      if src != ""
+        stem = File.basename(src)
+        stem = stem[0, stem.length - 2]
         pack_copy(src, File.join(outdir, "native", stem + ".c"))
         natives += " native/" + stem + ".o"
-        Dir.glob(File.join(File.dirname(val), "*.h")).each do |hf|
+        Dir.glob(File.join(File.dirname(src), "*.h")).each do |hf|
           pack_copy(hf, File.join(outdir, "native", File.basename(hf)))
         end
       else
-        puts "pack: warning: no source beside #{base}; the pack will not build without it"
+        puts "pack: warning: no source for #{File.basename(val)}; the pack will not build without it"
       end
     end
   end

--- a/tools/spin.rb
+++ b/tools/spin.rb
@@ -1447,7 +1447,12 @@ def cmd_pack(prj, targets, outdir)
     if kind == "define" || kind == "cflag"
       cflags += " " + val
     elsif kind == "lib"
-      libs += " " + val
+      # -lcrypt is the one ingredient the compiler reports for ITS platform
+      # rather than the program's: String#crypt is libc crypt(3), which glibc
+      # ships as a separate library and Darwin folds into libSystem. A pack
+      # made on a Mac would omit it and fail to link on Linux, so the Makefile
+      # decides it from the recipient's uname instead (below).
+      libs += " " + val unless val == "-lcrypt"
     elsif kind == "include"
       # every include pointed into the compiler's tree; the pack has its own
     elsif kind == "source"
@@ -1520,6 +1525,11 @@ def cmd_pack(prj, targets, outdir)
 "        "CC ?= cc
 "        "CFLAGS ?= -O2#{cflags} -Ilib -Ilib/regexp
 "        "LIBS ?=#{libs}
+"        "# String#crypt is libc crypt(3): a separate library on glibc, inside
+"        "# libSystem on Darwin. The recipient's platform decides, not the packer's.
+"        "ifneq ($(shell uname -s),Darwin)
+"        "LIBS += -lcrypt
+"        "endif
 "        "
 "        "RT := $(wildcard lib/*.c) $(wildcard lib/regexp/*.c)
 "        "NATIVE :=#{natives}

--- a/tools/spin_e2e.sh
+++ b/tools/spin_e2e.sh
@@ -888,15 +888,20 @@ fi
 # package on purpose: those are what make the pack more than a copy, since the
 # threaded runtime needs -DSP_THREADS to reach the runtime sources as well as
 # the generated TU, and a package travels as source rather than as the object
-# built for the packer's platform.
+# built for the packer's platform. The dependency with carried C (spinel-fast,
+# from the M2 case above) is the other kind of native package: a bundled one
+# compiles beside its source, a dependency compiles into the shared cache, and
+# the pack has to find the source of each.
 cd "$WORK"
 "$SPIN" new packer >/dev/null || fail "pack: new"
 cd packer
+printf '[package]\nname = "packer"\n\n[dependencies]\nfast = { path = "../spinel-fast" }\n' > spin.toml
 cat > bin/packer.rb <<'RBEOF'
 require "json"
+require "fast"
 ths = (0...4).map { |i| Thread.new(i) { |n| n * 10 } }
 puts "threads #{ths.map(&:value).inspect}"
-puts "json #{JSON.generate({ "a" => 1, "b" => [2, 3] })}"
+puts "json #{JSON.generate({ "a" => 1, "b" => [2, 3] })} fast #{Fast.fast_quad(10)}"
 RBEOF
 REF=$("$SPIN" run 2>&1 | tail -2 | tr '\n' '|')
 "$SPIN" pack >/dev/null 2>&1 || fail "pack: spin pack"
@@ -905,6 +910,7 @@ REF=$("$SPIN" run 2>&1 | tail -2 | tr '\n' '|')
 [ -f build/pack/packer/lib/sp_gc.c ] || fail "pack: no runtime source"
 [ -f build/pack/packer/lib/spinel/runtime.h ] || fail "pack: no package ABI header"
 [ -f build/pack/packer/native/sp_json.c ] || fail "pack: native package not carried as source"
+[ -f build/pack/packer/native/fast_ext.c ] || fail "pack: dependency's native C not carried as source"
 grep -q -- "-DSP_THREADS" build/pack/packer/Makefile || fail "pack: threaded program without -DSP_THREADS"
 grep -q -- "-lpthread" build/pack/packer/Makefile || fail "pack: threaded program without -lpthread"
 # What the pack must NOT carry: how THIS build was run. The compiler reports

--- a/tools/spin_e2e.sh
+++ b/tools/spin_e2e.sh
@@ -901,7 +901,7 @@ require "json"
 require "fast"
 ths = (0...4).map { |i| Thread.new(i) { |n| n * 10 } }
 puts "threads #{ths.map(&:value).inspect}"
-puts "json #{JSON.generate({ "a" => 1, "b" => [2, 3] })} fast #{Fast.fast_quad(10)}"
+puts "json #{JSON.generate({ "a" => 1, "b" => [2, 3] })} fast #{Fast.fast_quad(10)} crypt #{"spin".crypt("ab")}"
 RBEOF
 REF=$("$SPIN" run 2>&1 | tail -2 | tr '\n' '|')
 "$SPIN" pack >/dev/null 2>&1 || fail "pack: spin pack"
@@ -913,6 +913,11 @@ REF=$("$SPIN" run 2>&1 | tail -2 | tr '\n' '|')
 [ -f build/pack/packer/native/fast_ext.c ] || fail "pack: dependency's native C not carried as source"
 grep -q -- "-DSP_THREADS" build/pack/packer/Makefile || fail "pack: threaded program without -DSP_THREADS"
 grep -q -- "-lpthread" build/pack/packer/Makefile || fail "pack: threaded program without -lpthread"
+# -lcrypt is the recipient's platform's to decide (glibc ships it, Darwin does
+# not), so it must not be baked from the packer's: the Makefile carries the
+# uname conditional, and the program's String#crypt above links through it.
+grep -q -- "^LIBS ?=.*-lcrypt" build/pack/packer/Makefile && fail "pack: -lcrypt baked from the packer's platform"
+grep -q -- "uname -s" build/pack/packer/Makefile || fail "pack: Makefile does not decide -lcrypt by platform"
 # What the pack must NOT carry: how THIS build was run. The compiler reports
 # ingredients, not a command line, so the packer's optimisation level, its
 # warning policy, its diagnostic formatting and its linker's spelling of


### PR DESCRIPTION
Stacked on #4433 (both touch the same lines of the e2e pack case; this one carries that commit and merges cleanly after it).

`--print-build` reports what the program requires, and one line of that report is about the *compiler's host* instead: `-lcrypt` is emitted under `#if !defined(__APPLE__)` (src/main.c), because `String#crypt` is libc `crypt(3)`, which glibc ships as a separate library and Darwin folds into libSystem. So a pack made on a Mac carries no `-lcrypt`, and the pack's own header — "the ingredients travel unchanged" across cross-compiles — does not hold for this one.

## Reproduction

On macOS:

```
$ spin new cr && cd cr
$ printf 'puts "spin".crypt("ab")\n' > bin/cr.rb
$ spin pack
$ grep ^LIBS build/pack/cr/Makefile
LIBS ?= -lm
```

Then on Linux (here, `gcc:14` in Docker with the pack mounted):

```
$ make -j
/usr/bin/ld: lib/sp_str.o: in function `sp_str_crypt':
sp_str.c:(.text+0x...): undefined reference to `crypt'
```

Found packing ONCE Campfire (rubys/roundhouse) on a Mac for a `debian:trixie-slim` image.

## Change

The Makefile is where the recipient's platform is known, so the decision moves there: `cmd_pack` drops `-lcrypt` from the reported libs and always writes

```make
ifneq ($(shell uname -s),Darwin)
LIBS += -lcrypt
endif
```

It is the only platform-conditional *library* the driver has; the other two `#if !__APPLE__` arms (`-rdynamic` under `--debug`, the linker's section-GC spelling) are already kept out of the pack as the packer's own. `--print-build` itself is unchanged — its answer is honest for the host it runs on, and the pack is the consumer that needs the platform left open.

## Test

The e2e pack program now calls `String#crypt`, so the link goes through the conditional on whichever host runs the check; the Makefile is asserted to carry the conditional and not a baked `-lcrypt` in `LIBS ?=`. Confirmed discriminating against the previous `bin/spin`. And the actual claim: the `cr` pack above, made on macOS, built and ran under `gcc:14` on Linux with this change, `ldd` showing `libcrypt.so.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5CqTWStgx9F3iqeYoTNRD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `spin pack` now includes native C sources and headers from dependencies, including sources stored in the shared cache.
  - Packed builds now handle `String#crypt` linking correctly across glibc-based Linux and Darwin systems.
  - Threaded native dependencies are supported during pack generation.

- **Documentation**
  - Updated `spin pack` documentation to describe native dependency inclusion and platform-specific cryptographic library handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->