### PR TITLE
packages/uri: the component writers (`host=`, `path=`, `query=`, …)

### DIFF
--- a/packages/uri/test/uri_parse.rb
+++ b/packages/uri/test/uri_parse.rb
@@ -27,3 +27,7 @@ w.fragment = "f"
 p w.to_s
 w.hostname = "example.org"
 p [w.host, w.hostname]
+w.port = nil
+p w.to_s
+w.userinfo = "me:pw"
+p w.to_s

--- a/packages/uri/test/uri_parse.rb
+++ b/packages/uri/test/uri_parse.rb
@@ -16,3 +16,14 @@ p URI.encode_www_form({"a" => 1, "b" => "x y"})
 p URI.join("https://example.com/a/b", "c").to_s
 p URI.join("https://example.com/a/b", "/z").to_s
 p URI("https://example.com/x") == URI("https://example.com/x")
+w = URI("https://twitter.com/user/status/1?x=1")
+w.host = "fxtwitter.com"
+p w.to_s
+w.path = "/other"
+w.query = nil
+w.port = 8443
+w.scheme = "http"
+w.fragment = "f"
+p w.to_s
+w.hostname = "example.org"
+p [w.host, w.hostname]

--- a/packages/uri/test/uri_parse.rb.expected
+++ b/packages/uri/test/uri_parse.rb.expected
@@ -10,3 +10,6 @@
 "https://example.com/a/c"
 "https://example.com/z"
 true
+"https://fxtwitter.com/user/status/1?x=1"
+"http://fxtwitter.com:8443/other#f"
+["example.org", "example.org"]

--- a/packages/uri/test/uri_parse.rb.expected
+++ b/packages/uri/test/uri_parse.rb.expected
@@ -13,3 +13,5 @@ true
 "https://fxtwitter.com/user/status/1?x=1"
 "http://fxtwitter.com:8443/other#f"
 ["example.org", "example.org"]
+"http://example.org/other#f"
+"http://me:pw@example.org/other#f"

--- a/packages/uri/uri.rb
+++ b/packages/uri/uri.rb
@@ -66,7 +66,8 @@ module URI
       s << "#{@scheme}://" unless @scheme.nil? || @scheme.empty?
       s << "#{@userinfo}@" unless @userinfo.nil? || @userinfo.empty?
       s << @host.to_s
-      s << ":#{@port}" if @port != default_port && @port > 0
+      # A cleared port (`uri.port = nil`) is omitted, as CRuby omits it.
+      s << ":#{@port}" if !@port.nil? && @port != default_port && @port > 0
       s << @path.to_s
       s << "?#{@query}" unless @query.nil? || @query.empty?
       s << "##{@fragment}" unless @fragment.nil? || @fragment.empty?

--- a/packages/uri/uri.rb
+++ b/packages/uri/uri.rb
@@ -21,6 +21,16 @@ module URI
 
   class Generic
     attr_reader :scheme, :userinfo, :host, :port, :path, :query, :fragment
+    # The component writers CRuby's Generic has: a parsed URI is edited
+    # in place and re-serialised with #to_s (`uri.host = "fxtwitter.com"`
+    # is how a Rails app swaps a domain). Assignment only -- CRuby also
+    # validates the new component and raises InvalidComponentError on a
+    # bad one, which is absent here the way the rest of the subset is.
+    attr_writer :scheme, :userinfo, :host, :port, :path, :query, :fragment
+
+    def hostname=(value)
+      @host = value
+    end
 
     def initialize(scheme, userinfo, host, port, path, query, fragment)
       @scheme = scheme


### PR DESCRIPTION
`URI::Generic` in `packages/uri` has the component readers and `#to_s`, and no writers. campfire rewrites a parsed URL's host before re-serialising it:

```ruby
uri = URI.parse(url)
uri.host = FX_TWITTER_HOST if uri.host.in?(TWITTER_HOSTS)
uri.to_s
```

which is `undefined method 'host=' for an instance of URI::HTTPS` at run time. This adds `attr_writer` for the seven components CRuby's `Generic` exposes (`scheme`, `userinfo`, `host`, `port`, `path`, `query`, `fragment`) and `hostname=` beside the existing `hostname` reader. Assignment only — CRuby also validates the new component and raises `InvalidComponentError`; that is absent here the way the rest of the subset is, and the comment says so.

The package test (`packages/uri/test/uri_parse.rb`) gains an edit through every writer and prints `#to_s`; `.expected` is regenerated from CRuby. Fails before the change (NoMethodError, exit 1), passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACT7uLEdCrdWxGMdD4VdWV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - URI objects can now be updated after parsing by changing their scheme, host, hostname, port, path, query, fragment, or user information.
  - Updated URI components are reflected when the URI is converted back to text.
  - Assigning a hostname separately removes any existing port from the host value.

- **Bug Fixes**
  - Clearing a URI’s port now correctly removes it from the serialized URI.

- **Tests**
  - Added coverage for updating URI components and parsing URLs with queries, ports, fragments, and user information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->