### PR TITLE
force_encoding, encode! and zero-argument concat evaluate their receiver once

### DIFF
--- a/src/codegen_call.c
+++ b/src/codegen_call.c
@@ -27178,9 +27178,11 @@ else {
   /* String#concat with no arguments returns the receiver unchanged (#2309) */
   if (recv >= 0 && rt == TY_STRING && sp_streq(name, "concat") && argc == 0) {
     /* zero-argument concat returns the receiver, but CRuby checks frozen
-       first -- the empty append is still a mutation attempt (#3339) */
-    buf_puts(b, "(sp_str_check_mutable("); emit_expr(c, recv, b); buf_puts(b, "), ");
-    emit_expr(c, recv, b); buf_puts(b, ")");
+       first -- the empty append is still a mutation attempt (#3339). The
+       receiver once: a call with effects must not run twice. */
+    int tcc = ++g_tmp;
+    buf_printf(b, "({ const char *_t%d = ", tcc); emit_expr(c, recv, b);
+    buf_printf(b, "; sp_str_check_mutable(_t%d); _t%d; })", tcc, tcc);
     return;
   }
   /* String#clear consumed as a value: empty the assignable receiver in place

--- a/src/codegen_call_recv.c
+++ b/src/codegen_call_recv.c
@@ -7399,8 +7399,11 @@ int emit_scalar_call(Compiler *c, int id, Buf *b) {
          `b` and non-bang `encode` return a NEW string, so they never raise. */
       /* zero-argument concat / prepend return the receiver; a frozen one still
          raises, as CRuby checks before the (empty) append (#3339). */
-      else if ((sp_streq(name, "concat") || sp_streq(name, "prepend")) && argc == 0)
-        buf_printf(b, "(sp_str_check_mutable(%s), (%s))", r, r);
+      else if ((sp_streq(name, "concat") || sp_streq(name, "prepend")) && argc == 0) {
+        /* the receiver once: it is a call with effects as often as a local */
+        int trc0 = ++g_tmp;
+        buf_printf(b, "({ const char *_t%d = %s; sp_str_check_mutable(_t%d); _t%d; })", trc0, r, trc0, trc0);
+      }
       else if ((sp_streq(name, "force_encoding") || sp_streq(name, "encode!")) && argc <= 2)
         emit_str_force_encoding(c, r, argv, argc, b);
       else if ((sp_streq(name, "=~") || sp_streq(name, "!~")) && argc == 1 &&
@@ -10156,7 +10159,11 @@ int emit_object_call(Compiler *c, int id, Buf *b) {
    left the string naming UTF-8 -- and spinel's one tag is exactly what that
    argument asks for. A constant path (Encoding::BINARY) or a string literal
    both name it; anything else keeps the no-op, since spinel has no third
-   encoding to move to. */
+   encoding to move to.
+   The receiver is evaluated ONCE, into a temp: it feeds both the mutability
+   check and the retag, and a receiver that is a call with effects --
+   campfire's `request.body.read.force_encoding("UTF-8")`, where `read`
+   advances a cursor -- ran twice and retagged the second, empty, read. */
 static void emit_str_force_encoding(Compiler *c, const char *r, const int *argv, int argc, Buf *b) {
   const NodeTable *nt = c->nt;
   const char *fe_nm = NULL;
@@ -10179,9 +10186,11 @@ static void emit_str_force_encoding(Compiler *c, const char *r, const int *argv,
     fe_bin = sp_streq(fe_up, "ASCII-8BIT") || sp_streq(fe_up, "BINARY");
     fe_txt = sp_streq(fe_up, "UTF-8");
   }
-  if (fe_bin) buf_printf(b, "(sp_str_check_mutable(%s), sp_str_as_binary(%s))", r, r);
-  else if (fe_txt) buf_printf(b, "(sp_str_check_mutable(%s), sp_str_as_text(%s))", r, r);
-  else buf_printf(b, "(sp_str_check_mutable(%s), (%s))", r, r);
+  int trc = ++g_tmp;
+  buf_printf(b, "({ const char *_t%d = %s; sp_str_check_mutable(_t%d); ", trc, r, trc);
+  if (fe_bin) buf_printf(b, "sp_str_as_binary(_t%d); })", trc);
+  else if (fe_txt) buf_printf(b, "sp_str_as_text(_t%d); })", trc);
+  else buf_printf(b, "_t%d; })", trc);
 }
 static void emit_str_encode_call(Compiler *c, const char *recv_txt, const int *argv, int argc, Buf *b) {
   const NodeTable *nt = c->nt;

--- a/test/string_force_encoding_receiver_once.rb
+++ b/test/string_force_encoding_receiver_once.rb
@@ -1,0 +1,42 @@
+# `force_encoding` / `encode!` / zero-argument `concat` on a receiver that is
+# a CALL: the emit fed the receiver expression to both the mutability check
+# and the retag, so a receiver with effects ran twice. campfire's
+# `request.body.read.force_encoding("UTF-8")` is the caller -- `read`
+# advances a cursor, and the second read (the one retagged and returned) was
+# empty, so every bot POST arrived with a blank body.
+# (Literals are frozen in spinel, so the strings here are built.)
+class Body
+  def initialize(text)
+    @text = text
+    @pos = 0
+    @reads = 0
+  end
+
+  def read
+    @reads += 1
+    out = @text[@pos, @text.length - @pos].to_s
+    @pos = @text.length
+    out
+  end
+
+  def rewind
+    @pos = 0
+  end
+
+  def reads
+    @reads
+  end
+end
+
+b = Body.new(String.new("Hello Bot World!"))
+p b.read.force_encoding("UTF-8")
+p b.reads
+b.rewind
+p b.read.force_encoding("ASCII-8BIT").bytesize
+p b.reads
+b.rewind
+p b.read.encode!("UTF-8")
+p b.reads
+b.rewind
+p b.read.concat
+p b.reads

--- a/test/string_force_encoding_receiver_once.rb.expected
+++ b/test/string_force_encoding_receiver_once.rb.expected
@@ -1,0 +1,8 @@
+"Hello Bot World!"
+1
+16
+2
+"Hello Bot World!"
+3
+"Hello Bot World!"
+4


### PR DESCRIPTION
The three emits fed the receiver expression to both the mutability check and the result — `(sp_str_check_mutable(<recv>), sp_str_as_text(<recv>))` — so a receiver that is a call with effects ran twice.

```ruby
class Body
  def initialize(text); @text = text; @pos = 0; end
  def read
    out = @text[@pos, @text.length - @pos].to_s
    @pos = @text.length
    out
  end
end

b = Body.new(String.new("Hello Bot World!"))
p b.read.force_encoding("UTF-8")   # spinel: ""   CRuby: "Hello Bot World!"
```

campfire's `request.body.read.force_encoding("UTF-8")` (`RawRequestBody#raw_request_body`) is the caller: `read` advances a cursor, the second read was retagged and returned, and every bot POST arrived with a blank body — a 422 from the app's `ensure_body_or_attachment_present`, 10 tests on the compiled suite lane.

The receiver now lands in a temp both halves read, the shape the argument-taking `concat` already uses (`codegen_call_recv.c` for `force_encoding`/`encode!`/zero-arg `concat`+`prepend` on the String path, `codegen_call.c` for the other zero-arg `concat` site). Test added; `make test` 3597 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ToBsHgTtrSoAvNDmHdTtpf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed string operations so receiver expressions are evaluated only once.
  * Prevented unintended repeated side effects when using `concat`, `prepend`, `force_encoding`, and `encode!` with expression-based receivers.

* **Tests**
  * Added regression coverage confirming correct single-evaluation behavior and expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->