### PR TITLE
`s[/re/, n]` on a boxed String answers the capture

### DIFF
--- a/lib/spinel_rt.h
+++ b/lib/spinel_rt.h
@@ -6752,6 +6752,18 @@ static sp_PolyArray *sp_poly_zip_none(sp_RbVal a) {
    Method arm it already had. */
 static sp_RbVal sp_poly_callable_call(sp_RbVal v, sp_int n, const sp_int *args);
 static sp_RbVal sp_poly_slice_or_call(sp_RbVal v, sp_RbVal a, sp_RbVal b) {
+  /* `s[/re/, n]` on a boxed String: capture n of the first match, nil when
+     there is none -- the form the typed emitter answers inline. Read as a
+     two-integer slice, the Regexp operand raised TypeError (campfire's
+     `response.headers["Link"][/<(.*)>/, 1]` off a Hash[String, String]). */
+  if (v.tag == SP_TAG_STR && a.tag == SP_TAG_OBJ && a.v.p && a.cls_id == SP_BUILTIN_REGEX &&
+      b.tag == SP_TAG_INT) {
+    sp_int n = b.v.i;
+    if (sp_re_match((mrb_regexp_pattern *)a.v.p, v.v.s ? v.v.s : "") < 0) return sp_box_nil();
+    if (n == 0) return sp_box_nullable_str(sp_re_match_str);
+    if (n >= 1 && n <= 9) return sp_box_nullable_str(sp_re_captures[n]);
+    return sp_box_nil();
+  }
   if (v.tag == SP_TAG_OBJ && v.v.p &&
       (v.cls_id == SP_BUILTIN_PROC || v.cls_id == SP_BUILTIN_CURRY)) {
     _sp_proc_poly_args[0] = a;

--- a/test/poly_string_aref_regexp.rb
+++ b/test/poly_string_aref_regexp.rb
@@ -1,0 +1,17 @@
+# `s[/re/, n]` on a receiver typed `String | nil`: the typed emitter answers
+# the capture inline, the boxed path read the two operands as an integer
+# slice and raised TypeError on the Regexp. campfire's
+# `response.headers["Link"][/<(.*)>/, 1]` -- a read off a
+# Hash[String, String] -- is the caller.
+def pick(ok)
+  ok ? "<http://x/y?before=3>; rel=\"next\"" : nil
+end
+
+v = pick(true)
+p v[/<(.*)>/, 1]
+p v[/<(.*)>/, 0]
+p v[/before=(\d+)/, 1]
+p v[/nothing/, 1]
+p v[/<(.*)>/, 4]
+h = { "link" => "<http://x/y?before=3>; rel=\"next\"" }
+p h["link"][/<(.*)>/, 1]

--- a/test/poly_string_aref_regexp.rb.expected
+++ b/test/poly_string_aref_regexp.rb.expected
@@ -1,0 +1,6 @@
+"http://x/y?before=3"
+"<http://x/y?before=3>"
+"3"
+nil
+nil
+"http://x/y?before=3"


### PR DESCRIPTION
The typed emitter answers `str[regexp, n]` inline; the boxed path (`sp_poly_slice_or_call`) read the two operands as an integer slice and raised on the first:

```ruby
def pick(ok)
  ok ? "<http://x/y?before=3>; rel=\"next\"" : nil
end

v = pick(true)
p v[/<(.*)>/, 1]   # no implicit conversion of Regexp into Integer (TypeError)
```

campfire's `response.headers["Link"][/<(.*)>/, 1]` — a read off a `Hash[String, String]`, so a `String | nil` receiver — is the caller (the bot API's Link-header paging test). The arm answers capture `n` of the first match (0 = the whole match), nil when there is none or `n` is out of range, as the typed form does. Test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ToBsHgTtrSoAvNDmHdTtpf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed regexp-based string indexing with a capture-group number.
  * String expressions that may be `nil` now correctly return the requested capture, the full match, or `nil` when no match or capture group exists.
  * Resolved errors affecting regexp indexing in values retrieved from hashes and other dynamically typed expressions.

* **Tests**
  * Added coverage for matching captures, unmatched patterns, invalid group numbers, and nullable string values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->