### PR TITLE
spin-e2e: the `spin flags` line count reads the same on BSD wc

### DIFF
--- a/tools/spin_e2e.sh
+++ b/tools/spin_e2e.sh
@@ -591,7 +591,7 @@ rm -rf "$XDG_CACHE_HOME/spin/native"          # cold: `flags` must compile the c
 FLAGS=$("$SPIN" flags 2>/dev/null)
 # One line. A cold cache compiles here, and that progress used to print on
 # stdout, which would splice `cc fast/fast_ext.c` into the flag string.
-[ "$(printf '%s' "$FLAGS" | wc -l)" = "0" ] || fail "spin flags: progress leaked onto stdout"
+[ "$(printf '%s' "$FLAGS" | wc -l | tr -d ' ')" = "0" ] || fail "spin flags: progress leaked onto stdout"
 case "$FLAGS" in
   --require-gate*) ;;
   *) fail "spin flags: does not carry the require gate spin build compiles under" ;;


### PR DESCRIPTION
On macOS, `tools/spin_e2e.sh bin/spin` stops at

```
spin-e2e FAIL: spin flags: progress leaked onto stdout
```

with nothing wrong in spin: BSD `wc -l` pads its count to a fixed width, so the check compares `"       0"` against `"0"`. Everything after that line — the vendor, index, pack and CC-wrapper cases — never runs on a Mac.

The script's other `wc` (line 376, `N_ART=…| wc -l | tr -d ' '`) already strips the padding; this makes line 594 do the same. One line.

Verified: full `tools/spin_e2e.sh` on macOS 15 / Apple clang is ALL GREEN with the change and fails at that line without it. (This is the aside from #4433; independent of it and of #4434.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5CqTWStgx9F3iqeYoTNRD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved the `spin flags` handoff check so it reliably verifies that no compile-progress output appears on standard output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->