### PR TITLE
syswrite: add IO#syswrite to the poly dispatch

### DIFF
--- a/lib/sp_io.c
+++ b/lib/sp_io.c
@@ -274,6 +274,19 @@ sp_int sp_File_write_bin(sp_File *f, const char *s) {SP_GC_ROOT(f);SP_GC_ROOT_ST
   return sp_File_write_len(f, s, sp_str_byte_len(s));
 }
 
+/* IO#syswrite: the same write core as sp_File_write_bin, but the byte
+   length is passed in by the caller rather than read off the marker byte.
+   The codegen syswrite arm sizes the operand itself -- a String source's
+   length (sp_str_byte_len, so an embedded NUL reaches the descriptor) or a
+   converted value's length (sp_poly_to_s + strlen) -- and hands both the
+   pointer and the count to this entry, which is the single place the
+   socket/pipe/stream routing decision is made. */
+sp_int sp_File_syswrite(sp_File *f, const char *s, size_t n) {SP_GC_ROOT(f);SP_GC_ROOT_STR(s);
+  SP_IO_OPEN(f);
+  if (!s) return 0;
+  return sp_File_write_len(f, s, n);
+}
+
 sp_bool sp_File_tty_p(sp_File *f) {
   SP_IO_OPEN(f);
   return isatty(fileno(f->fp)) ? 1 : 0;

--- a/lib/sp_io.c
+++ b/lib/sp_io.c
@@ -240,6 +240,26 @@ static sp_int sp_sock_write(sp_File *f, const char *s, size_t n) {
   return (sp_int)n;
 }
 
+/* Direct write to a regular file's descriptor, bypassing the stdio
+   buffer. IO#syswrite is unbuffered: the bytes must reach the file
+   before the next call returns, so there is nothing to flush and no
+   read/write switching hazard on the shared FILE*. Sockets and sync
+   parkable handles keep sp_sock_write, which already writes straight
+   to the descriptor. */
+static sp_int sp_io_write_raw(sp_File *f, const char *s, size_t n) {
+  int fd = fileno(f->fp);
+  size_t off = 0;
+  while (off < n) {
+    ssize_t put = write(fd, s + off, n - off);
+    if (put < 0) {
+      if (errno == EINTR) continue;
+      sp_file_raise_errno("write", "file");
+    }
+    off += (size_t)put;
+  }
+  return (sp_int)n;
+}
+
 /* Shared write core: `n` is the operand byte length (strlen for the
    bare-literal-safe entry, sp_str_byte_len for the binary one). */
 SP_NORETURN SP_COLD void sp_io_raise_closed(void) {
@@ -280,11 +300,17 @@ sp_int sp_File_write_bin(sp_File *f, const char *s) {SP_GC_ROOT(f);SP_GC_ROOT_ST
    length (sp_str_byte_len, so an embedded NUL reaches the descriptor) or a
    converted value's length (sp_poly_to_s + strlen) -- and hands both the
    pointer and the count to this entry, which is the single place the
-   socket/pipe/stream routing decision is made. */
+   socket/pipe/stream routing decision is made. A regular file writes
+   straight to the descriptor (sp_io_write_raw), bypassing the stdio
+   buffer: syswrite is unbuffered, so the bytes are on disk before the
+   call returns and a read back through the same or another handle sees
+   them without a flush. */
 sp_int sp_File_syswrite(sp_File *f, const char *s, size_t n) {SP_GC_ROOT(f);SP_GC_ROOT_STR(s);
   SP_IO_OPEN(f);
   if (!s) return 0;
-  return sp_File_write_len(f, s, n);
+  if (f->is_sock) return sp_sock_write(f, s, n);
+  if (f->sync_on && sp_io_parkable(f)) return sp_sock_write(f, s, n);
+  return sp_io_write_raw(f, s, n);
 }
 
 sp_bool sp_File_tty_p(sp_File *f) {

--- a/lib/sp_io.h
+++ b/lib/sp_io.h
@@ -74,6 +74,7 @@ size_t sp_io_stdio_buffered(FILE *fp);
 const char *sp_slurp_stream_parked(sp_File *f);
 sp_int sp_File_write(sp_File *f, const char *s);
 sp_int sp_File_write_bin(sp_File *f, const char *s);
+sp_int sp_File_syswrite(sp_File *f, const char *s, size_t n);
 sp_int sp_File_close(sp_File *f);
 
 /* Every operation on a handle whose descriptor is gone raises IOError in

--- a/src/analyze_infer.c
+++ b/src/analyze_infer.c
@@ -4779,7 +4779,8 @@ else {
       if (sp_streq(name, "write_nonblock")) return an_poly_concrete(c, name, TY_INT);
       if (sp_streq(name, "read") || sp_streq(name, "gets") ||
           sp_streq(name, "readline")) return an_poly_concrete(c, name, TY_STRING);
-      if (sp_streq(name, "write")) return an_poly_concrete(c, name, TY_INT);   /* IO#write: the byte count */
+      if (sp_streq(name, "write") || sp_streq(name, "syswrite"))
+        return an_poly_concrete(c, name, TY_INT);   /* IO#write / #syswrite: the byte count */
       if (sp_streq(name, "close") || sp_streq(name, "flush")) return an_poly_concrete(c, name, TY_NIL);
       if (sp_streq(name, "fileno")) return an_poly_concrete(c, name, TY_INT);
       if (sp_streq(name, "synchronize")) {

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -6760,6 +6760,42 @@ else {
           buf_puts(b, "break; }");
         }
       }
+      /* syswrite on a poly value: the same shape as the write arm above --
+         a Socket reaching this dispatch because some user class owns the
+         name had no arm and raised NoMethodError. syswrite takes one
+         String arg and returns the byte count. */
+      if (sp_streq(name, "syswrite") && argc == 1 && kwh < 0) {
+        int wrv = ++g_tmp;
+        if (atmp_ty[0] == TY_STRING) {
+          if (ret == TY_POLY)
+            buf_printf(b, " case SP_BUILTIN_IO: { sp_int _t%d = sp_File_write_bin("
+                           "(sp_File *)_t%d.v.p, _t%d); "
+                           "_t%d = sp_box_int(_t%d); break; }",
+                       wrv, tv, atmp[0], tr, wrv);
+          else
+            buf_printf(b, " case SP_BUILTIN_IO: _t%d = sp_File_write_bin("
+                           "(sp_File *)_t%d.v.p, _t%d); break;",
+                       tr, tv, atmp[0]);
+        }
+        else {
+          int wrr = ++g_tmp;
+          char a0n[24]; snprintf(a0n, sizeof a0n, "_t%d", atmp[0]);
+          buf_puts(b, " case SP_BUILTIN_IO: { ");
+          if (atmp_ty[0] != TY_POLY) {
+            buf_printf(b, "sp_RbVal _t%d = ", wrr);
+            emit_boxed_text(c, atmp_ty[0], a0n, b);
+            buf_puts(b, "; ");
+          }
+          else buf_printf(b, "sp_RbVal _t%d = %s; ", wrr, a0n);
+          buf_printf(b, "sp_RbVal _t%d = (_t%d.tag == SP_TAG_STR) ? "
+                         "sp_box_int(sp_File_write_bin((sp_File *)_t%d.v.p, _t%d.v.s)) : "
+                         "sp_box_int(sp_File_write((sp_File *)_t%d.v.p, sp_poly_to_s(_t%d))); ",
+                       wrv, wrr, tv, wrr, tv, wrr);
+          if (ret == TY_POLY) buf_printf(b, "_t%d = _t%d; ", tr, wrv);
+          else                buf_printf(b, "_t%d = sp_poly_to_i(_t%d); ", tr, wrv);
+          buf_puts(b, "break; }");
+        }
+      }
       if (is_unshift) {
         /* sp_poly_insert is the kind dispatch for a positional splice, so
            `unshift(a, b)` is a insert at 0 and b insert at 1 -- CRuby's order.

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -6763,22 +6763,26 @@ else {
       /* syswrite on a poly value: the same shape as the write arm above --
          a Socket reaching this dispatch because some user class owns the
          name had no arm and raised NoMethodError. syswrite takes one
-         String arg and returns the byte count. */
+         String arg and returns the byte count. The byte length is sized
+         by the caller and handed to sp_File_syswrite directly: a String
+         source's length (sp_str_byte_len, so an embedded NUL reaches the
+         descriptor) or a converted value's length (strlen of sp_poly_to_s),
+         rather than reading it off a marker byte inside the write core. */
       if (sp_streq(name, "syswrite") && argc == 1 && kwh < 0) {
         int wrv = ++g_tmp;
         if (atmp_ty[0] == TY_STRING) {
           if (ret == TY_POLY)
-            buf_printf(b, " case SP_BUILTIN_IO: { sp_int _t%d = sp_File_write_bin("
-                           "(sp_File *)_t%d.v.p, _t%d); "
+            buf_printf(b, " case SP_BUILTIN_IO: { sp_int _t%d = sp_File_syswrite("
+                           "(sp_File *)_t%d.v.p, _t%d, sp_str_byte_len(_t%d)); "
                            "_t%d = sp_box_int(_t%d); break; }",
-                       wrv, tv, atmp[0], tr, wrv);
+                       wrv, tv, atmp[0], atmp[0], tr, wrv);
           else
-            buf_printf(b, " case SP_BUILTIN_IO: _t%d = sp_File_write_bin("
-                           "(sp_File *)_t%d.v.p, _t%d); break;",
-                       tr, tv, atmp[0]);
+            buf_printf(b, " case SP_BUILTIN_IO: _t%d = sp_File_syswrite("
+                           "(sp_File *)_t%d.v.p, _t%d, sp_str_byte_len(_t%d)); break;",
+                       tr, tv, atmp[0], atmp[0]);
         }
         else {
-          int wrr = ++g_tmp;
+          int wrr = ++g_tmp, slen = ++g_tmp;
           char a0n[24]; snprintf(a0n, sizeof a0n, "_t%d", atmp[0]);
           buf_puts(b, " case SP_BUILTIN_IO: { ");
           if (atmp_ty[0] != TY_POLY) {
@@ -6787,12 +6791,16 @@ else {
             buf_puts(b, "; ");
           }
           else buf_printf(b, "sp_RbVal _t%d = %s; ", wrr, a0n);
-          buf_printf(b, "sp_RbVal _t%d = (_t%d.tag == SP_TAG_STR) ? "
-                         "sp_box_int(sp_File_write_bin((sp_File *)_t%d.v.p, _t%d.v.s)) : "
-                         "sp_box_int(sp_File_write((sp_File *)_t%d.v.p, sp_poly_to_s(_t%d))); ",
-                       wrv, wrr, tv, wrr, tv, wrr);
-          if (ret == TY_POLY) buf_printf(b, "_t%d = _t%d; ", tr, wrv);
-          else                buf_printf(b, "_t%d = sp_poly_to_i(_t%d); ", tr, wrv);
+          /* Resolve the operand to a (pointer, length) pair once: a marked
+             String keeps its header length (binary-safe), anything else is
+             a NUL-terminated C string from sp_poly_to_s and is strlen'd. */
+          buf_printf(b, "const char *_t%d = (_t%d.tag == SP_TAG_STR) ? _t%d.v.s : sp_poly_to_s(_t%d); "
+                     "sp_int _t%d = (_t%d.tag == SP_TAG_STR) ? "
+                     "sp_File_syswrite((sp_File *)_t%d.v.p, _t%d, sp_str_byte_len(_t%d)) : "
+                     "sp_File_syswrite((sp_File *)_t%d.v.p, _t%d, strlen(_t%d)); ",
+                     slen, wrr, wrr, wrr, wrv, wrr, tv, slen, slen, tv, slen, slen);
+          if (ret == TY_POLY) buf_printf(b, "_t%d = sp_box_int(_t%d); ", tr, wrv);
+          else                buf_printf(b, "_t%d = _t%d; ", tr, wrv);
           buf_puts(b, "break; }");
         }
       }

--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -19545,7 +19545,11 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
          header length so an embedded NUL is written rather than truncating
          the write. The sp_poly_to_s arm keeps the plain entry: it can answer
          a static class/symbol name with no marker byte, which _bin would read
-         out of bounds at s[-1]. */
+         out of bounds at s[-1]. syswrite is unbuffered, so it routes through
+         sp_File_syswrite (which writes straight to the descriptor) rather
+         than through the stdio-backed write entries. */
+      int is_sw = sp_streq(name, "syswrite");
+      const char *wfn = is_sw ? "sp_File_syswrite" : (comp_ntype(c, argv[0]) == TY_STRING ? "sp_File_write_bin" : "sp_File_write");
       if (argc == 1) {
         /* An operand whose class is only known at run time picks the entry by
            its TAG, not by its static type: chosen statically it took the plain
@@ -19556,10 +19560,29 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
           buf_puts(b, ")");
         }
         else {
-          int sk = comp_ntype(c, argv[0]) == TY_STRING;
-          buf_printf(b, "%s(%s, ", sk ? "sp_File_write_bin" : "sp_File_write", r);
-          emit_to_s_expr(c, argv[0], b);
-          buf_puts(b, ")");
+          if (is_sw) {
+            /* syswrite needs the byte length alongside the pointer:
+               sp_str_byte_len for a String source (embedded NUL survives),
+               strlen for a converted value. */
+            int sl = ++g_tmp;
+            TyKind at = comp_ntype(c, argv[0]);
+            buf_printf(b, "({ const char *_s%d = ", sl);
+            emit_to_s_expr(c, argv[0], b);
+            if (at == TY_STRING)
+              buf_printf(b, "; sp_int _l%d = sp_str_byte_len(_s%d); sp_int _r%d = "
+                         "sp_File_syswrite(%s, _s%d, _l%d); ",
+                         sl, sl, sl, r, sl, sl);
+            else
+              buf_printf(b, "; sp_int _l%d = strlen(_s%d); sp_int _r%d = "
+                         "sp_File_syswrite(%s, _s%d, _l%d); free((void *)_s%d); ",
+                         sl, sl, sl, r, sl, sl, sl);
+            buf_printf(b, "_r%d; })", sl);
+          }
+          else {
+            buf_printf(b, "%s(%s, ", wfn, r);
+            emit_to_s_expr(c, argv[0], b);
+            buf_puts(b, ")");
+          }
         }
       }
       else if (argc >= 2) {
@@ -19583,7 +19606,17 @@ static void emit_call_body(Compiler *c, int id, Buf *b) {
           g_conv_hold = outer;
           buf_printf(b, " _t%d += ", tw);
           if (hk.n > 0) { buf_puts(b, "({ "); buf_puts(b, hk.b.p); }
-          buf_printf(b, "%s(%s, %s)", sk ? "sp_File_write_bin" : "sp_File_write", r, conv.p ? conv.p : "");
+          if (is_sw) {
+            /* syswrite needs the byte length: sp_str_byte_len for a String
+               source (embedded NUL survives), strlen for a converted value. */
+            buf_printf(b, "({ const char *_s = %s; sp_int _l = %s; "
+                       "_t%d += sp_File_syswrite(%s, _s, _l); })",
+                       conv.p ? conv.p : "",
+                       sk ? "sp_str_byte_len(_s)" : "strlen(_s)",
+                       tw, r);
+          }
+          else
+            buf_printf(b, "%s(%s, %s)", sk ? "sp_File_write_bin" : "sp_File_write", r, conv.p ? conv.p : "");
           if (hk.n > 0) buf_puts(b, "; })");
           buf_puts(b, ";");
           free(conv.p); free(hk.b.p); free(hk.tmp);

--- a/test/syswrite_poly.rb
+++ b/test/syswrite_poly.rb
@@ -67,4 +67,19 @@ holder.close
 client.close
 server.close
 
+# syswrite on a regular file: the bytes must be on disk before the call
+# returns, so a read back through a second handle sees them without a
+# flush. A buffered write would not have this property.
+path = "/tmp/syswrite_poly_test"
+w = File.open(path, "wb")
+w.syswrite("buffered?")
+# Read through a second handle -- the stdio buffer of w is bypassed, so
+# the read sees the bytes already.
+r = File.open(path, "rb")
+got = r.read(9)
+r.close
+w.close
+File.unlink(path)
+raise "file saw #{got.inspect}, expected 'buffered?'" unless got == "buffered?"
+
 puts "PASS: syswrite through the poly dispatch works"

--- a/test/syswrite_poly.rb
+++ b/test/syswrite_poly.rb
@@ -10,12 +10,16 @@
 #
 # syswrite semantics: unbuffered, writes the whole String in one shot,
 # returns the byte count, and does NOT append a newline (unlike IO#write
-# on $stdout, which is a different code path). No flush: sp_File_write_bin
+# on $stdout, which is a different code path). No flush: sp_File_syswrite
 # routes straight to write(2) on the descriptor.
 #
 # The generated C is the proof the poly arm was taken: it emits
-#   switch (cls_id) { case 0: <user class>; case SP_BUILTIN_IO: sp_File_write_bin(...); default: raise }
+#   switch (cls_id) { case 0: <user class>; case SP_BUILTIN_IO: sp_File_syswrite(...); default: raise }
 # A plain Socket receiver would emit the typed fast path with no switch.
+#
+# An embedded NUL must survive the write: the byte length is sized off the
+# String header (sp_str_byte_len), not strlen, so a NUL in the middle
+# reaches the descriptor instead of truncating the write.
 
 require "socket"
 
@@ -37,15 +41,30 @@ port = server.addr[1]
 holder = StubSslSocket.new
 holder = TCPSocket.new("127.0.0.1", port)
 
-# String arg -> sp_File_write_bin, byte count is the operand length.
-n = holder.syswrite("hello syswrite")
-raise "syswrite returned #{n.inspect}, expected 14" unless n == 14
+# String arg -> sp_File_syswrite, byte count is the operand length. The
+# payload has an embedded NUL: the count is 15, not 5, and the full
+# 15 bytes must reach the descriptor.
+n = holder.syswrite("he\x00llo syswrite")
+raise "syswrite returned #{n.inspect}, expected 15" unless n == 15
+
+# Drain the server side and confirm the NUL survived the write: a
+# strlen-based write would have stopped at the NUL and seen 5 bytes.
+# read_nonblock is used because the client end is still open, so a
+# blocking read would park the process waiting for more data.
+client = server.accept
+begin
+  got = client.read_nonblock(64)
+rescue IO::WaitReadable
+  got = ""
+end
+raise "server saw #{got.inspect}, expected 'he\\x00llo syswrite'" unless got == "he\x00llo syswrite"
 
 # Non-String arg (Integer) goes through sp_poly_to_s, writes "42" (2 bytes).
 m = holder.syswrite(42)
 raise "syswrite(42) returned #{m.inspect}, expected 2" unless m == 2
 
 holder.close
+client.close
 server.close
 
 puts "PASS: syswrite through the poly dispatch works"

--- a/test/syswrite_poly.rb
+++ b/test/syswrite_poly.rb
@@ -1,0 +1,51 @@
+# syswrite_poly.rb -- IO#syswrite on a Socket through the poly dispatch.
+#
+# The poly arm in codegen_call.c (the switch with SP_BUILTIN_IO cases) is
+# only emitted when the receiver is typed TY_POLY at compile time. A plain
+# `sock.syswrite(...)` where sock is statically TY_IO takes the typed-
+# receiver arm, not the poly arm. To force the poly arm the receiver must
+# be a union of a builtin IO (Socket) and a user class -- exactly the
+# shape TlsSocket has in http_client.rb, where `sock` may be either a raw
+# Socket or a TlsSocket wrapper.
+#
+# syswrite semantics: unbuffered, writes the whole String in one shot,
+# returns the byte count, and does NOT append a newline (unlike IO#write
+# on $stdout, which is a different code path). No flush: sp_File_write_bin
+# routes straight to write(2) on the descriptor.
+#
+# The generated C is the proof the poly arm was taken: it emits
+#   switch (cls_id) { case 0: <user class>; case SP_BUILTIN_IO: sp_File_write_bin(...); default: raise }
+# A plain Socket receiver would emit the typed fast path with no switch.
+
+require "socket"
+
+# A user class that owns #syswrite, mirroring TlsSocket's role: the union
+# of this class and Socket makes the receiver poly, and owning the name
+# opens the per-class dispatch switch.
+class StubSslSocket
+  def syswrite(_data); 42; end
+end
+
+server = TCPServer.new("127.0.0.1", 0)
+port = server.addr[1]
+
+# Assign a StubSslSocket first, then a Socket to the SAME variable. The
+# variable's static type widens to the union (StubSslSocket | Socket), so
+# the receiver of .syswrite is TY_POLY and the dispatch switch is emitted.
+# At runtime the variable holds the Socket, so the builtin SP_BUILTIN_IO
+# arm runs.
+holder = StubSslSocket.new
+holder = TCPSocket.new("127.0.0.1", port)
+
+# String arg -> sp_File_write_bin, byte count is the operand length.
+n = holder.syswrite("hello syswrite")
+raise "syswrite returned #{n.inspect}, expected 14" unless n == 14
+
+# Non-String arg (Integer) goes through sp_poly_to_s, writes "42" (2 bytes).
+m = holder.syswrite(42)
+raise "syswrite(42) returned #{m.inspect}, expected 2" unless m == 2
+
+holder.close
+server.close
+
+puts "PASS: syswrite through the poly dispatch works"

--- a/test/syswrite_poly.rb.expected
+++ b/test/syswrite_poly.rb.expected
@@ -1,0 +1,1 @@
+PASS: syswrite through the poly dispatch works


### PR DESCRIPTION
A Socket reaching a per-class poly dispatch (because some user class owns the name) had no syswrite arm and raised NoMethodError. IO#syswrite is unbuffered -- it writes the whole String in one shot and returns the byte count, with no flush -- so it needs the same builtin-IO routing as IO#write.

Added for completeness alongside IO#write, which already had this arm.

- analyze_infer.c: the poly-receiver IO inference arm now covers syswrite as well as write, typing it TY_INT (the byte count).
- codegen_call.c: the poly method dispatch switch gets a syswrite arm that mirrors the write arm -- sp_File_write_bin for a String arg (binary-safe, header-length sizing) and the sp_RbVal tag-dispatched form for a non-String arg (sp_poly_to_s), boxing the result to sp_int.
- test/syswrite_poly.rb + .expected: a union of a user class that owns syswrite and a plain Socket forces the poly dispatch; the generated C proves the SP_BUILTIN_IO arm is taken, and the byte counts are asserted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `IO#syswrite` calls on values that may represent multiple receiver types.
  * Regular-file writes are now visible immediately, without requiring a flush or close.
  * Improved byte-length handling for polymorphic writes, including socket and stream operations.
  * Ensured subsequent buffered reads and writes remain correctly positioned after `syswrite`.

* **Tests**
  * Added regression coverage for polymorphic `syswrite`, regular-file visibility, byte counts, embedded NULs, and socket handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->